### PR TITLE
feat(server): improve health check endpoint

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -59,35 +59,47 @@ export async function registerRoutes(
   // ==========================================================================
   app.get("/api/health", async (req, res) => {
     try {
-      const startTime = Date.now();
-      
-      // Check database connectivity
-      const sites = await storage.getSites();
-      const dbLatency = Date.now() - startTime;
+      // Check database connectivity with lightweight query
+      const dbHealth = await storage.healthCheck();
       
       // Check blockchain service
-      const blockchainStatus = blockchainService.isEnabled() ? "connected" : "disconnected";
+      const blockchainConnected = blockchainService.isEnabled();
       
-      res.json({
-        status: "healthy",
+      // Determine overall health status
+      const isHealthy = dbHealth.connected;
+      
+      const response = {
+        status: isHealthy ? "healthy" : "unhealthy",
         timestamp: new Date().toISOString(),
         version: "1.0.0",
         uptime: process.uptime(),
-        checks: {
+        components: {
           database: {
-            status: "healthy",
-            latency: `${dbLatency}ms`,
+            status: dbHealth.connected ? "up" : "down",
+            latencyMs: dbHealth.latencyMs,
           },
           blockchain: {
-            status: blockchainStatus,
+            status: blockchainConnected ? "up" : "down",
           },
         },
-      });
+      };
+      
+      if (isHealthy) {
+        res.status(200).json(response);
+      } else {
+        res.status(503).json(response);
+      }
     } catch (error) {
       console.error("Health check failed:", error);
       res.status(503).json({
         status: "unhealthy",
         timestamp: new Date().toISOString(),
+        version: "1.0.0",
+        uptime: process.uptime(),
+        components: {
+          database: { status: "down" },
+          blockchain: { status: "unknown" },
+        },
         error: error instanceof Error ? error.message : "Unknown error",
       });
     }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -48,6 +48,9 @@ import type {
 const { Pool } = pg;
 
 export interface IStorage {
+  // Health Check
+  healthCheck(): Promise<{ connected: boolean; latencyMs: number }>;
+
   // Sites
   createSite(site: InsertSite): Promise<Site>;
   getSites(): Promise<Site[]>;
@@ -173,6 +176,24 @@ export class DatabaseStorage implements IStorage {
       connectionString: process.env.DATABASE_URL,
     });
     this.db = drizzle(pool, { schema });
+  }
+
+  // Health Check
+  async healthCheck(): Promise<{ connected: boolean; latencyMs: number }> {
+    const startTime = Date.now();
+    try {
+      // Simple query to verify database connectivity
+      await this.db.execute("SELECT 1");
+      return {
+        connected: true,
+        latencyMs: Date.now() - startTime,
+      };
+    } catch {
+      return {
+        connected: false,
+        latencyMs: Date.now() - startTime,
+      };
+    }
   }
 
   // Sites


### PR DESCRIPTION
## Summary
Improve the health check endpoint to match standard monitoring patterns and fulfill all acceptance criteria.

## Changes
- Added dedicated healthCheck() method to storage using lightweight SELECT 1 query
- Renamed checks to components to match standard health check patterns
- Use up/down status for component health indicators
- Returns 200 OK when healthy, 503 Service Unavailable when database unreachable
- Include latencyMs for database component timing
- Improved error handling with consistent response format

## Response Format
Success (200):
- status: healthy
- timestamp: ISO string
- version: 1.0.0
- uptime: seconds
- components.database: {status: up, latencyMs: N}
- components.blockchain: {status: up/down}

Failure (503):
- status: unhealthy
- Same fields plus error message

Closes #4