### PR TITLE
feat(kernel): add hello world kernel module

### DIFF
--- a/linux-fork/0xscada/modules/hello/Makefile
+++ b/linux-fork/0xscada/modules/hello/Makefile
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Makefile for 0xSCADA Hello World Kernel Module
+#
+# Usage:
+#   # Build against running kernel
+#   make
+#
+#   # Build against specific kernel
+#   make KDIR=/path/to/linux-fork
+#
+#   # Build against linux-fork (relative path)
+#   make KDIR=../../../..
+#
+#   # Install module
+#   sudo make install
+#
+#   # Clean build artifacts
+#   make clean
+#
+
+# Module name
+MODULE_NAME := hello_scada
+
+# Kernel build directory (default to running kernel)
+KDIR ?= /lib/modules/$(shell uname -r)/build
+
+# Current directory (where module sources are)
+PWD := $(shell pwd)
+
+# Object file(s) that make up the module
+obj-m := $(MODULE_NAME).o
+
+# Default target: build the module
+all:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+# Install the module
+install:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
+
+# Clean build artifacts
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean
+	rm -f Module.symvers modules.order
+
+# Load the module
+load: all
+	sudo insmod $(MODULE_NAME).ko
+
+# Unload the module
+unload:
+	sudo rmmod $(MODULE_NAME)
+
+# Reload the module (unload then load)
+reload: unload load
+
+# Show kernel messages related to the module
+dmesg:
+	dmesg | grep -i "0xscada" | tail -30
+
+# Test the module (load, show messages, unload)
+test: load
+	@echo "=== Module loaded. Kernel messages: ==="
+	@dmesg | grep -i "0xscada" | tail -20
+	@echo ""
+	@echo "Press Enter to unload module..."
+	@read
+	$(MAKE) unload
+	@echo "=== Module unloaded. Final messages: ==="
+	@dmesg | grep -i "0xscada" | tail -10
+
+# Show module info
+info:
+	@modinfo $(MODULE_NAME).ko 2>/dev/null || echo "Module not built yet"
+
+# Phony targets
+.PHONY: all install clean load unload reload dmesg test info

--- a/linux-fork/0xscada/modules/hello/README.md
+++ b/linux-fork/0xscada/modules/hello/README.md
@@ -1,0 +1,134 @@
+# 0xSCADA Hello World Kernel Module
+
+A simple kernel module to verify the 0xSCADA kernel development environment is working correctly.
+
+## Overview
+
+This module demonstrates:
+- Basic kernel module structure (init/exit functions)
+- Kernel logging with `printk`/`pr_info`
+- Module parameters
+- Module metadata (license, author, version)
+
+## Prerequisites
+
+- Linux kernel headers installed
+- Build tools (gcc, make)
+- Root access for loading modules
+
+For building against linux-fork:
+```bash
+cd /path/to/0xSCADA-QE/linux-fork
+make defconfig
+make modules_prepare
+```
+
+## Building
+
+### Against running kernel:
+```bash
+make
+```
+
+### Against linux-fork:
+```bash
+make KDIR=/path/to/0xSCADA-QE/linux-fork
+# or with relative path
+make KDIR=../../../..
+```
+
+## Loading and Testing
+
+```bash
+# Load the module
+sudo insmod hello_scada.ko
+
+# View messages
+dmesg | tail -20
+
+# Unload the module
+sudo rmmod hello_scada
+
+# View final messages
+dmesg | tail -10
+```
+
+## Module Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| greeting | string | "Hello from 0xSCADA!" | Custom greeting message |
+
+Example:
+```bash
+sudo insmod hello_scada.ko greeting="Custom message"
+```
+
+## Expected Output
+
+On load (visible via `dmesg`):
+```
+========================================
+0xSCADA Hello World Module Loaded
+========================================
+  Version: 1.0.0
+  Build Date: <build date/time>
+  Kernel: <kernel version>
+  Machine: <architecture>
+  Message: Hello from 0xSCADA!
+========================================
+0xSCADA kernel development environment is ready!
+========================================
+```
+
+On unload:
+```
+========================================
+0xSCADA Hello World Module Unloading
+========================================
+  Module was loaded for: X min Y sec
+  Cleanup completed successfully.
+  Goodbye from 0xSCADA!
+========================================
+```
+
+## Makefile Targets
+
+| Target | Description |
+|--------|-------------|
+| all | Build the module (default) |
+| clean | Remove build artifacts |
+| install | Install to kernel modules directory |
+| load | Build and load the module |
+| unload | Unload the module |
+| reload | Unload then reload the module |
+| dmesg | Show recent kernel messages |
+| test | Interactive test (load, show messages, wait, unload) |
+| info | Show module metadata |
+
+## Troubleshooting
+
+### "Module verification failed"
+If your kernel has module signature verification enabled:
+```bash
+# Disable temporarily (not recommended for production)
+sudo modprobe -r hello_scada
+sudo modprobe -f hello_scada
+```
+
+### "Required key not available"
+The kernel may require signed modules. For development, you can:
+1. Sign the module
+2. Disable secure boot
+3. Build with the kernel's signing key
+
+### Build errors
+Ensure kernel headers match your running kernel:
+```bash
+uname -r
+ls /lib/modules/$(uname -r)/build
+```
+
+## License
+
+GPL-2.0 (required for Linux kernel modules)

--- a/linux-fork/0xscada/modules/hello/hello_scada.c
+++ b/linux-fork/0xscada/modules/hello/hello_scada.c
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * 0xSCADA Hello World Kernel Module
+ *
+ * A simple kernel module to verify the 0xSCADA kernel development environment.
+ * This module demonstrates basic module operations and prints diagnostic
+ * information on load and unload.
+ *
+ * Usage:
+ *   make -C /path/to/linux-fork M=$(pwd) modules
+ *   sudo insmod hello_scada.ko
+ *   dmesg | tail -20
+ *   sudo rmmod hello_scada
+ *
+ * Author: 0xSCADA Team
+ * Date: 2024
+ */
+
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/version.h>
+#include <linux/utsname.h>
+
+/* Module version information */
+#define OXSCADA_HELLO_VERSION "1.0.0"
+#define OXSCADA_HELLO_BUILD_DATE __DATE__ " " __TIME__
+
+/* Module parameter for custom message */
+static char *greeting = "Hello from 0xSCADA!";
+module_param(greeting, charp, 0644);
+MODULE_PARM_DESC(greeting, "Custom greeting message to display on load");
+
+/* Track load timestamp for uptime reporting */
+static u64 load_jiffies;
+
+/**
+ * oxscada_hello_init - Module initialization function
+ *
+ * Called when the module is loaded with insmod/modprobe.
+ * Prints version information and system diagnostics.
+ *
+ * Return: 0 on success
+ */
+static int __init oxscada_hello_init(void)
+{
+	load_jiffies = get_jiffies_64();
+
+	pr_info("========================================\n");
+	pr_info("0xSCADA Hello World Module Loaded\n");
+	pr_info("========================================\n");
+	pr_info("  Version: %s\n", OXSCADA_HELLO_VERSION);
+	pr_info("  Build Date: %s\n", OXSCADA_HELLO_BUILD_DATE);
+	pr_info("  Kernel: %s\n", utsname()->release);
+	pr_info("  Machine: %s\n", utsname()->machine);
+	pr_info("  Message: %s\n", greeting);
+	pr_info("========================================\n");
+	pr_info("0xSCADA kernel development environment is ready!\n");
+	pr_info("========================================\n");
+
+	return 0;
+}
+
+/**
+ * oxscada_hello_exit - Module cleanup function
+ *
+ * Called when the module is unloaded with rmmod/modprobe -r.
+ * Cleans up resources and prints farewell message with uptime.
+ */
+static void __exit oxscada_hello_exit(void)
+{
+	u64 uptime_jiffies = get_jiffies_64() - load_jiffies;
+	unsigned long uptime_secs = jiffies_to_msecs(uptime_jiffies) / 1000;
+	unsigned long uptime_mins = uptime_secs / 60;
+	unsigned long uptime_secs_rem = uptime_secs % 60;
+
+	pr_info("========================================\n");
+	pr_info("0xSCADA Hello World Module Unloading\n");
+	pr_info("========================================\n");
+	pr_info("  Module was loaded for: %lu min %lu sec\n", 
+		uptime_mins, uptime_secs_rem);
+	pr_info("  Cleanup completed successfully.\n");
+	pr_info("  Goodbye from 0xSCADA!\n");
+	pr_info("========================================\n");
+}
+
+module_init(oxscada_hello_init);
+module_exit(oxscada_hello_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("0xSCADA Team");
+MODULE_DESCRIPTION("Hello World kernel module for 0xSCADA development environment verification");
+MODULE_VERSION(OXSCADA_HELLO_VERSION);


### PR DESCRIPTION
## Summary
Add a simple hello world kernel module to verify the 0xSCADA kernel development environment.

## Files Added
- linux-fork/0xscada/modules/hello/hello_scada.c - Module source
- linux-fork/0xscada/modules/hello/Makefile - Build configuration
- linux-fork/0xscada/modules/hello/README.md - Documentation

## Features
- Prints version info on load (visible in dmesg)
- Shows kernel version and machine architecture
- Supports custom greeting message via module parameter
- Reports module uptime on unload
- Cleans up properly on unload

## Makefile Targets
- all, clean, install - Build management
- load, unload, reload - Module management
- test - Interactive testing
- dmesg - View kernel messages

Closes #7