### PR TITLE
fix(ci): repair broken DCO action and add lint script

### DIFF
--- a/.github/workflows/ci-enhanced.yml
+++ b/.github/workflows/ci-enhanced.yml
@@ -28,9 +28,15 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO
-        uses: dcoapp/dco-check@v3
-        with:
-          check: signature
+        run: |
+          commits=$(git log --format='%H' origin/${{ github.base_ref }}..HEAD)
+          for commit in $commits; do
+            if ! git log -1 --format='%B' "$commit" | grep -q "Signed-off-by:"; then
+              echo "❌ Missing DCO sign-off in commit: $commit"
+              exit 1
+            fi
+          done
+          echo "✅ All commits have DCO sign-off!"
 
   # ==========================================================================
   # LINT & TYPE CHECK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,15 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO
-        uses: dcoapp/dco-check@v3
-        with:
-          check: signature
+        run: |
+          commits=$(git log --format='%H' origin/${{ github.base_ref }}..HEAD)
+          for commit in $commits; do
+            if ! git log -1 --format='%B' "$commit" | grep -q "Signed-off-by:"; then
+              echo "❌ Missing DCO sign-off in commit: $commit"
+              exit 1
+            fi
+          done
+          echo "✅ All commits have DCO sign-off!"
 
   # ==========================================================================
   # LINT & TYPE CHECK

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -15,21 +15,37 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO
-        uses: dcoapp/dco-check@v3
-        with:
-          # Require all commits to be signed off
-          # This enforces the Developer Certificate of Origin 1.2
-          # https://developercertificate.org/
-          check: signature
-          message: |
-            Developer Certificate of Origin 1.2
+        run: |
+          # Check all commits in the PR for DCO sign-off
+          commits=$(git log --format='%H %s' origin/${{ github.base_ref }}..HEAD)
+          missing_signoff=false
+          
+          while IFS= read -r line; do
+            if [ -z "$line" ]; then continue; fi
+            commit_hash=$(echo "$line" | cut -d' ' -f1)
+            commit_msg=$(git log -1 --format='%B' "$commit_hash")
             
-            By making a contribution to this project, I certify that:
-            
-            (a) The contribution was created in whole or in part by me, or under my direction, and I have the right to submit it under the open source license indicated in the file; or
-            
-            (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me or with the assistance of tools, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
-            
-            (c) The contribution was provided directly to me by some other person who certified (a), (b), or (c) and I have not modified it.
-            
-            (d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+            if ! echo "$commit_msg" | grep -q "Signed-off-by:"; then
+              echo "❌ Missing DCO sign-off in commit: $commit_hash"
+              echo "   Message: $(echo "$line" | cut -d' ' -f2-)"
+              missing_signoff=true
+            else
+              echo "✅ DCO sign-off found in commit: $(echo "$line" | cut -d' ' -f2-)"
+            fi
+          done <<< "$commits"
+          
+          if [ "$missing_signoff" = true ]; then
+            echo ""
+            echo "=================================================="
+            echo "Developer Certificate of Origin (DCO) Check Failed"
+            echo "=================================================="
+            echo ""
+            echo "Please sign off your commits using: git commit --signoff"
+            echo "Or amend existing commits: git commit --amend --signoff"
+            echo ""
+            echo "See: https://developercertificate.org/"
+            exit 1
+          fi
+          
+          echo ""
+          echo "✅ All commits have DCO sign-off!"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build": "tsx script/build.ts",
     "start": "NODE_ENV=production node dist/index.cjs",
     "check": "tsc",
+    "lint": "tsc --noEmit",
+    "lint:fix": "echo 'No auto-fix available for TypeScript errors'",
     "db:push": "drizzle-kit push",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Problem
- DCO check action `dcoapp/dco-check@v3` no longer exists (repo deleted/moved)
- No `lint` script in package.json, causing CI failures

## Solution
- Replace DCO action with inline shell script that checks for 'Signed-off-by:' in commits
- Add `lint` script to package.json (runs `tsc --noEmit`)

## Impact
**This PR unblocks all pending PRs** that are currently failing due to:
- DCO Check failures
- Lint script not found

### PRs that will be unblocked:
- #46: feat(qe): Phase 3 Backend API Tests
- #45: chore: update minor dependencies
- #56-63: All new feature PRs

## Files Changed
- `.github/workflows/dco.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/ci-enhanced.yml`
- `package.json`
