### PR TITLE
feat(cli): add DevOps deployment commands (Docker, K8s, Helm)

### DIFF
--- a/cli/__tests__/commands/deploy.test.ts
+++ b/cli/__tests__/commands/deploy.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import { registerDeployCommand } from "../../src/commands/deploy.js";
+import fs from "fs";
+
+vi.mock("child_process", () => ({ execSync: vi.fn().mockReturnValue(""), spawn: vi.fn(() => ({ on: vi.fn((event: string, handler: Function) => { if (event === "close") setTimeout(() => handler(0), 10); return { on: vi.fn() }; }), kill: vi.fn() })) }));
+vi.mock("fs", async () => { const actual = await vi.importActual("fs"); return { ...actual, writeFileSync: vi.fn(), mkdirSync: vi.fn(), existsSync: vi.fn().mockReturnValue(true) }; });
+vi.mock("ora", () => ({ default: vi.fn(() => ({ start: vi.fn().mockReturnThis(), stop: vi.fn(), fail: vi.fn(), succeed: vi.fn(), text: "" })) }));
+vi.mock("../../src/output.js", () => ({ setOutputOptions: vi.fn(), output: vi.fn(), outputSection: vi.fn(), outputKeyValue: vi.fn(), outputError: vi.fn(), outputSuccess: vi.fn(), outputWarning: vi.fn(), outputInfo: vi.fn(), outputTable: vi.fn(), colors: { success: (t: string) => t, error: (t: string) => t, warning: (t: string) => t, info: (t: string) => t, dim: (t: string) => t, bold: (t: string) => t, cyan: (t: string) => t, magenta: (t: string) => t } }));
+
+global.fetch = vi.fn();
+
+import { output, outputError, outputSuccess, outputInfo } from "../../src/output.js";
+
+describe("Deploy Command", () => {
+  let program: Command;
+
+  beforeEach(() => { vi.clearAllMocks(); program = new Command(); program.exitOverride(); registerDeployCommand(program); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  describe("command registration", () => {
+    it("should register deploy command", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); expect(deployCmd).toBeDefined(); });
+    it("should have global options", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); expect(deployCmd?.options.find((o) => o.long === "--env")).toBeDefined(); expect(deployCmd?.options.find((o) => o.long === "--replicas")).toBeDefined(); expect(deployCmd?.options.find((o) => o.long === "--namespace")).toBeDefined(); expect(deployCmd?.options.find((o) => o.long === "--registry")).toBeDefined(); expect(deployCmd?.options.find((o) => o.long === "--dry-run")).toBeDefined(); });
+    it("should have compose subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); expect(deployCmd?.commands.find((c) => c.name() === "compose")).toBeDefined(); });
+    it("should have k8s subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); expect(deployCmd?.commands.find((c) => c.name() === "k8s")).toBeDefined(); });
+    it("should have healthcheck subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); expect(deployCmd?.commands.find((c) => c.name() === "healthcheck")).toBeDefined(); });
+    it("should have metrics subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); expect(deployCmd?.commands.find((c) => c.name() === "metrics")).toBeDefined(); });
+    it("should have helm subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); expect(deployCmd?.commands.find((c) => c.name() === "helm")).toBeDefined(); });
+  });
+
+  describe("deploy compose subcommands", () => {
+    it("should have generate subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); const composeCmd = deployCmd?.commands.find((c) => c.name() === "compose"); expect(composeCmd?.commands.find((c) => c.name() === "generate")).toBeDefined(); });
+    it("should have up subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); const composeCmd = deployCmd?.commands.find((c) => c.name() === "compose"); expect(composeCmd?.commands.find((c) => c.name() === "up")).toBeDefined(); });
+    it("should have down subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); const composeCmd = deployCmd?.commands.find((c) => c.name() === "compose"); expect(composeCmd?.commands.find((c) => c.name() === "down")).toBeDefined(); });
+    it("should have logs subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); const composeCmd = deployCmd?.commands.find((c) => c.name() === "compose"); expect(composeCmd?.commands.find((c) => c.name() === "logs")).toBeDefined(); });
+    it("should generate docker-compose file", async () => { await program.parseAsync(["node", "test", "deploy", "compose", "generate"]); expect(fs.writeFileSync).toHaveBeenCalled(); expect(outputSuccess).toHaveBeenCalled(); });
+    it("should support dry-run", async () => { await program.parseAsync(["node", "test", "deploy", "--dry-run", "compose", "generate"]); expect(fs.writeFileSync).not.toHaveBeenCalled(); expect(outputInfo).toHaveBeenCalledWith(expect.stringContaining("[DRY-RUN]")); });
+    it("should output JSON when flag is set", async () => { await program.parseAsync(["node", "test", "deploy", "--json", "compose", "generate"]); expect(output).toHaveBeenCalledWith(expect.objectContaining({ success: true })); });
+  });
+
+  describe("deploy k8s subcommands", () => {
+    it("should have generate subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); const k8sCmd = deployCmd?.commands.find((c) => c.name() === "k8s"); expect(k8sCmd?.commands.find((c) => c.name() === "generate")).toBeDefined(); });
+    it("should have apply subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); const k8sCmd = deployCmd?.commands.find((c) => c.name() === "k8s"); expect(k8sCmd?.commands.find((c) => c.name() === "apply")).toBeDefined(); });
+    it("should have status subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); const k8sCmd = deployCmd?.commands.find((c) => c.name() === "k8s"); expect(k8sCmd?.commands.find((c) => c.name() === "status")).toBeDefined(); });
+    it("should have helm subcommand", () => { const deployCmd = program.commands.find((c) => c.name() === "deploy"); const k8sCmd = deployCmd?.commands.find((c) => c.name() === "k8s"); expect(k8sCmd?.commands.find((c) => c.name() === "helm")).toBeDefined(); });
+    it("should generate K8s manifests", async () => { await program.parseAsync(["node", "test", "deploy", "k8s", "generate"]); expect(fs.writeFileSync).toHaveBeenCalled(); expect(outputSuccess).toHaveBeenCalled(); });
+  });
+
+  describe("deploy helm command", () => {
+    it("should generate Helm chart files", async () => { await program.parseAsync(["node", "test", "deploy", "helm"]); expect(fs.mkdirSync).toHaveBeenCalled(); expect(fs.writeFileSync).toHaveBeenCalled(); expect(outputSuccess).toHaveBeenCalled(); });
+    it("should support dry-run", async () => { await program.parseAsync(["node", "test", "deploy", "--dry-run", "helm"]); expect(fs.writeFileSync).not.toHaveBeenCalled(); expect(outputInfo).toHaveBeenCalledWith(expect.stringContaining("[DRY-RUN]")); });
+  });
+
+  describe("deploy healthcheck command", () => {
+    it("should check service health", async () => { vi.mocked(global.fetch).mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({ status: "healthy" }) } as Response); await program.parseAsync(["node", "test", "deploy", "healthcheck"]); expect(global.fetch).toHaveBeenCalledWith("http://localhost:5000/api/health"); expect(outputSuccess).toHaveBeenCalled(); });
+    it("should handle health check failure", async () => { vi.mocked(global.fetch).mockResolvedValue({ ok: false, status: 503, json: () => Promise.resolve({ status: "unhealthy" }) } as Response); await program.parseAsync(["node", "test", "deploy", "healthcheck"]); expect(outputError).toHaveBeenCalled(); });
+    it("should handle network errors", async () => { vi.mocked(global.fetch).mockRejectedValue(new Error("Connection refused")); await program.parseAsync(["node", "test", "deploy", "healthcheck"]); expect(outputError).toHaveBeenCalledWith("Failed to connect to service", "Connection refused"); });
+    it("should support dry-run", async () => { await program.parseAsync(["node", "test", "deploy", "--dry-run", "healthcheck"]); expect(global.fetch).not.toHaveBeenCalled(); expect(outputInfo).toHaveBeenCalledWith(expect.stringContaining("[DRY-RUN]")); });
+  });
+
+  describe("deploy metrics command", () => {
+    it("should export metrics in JSON format by default", async () => { await program.parseAsync(["node", "test", "deploy", "metrics"]); expect(output).toHaveBeenCalledWith(expect.objectContaining({ timestamp: expect.any(String), environment: expect.any(String) })); });
+    it("should support dry-run", async () => { await program.parseAsync(["node", "test", "deploy", "--dry-run", "metrics"]); expect(outputInfo).toHaveBeenCalledWith(expect.stringContaining("[DRY-RUN]")); });
+  });
+
+  describe("environment configurations", () => {
+    it("should generate dev configuration by default", async () => { await program.parseAsync(["node", "test", "deploy", "compose", "generate"]); const callArgs = vi.mocked(fs.writeFileSync).mock.calls[0]; expect(callArgs[1]).toContain("development"); });
+    it("should generate production configuration", async () => { await program.parseAsync(["node", "test", "deploy", "--env", "production", "compose", "generate"]); const callArgs = vi.mocked(fs.writeFileSync).mock.calls[0]; expect(callArgs[1]).toContain("production"); });
+    it("should generate staging configuration", async () => { await program.parseAsync(["node", "test", "deploy", "--env", "staging", "compose", "generate"]); const callArgs = vi.mocked(fs.writeFileSync).mock.calls[0]; expect(callArgs[1]).toContain("staging"); });
+  });
+});

--- a/cli/src/commands/deploy.ts
+++ b/cli/src/commands/deploy.ts
@@ -1,0 +1,393 @@
+import { Command } from "commander";
+import { spawn, execSync } from "child_process";
+import path from "path";
+import fs from "fs";
+import { fileURLToPath } from "url";
+import ora from "ora";
+import {
+  output,
+  outputKeyValue,
+  outputError,
+  outputSuccess,
+  outputInfo,
+  setOutputOptions,
+  colors,
+  outputTable,
+} from "../output.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PROJECT_ROOT = path.resolve(__dirname, "../../../../");
+
+export interface DeployOptions {
+  env: "production" | "staging" | "dev";
+  replicas: number;
+  namespace: string;
+  registry: string;
+  dryRun: boolean;
+  json?: boolean;
+  color?: boolean;
+}
+
+function generateDockerCompose(options: DeployOptions): string {
+  const envConfig = {
+    production: { nodeEnv: "production", replicas: options.replicas || 3, restartPolicy: "always" },
+    staging: { nodeEnv: "staging", replicas: options.replicas || 2, restartPolicy: "unless-stopped" },
+    dev: { nodeEnv: "development", replicas: options.replicas || 1, restartPolicy: "no" },
+  };
+  const config = envConfig[options.env];
+
+  return `version: '3.8'
+services:
+  db:
+    image: postgres:15-alpine
+    container_name: oxscada-db-${options.env}
+    restart: ${config.restartPolicy}
+    environment:
+      POSTGRES_USER: \${DB_USER:-oxscada}
+      POSTGRES_PASSWORD: \${DB_PASSWORD:-oxscada_secret}
+      POSTGRES_DB: \${DB_NAME:-oxscada}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \${DB_USER:-oxscada}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - oxscada-network
+  app:
+    image: ${options.registry}/oxscada-app:latest
+    container_name: oxscada-app-${options.env}
+    restart: ${config.restartPolicy}
+    deploy:
+      replicas: ${config.replicas}
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      NODE_ENV: ${config.nodeEnv}
+      DATABASE_URL: postgresql://\${DB_USER:-oxscada}:\${DB_PASSWORD:-oxscada_secret}@db:5432/\${DB_NAME:-oxscada}
+      PORT: 5000
+    ports:
+      - "5000:5000"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - oxscada-network
+${options.env === "dev" ? `  hardhat:
+    image: node:20-alpine
+    container_name: oxscada-hardhat
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: npx hardhat node
+    ports:
+      - "8545:8545"
+    networks:
+      - oxscada-network
+` : ""}volumes:
+  postgres_data:
+networks:
+  oxscada-network:
+    name: oxscada-network-${options.env}
+`;
+}
+
+function generateK8sDeployment(options: DeployOptions): string {
+  return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oxscada-app
+  namespace: ${options.namespace}
+  labels:
+    app: oxscada
+    environment: ${options.env}
+spec:
+  replicas: ${options.replicas}
+  selector:
+    matchLabels:
+      app: oxscada
+  template:
+    metadata:
+      labels:
+        app: oxscada
+        environment: ${options.env}
+    spec:
+      containers:
+      - name: oxscada
+        image: ${options.registry}/oxscada-app:latest
+        ports:
+        - containerPort: 5000
+        env:
+        - name: NODE_ENV
+          value: "${options.env === "dev" ? "development" : options.env}"
+        - name: PORT
+          value: "5000"
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: oxscada-secrets
+              key: database-url
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        readinessProbe:
+          httpGet:
+            path: /api/health
+            port: 5000
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /api/health
+            port: 5000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: oxscada-service
+  namespace: ${options.namespace}
+spec:
+  selector:
+    app: oxscada
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 5000
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oxscada-secrets
+  namespace: ${options.namespace}
+type: Opaque
+stringData:
+  database-url: "postgresql://oxscada:oxscada_secret@oxscada-db:5432/oxscada"
+`;
+}
+
+function generateHelmChart(options: DeployOptions): { [key: string]: string } {
+  return {
+    "Chart.yaml": `apiVersion: v2
+name: oxscada
+description: A Helm chart for 0xSCADA
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+`,
+    "values.yaml": `replicaCount: ${options.replicas}
+image:
+  repository: ${options.registry}/oxscada-app
+  pullPolicy: IfNotPresent
+  tag: "latest"
+environment: ${options.env}
+service:
+  type: LoadBalancer
+  port: 80
+  targetPort: 5000
+`,
+    "templates/deployment.yaml": `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oxscada.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: oxscada
+  template:
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+`,
+    "templates/service.yaml": `apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oxscada.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+`,
+    "templates/_helpers.tpl": `{{- define "oxscada.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- define "oxscada.fullname" -}}
+{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+`,
+  };
+}
+
+function execCommand(command: string, options: { cwd?: string; dryRun?: boolean } = {}): { success: boolean; output?: string; error?: string } {
+  if (options.dryRun) return { success: true, output: `[DRY-RUN] Would execute: ${command}` };
+  try {
+    const cmdOutput = execSync(command, { cwd: options.cwd || PROJECT_ROOT, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
+    return { success: true, output: cmdOutput.trim() };
+  } catch (error: unknown) {
+    const execError = error as { stderr?: Buffer | string; message?: string };
+    return { success: false, error: execError.stderr?.toString() || execError.message || "Command failed" };
+  }
+}
+
+export function registerDeployCommand(program: Command): void {
+  const deploy = program.command("deploy").description("Deployment and DevOps commands for Docker, Kubernetes, and Helm");
+
+  deploy
+    .option("--env <environment>", "Deployment environment (production|staging|dev)", "dev")
+    .option("--replicas <number>", "Number of replicas", "1")
+    .option("--namespace <namespace>", "Kubernetes namespace", "default")
+    .option("--registry <registry>", "Container registry", "docker.io")
+    .option("--dry-run", "Preview commands without executing", false)
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output");
+
+  const compose = deploy.command("compose").description("Docker Compose deployment commands");
+
+  compose.command("generate").description("Generate docker-compose.yml").option("--output <path>", "Output file path", "docker-compose.generated.yml")
+    .action(async (cmdOptions, cmd) => {
+      const parentOpts = cmd.parent.parent.opts();
+      setOutputOptions({ json: parentOpts.json, color: parentOpts.color });
+      const options: DeployOptions = { env: parentOpts.env, replicas: parseInt(parentOpts.replicas, 10), namespace: parentOpts.namespace, registry: parentOpts.registry, dryRun: parentOpts.dryRun, json: parentOpts.json };
+      const content = generateDockerCompose(options);
+      const outputPath = path.resolve(PROJECT_ROOT, cmdOptions.output);
+      if (options.dryRun) { if (parentOpts.json) output({ dryRun: true, content, outputPath }); else { outputInfo(`[DRY-RUN] Would write to: ${outputPath}`); console.log(content); } return; }
+      try { fs.writeFileSync(outputPath, content); if (parentOpts.json) output({ success: true, outputPath, environment: options.env }); else { outputSuccess(`Generated ${cmdOptions.output} for ${options.env} environment`); outputKeyValue([{ key: "Environment", value: options.env }, { key: "Replicas", value: String(options.replicas) }, { key: "Registry", value: options.registry }, { key: "Output", value: outputPath }]); } } catch (error) { outputError("Failed to generate docker-compose file", error instanceof Error ? error.message : "Unknown error"); }
+    });
+
+  compose.command("up").description("Start services using Docker Compose").option("-d, --detach", "Run in detached mode", false).option("-f, --file <path>", "Compose file path", "docker-compose.yml")
+    .action(async (cmdOptions, cmd) => {
+      const parentOpts = cmd.parent.parent.opts();
+      setOutputOptions({ json: parentOpts.json, color: parentOpts.color });
+      const command = `docker compose -f ${cmdOptions.file} up ${cmdOptions.detach ? "-d" : ""}`.trim();
+      if (parentOpts.dryRun) { if (parentOpts.json) output({ dryRun: true, command }); else outputInfo(`[DRY-RUN] Would execute: ${command}`); return; }
+      if (parentOpts.json) { output(execCommand(command)); return; }
+      outputInfo(`Starting services with: ${command}`);
+      const proc = spawn("docker", ["compose", "-f", cmdOptions.file, "up", ...(cmdOptions.detach ? ["-d"] : [])], { cwd: PROJECT_ROOT, stdio: "inherit", shell: true });
+      proc.on("error", (error) => { outputError("Failed to start Docker Compose", error.message); process.exit(1); });
+      proc.on("close", (code) => { if (code === 0) outputSuccess("Services started successfully"); else outputError(`Docker Compose exited with code ${code}`); });
+    });
+
+  compose.command("down").description("Stop and remove Docker Compose services").option("-v, --volumes", "Remove volumes", false).option("-f, --file <path>", "Compose file path", "docker-compose.yml")
+    .action(async (cmdOptions, cmd) => {
+      const parentOpts = cmd.parent.parent.opts();
+      setOutputOptions({ json: parentOpts.json, color: parentOpts.color });
+      const command = `docker compose -f ${cmdOptions.file} down ${cmdOptions.volumes ? "-v" : ""}`.trim();
+      if (parentOpts.dryRun) { if (parentOpts.json) output({ dryRun: true, command }); else outputInfo(`[DRY-RUN] Would execute: ${command}`); return; }
+      const spinner = parentOpts.json ? null : ora("Stopping services...").start();
+      const result = execCommand(command);
+      if (result.success) { spinner?.succeed("Services stopped successfully"); if (parentOpts.json) output({ success: true, message: "Services stopped", output: result.output }); }
+      else { spinner?.fail("Failed to stop services"); outputError("Docker Compose down failed", result.error); }
+    });
+
+  compose.command("logs").description("View Docker Compose service logs").option("-f, --follow", "Follow log output", false).option("--tail <lines>", "Number of lines to show", "100").option("-s, --service <name>", "Service name").option("--file <path>", "Compose file path", "docker-compose.yml")
+    .action(async (cmdOptions, cmd) => {
+      const parentOpts = cmd.parent.parent.opts();
+      setOutputOptions({ json: parentOpts.json, color: parentOpts.color });
+      const args = ["compose", "-f", cmdOptions.file, "logs"]; if (cmdOptions.follow) args.push("-f"); args.push("--tail", cmdOptions.tail); if (cmdOptions.service) args.push(cmdOptions.service);
+      const command = `docker ${args.join(" ")}`;
+      if (parentOpts.dryRun) { if (parentOpts.json) output({ dryRun: true, command }); else outputInfo(`[DRY-RUN] Would execute: ${command}`); return; }
+      if (parentOpts.json) { output(execCommand(command)); return; }
+      spawn("docker", args, { cwd: PROJECT_ROOT, stdio: "inherit", shell: true }).on("error", (error) => outputError("Failed to get logs", error.message));
+    });
+
+  const k8s = deploy.command("k8s").description("Kubernetes deployment commands");
+
+  k8s.command("generate").description("Generate Kubernetes deployment manifests").option("--output <path>", "Output file path", "k8s-deployment.yaml")
+    .action(async (cmdOptions, cmd) => {
+      const parentOpts = cmd.parent.parent.opts();
+      setOutputOptions({ json: parentOpts.json, color: parentOpts.color });
+      const options: DeployOptions = { env: parentOpts.env, replicas: parseInt(parentOpts.replicas, 10), namespace: parentOpts.namespace, registry: parentOpts.registry, dryRun: parentOpts.dryRun, json: parentOpts.json };
+      const content = generateK8sDeployment(options);
+      const outputPath = path.resolve(PROJECT_ROOT, cmdOptions.output);
+      if (options.dryRun) { if (parentOpts.json) output({ dryRun: true, content, outputPath }); else { outputInfo(`[DRY-RUN] Would write to: ${outputPath}`); console.log(content); } return; }
+      try { fs.writeFileSync(outputPath, content); if (parentOpts.json) output({ success: true, outputPath, environment: options.env, namespace: options.namespace }); else { outputSuccess(`Generated ${cmdOptions.output} for ${options.env} environment`); outputKeyValue([{ key: "Environment", value: options.env }, { key: "Namespace", value: options.namespace }, { key: "Replicas", value: String(options.replicas) }, { key: "Registry", value: options.registry }, { key: "Output", value: outputPath }]); } } catch (error) { outputError("Failed to generate K8s manifests", error instanceof Error ? error.message : "Unknown error"); }
+    });
+
+  k8s.command("apply").description("Apply Kubernetes manifests to cluster").option("-f, --file <path>", "Manifest file path", "k8s-deployment.yaml")
+    .action(async (cmdOptions, cmd) => {
+      const parentOpts = cmd.parent.parent.opts();
+      setOutputOptions({ json: parentOpts.json, color: parentOpts.color });
+      const command = `kubectl apply -f ${cmdOptions.file} --namespace=${parentOpts.namespace}`;
+      if (parentOpts.dryRun) { const dryRunCommand = `${command} --dry-run=client`; if (parentOpts.json) output({ dryRun: true, command, result: execCommand(dryRunCommand) }); else { outputInfo(`[DRY-RUN] Would execute: ${command}`); const result = execCommand(dryRunCommand); if (result.output) console.log(result.output); } return; }
+      const spinner = parentOpts.json ? null : ora("Applying Kubernetes manifests...").start();
+      const result = execCommand(command);
+      if (result.success) { spinner?.succeed("Manifests applied successfully"); if (parentOpts.json) output({ success: true, output: result.output }); else if (result.output) console.log(result.output); }
+      else { spinner?.fail("Failed to apply manifests"); outputError("kubectl apply failed", result.error); }
+    });
+
+  k8s.command("status").description("Show Kubernetes deployment status")
+    .action(async (_cmdOptions, cmd) => {
+      const parentOpts = cmd.parent.parent.opts();
+      setOutputOptions({ json: parentOpts.json, color: parentOpts.color });
+      const namespace = parentOpts.namespace;
+      if (parentOpts.dryRun) { if (parentOpts.json) output({ dryRun: true, commands: ["kubectl get pods", "kubectl get services", "kubectl get deployments"] }); else outputInfo("[DRY-RUN] Would check Kubernetes cluster status"); return; }
+      const statusData: Record<string, unknown> = { namespace };
+      const podsResult = execCommand(`kubectl get pods -n ${namespace} -l app=oxscada -o json`);
+      if (podsResult.success && podsResult.output) { try { const pods = JSON.parse(podsResult.output); statusData.pods = pods.items?.map((p: Record<string, unknown>) => ({ name: (p.metadata as Record<string, unknown>)?.name, status: (p.status as Record<string, unknown>)?.phase })) || []; } catch { statusData.pods = []; } }
+      if (parentOpts.json) { output(statusData); return; }
+      console.log(colors.bold("\nPods:")); if ((statusData.pods as Array<Record<string, unknown>>)?.length > 0) outputTable(["Name", "Status"], (statusData.pods as Array<Record<string, unknown>>).map((p) => [String(p.name), String(p.status)])); else console.log(colors.dim("  No pods found"));
+    });
+
+  k8s.command("helm").alias("helm-chart").description("Generate Helm chart for 0xSCADA").option("--output <path>", "Output directory", "charts/oxscada")
+    .action(async (cmdOptions, cmd) => {
+      const parentOpts = cmd.parent.parent.opts();
+      setOutputOptions({ json: parentOpts.json, color: parentOpts.color });
+      const options: DeployOptions = { env: parentOpts.env, replicas: parseInt(parentOpts.replicas, 10), namespace: parentOpts.namespace, registry: parentOpts.registry, dryRun: parentOpts.dryRun, json: parentOpts.json };
+      const chartFiles = generateHelmChart(options);
+      const outputDir = path.resolve(PROJECT_ROOT, cmdOptions.output);
+      if (options.dryRun) { if (parentOpts.json) output({ dryRun: true, files: Object.keys(chartFiles), outputDir }); else { outputInfo(`[DRY-RUN] Would create Helm chart at: ${outputDir}`); Object.keys(chartFiles).forEach((file) => console.log(colors.dim(`  - ${file}`))); } return; }
+      try { fs.mkdirSync(path.join(outputDir, "templates"), { recursive: true }); for (const [filename, content] of Object.entries(chartFiles)) { const filePath = path.join(outputDir, filename); fs.mkdirSync(path.dirname(filePath), { recursive: true }); fs.writeFileSync(filePath, content); } if (parentOpts.json) output({ success: true, outputDir, files: Object.keys(chartFiles) }); else { outputSuccess(`Generated Helm chart at ${cmdOptions.output}`); outputKeyValue([{ key: "Environment", value: options.env }, { key: "Replicas", value: String(options.replicas) }, { key: "Registry", value: options.registry }, { key: "Output", value: outputDir }]); } } catch (error) { outputError("Failed to generate Helm chart", error instanceof Error ? error.message : "Unknown error"); }
+    });
+
+  deploy.command("helm").description("Generate Helm chart (alias for deploy k8s helm)").option("--output <path>", "Output directory", "charts/oxscada")
+    .action(async (cmdOptions, cmd) => {
+      const parentOpts = cmd.parent.opts();
+      setOutputOptions({ json: parentOpts.json, color: parentOpts.color });
+      const options: DeployOptions = { env: parentOpts.env, replicas: parseInt(parentOpts.replicas, 10), namespace: parentOpts.namespace, registry: parentOpts.registry, dryRun: parentOpts.dryRun, json: parentOpts.json };
+      const chartFiles = generateHelmChart(options);
+      const outputDir = path.resolve(PROJECT_ROOT, cmdOptions.output);
+      if (options.dryRun) { if (parentOpts.json) output({ dryRun: true, files: Object.keys(chartFiles), outputDir }); else { outputInfo(`[DRY-RUN] Would create Helm chart at: ${outputDir}`); Object.keys(chartFiles).forEach((file) => console.log(colors.dim(`  - ${file}`))); } return; }
+      try { fs.mkdirSync(path.join(outputDir, "templates"), { recursive: true }); for (const [filename, content] of Object.entries(chartFiles)) { const filePath = path.join(outputDir, filename); fs.mkdirSync(path.dirname(filePath), { recursive: true }); fs.writeFileSync(filePath, content); } if (parentOpts.json) output({ success: true, outputDir, files: Object.keys(chartFiles) }); else outputSuccess(`Generated Helm chart at ${cmdOptions.output}`); } catch (error) { outputError("Failed to generate Helm chart", error instanceof Error ? error.message : "Unknown error"); }
+    });
+
+  deploy.command("healthcheck").description("Check health of deployed services").option("--url <url>", "Health check URL", "http://localhost:5000/api/health")
+    .action(async (cmdOptions, cmd) => {
+      const parentOpts = cmd.parent.opts();
+      setOutputOptions({ json: parentOpts.json, color: parentOpts.color });
+      if (parentOpts.dryRun) { if (parentOpts.json) output({ dryRun: true, url: cmdOptions.url }); else outputInfo(`[DRY-RUN] Would check health at: ${cmdOptions.url}`); return; }
+      const spinner = parentOpts.json ? null : ora("Checking service health...").start();
+      try { const response = await fetch(cmdOptions.url); const data = await response.json(); spinner?.stop(); if (parentOpts.json) { output({ success: response.ok, statusCode: response.status, url: cmdOptions.url, data }); return; } if (response.ok) { outputSuccess(`Service is healthy (${response.status})`); outputKeyValue([{ key: "URL", value: cmdOptions.url }, { key: "Status", value: String(response.status) }]); } else outputError(`Health check failed (${response.status})`, JSON.stringify(data)); } catch (error) { spinner?.fail("Health check failed"); outputError("Failed to connect to service", error instanceof Error ? error.message : "Unknown error"); }
+    });
+
+  deploy.command("metrics").description("Export deployment metrics").option("--format <format>", "Output format (json|prometheus|csv)", "json")
+    .action(async (cmdOptions, cmd) => {
+      const parentOpts = cmd.parent.opts();
+      setOutputOptions({ json: parentOpts.json || cmdOptions.format === "json", color: parentOpts.color });
+      if (parentOpts.dryRun) { if (parentOpts.json) output({ dryRun: true, format: cmdOptions.format }); else outputInfo(`[DRY-RUN] Would export metrics in ${cmdOptions.format} format`); return; }
+      const metrics: Record<string, unknown> = { timestamp: new Date().toISOString(), environment: parentOpts.env, namespace: parentOpts.namespace };
+      const k8sMetrics = execCommand(`kubectl top pods -n ${parentOpts.namespace} --no-headers 2>/dev/null || echo ""`);
+      if (k8sMetrics.success && k8sMetrics.output) { metrics.kubernetes = k8sMetrics.output.split("\n").filter(Boolean).map((line) => { const [name, cpu, memory] = line.trim().split(/\s+/); return { name, cpu, memory }; }); }
+      switch (cmdOptions.format) {
+        case "prometheus": console.log(`# HELP oxscada_deployment_info Deployment information\n# TYPE oxscada_deployment_info gauge\noxscada_deployment_info{environment="${metrics.environment}",namespace="${metrics.namespace}"} 1`); break;
+        case "csv": console.log("timestamp,environment,namespace,pod_name,cpu,memory"); if ((metrics.kubernetes as Array<Record<string, unknown>>)?.length > 0) (metrics.kubernetes as Array<Record<string, unknown>>).forEach((pod) => console.log(`${metrics.timestamp},${metrics.environment},${metrics.namespace},${pod.name},${pod.cpu},${pod.memory}`)); else console.log(`${metrics.timestamp},${metrics.environment},${metrics.namespace},N/A,N/A,N/A`); break;
+        default: output(metrics); break;
+      }
+    });
+}


### PR DESCRIPTION
## Summary
- Add deploy compose generate/up/down/logs commands
- Add deploy k8s generate/apply/status commands
- Add deploy helm chart generation
- Add deploy healthcheck and metrics export
- Support --env, --replicas, --namespace, --dry-run options

## Test plan
- [ ] Run npm test in cli/ directory
- [ ] Test 0xscada deploy compose generate
- [ ] Test 0xscada deploy k8s generate --dry-run

Closes #96

Generated with Claude Code