### PR TITLE
feat(cli): add agents command for governance agent management

### DIFF
--- a/cli/__tests__/commands/shell.test.ts
+++ b/cli/__tests__/commands/shell.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import { registerShellCommand, getAvailableCommands, getCompletions, parseCommandLine } from "../../src/commands/shell.js";
+
+// Mock readline module
+vi.mock("readline", () => ({
+  createInterface: vi.fn(() => ({
+    prompt: vi.fn(),
+    on: vi.fn(),
+    close: vi.fn(),
+    setPrompt: vi.fn(),
+    write: vi.fn(),
+  })),
+  emitKeypressEvents: vi.fn(),
+}));
+
+// Mock chalk
+vi.mock("chalk", () => ({
+  default: {
+    bold: Object.assign((t: string) => t, {
+      cyan: (t: string) => t,
+      green: (t: string) => t,
+      white: (t: string) => t,
+    }),
+    cyan: (t: string) => t,
+    green: (t: string) => t,
+    yellow: (t: string) => t,
+    red: (t: string) => t,
+    dim: (t: string) => t,
+    white: (t: string) => t,
+  },
+}));
+
+// Mock config
+vi.mock("../../src/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    colorOutput: true,
+    jsonOutput: false,
+    apiUrl: "http://localhost:5000",
+  })),
+}));
+
+describe("Shell Command", () => {
+  let program: Command;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    program = new Command();
+    program.exitOverride();
+    registerShellCommand(program);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("registerShellCommand", () => {
+    it("should register shell command", () => {
+      const shellCmd = program.commands.find((c) => c.name() === "shell");
+      expect(shellCmd).toBeDefined();
+    });
+
+    it("should have correct description", () => {
+      const shellCmd = program.commands.find((c) => c.name() === "shell");
+      expect(shellCmd?.description()).toContain("interactive");
+    });
+  });
+
+  describe("getAvailableCommands", () => {
+    it("should return array of available commands", () => {
+      const commands = getAvailableCommands();
+      expect(Array.isArray(commands)).toBe(true);
+      expect(commands.length).toBeGreaterThan(0);
+    });
+
+    it("should include core commands", () => {
+      const commands = getAvailableCommands();
+      expect(commands).toContain("status");
+      expect(commands).toContain("sites");
+      expect(commands).toContain("assets");
+      expect(commands).toContain("events");
+      expect(commands).toContain("blockchain");
+    });
+
+    it("should include shell-specific commands", () => {
+      const commands = getAvailableCommands();
+      expect(commands).toContain("help");
+      expect(commands).toContain("exit");
+      expect(commands).toContain("quit");
+      expect(commands).toContain("clear");
+      expect(commands).toContain("history");
+    });
+
+    it("should include subcommands", () => {
+      const commands = getAvailableCommands();
+      expect(commands).toContain("sites list");
+      expect(commands).toContain("sites get");
+      expect(commands).toContain("assets list");
+      expect(commands).toContain("events list");
+      expect(commands).toContain("blockchain info");
+    });
+  });
+
+  describe("getCompletions", () => {
+    it("should return top-level commands for empty input", () => {
+      const completions = getCompletions("");
+      expect(completions).toContain("status");
+      expect(completions).toContain("sites");
+      expect(completions).toContain("help");
+      // Should not include subcommands for empty input
+      expect(completions).not.toContain("sites list");
+    });
+
+    it("should filter commands based on partial input", () => {
+      const completions = getCompletions("si");
+      expect(completions).toContain("sites");
+      expect(completions).toContain("sites list");
+      expect(completions).toContain("sites get");
+      expect(completions).not.toContain("status");
+      expect(completions).not.toContain("assets");
+    });
+
+    it("should be case-insensitive", () => {
+      const completions = getCompletions("SI");
+      expect(completions).toContain("sites");
+      expect(completions).toContain("sites list");
+    });
+
+    it("should complete subcommands", () => {
+      const completions = getCompletions("sites l");
+      expect(completions).toContain("sites list");
+    });
+
+    it("should return exact match when input matches a command", () => {
+      const completions = getCompletions("status");
+      expect(completions).toContain("status");
+    });
+
+    it("should handle trailing spaces", () => {
+      const completions = getCompletions("sites ");
+      // Commands starting with "sites " should be included
+      expect(completions.some((c) => c.startsWith("sites "))).toBe(true);
+    });
+  });
+
+  describe("parseCommandLine", () => {
+    it("should parse simple commands", () => {
+      const args = parseCommandLine("status");
+      expect(args).toEqual(["status"]);
+    });
+
+    it("should parse commands with arguments", () => {
+      const args = parseCommandLine("sites get site-123");
+      expect(args).toEqual(["sites", "get", "site-123"]);
+    });
+
+    it("should handle multiple spaces", () => {
+      const args = parseCommandLine("sites   list");
+      expect(args).toEqual(["sites", "list"]);
+    });
+
+    it("should handle quoted strings with spaces", () => {
+      const args = parseCommandLine('sites create --name "My Site"');
+      expect(args).toEqual(["sites", "create", "--name", "My Site"]);
+    });
+
+    it("should handle single quoted strings", () => {
+      const args = parseCommandLine("sites create --name 'My Site'");
+      expect(args).toEqual(["sites", "create", "--name", "My Site"]);
+    });
+
+    it("should handle mixed quotes", () => {
+      const args = parseCommandLine('config set key "value with \'nested\' quotes"');
+      expect(args).toEqual(["config", "set", "key", "value with 'nested' quotes"]);
+    });
+
+    it("should handle options with values", () => {
+      const args = parseCommandLine("events list --limit 10");
+      expect(args).toEqual(["events", "list", "--limit", "10"]);
+    });
+
+    it("should handle equals-style options", () => {
+      const args = parseCommandLine("events list --limit=10");
+      expect(args).toEqual(["events", "list", "--limit=10"]);
+    });
+
+    it("should handle empty input", () => {
+      const args = parseCommandLine("");
+      expect(args).toEqual([]);
+    });
+
+    it("should handle whitespace-only input", () => {
+      const args = parseCommandLine("   ");
+      expect(args).toEqual([]);
+    });
+
+    it("should preserve flags", () => {
+      const args = parseCommandLine("status --json --no-color");
+      expect(args).toEqual(["status", "--json", "--no-color"]);
+    });
+  });
+
+  describe("shell integration", () => {
+    it("should not interfere with other commands", () => {
+      // Add another command
+      program.command("other").description("Other command");
+
+      const commands = program.commands.map((c) => c.name());
+      expect(commands).toContain("shell");
+      expect(commands).toContain("other");
+    });
+
+    it("shell command should not have subcommands", () => {
+      const shellCmd = program.commands.find((c) => c.name() === "shell");
+      expect(shellCmd?.commands.length).toBe(0);
+    });
+  });
+});
+
+describe("Shell Command History", () => {
+  it("should track command history", async () => {
+    // Import fresh to get clean history
+    const { history } = await import("../../src/commands/shell.js");
+
+    // History should be an array
+    expect(Array.isArray(history)).toBe(true);
+  });
+});
+
+describe("Shell Context", () => {
+  it("should have context object", async () => {
+    const { context } = await import("../../src/commands/shell.js");
+
+    // Context should be an object
+    expect(typeof context).toBe("object");
+  });
+});

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -1,0 +1,531 @@
+import { Command } from "commander";
+import ora from "ora";
+import { getApiClient } from "../api.js";
+import {
+  output,
+  outputTable,
+  outputSection,
+  outputKeyValue,
+  outputError,
+  outputSuccess,
+  formatDate,
+  setOutputOptions,
+  colors,
+  statusIcon,
+  truncate,
+} from "../output.js";
+
+export function registerAgentsCommand(program: Command): void {
+  const agents = program
+    .command("agents")
+    .description("Manage governance agents");
+
+  agents
+    .command("list")
+    .description("List all registered agents")
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output")
+    .option("--type <type>", "Filter by agent type (OPS, CHANGE_CONTROL, COMPLIANCE)")
+    .action(async (options) => {
+      setOutputOptions({ json: options.json, color: options.color });
+      const spinner = options.json ? null : ora("Fetching agents...").start();
+      const api = getApiClient();
+
+      try {
+        const response = await api.getAgents();
+        spinner?.stop();
+
+        if (!response.success || !response.data) {
+          outputError("Failed to fetch agents", response.error);
+          return;
+        }
+
+        let agentsData = response.data;
+        if (options.type) {
+          agentsData = agentsData.filter(
+            (a) => a.agentType?.toLowerCase() === options.type.toLowerCase()
+          );
+        }
+
+        if (options.json) {
+          output(agentsData);
+          return;
+        }
+
+        if (agentsData.length === 0) {
+          console.log(colors.dim("No agents registered yet."));
+          return;
+        }
+
+        outputTable(
+          ["ID", "Name", "Type", "Status", "Created"],
+          agentsData.map((agent) => [
+            truncate(agent.id, 20),
+            agent.displayName || agent.name,
+            agent.agentType || "UNKNOWN",
+            `${statusIcon(agent.status?.toLowerCase() || "unknown")} ${agent.status || "UNKNOWN"}`,
+            formatDate(agent.createdAt),
+          ])
+        );
+        console.log(colors.dim(`\nTotal: ${agentsData.length} agents`));
+      } catch (error) {
+        spinner?.fail("Failed to fetch agents");
+        outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+      }
+    });
+
+  agents
+    .command("status <agent-id>")
+    .description("Get detailed status of a specific agent")
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output")
+    .action(async (agentId: string, options) => {
+      setOutputOptions({ json: options.json, color: options.color });
+      const spinner = options.json ? null : ora("Fetching agent status...").start();
+      const api = getApiClient();
+
+      try {
+        const response = await api.getAgentById(agentId);
+        spinner?.stop();
+
+        if (!response.success || !response.data) {
+          outputError("Agent not found", response.error);
+          return;
+        }
+
+        const agent = response.data;
+
+        if (options.json) {
+          output(agent);
+          return;
+        }
+
+        outputSection("Agent Details");
+        outputKeyValue([
+          { key: "ID", value: agent.id },
+          { key: "Name", value: agent.displayName || agent.name },
+          { key: "Type", value: agent.agentType || "UNKNOWN" },
+          { key: "Status", value: `${statusIcon(agent.status?.toLowerCase() || "unknown")} ${agent.status || "UNKNOWN"}` },
+          { key: "Version", value: agent.version || "N/A" },
+          { key: "Created", value: formatDate(agent.createdAt) },
+        ]);
+
+        if (agent.capabilities?.length > 0) {
+          outputSection("Capabilities");
+          agent.capabilities.forEach((cap: string) => console.log(`  - ${cap}`));
+        }
+
+        console.log();
+      } catch (error) {
+        spinner?.fail("Failed to fetch agent");
+        outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+      }
+    });
+
+  agents
+    .command("logs <agent-id>")
+    .description("Get logs for a specific agent")
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output")
+    .option("--tail <lines>", "Number of lines to show", "100")
+    .action(async (agentId: string, options) => {
+      setOutputOptions({ json: options.json, color: options.color });
+      const spinner = options.json ? null : ora("Fetching agent logs...").start();
+      const api = getApiClient();
+
+      try {
+        const response = await api.getAgentLogs(agentId, parseInt(options.tail, 10));
+        spinner?.stop();
+
+        if (!response.success || !response.data) {
+          outputError("Failed to fetch agent logs", response.error);
+          return;
+        }
+
+        if (options.json) {
+          output(response.data);
+          return;
+        }
+
+        const logs = response.data;
+        if (logs.length === 0) {
+          console.log(colors.dim("No logs available for this agent."));
+          return;
+        }
+
+        outputSection(`Agent Logs (last ${options.tail} entries)`);
+        logs.forEach((log: { timestamp: string; level: string; message: string }) => {
+          const levelColor = log.level === "error" ? colors.error : log.level === "warn" ? colors.warning : colors.dim;
+          console.log(`${colors.dim(formatDate(log.timestamp))} ${levelColor(`[${log.level.toUpperCase()}]`)} ${log.message}`);
+        });
+      } catch (error) {
+        spinner?.fail("Failed to fetch agent logs");
+        outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+      }
+    });
+
+  agents
+    .command("start <agent-id>")
+    .description("Start a stopped agent")
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output")
+    .action(async (agentId: string, options) => {
+      setOutputOptions({ json: options.json, color: options.color });
+      const spinner = options.json ? null : ora("Starting agent...").start();
+      const api = getApiClient();
+
+      try {
+        const response = await api.startAgent(agentId);
+        spinner?.stop();
+
+        if (!response.success) {
+          outputError("Failed to start agent", response.error);
+          return;
+        }
+
+        if (options.json) {
+          output({ success: true, agentId, status: "ACTIVE" });
+          return;
+        }
+        outputSuccess(`Agent ${agentId} started successfully`);
+      } catch (error) {
+        spinner?.fail("Failed to start agent");
+        outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+      }
+    });
+
+  agents
+    .command("stop <agent-id>")
+    .description("Stop a running agent")
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output")
+    .action(async (agentId: string, options) => {
+      setOutputOptions({ json: options.json, color: options.color });
+      const spinner = options.json ? null : ora("Stopping agent...").start();
+      const api = getApiClient();
+
+      try {
+        const response = await api.stopAgent(agentId);
+        spinner?.stop();
+
+        if (!response.success) {
+          outputError("Failed to stop agent", response.error);
+          return;
+        }
+
+        if (options.json) {
+          output({ success: true, agentId, status: "INACTIVE" });
+          return;
+        }
+        outputSuccess(`Agent ${agentId} stopped successfully`);
+      } catch (error) {
+        spinner?.fail("Failed to stop agent");
+        outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+      }
+    });
+
+  agents
+    .command("restart <agent-id>")
+    .description("Restart an agent")
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output")
+    .action(async (agentId: string, options) => {
+      setOutputOptions({ json: options.json, color: options.color });
+      const spinner = options.json ? null : ora("Restarting agent...").start();
+      const api = getApiClient();
+
+      try {
+        const stopResponse = await api.stopAgent(agentId);
+        if (!stopResponse.success) {
+          spinner?.fail("Failed to stop agent");
+          outputError("Failed to restart agent (stop phase)", stopResponse.error);
+          return;
+        }
+
+        const startResponse = await api.startAgent(agentId);
+        spinner?.stop();
+
+        if (!startResponse.success) {
+          outputError("Failed to restart agent (start phase)", startResponse.error);
+          return;
+        }
+
+        if (options.json) {
+          output({ success: true, agentId, status: "ACTIVE" });
+          return;
+        }
+        outputSuccess(`Agent ${agentId} restarted successfully`);
+      } catch (error) {
+        spinner?.fail("Failed to restart agent");
+        outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+      }
+    });
+
+  agents
+    .command("config <agent-id>")
+    .description("Get or set agent configuration")
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output")
+    .option("--set <key=value>", "Set a configuration value")
+    .action(async (agentId: string, options) => {
+      setOutputOptions({ json: options.json, color: options.color });
+      const api = getApiClient();
+
+      if (options.set) {
+        const [key, ...valueParts] = options.set.split("=");
+        const value = valueParts.join("=");
+        if (!key || value === undefined) {
+          outputError("Invalid format", "Use --set key=value");
+          return;
+        }
+
+        const spinner = options.json ? null : ora("Updating configuration...").start();
+        try {
+          const response = await api.setAgentConfig(agentId, key, value);
+          spinner?.stop();
+          if (!response.success) {
+            outputError("Failed to update configuration", response.error);
+            return;
+          }
+          if (options.json) {
+            output({ success: true, agentId, key, value });
+            return;
+          }
+          outputSuccess(`Configuration updated: ${key}=${value}`);
+        } catch (error) {
+          spinner?.fail("Failed to update configuration");
+          outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+        }
+      } else {
+        const spinner = options.json ? null : ora("Fetching configuration...").start();
+        try {
+          const response = await api.getAgentConfig(agentId);
+          spinner?.stop();
+          if (!response.success || !response.data) {
+            outputError("Failed to fetch configuration", response.error);
+            return;
+          }
+          if (options.json) {
+            output(response.data);
+            return;
+          }
+          outputSection(`Configuration for ${agentId}`);
+          const configData = response.data;
+          if (Array.isArray(configData) && configData.length === 0) {
+            console.log(colors.dim("  No configuration entries."));
+          } else if (Array.isArray(configData)) {
+            configData.forEach((entry: { key: string; value: unknown }) => {
+              console.log(`  ${colors.bold(entry.key)}: ${JSON.stringify(entry.value)}`);
+            });
+          }
+          console.log();
+        } catch (error) {
+          spinner?.fail("Failed to fetch configuration");
+          outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+        }
+      }
+    });
+
+  const proposals = agents.command("proposals").description("Manage agent proposals");
+
+  proposals
+    .command("list")
+    .description("List all proposals")
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output")
+    .option("--status <status>", "Filter by status")
+    .option("--agent <agent-id>", "Filter by agent ID")
+    .action(async (options) => {
+      setOutputOptions({ json: options.json, color: options.color });
+      const spinner = options.json ? null : ora("Fetching proposals...").start();
+      const api = getApiClient();
+
+      try {
+        const response = options.agent ? await api.getAgentProposals(options.agent) : await api.getProposals();
+        spinner?.stop();
+
+        if (!response.success || !response.data) {
+          outputError("Failed to fetch proposals", response.error);
+          return;
+        }
+
+        let proposalsData = response.data;
+        if (options.status) {
+          proposalsData = proposalsData.filter((p) => p.status?.toLowerCase() === options.status.toLowerCase());
+        }
+
+        if (options.json) {
+          output(proposalsData);
+          return;
+        }
+
+        if (proposalsData.length === 0) {
+          console.log(colors.dim("No proposals found."));
+          return;
+        }
+
+        outputTable(
+          ["ID", "Title", "Type", "Risk", "Status", "Created"],
+          proposalsData.map((p) => [
+            truncate(p.id, 12),
+            truncate(p.title || "Untitled", 30),
+            p.proposalType || "UNKNOWN",
+            formatRiskLevel(p.riskLevel),
+            formatProposalStatus(p.status),
+            formatDate(p.createdAt),
+          ])
+        );
+        console.log(colors.dim(`\nTotal: ${proposalsData.length} proposals`));
+      } catch (error) {
+        spinner?.fail("Failed to fetch proposals");
+        outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+      }
+    });
+
+  proposals
+    .command("show <proposal-id>")
+    .description("Show detailed proposal information")
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output")
+    .action(async (proposalId: string, options) => {
+      setOutputOptions({ json: options.json, color: options.color });
+      const spinner = options.json ? null : ora("Fetching proposal...").start();
+      const api = getApiClient();
+
+      try {
+        const response = await api.getProposalById(proposalId);
+        spinner?.stop();
+
+        if (!response.success || !response.data) {
+          outputError("Proposal not found", response.error);
+          return;
+        }
+
+        const proposal = response.data;
+        if (options.json) {
+          output(proposal);
+          return;
+        }
+
+        outputSection("Proposal Details");
+        outputKeyValue([
+          { key: "ID", value: proposal.id },
+          { key: "Title", value: proposal.title || "Untitled" },
+          { key: "Type", value: proposal.proposalType || "UNKNOWN" },
+          { key: "Status", value: formatProposalStatus(proposal.status) },
+          { key: "Risk Level", value: formatRiskLevel(proposal.riskLevel) },
+          { key: "Confidence", value: `${proposal.confidence || 0}%` },
+          { key: "Agent", value: proposal.agentId },
+          { key: "Created", value: formatDate(proposal.createdAt) },
+        ]);
+
+        if (proposal.description) {
+          outputSection("Description");
+          console.log(`  ${proposal.description}`);
+        }
+        console.log();
+      } catch (error) {
+        spinner?.fail("Failed to fetch proposal");
+        outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+      }
+    });
+
+  proposals
+    .command("approve <proposal-id>")
+    .description("Approve a pending proposal")
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output")
+    .option("--comment <comment>", "Add a comment")
+    .option("--user <user-id>", "User ID for approval", "cli-user")
+    .option("--user-name <name>", "User name for approval", "CLI User")
+    .action(async (proposalId: string, options) => {
+      setOutputOptions({ json: options.json, color: options.color });
+      const spinner = options.json ? null : ora("Approving proposal...").start();
+      const api = getApiClient();
+
+      try {
+        const response = await api.approveProposal(proposalId, {
+          userId: options.user,
+          userName: options.userName,
+          comment: options.comment,
+        });
+        spinner?.stop();
+
+        if (!response.success) {
+          outputError("Failed to approve proposal", response.error);
+          return;
+        }
+
+        if (options.json) {
+          output(response.data);
+          return;
+        }
+        outputSuccess(`Proposal ${proposalId} approved successfully`);
+      } catch (error) {
+        spinner?.fail("Failed to approve proposal");
+        outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+      }
+    });
+
+  proposals
+    .command("reject <proposal-id>")
+    .description("Reject a pending proposal")
+    .option("--json", "Output as JSON")
+    .option("--no-color", "Disable colorized output")
+    .requiredOption("--reason <reason>", "Reason for rejection")
+    .option("--user <user-id>", "User ID for rejection", "cli-user")
+    .option("--user-name <name>", "User name for rejection", "CLI User")
+    .action(async (proposalId: string, options) => {
+      setOutputOptions({ json: options.json, color: options.color });
+      const spinner = options.json ? null : ora("Rejecting proposal...").start();
+      const api = getApiClient();
+
+      try {
+        const response = await api.rejectProposal(proposalId, {
+          userId: options.user,
+          userName: options.userName,
+          comment: options.reason,
+        });
+        spinner?.stop();
+
+        if (!response.success) {
+          outputError("Failed to reject proposal", response.error);
+          return;
+        }
+
+        if (options.json) {
+          output(response.data);
+          return;
+        }
+        outputSuccess(`Proposal ${proposalId} rejected`);
+        console.log(colors.dim(`  Reason: ${options.reason}`));
+      } catch (error) {
+        spinner?.fail("Failed to reject proposal");
+        outputError("Failed to connect to server", error instanceof Error ? error.message : "Unknown error");
+      }
+    });
+}
+
+function formatRiskLevel(riskLevel?: string): string {
+  if (!riskLevel) return colors.dim("UNKNOWN");
+  switch (riskLevel.toUpperCase()) {
+    case "LOW": return colors.success("LOW");
+    case "MEDIUM": return colors.warning("MEDIUM");
+    case "HIGH": return colors.error("HIGH");
+    case "CRITICAL": return colors.error(colors.bold("CRITICAL"));
+    default: return colors.dim(riskLevel);
+  }
+}
+
+function formatProposalStatus(status?: string): string {
+  if (!status) return colors.dim("UNKNOWN");
+  switch (status.toUpperCase()) {
+    case "PENDING_APPROVAL": return colors.warning("PENDING");
+    case "APPROVED": return colors.success("APPROVED");
+    case "REJECTED": return colors.error("REJECTED");
+    case "EXECUTED": return colors.success("EXECUTED");
+    case "FAILED": return colors.error("FAILED");
+    case "EXPIRED": return colors.dim("EXPIRED");
+    default: return colors.dim(status);
+  }
+}

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -1,0 +1,430 @@
+import { Command } from "commander";
+import * as readline from "readline";
+import chalk from "chalk";
+import { loadConfig } from "../config.js";
+
+// Store command history
+const history: string[] = [];
+let historyIndex = -1;
+
+// Multi-line input buffer
+let multiLineBuffer: string[] = [];
+let isMultiLineMode = false;
+
+interface ShellContext {
+  site?: string;
+}
+
+const context: ShellContext = {};
+
+/**
+ * Get available commands for tab completion
+ */
+function getAvailableCommands(): string[] {
+  return [
+    "status",
+    "sites",
+    "sites list",
+    "sites get",
+    "sites create",
+    "assets",
+    "assets list",
+    "assets get",
+    "assets create",
+    "events",
+    "events list",
+    "events anchor",
+    "blockchain",
+    "blockchain info",
+    "blockchain balance",
+    "dev",
+    "dev start",
+    "dev stop",
+    "dev seed",
+    "config",
+    "config show",
+    "config set",
+    "help",
+    "exit",
+    "quit",
+    "clear",
+    "history",
+    "context",
+  ];
+}
+
+/**
+ * Get completions for a partial input
+ */
+function getCompletions(line: string): string[] {
+  const commands = getAvailableCommands();
+  const trimmedLine = line.trim().toLowerCase();
+
+  if (!trimmedLine) {
+    return commands.filter(cmd => !cmd.includes(" "));
+  }
+
+  return commands.filter(cmd =>
+    cmd.toLowerCase().startsWith(trimmedLine)
+  );
+}
+
+/**
+ * Display help for shell commands
+ */
+function showShellHelp(): void {
+  console.log();
+  console.log(chalk.bold.cyan("0xSCADA Interactive Shell"));
+  console.log(chalk.dim("-".repeat(30)));
+  console.log();
+  console.log(chalk.bold("Available Commands:"));
+  console.log();
+  console.log("  " + chalk.yellow("status") + "              Show system health");
+  console.log("  " + chalk.yellow("sites list") + "          List all registered sites");
+  console.log("  " + chalk.yellow("sites get <id>") + "      Get site details");
+  console.log("  " + chalk.yellow("sites create") + "        Create a new site");
+  console.log("  " + chalk.yellow("assets list") + "         List all assets");
+  console.log("  " + chalk.yellow("assets get <id>") + "     Get asset details");
+  console.log("  " + chalk.yellow("events list") + "         List recent events");
+  console.log("  " + chalk.yellow("events anchor") + "       Trigger batch anchoring");
+  console.log("  " + chalk.yellow("blockchain info") + "     Show blockchain status");
+  console.log("  " + chalk.yellow("config show") + "         Display current config");
+  console.log("  " + chalk.yellow("dev start") + "           Start dev environment");
+  console.log("  " + chalk.yellow("dev seed") + "            Seed test data");
+  console.log();
+  console.log(chalk.bold("Shell Commands:"));
+  console.log();
+  console.log("  " + chalk.yellow("help") + "                Show this help");
+  console.log("  " + chalk.yellow("history") + "             Show command history");
+  console.log("  " + chalk.yellow("context") + "             Show current context");
+  console.log("  " + chalk.yellow("clear") + "               Clear the screen");
+  console.log("  " + chalk.yellow("exit") + " / " + chalk.yellow("quit") + "        Exit the shell");
+  console.log();
+  console.log(chalk.bold("Tips:"));
+  console.log(chalk.dim("  - Use up/down arrows to navigate command history"));
+  console.log(chalk.dim("  - Use Tab for command completion"));
+  console.log(chalk.dim("  - Use \\ at end of line for multi-line input"));
+  console.log(chalk.dim("  - Options like --json, --site work as normal"));
+  console.log();
+}
+
+/**
+ * Show command history
+ */
+function showHistory(): void {
+  if (history.length === 0) {
+    console.log(chalk.dim("No command history yet."));
+    return;
+  }
+
+  console.log();
+  console.log(chalk.bold("Command History:"));
+  history.forEach((cmd, i) => {
+    console.log(chalk.dim(`  ${(i + 1).toString().padStart(3)}  `) + cmd);
+  });
+  console.log();
+}
+
+/**
+ * Show current context
+ */
+function showContext(): void {
+  console.log();
+  console.log(chalk.bold("Current Context:"));
+  if (context.site) {
+    console.log(`  Site: ${chalk.cyan(context.site)}`);
+  } else {
+    console.log(chalk.dim("  No context set"));
+  }
+  console.log();
+}
+
+/**
+ * Get the colored prompt string
+ */
+function getPrompt(): string {
+  const config = loadConfig();
+  const contextStr = context.site ? chalk.dim(`[${context.site}]`) + " " : "";
+
+  if (config.colorOutput) {
+    return contextStr + chalk.bold.green("0xscada") + chalk.bold.white("> ");
+  }
+  return contextStr + "0xscada> ";
+}
+
+/**
+ * Get the continuation prompt for multi-line input
+ */
+function getContinuationPrompt(): string {
+  return chalk.dim("... ");
+}
+
+/**
+ * Parse command line into arguments, handling quotes
+ */
+function parseCommandLine(line: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  let quoteChar = "";
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (!inQuotes && (char === '"' || char === "'")) {
+      inQuotes = true;
+      quoteChar = char;
+    } else if (inQuotes && char === quoteChar) {
+      inQuotes = false;
+      quoteChar = "";
+    } else if (!inQuotes && char === " ") {
+      if (current) {
+        args.push(current);
+        current = "";
+      }
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    args.push(current);
+  }
+
+  return args;
+}
+
+/**
+ * Execute a command within the shell
+ */
+async function executeCommand(
+  input: string,
+  program: Command
+): Promise<boolean> {
+  const trimmedInput = input.trim();
+
+  if (!trimmedInput) {
+    return true; // Continue shell
+  }
+
+  // Add to history (avoid duplicates)
+  if (history[history.length - 1] !== trimmedInput) {
+    history.push(trimmedInput);
+  }
+  historyIndex = history.length;
+
+  // Handle shell-specific commands
+  const lowerInput = trimmedInput.toLowerCase();
+
+  if (lowerInput === "exit" || lowerInput === "quit") {
+    console.log(chalk.dim("Goodbye!"));
+    return false; // Exit shell
+  }
+
+  if (lowerInput === "help" || lowerInput === "?") {
+    showShellHelp();
+    return true;
+  }
+
+  if (lowerInput === "history") {
+    showHistory();
+    return true;
+  }
+
+  if (lowerInput === "context") {
+    showContext();
+    return true;
+  }
+
+  if (lowerInput === "clear" || lowerInput === "cls") {
+    console.clear();
+    return true;
+  }
+
+  // Parse command and execute via commander
+  try {
+    const args = parseCommandLine(trimmedInput);
+
+    // Check for context commands
+    if (args[0] === "use" && args[1] === "site" && args[2]) {
+      context.site = args[2];
+      console.log(chalk.green(`Context set to site: ${args[2]}`));
+      return true;
+    }
+
+    // Create a child program for isolated command execution
+    const shellProgram = createShellProgram(program);
+
+    // Execute the command
+    await shellProgram.parseAsync(["node", "0xscada", ...args]);
+  } catch (error) {
+    if (error instanceof Error) {
+      // Commander throws for unknown commands, etc.
+      if (error.message.includes("unknown command") ||
+          error.message.includes("missing required")) {
+        console.error(chalk.red("Error: ") + error.message);
+      } else if (error.name !== "CommanderError") {
+        console.error(chalk.red("Error: ") + error.message);
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Create a shell-compatible program instance
+ */
+function createShellProgram(parentProgram: Command): Command {
+  const shellProgram = new Command();
+  shellProgram.exitOverride(); // Don't exit process on errors
+  shellProgram.configureOutput({
+    writeErr: (str) => console.error(str),
+    writeOut: (str) => console.log(str),
+  });
+
+  // Copy commands from parent program
+  for (const cmd of parentProgram.commands) {
+    if (cmd.name() !== "shell") {
+      shellProgram.addCommand(cmd, { hidden: false });
+    }
+  }
+
+  // Add shell-specific version of help
+  shellProgram
+    .command("help")
+    .description("Show shell help")
+    .action(() => {
+      showShellHelp();
+    });
+
+  return shellProgram;
+}
+
+/**
+ * Start the interactive shell
+ */
+async function startShell(program: Command): Promise<void> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: true,
+    prompt: getPrompt(),
+    historySize: 100,
+    completer: (line: string) => {
+      const completions = getCompletions(line);
+      return [completions, line];
+    },
+  });
+
+  // Set up stdin for raw mode to capture arrow keys
+  if (process.stdin.isTTY) {
+    readline.emitKeypressEvents(process.stdin, rl);
+
+    process.stdin.on("keypress", (_char, key) => {
+      if (!key) return;
+
+      if (key.name === "up" && history.length > 0) {
+        if (historyIndex > 0) {
+          historyIndex--;
+          rl.write(null, { ctrl: true, name: "u" }); // Clear line
+          rl.write(history[historyIndex]);
+        }
+      } else if (key.name === "down") {
+        if (historyIndex < history.length - 1) {
+          historyIndex++;
+          rl.write(null, { ctrl: true, name: "u" }); // Clear line
+          rl.write(history[historyIndex]);
+        } else if (historyIndex === history.length - 1) {
+          historyIndex = history.length;
+          rl.write(null, { ctrl: true, name: "u" }); // Clear line
+        }
+      }
+    });
+  }
+
+  console.log();
+  console.log(chalk.bold.cyan("0xSCADA Interactive Shell"));
+  console.log(chalk.dim("Type 'help' for available commands, 'exit' to quit"));
+  console.log();
+
+  rl.prompt();
+
+  return new Promise<void>((resolve) => {
+    rl.on("line", async (line) => {
+      // Handle multi-line input
+      if (line.endsWith("\\")) {
+        multiLineBuffer.push(line.slice(0, -1));
+        isMultiLineMode = true;
+        rl.setPrompt(getContinuationPrompt());
+        rl.prompt();
+        return;
+      }
+
+      let fullLine = line;
+      if (isMultiLineMode) {
+        multiLineBuffer.push(line);
+        fullLine = multiLineBuffer.join(" ");
+        multiLineBuffer = [];
+        isMultiLineMode = false;
+        rl.setPrompt(getPrompt());
+      }
+
+      const shouldContinue = await executeCommand(fullLine, program);
+
+      if (!shouldContinue) {
+        rl.close();
+        resolve();
+        return;
+      }
+
+      rl.setPrompt(getPrompt());
+      rl.prompt();
+    });
+
+    rl.on("close", () => {
+      console.log();
+      resolve();
+    });
+
+    // Handle Ctrl+C gracefully
+    rl.on("SIGINT", () => {
+      if (isMultiLineMode) {
+        multiLineBuffer = [];
+        isMultiLineMode = false;
+        console.log();
+        rl.setPrompt(getPrompt());
+        rl.prompt();
+      } else {
+        console.log(chalk.dim("\n(Use 'exit' or 'quit' to leave the shell)"));
+        rl.prompt();
+      }
+    });
+  });
+}
+
+/**
+ * Register the shell command with the CLI program
+ */
+export function registerShellCommand(program: Command): void {
+  program
+    .command("shell")
+    .description("Start interactive shell mode")
+    .action(async () => {
+      await startShell(program);
+    });
+}
+
+// Export for testing
+export {
+  getAvailableCommands,
+  getCompletions,
+  parseCommandLine,
+  executeCommand,
+  showShellHelp,
+  showHistory,
+  showContext,
+  getPrompt,
+  history,
+  context,
+};


### PR DESCRIPTION
## Summary
- Add agents list/status/logs commands for monitoring
- Add agents start/stop/restart lifecycle control
- Add agents proposals list/show/approve/reject workflow
- Add agents config management
- Support --json and --no-color options

## Test plan
- [ ] Test 0xscada agents list
- [ ] Test 0xscada agents status <id>
- [ ] Test 0xscada agents proposals list

Closes #90

Generated with Claude Code