### PR TITLE
feat: OPC-UA Address Space Browsing Service (6.1.2)

### DIFF
--- a/server/__tests__/opcua-address-space-browser.test.ts
+++ b/server/__tests__/opcua-address-space-browser.test.ts
@@ -1,0 +1,336 @@
+/**
+ * OPC-UA Address Space Browser - Tests
+ *
+ * Issue #11 child: 6.1.2 - OPC-UA Address Space Browsing Service
+ * TDD: Tests written first, then implementation.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  OpcUaAddressSpaceBrowser,
+  BrowseResult,
+  NodeInfo,
+  OpcUaNodeClass,
+  OpcUaAccessLevel,
+} from "../gateway/opcua-address-space-browser";
+
+// =============================================================================
+// MOCK SESSION
+// =============================================================================
+
+function createMockSession() {
+  const session = {
+    browse: vi.fn(),
+    read: vi.fn(),
+  };
+  return session;
+}
+
+function makeBrowseReference(opts: {
+  nodeId: string;
+  browseName: string;
+  displayName: string;
+  nodeClass: number;
+  isForward?: boolean;
+}) {
+  return {
+    nodeId: { toString: () => opts.nodeId },
+    browseName: { name: opts.browseName },
+    displayName: { text: opts.displayName },
+    nodeClass: opts.nodeClass,
+    isForward: opts.isForward ?? true,
+  };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("OpcUaAddressSpaceBrowser", () => {
+  let browser: OpcUaAddressSpaceBrowser;
+  let mockSession: ReturnType<typeof createMockSession>;
+
+  beforeEach(() => {
+    mockSession = createMockSession();
+    browser = new OpcUaAddressSpaceBrowser(mockSession as any);
+  });
+
+  afterEach(() => {
+    browser.clearCache();
+  });
+
+  // ---------------------------------------------------------------------------
+  // browse()
+  // ---------------------------------------------------------------------------
+
+  describe("browse()", () => {
+    it("should browse root node and return child references", async () => {
+      mockSession.browse.mockResolvedValue({
+        references: [
+          makeBrowseReference({
+            nodeId: "ns=0;i=85",
+            browseName: "Objects",
+            displayName: "Objects",
+            nodeClass: OpcUaNodeClass.Object,
+          }),
+          makeBrowseReference({
+            nodeId: "ns=0;i=86",
+            browseName: "Types",
+            displayName: "Types",
+            nodeClass: OpcUaNodeClass.Object,
+          }),
+        ],
+      });
+
+      const result = await browser.browse("ns=0;i=84"); // Root
+      expect(result).toHaveLength(2);
+      expect(result[0].nodeId).toBe("ns=0;i=85");
+      expect(result[0].browseName).toBe("Objects");
+      expect(result[0].nodeClass).toBe(OpcUaNodeClass.Object);
+      expect(result[1].nodeId).toBe("ns=0;i=86");
+    });
+
+    it("should return empty array when no references", async () => {
+      mockSession.browse.mockResolvedValue({ references: [] });
+      const result = await browser.browse("ns=0;i=999");
+      expect(result).toEqual([]);
+    });
+
+    it("should handle null references", async () => {
+      mockSession.browse.mockResolvedValue({ references: null });
+      const result = await browser.browse("ns=0;i=999");
+      expect(result).toEqual([]);
+    });
+
+    it("should filter forward references only by default", async () => {
+      mockSession.browse.mockResolvedValue({
+        references: [
+          makeBrowseReference({
+            nodeId: "ns=0;i=85",
+            browseName: "Objects",
+            displayName: "Objects",
+            nodeClass: OpcUaNodeClass.Object,
+            isForward: true,
+          }),
+          makeBrowseReference({
+            nodeId: "ns=0;i=1",
+            browseName: "Parent",
+            displayName: "Parent",
+            nodeClass: OpcUaNodeClass.Object,
+            isForward: false,
+          }),
+        ],
+      });
+
+      const result = await browser.browse("ns=0;i=50");
+      expect(result).toHaveLength(1);
+      expect(result[0].browseName).toBe("Objects");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // browseRecursive()
+  // ---------------------------------------------------------------------------
+
+  describe("browseRecursive()", () => {
+    it("should browse recursively to specified depth", async () => {
+      // Depth 0: root has one child folder
+      mockSession.browse.mockResolvedValueOnce({
+        references: [
+          makeBrowseReference({
+            nodeId: "ns=1;s=Folder1",
+            browseName: "Folder1",
+            displayName: "Folder1",
+            nodeClass: OpcUaNodeClass.Object,
+          }),
+        ],
+      });
+      // Depth 1: Folder1 has a variable
+      mockSession.browse.mockResolvedValueOnce({
+        references: [
+          makeBrowseReference({
+            nodeId: "ns=1;s=Var1",
+            browseName: "Var1",
+            displayName: "Variable 1",
+            nodeClass: OpcUaNodeClass.Variable,
+          }),
+        ],
+      });
+
+      const result = await browser.browseRecursive("ns=0;i=85", 2);
+      expect(result).toHaveLength(1);
+      expect(result[0].nodeId).toBe("ns=1;s=Folder1");
+      expect(result[0].children).toHaveLength(1);
+      expect(result[0].children![0].nodeId).toBe("ns=1;s=Var1");
+    });
+
+    it("should stop at max depth", async () => {
+      mockSession.browse.mockResolvedValue({
+        references: [
+          makeBrowseReference({
+            nodeId: "ns=1;s=Deep",
+            browseName: "Deep",
+            displayName: "Deep",
+            nodeClass: OpcUaNodeClass.Object,
+          }),
+        ],
+      });
+
+      const result = await browser.browseRecursive("ns=0;i=85", 1);
+      // depth=1 means only browse the root, don't recurse into children
+      expect(result).toHaveLength(1);
+      expect(result[0].children).toBeUndefined();
+      // session.browse called only once (for the root)
+      expect(mockSession.browse).toHaveBeenCalledTimes(1);
+    });
+
+    it("should default depth to 1 if not specified", async () => {
+      mockSession.browse.mockResolvedValue({
+        references: [
+          makeBrowseReference({
+            nodeId: "ns=1;s=Child",
+            browseName: "Child",
+            displayName: "Child",
+            nodeClass: OpcUaNodeClass.Object,
+          }),
+        ],
+      });
+
+      await browser.browseRecursive("ns=0;i=85");
+      expect(mockSession.browse).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getNodeInfo()
+  // ---------------------------------------------------------------------------
+
+  describe("getNodeInfo()", () => {
+    it("should retrieve detailed node information", async () => {
+      mockSession.read.mockResolvedValue([
+        { value: { value: "Temperature" } },   // DisplayName
+        { value: { value: "A temperature sensor" } }, // Description
+        { value: { value: OpcUaNodeClass.Variable } }, // NodeClass
+        { value: { value: "Double" } },         // DataType
+        { value: { value: 3 } },                // AccessLevel (CurrentRead | CurrentWrite)
+      ]);
+
+      const info = await browser.getNodeInfo("ns=1;s=Temp");
+      expect(info.nodeId).toBe("ns=1;s=Temp");
+      expect(info.displayName).toBe("Temperature");
+      expect(info.description).toBe("A temperature sensor");
+      expect(info.nodeClass).toBe(OpcUaNodeClass.Variable);
+      expect(info.dataType).toBe("Double");
+      expect(info.accessLevel).toBe(3);
+    });
+
+    it("should handle missing optional attributes gracefully", async () => {
+      mockSession.read.mockResolvedValue([
+        { value: { value: "MyNode" } },
+        { value: { value: null } },
+        { value: { value: OpcUaNodeClass.Object } },
+        { value: { value: null } },
+        { value: { value: null } },
+      ]);
+
+      const info = await browser.getNodeInfo("ns=1;s=Obj");
+      expect(info.displayName).toBe("MyNode");
+      expect(info.description).toBeUndefined();
+      expect(info.dataType).toBeUndefined();
+      expect(info.accessLevel).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Caching
+  // ---------------------------------------------------------------------------
+
+  describe("caching", () => {
+    it("should cache browse results and not re-query", async () => {
+      mockSession.browse.mockResolvedValue({
+        references: [
+          makeBrowseReference({
+            nodeId: "ns=1;s=Cached",
+            browseName: "Cached",
+            displayName: "Cached",
+            nodeClass: OpcUaNodeClass.Variable,
+          }),
+        ],
+      });
+
+      const r1 = await browser.browse("ns=0;i=85");
+      const r2 = await browser.browse("ns=0;i=85");
+      expect(r1).toEqual(r2);
+      expect(mockSession.browse).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return fresh results after clearCache()", async () => {
+      mockSession.browse.mockResolvedValue({
+        references: [
+          makeBrowseReference({
+            nodeId: "ns=1;s=A",
+            browseName: "A",
+            displayName: "A",
+            nodeClass: OpcUaNodeClass.Variable,
+          }),
+        ],
+      });
+
+      await browser.browse("ns=0;i=85");
+      browser.clearCache();
+      await browser.browse("ns=0;i=85");
+      expect(mockSession.browse).toHaveBeenCalledTimes(2);
+    });
+
+    it("should cache node info results", async () => {
+      mockSession.read.mockResolvedValue([
+        { value: { value: "X" } },
+        { value: { value: null } },
+        { value: { value: OpcUaNodeClass.Variable } },
+        { value: { value: "Int32" } },
+        { value: { value: 1 } },
+      ]);
+
+      await browser.getNodeInfo("ns=1;s=X");
+      await browser.getNodeInfo("ns=1;s=X");
+      expect(mockSession.read).toHaveBeenCalledTimes(1);
+    });
+
+    it("should respect cache TTL", async () => {
+      const shortTtlBrowser = new OpcUaAddressSpaceBrowser(mockSession as any, { cacheTtlMs: 50 });
+
+      mockSession.browse.mockResolvedValue({
+        references: [
+          makeBrowseReference({
+            nodeId: "ns=1;s=T",
+            browseName: "T",
+            displayName: "T",
+            nodeClass: OpcUaNodeClass.Variable,
+          }),
+        ],
+      });
+
+      await shortTtlBrowser.browse("ns=0;i=85");
+      // Wait for TTL to expire
+      await new Promise((r) => setTimeout(r, 60));
+      await shortTtlBrowser.browse("ns=0;i=85");
+      expect(mockSession.browse).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  describe("error handling", () => {
+    it("should throw when session.browse fails", async () => {
+      mockSession.browse.mockRejectedValue(new Error("Connection lost"));
+      await expect(browser.browse("ns=0;i=85")).rejects.toThrow("Connection lost");
+    });
+
+    it("should throw when session.read fails", async () => {
+      mockSession.read.mockRejectedValue(new Error("Timeout"));
+      await expect(browser.getNodeInfo("ns=1;s=X")).rejects.toThrow("Timeout");
+    });
+  });
+});

--- a/server/gateway/opcua-address-space-browser.ts
+++ b/server/gateway/opcua-address-space-browser.ts
@@ -1,0 +1,182 @@
+/**
+ * OPC-UA Address Space Browsing Service
+ *
+ * Issue #11 child: 6.1.2 - OPC-UA Address Space Browsing Service
+ *
+ * Features:
+ * - Browse OPC-UA server address space (list nodes, folders, variables)
+ * - Recursive browsing with configurable depth
+ * - Node info retrieval (data type, access level, description)
+ * - Caching of browse results for performance
+ */
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export enum OpcUaNodeClass {
+  Object = 1,
+  Variable = 2,
+  Method = 4,
+  ObjectType = 8,
+  VariableType = 16,
+  ReferenceType = 32,
+  DataType = 64,
+  View = 128,
+}
+
+export enum OpcUaAccessLevel {
+  CurrentRead = 1,
+  CurrentWrite = 2,
+  HistoryRead = 4,
+  HistoryWrite = 8,
+}
+
+export interface BrowseResult {
+  nodeId: string;
+  browseName: string;
+  displayName: string;
+  nodeClass: OpcUaNodeClass;
+  children?: BrowseResult[];
+}
+
+export interface NodeInfo {
+  nodeId: string;
+  displayName: string;
+  description?: string;
+  nodeClass: OpcUaNodeClass;
+  dataType?: string;
+  accessLevel?: number;
+}
+
+export interface BrowserOptions {
+  /** Cache time-to-live in milliseconds. Default: 60000 (1 min) */
+  cacheTtlMs?: number;
+}
+
+/** Minimal OPC-UA session interface we depend on */
+export interface OpcUaSession {
+  browse(nodeId: string | { nodeId: string }): Promise<{
+    references: Array<{
+      nodeId: { toString(): string };
+      browseName: { name: string };
+      displayName: { text: string };
+      nodeClass: number;
+      isForward: boolean;
+    }> | null;
+  }>;
+  read(attrs: unknown[]): Promise<Array<{ value: { value: unknown } }>>;
+}
+
+// =============================================================================
+// CACHE
+// =============================================================================
+
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+}
+
+// =============================================================================
+// IMPLEMENTATION
+// =============================================================================
+
+export class OpcUaAddressSpaceBrowser {
+  private session: OpcUaSession;
+  private cacheTtlMs: number;
+  private browseCache = new Map<string, CacheEntry<BrowseResult[]>>();
+  private nodeInfoCache = new Map<string, CacheEntry<NodeInfo>>();
+
+  constructor(session: OpcUaSession, options?: BrowserOptions) {
+    this.session = session;
+    this.cacheTtlMs = options?.cacheTtlMs ?? 60_000;
+  }
+
+  /**
+   * Browse direct children of a node. Returns only forward references.
+   */
+  async browse(nodeId: string): Promise<BrowseResult[]> {
+    // Check cache
+    const cached = this.browseCache.get(nodeId);
+    if (cached && Date.now() - cached.timestamp < this.cacheTtlMs) {
+      return cached.data;
+    }
+
+    const response = await this.session.browse(nodeId);
+    const refs = response.references ?? [];
+
+    const results: BrowseResult[] = refs
+      .filter((r) => r.isForward)
+      .map((r) => ({
+        nodeId: r.nodeId.toString(),
+        browseName: r.browseName.name,
+        displayName: r.displayName.text,
+        nodeClass: r.nodeClass as OpcUaNodeClass,
+      }));
+
+    this.browseCache.set(nodeId, { data: results, timestamp: Date.now() });
+    return results;
+  }
+
+  /**
+   * Browse recursively with configurable depth.
+   * depth=1 returns only immediate children (no recursion into them).
+   * depth=2 returns children + their children, etc.
+   */
+  async browseRecursive(nodeId: string, depth: number = 1): Promise<BrowseResult[]> {
+    const children = await this.browse(nodeId);
+
+    if (depth <= 1) {
+      return children;
+    }
+
+    // Recurse into Object nodes
+    for (let i = 0; i < children.length; i++) {
+      if (children[i].nodeClass === OpcUaNodeClass.Object) {
+        children[i].children = await this.browseRecursive(children[i].nodeId, depth - 1);
+      }
+    }
+
+    return children;
+  }
+
+  /**
+   * Get detailed information about a single node.
+   */
+  async getNodeInfo(nodeId: string): Promise<NodeInfo> {
+    const cached = this.nodeInfoCache.get(nodeId);
+    if (cached && Date.now() - cached.timestamp < this.cacheTtlMs) {
+      return cached.data;
+    }
+
+    const attrs = [
+      { nodeId, attributeId: 4 },  // DisplayName
+      { nodeId, attributeId: 5 },  // Description
+      { nodeId, attributeId: 2 },  // NodeClass
+      { nodeId, attributeId: 14 }, // DataType
+      { nodeId, attributeId: 17 }, // AccessLevel
+    ];
+
+    const results = await this.session.read(attrs);
+
+    const info: NodeInfo = {
+      nodeId,
+      displayName: results[0].value.value as string,
+      description: results[1].value.value as string | undefined || undefined,
+      nodeClass: results[2].value.value as OpcUaNodeClass,
+      dataType: results[3].value.value as string | undefined || undefined,
+      accessLevel: results[4].value.value as number | undefined || undefined,
+    };
+
+    this.nodeInfoCache.set(nodeId, { data: info, timestamp: Date.now() });
+    return info;
+  }
+
+  /**
+   * Clear all cached browse and node info results.
+   */
+  clearCache(): void {
+    this.browseCache.clear();
+    this.nodeInfoCache.clear();
+  }
+}


### PR DESCRIPTION
## OPC-UA Address Space Browsing Service

Issue #11 child: 6.1.2

### Features
- Browse OPC-UA server address space (list nodes, folders, variables)
- Recursive browsing with configurable depth
- Node info retrieval (data type, access level, description)
- Caching of browse results with configurable TTL

### TDD Approach
- 15 tests written first, all passing
- Mocked OPC-UA session (no real server needed)

### Files
- \server/gateway/opcua-address-space-browser.ts\ - Implementation
- \server/__tests__/opcua-address-space-browser.test.ts\ - Tests

Relates to #11