### PR TITLE
feat(adr-0010): implement agent certification framework with four levels

### DIFF
--- a/server/__tests__/certification.test.ts
+++ b/server/__tests__/certification.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for ADR-0010: Agent Certification Framework
+ * 
+ * Covers:
+ * - Certification lifecycle (initiate → check → finalize)
+ * - Level requirements validation
+ * - Certifier sign-off
+ * - Revocation and recertification triggers
+ * - Level comparison (isAgentCertified)
+ * - Progress tracking
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { CertificationManager } from "../agents/certification-manager";
+import {
+  CertificationLevel,
+  CERTIFICATION_LEVEL_ORDER,
+  CERTIFICATION_LEVEL_META,
+  REQUIREMENTS_BY_LEVEL,
+  RecertificationTrigger,
+} from "@shared/types/agent-certification";
+
+describe("CertificationManager", () => {
+  let mgr: CertificationManager;
+  const AGENT_ID = "ops-agent-001";
+  const AGENT_VERSION = "1.2.0";
+
+  beforeEach(() => {
+    mgr = new CertificationManager();
+  });
+
+  describe("initiateCertification", () => {
+    it("should create a certification with all checks in PENDING state", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC1_OBSERVER);
+
+      expect(cert.id).toBeDefined();
+      expect(cert.agentId).toBe(AGENT_ID);
+      expect(cert.level).toBe("AC1_OBSERVER");
+      expect(cert.status).toBe("IN_PROGRESS");
+      expect(cert.checks.length).toBe(REQUIREMENTS_BY_LEVEL[CertificationLevel.AC1_OBSERVER].length);
+      expect(cert.checks.every((c) => c.status === "PENDING")).toBe(true);
+    });
+
+    it("should include inherited requirements for higher levels", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC3_OPERATOR);
+
+      // AC-3 includes AC-1 and AC-2 requirements plus its own
+      const ac3Reqs = REQUIREMENTS_BY_LEVEL[CertificationLevel.AC3_OPERATOR];
+      expect(cert.checks.length).toBe(ac3Reqs.length);
+
+      // Should include AC-1 check IDs
+      const checkIds = cert.checks.map((c) => c.id);
+      expect(checkIds).toContain("ac1-identity");
+      expect(checkIds).toContain("ac3-envelope");
+    });
+  });
+
+  describe("updateCheck", () => {
+    it("should update a check status with evidence", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC1_OBSERVER);
+
+      const updated = mgr.updateCheck(cert.id, "ac1-identity", "PASSED", {
+        evidenceHash: "abc123",
+        verifiedBy: "admin-001",
+        notes: "On-chain registration confirmed",
+      });
+
+      expect(updated).not.toBeNull();
+      const check = updated!.checks.find((c) => c.id === "ac1-identity");
+      expect(check?.status).toBe("PASSED");
+      expect(check?.evidenceHash).toBe("abc123");
+      expect(check?.verifiedBy).toBe("admin-001");
+    });
+
+    it("should return null for non-existent certification", () => {
+      const result = mgr.updateCheck("fake-id", "ac1-identity", "PASSED");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for non-existent check", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC1_OBSERVER);
+      const result = mgr.updateCheck(cert.id, "nonexistent-check", "PASSED");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("finalizeCertification", () => {
+    it("should certify when all checks pass", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC1_OBSERVER);
+
+      // Pass all checks
+      for (const check of cert.checks) {
+        mgr.updateCheck(cert.id, check.id, "PASSED", { verifiedBy: "tester" });
+      }
+
+      // Submit test results
+      mgr.submitTestResults(cert.id, { coverage: 97, passed: 150, failed: 0 });
+
+      // Add certifier
+      mgr.addCertifierSignOff(cert.id, {
+        id: "certifier-001",
+        name: "Jane Engineer",
+        role: "Safety Lead",
+        signature: "sig-abc",
+      });
+
+      const result = mgr.finalizeCertification(cert.id);
+      expect(result.success).toBe(true);
+      expect(result.record?.status).toBe("CERTIFIED");
+      expect(result.record?.issuedAt).toBeDefined();
+      expect(result.record?.expiresAt).toBeDefined();
+    });
+
+    it("should reject when checks are still pending", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC1_OBSERVER);
+
+      mgr.submitTestResults(cert.id, { coverage: 97 });
+      mgr.addCertifierSignOff(cert.id, {
+        id: "c1", name: "Test", role: "Lead", signature: "sig",
+      });
+
+      const result = mgr.finalizeCertification(cert.id);
+      expect(result.success).toBe(false);
+      expect(result.failedChecks).toBeDefined();
+      expect(result.failedChecks!.length).toBeGreaterThan(0);
+    });
+
+    it("should reject when no test suite hash", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC1_OBSERVER);
+
+      for (const check of cert.checks) {
+        mgr.updateCheck(cert.id, check.id, "PASSED");
+      }
+
+      mgr.addCertifierSignOff(cert.id, {
+        id: "c1", name: "Test", role: "Lead", signature: "sig",
+      });
+
+      const result = mgr.finalizeCertification(cert.id);
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain("Test suite");
+    });
+
+    it("should reject when no certifier sign-off", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC1_OBSERVER);
+
+      for (const check of cert.checks) {
+        mgr.updateCheck(cert.id, check.id, "PASSED");
+      }
+      mgr.submitTestResults(cert.id, { ok: true });
+
+      const result = mgr.finalizeCertification(cert.id);
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain("certifier");
+    });
+
+    it("should require audit report for AC-3", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC3_OPERATOR);
+
+      for (const check of cert.checks) {
+        mgr.updateCheck(cert.id, check.id, "PASSED");
+      }
+      mgr.submitTestResults(cert.id, { ok: true });
+      mgr.addCertifierSignOff(cert.id, {
+        id: "c1", name: "Test", role: "Lead", signature: "sig",
+      });
+      // No audit report submitted
+
+      const result = mgr.finalizeCertification(cert.id);
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain("Audit report");
+    });
+  });
+
+  describe("revocation", () => {
+    it("should revoke an active certification", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC1_OBSERVER);
+      for (const check of cert.checks) {
+        mgr.updateCheck(cert.id, check.id, "PASSED");
+      }
+      mgr.submitTestResults(cert.id, { ok: true });
+      mgr.addCertifierSignOff(cert.id, {
+        id: "c1", name: "Test", role: "Lead", signature: "sig",
+      });
+      mgr.finalizeCertification(cert.id);
+
+      const revoked = mgr.revokeCertification(cert.id, "Security vulnerability discovered");
+      expect(revoked).toBe(true);
+
+      const record = mgr.getCertification(cert.id);
+      expect(record?.status).toBe("REVOKED");
+      expect(record?.revokedReason).toBe("Security vulnerability discovered");
+    });
+  });
+
+  describe("recertification triggers", () => {
+    it("should expire certifications when recertification is triggered", () => {
+      // Certify first
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC1_OBSERVER);
+      for (const check of cert.checks) {
+        mgr.updateCheck(cert.id, check.id, "PASSED");
+      }
+      mgr.submitTestResults(cert.id, { ok: true });
+      mgr.addCertifierSignOff(cert.id, {
+        id: "c1", name: "Test", role: "Lead", signature: "sig",
+      });
+      mgr.finalizeCertification(cert.id);
+
+      // Trigger recertification
+      mgr.triggerRecertification(AGENT_ID, RecertificationTrigger.CODE_UPDATE);
+
+      const active = mgr.getActiveCertification(AGENT_ID);
+      expect(active).toBeNull(); // Should be expired
+
+      const pending = mgr.getPendingRecertifications(AGENT_ID);
+      expect(pending.length).toBe(1);
+      expect(pending[0].trigger).toBe("CODE_UPDATE");
+    });
+  });
+
+  describe("isAgentCertified", () => {
+    it("should return true when certified at the required level", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC2_ADVISOR);
+      for (const check of cert.checks) {
+        mgr.updateCheck(cert.id, check.id, "PASSED");
+      }
+      mgr.submitTestResults(cert.id, { ok: true });
+      mgr.addCertifierSignOff(cert.id, {
+        id: "c1", name: "Test", role: "Lead", signature: "sig",
+      });
+      mgr.finalizeCertification(cert.id);
+
+      expect(mgr.isAgentCertified(AGENT_ID, CertificationLevel.AC1_OBSERVER)).toBe(true);
+      expect(mgr.isAgentCertified(AGENT_ID, CertificationLevel.AC2_ADVISOR)).toBe(true);
+      expect(mgr.isAgentCertified(AGENT_ID, CertificationLevel.AC3_OPERATOR)).toBe(false);
+    });
+
+    it("should return false when no certification exists", () => {
+      expect(mgr.isAgentCertified("unknown-agent", CertificationLevel.AC1_OBSERVER)).toBe(false);
+    });
+  });
+
+  describe("progress tracking", () => {
+    it("should track certification progress", () => {
+      const cert = mgr.initiateCertification(AGENT_ID, AGENT_VERSION, CertificationLevel.AC1_OBSERVER);
+      const total = cert.checks.length;
+
+      let progress = mgr.getCertificationProgress(cert.id);
+      expect(progress?.total).toBe(total);
+      expect(progress?.pending).toBe(total);
+      expect(progress?.percentComplete).toBe(0);
+
+      // Pass half the checks
+      const half = Math.floor(total / 2);
+      for (let i = 0; i < half; i++) {
+        mgr.updateCheck(cert.id, cert.checks[i].id, "PASSED");
+      }
+
+      progress = mgr.getCertificationProgress(cert.id);
+      expect(progress?.passed).toBe(half);
+      expect(progress?.percentComplete).toBeGreaterThan(0);
+    });
+  });
+
+  describe("constants", () => {
+    it("should have metadata for all certification levels", () => {
+      for (const level of CERTIFICATION_LEVEL_ORDER) {
+        expect(CERTIFICATION_LEVEL_META[level]).toBeDefined();
+        expect(CERTIFICATION_LEVEL_META[level].name).toBeTruthy();
+        expect(CERTIFICATION_LEVEL_META[level].analogousSIL).toBeTruthy();
+      }
+    });
+
+    it("should have requirements for all certification levels", () => {
+      for (const level of CERTIFICATION_LEVEL_ORDER) {
+        expect(REQUIREMENTS_BY_LEVEL[level]).toBeDefined();
+        expect(REQUIREMENTS_BY_LEVEL[level].length).toBeGreaterThan(0);
+      }
+    });
+
+    it("should have increasing requirements as level increases", () => {
+      let prevCount = 0;
+      for (const level of CERTIFICATION_LEVEL_ORDER) {
+        const count = REQUIREMENTS_BY_LEVEL[level].length;
+        expect(count).toBeGreaterThanOrEqual(prevCount);
+        prevCount = count;
+      }
+    });
+  });
+});

--- a/server/agents/certification-manager.ts
+++ b/server/agents/certification-manager.ts
@@ -1,0 +1,455 @@
+/**
+ * 0xSCADA Agent Certification Manager
+ * 
+ * ADR-0010: Agent Certification Framework
+ * 
+ * Manages the lifecycle of agent certifications:
+ * - Initiate certification process (SUBMIT → REVIEW → TEST → AUDIT → CERTIFY)
+ * - Evaluate requirements per certification level
+ * - Record certifier sign-offs
+ * - Track recertification triggers
+ * - Provide certification status queries
+ */
+
+import { randomUUID } from "crypto";
+import { sha256, canonicalize } from "../crypto";
+import { log, logError } from "../logger";
+import type {
+  CertificationRecord,
+  CertificationCheck,
+  CertificationLevel,
+  CertificationStage,
+  RecertificationTrigger,
+  LevelRequirement,
+} from "@shared/types/agent-certification";
+import {
+  CertificationLevel as Levels,
+  CertificationCheckStatus,
+  CertificationStage as Stages,
+  REQUIREMENTS_BY_LEVEL,
+  CERTIFICATION_LEVEL_META,
+  CERTIFICATION_LEVEL_ORDER,
+} from "@shared/types/agent-certification";
+
+// =============================================================================
+// CERTIFICATION MANAGER
+// =============================================================================
+
+export class CertificationManager {
+  /** Active certifications indexed by ID */
+  private certifications: Map<string, CertificationRecord> = new Map();
+
+  /** Certifications indexed by agent ID */
+  private agentCertifications: Map<string, string[]> = new Map();
+
+  /** Recertification watch list */
+  private recertificationTriggers: Array<{
+    agentId: string;
+    trigger: RecertificationTrigger;
+    triggeredAt: string;
+    resolved: boolean;
+  }> = [];
+
+  // ==========================================================================
+  // CERTIFICATION LIFECYCLE
+  // ==========================================================================
+
+  /**
+   * Initiate a new certification process for an agent
+   */
+  initiateCertification(
+    agentId: string,
+    agentVersion: string,
+    targetLevel: CertificationLevel
+  ): CertificationRecord {
+    const requirements = REQUIREMENTS_BY_LEVEL[targetLevel];
+    if (!requirements) {
+      throw new Error(`Unknown certification level: ${targetLevel}`);
+    }
+
+    // Build initial check list from requirements
+    const checks: CertificationCheck[] = requirements.map((req) => ({
+      id: req.id,
+      description: req.description,
+      requiredForLevel: targetLevel,
+      status: "PENDING" as const,
+    }));
+
+    const now = new Date().toISOString();
+    const record: CertificationRecord = {
+      id: randomUUID(),
+      agentId,
+      agentVersion,
+      level: targetLevel,
+      testSuiteHash: "",
+      checks,
+      certifiers: [],
+      status: "IN_PROGRESS",
+      revoked: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.certifications.set(record.id, record);
+
+    if (!this.agentCertifications.has(agentId)) {
+      this.agentCertifications.set(agentId, []);
+    }
+    this.agentCertifications.get(agentId)!.push(record.id);
+
+    log(
+      `📋 Certification initiated: ${agentId} → ${CERTIFICATION_LEVEL_META[targetLevel].name} (${record.id})`,
+      "certification"
+    );
+
+    return record;
+  }
+
+  /**
+   * Update a check result within a certification
+   */
+  updateCheck(
+    certificationId: string,
+    checkId: string,
+    status: "PASSED" | "FAILED" | "NOT_APPLICABLE",
+    options: { evidenceHash?: string; verifiedBy?: string; notes?: string } = {}
+  ): CertificationRecord | null {
+    const record = this.certifications.get(certificationId);
+    if (!record || record.status !== "IN_PROGRESS") {
+      return null;
+    }
+
+    const check = record.checks.find((c) => c.id === checkId);
+    if (!check) {
+      return null;
+    }
+
+    check.status = status;
+    check.evaluatedAt = new Date().toISOString();
+    if (options.evidenceHash) check.evidenceHash = options.evidenceHash;
+    if (options.verifiedBy) check.verifiedBy = options.verifiedBy;
+    if (options.notes) check.notes = options.notes;
+
+    record.updatedAt = new Date().toISOString();
+
+    log(
+      `✅ Check updated: ${checkId} → ${status} (cert: ${certificationId})`,
+      "certification"
+    );
+
+    return record;
+  }
+
+  /**
+   * Submit test suite results for a certification
+   */
+  submitTestResults(certificationId: string, testResultsData: unknown): CertificationRecord | null {
+    const record = this.certifications.get(certificationId);
+    if (!record || record.status !== "IN_PROGRESS") {
+      return null;
+    }
+
+    record.testSuiteHash = sha256(canonicalize(testResultsData));
+    record.updatedAt = new Date().toISOString();
+
+    return record;
+  }
+
+  /**
+   * Add a certifier sign-off
+   */
+  addCertifierSignOff(
+    certificationId: string,
+    certifier: { id: string; name: string; role: string; signature: string }
+  ): CertificationRecord | null {
+    const record = this.certifications.get(certificationId);
+    if (!record || record.status !== "IN_PROGRESS") {
+      return null;
+    }
+
+    record.certifiers.push({
+      ...certifier,
+      signedAt: new Date().toISOString(),
+    });
+    record.updatedAt = new Date().toISOString();
+
+    log(
+      `🖊️ Certifier sign-off: ${certifier.name} (${certifier.role}) on ${certificationId}`,
+      "certification"
+    );
+
+    return record;
+  }
+
+  /**
+   * Finalize certification — checks all requirements are met
+   */
+  finalizeCertification(certificationId: string): {
+    success: boolean;
+    record?: CertificationRecord;
+    failedChecks?: CertificationCheck[];
+    reason?: string;
+  } {
+    const record = this.certifications.get(certificationId);
+    if (!record) {
+      return { success: false, reason: "Certification not found" };
+    }
+
+    if (record.status !== "IN_PROGRESS") {
+      return { success: false, reason: `Certification is ${record.status}, not IN_PROGRESS` };
+    }
+
+    // Check all requirements are passed or N/A
+    const failedChecks = record.checks.filter(
+      (c) => c.status !== "PASSED" && c.status !== "NOT_APPLICABLE"
+    );
+
+    if (failedChecks.length > 0) {
+      return {
+        success: false,
+        failedChecks,
+        reason: `${failedChecks.length} checks not passed: ${failedChecks.map((c) => c.id).join(", ")}`,
+      };
+    }
+
+    // Check test suite hash is present
+    if (!record.testSuiteHash) {
+      return { success: false, reason: "Test suite results not submitted" };
+    }
+
+    // Check at least one certifier
+    if (record.certifiers.length === 0) {
+      return { success: false, reason: "No certifier sign-offs" };
+    }
+
+    // AC-3 and AC-4 require audit report
+    if (
+      (record.level === Levels.AC3_OPERATOR || record.level === Levels.AC4_AUTONOMOUS) &&
+      !record.auditReportHash
+    ) {
+      return { success: false, reason: "Audit report required for AC-3/AC-4" };
+    }
+
+    // Certify!
+    const now = new Date();
+    record.status = "CERTIFIED";
+    record.issuedAt = now.toISOString();
+    record.expiresAt = new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000).toISOString(); // 12 months
+    record.updatedAt = now.toISOString();
+
+    log(
+      `🏆 Certification granted: ${record.agentId} → ${CERTIFICATION_LEVEL_META[record.level].name}`,
+      "certification"
+    );
+
+    return { success: true, record };
+  }
+
+  /**
+   * Submit an audit report hash
+   */
+  submitAuditReport(certificationId: string, auditReportHash: string): CertificationRecord | null {
+    const record = this.certifications.get(certificationId);
+    if (!record || record.status !== "IN_PROGRESS") {
+      return null;
+    }
+
+    record.auditReportHash = auditReportHash;
+    record.updatedAt = new Date().toISOString();
+    return record;
+  }
+
+  // ==========================================================================
+  // REVOCATION & RECERTIFICATION
+  // ==========================================================================
+
+  /**
+   * Revoke a certification
+   */
+  revokeCertification(certificationId: string, reason: string): boolean {
+    const record = this.certifications.get(certificationId);
+    if (!record || record.status !== "CERTIFIED") {
+      return false;
+    }
+
+    record.status = "REVOKED";
+    record.revoked = true;
+    record.revokedReason = reason;
+    record.updatedAt = new Date().toISOString();
+
+    log(`🚫 Certification revoked: ${certificationId} — ${reason}`, "certification");
+
+    return true;
+  }
+
+  /**
+   * Record a recertification trigger
+   */
+  triggerRecertification(agentId: string, trigger: RecertificationTrigger): void {
+    this.recertificationTriggers.push({
+      agentId,
+      trigger,
+      triggeredAt: new Date().toISOString(),
+      resolved: false,
+    });
+
+    // Expire all active certifications for this agent
+    const certIds = this.agentCertifications.get(agentId) || [];
+    for (const certId of certIds) {
+      const record = this.certifications.get(certId);
+      if (record && record.status === "CERTIFIED") {
+        record.status = "EXPIRED";
+        record.updatedAt = new Date().toISOString();
+      }
+    }
+
+    log(
+      `⚠️ Recertification triggered for ${agentId}: ${trigger}`,
+      "certification"
+    );
+  }
+
+  // ==========================================================================
+  // QUERIES
+  // ==========================================================================
+
+  /**
+   * Get current active certification for an agent
+   */
+  getActiveCertification(agentId: string): CertificationRecord | null {
+    const certIds = this.agentCertifications.get(agentId) || [];
+    for (const certId of certIds) {
+      const record = this.certifications.get(certId);
+      if (record && record.status === "CERTIFIED") {
+        // Check expiry
+        if (record.expiresAt && new Date(record.expiresAt) < new Date()) {
+          record.status = "EXPIRED";
+          continue;
+        }
+        return record;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get certification by ID
+   */
+  getCertification(certificationId: string): CertificationRecord | undefined {
+    return this.certifications.get(certificationId);
+  }
+
+  /**
+   * Get all certifications for an agent
+   */
+  getAgentCertifications(agentId: string): CertificationRecord[] {
+    const certIds = this.agentCertifications.get(agentId) || [];
+    return certIds
+      .map((id) => this.certifications.get(id))
+      .filter((r): r is CertificationRecord => r !== undefined);
+  }
+
+  /**
+   * Get pending recertification triggers for an agent
+   */
+  getPendingRecertifications(agentId: string): typeof this.recertificationTriggers {
+    return this.recertificationTriggers.filter(
+      (t) => t.agentId === agentId && !t.resolved
+    );
+  }
+
+  /**
+   * Check if an agent is certified at or above a given level
+   */
+  isAgentCertified(agentId: string, minimumLevel: CertificationLevel): boolean {
+    const active = this.getActiveCertification(agentId);
+    if (!active) return false;
+
+    const activeIndex = CERTIFICATION_LEVEL_ORDER.indexOf(active.level as CertificationLevel);
+    const requiredIndex = CERTIFICATION_LEVEL_ORDER.indexOf(minimumLevel);
+
+    return activeIndex >= requiredIndex;
+  }
+
+  /**
+   * Get requirements for a certification level
+   */
+  getRequirements(level: CertificationLevel): LevelRequirement[] {
+    return REQUIREMENTS_BY_LEVEL[level] || [];
+  }
+
+  /**
+   * Get certification progress summary
+   */
+  getCertificationProgress(certificationId: string): {
+    total: number;
+    passed: number;
+    failed: number;
+    pending: number;
+    percentComplete: number;
+  } | null {
+    const record = this.certifications.get(certificationId);
+    if (!record) return null;
+
+    const total = record.checks.length;
+    const passed = record.checks.filter((c) => c.status === "PASSED" || c.status === "NOT_APPLICABLE").length;
+    const failed = record.checks.filter((c) => c.status === "FAILED").length;
+    const pending = record.checks.filter((c) => c.status === "PENDING").length;
+
+    return {
+      total,
+      passed,
+      failed,
+      pending,
+      percentComplete: total > 0 ? Math.round((passed / total) * 100) : 0,
+    };
+  }
+
+  /**
+   * Get statistics
+   */
+  getStats(): {
+    totalCertifications: number;
+    certified: number;
+    inProgress: number;
+    expired: number;
+    revoked: number;
+    pendingRecertifications: number;
+  } {
+    let certified = 0, inProgress = 0, expired = 0, revoked = 0;
+    for (const record of this.certifications.values()) {
+      switch (record.status) {
+        case "CERTIFIED": certified++; break;
+        case "IN_PROGRESS": inProgress++; break;
+        case "EXPIRED": expired++; break;
+        case "REVOKED": revoked++; break;
+      }
+    }
+    return {
+      totalCertifications: this.certifications.size,
+      certified,
+      inProgress,
+      expired,
+      revoked,
+      pendingRecertifications: this.recertificationTriggers.filter((t) => !t.resolved).length,
+    };
+  }
+}
+
+// =============================================================================
+// SINGLETON
+// =============================================================================
+
+let certManagerInstance: CertificationManager | null = null;
+
+export function getCertificationManager(): CertificationManager {
+  if (!certManagerInstance) {
+    certManagerInstance = new CertificationManager();
+  }
+  return certManagerInstance;
+}
+
+export function initCertificationManager(): CertificationManager {
+  certManagerInstance = new CertificationManager();
+  return certManagerInstance;
+}

--- a/shared/types/agent-certification.ts
+++ b/shared/types/agent-certification.ts
@@ -1,0 +1,260 @@
+/**
+ * 0xSCADA Agent Certification Framework
+ * 
+ * ADR-0010: Agent Certification Framework
+ * 
+ * Four-level certification system for industrial agentic systems:
+ * - AC-1: Observer (read-only monitoring)
+ * - AC-2: Advisor (recommendations, no direct control)
+ * - AC-3: Operator (bounded control within envelope)
+ * - AC-4: Autonomous (full autonomous within hard limits)
+ * 
+ * Certifications are recorded on-chain for transparency and immutability.
+ * Recertification is required on code update, envelope change, safety
+ * incident, 12-month expiry, new deployment site, or infra change.
+ */
+
+import { z } from "zod";
+
+// =============================================================================
+// CERTIFICATION LEVELS
+// =============================================================================
+
+export const CertificationLevel = {
+  AC1_OBSERVER: "AC1_OBSERVER",
+  AC2_ADVISOR: "AC2_ADVISOR",
+  AC3_OPERATOR: "AC3_OPERATOR",
+  AC4_AUTONOMOUS: "AC4_AUTONOMOUS",
+} as const;
+
+export type CertificationLevel = (typeof CertificationLevel)[keyof typeof CertificationLevel];
+
+export const CERTIFICATION_LEVEL_ORDER: CertificationLevel[] = [
+  CertificationLevel.AC1_OBSERVER,
+  CertificationLevel.AC2_ADVISOR,
+  CertificationLevel.AC3_OPERATOR,
+  CertificationLevel.AC4_AUTONOMOUS,
+];
+
+export const CERTIFICATION_LEVEL_META: Record<CertificationLevel, {
+  name: string;
+  description: string;
+  analogousSIL: string;
+  analogousDAL: string;
+}> = {
+  [CertificationLevel.AC1_OBSERVER]: {
+    name: "Observer",
+    description: "Read-only monitoring, alerting, reporting",
+    analogousSIL: "SIL 1",
+    analogousDAL: "DAL D",
+  },
+  [CertificationLevel.AC2_ADVISOR]: {
+    name: "Advisor",
+    description: "Recommendations to operators, no direct control",
+    analogousSIL: "SIL 1-2",
+    analogousDAL: "DAL C",
+  },
+  [CertificationLevel.AC3_OPERATOR]: {
+    name: "Operator",
+    description: "Bounded control actions within operational envelope",
+    analogousSIL: "SIL 2-3",
+    analogousDAL: "DAL B",
+  },
+  [CertificationLevel.AC4_AUTONOMOUS]: {
+    name: "Autonomous",
+    description: "Full autonomous operation within hard limits",
+    analogousSIL: "SIL 3",
+    analogousDAL: "DAL A",
+  },
+};
+
+// =============================================================================
+// CERTIFICATION REQUIREMENTS
+// =============================================================================
+
+export const CertificationCheckStatus = {
+  PASSED: "PASSED",
+  FAILED: "FAILED",
+  PENDING: "PENDING",
+  NOT_APPLICABLE: "NOT_APPLICABLE",
+} as const;
+
+export type CertificationCheckStatus = (typeof CertificationCheckStatus)[keyof typeof CertificationCheckStatus];
+
+export const certificationCheckSchema = z.object({
+  /** Check identifier */
+  id: z.string(),
+
+  /** Human-readable description */
+  description: z.string(),
+
+  /** Which certification level this check applies to */
+  requiredForLevel: z.enum(["AC1_OBSERVER", "AC2_ADVISOR", "AC3_OPERATOR", "AC4_AUTONOMOUS"]),
+
+  /** Check status */
+  status: z.enum(["PASSED", "FAILED", "PENDING", "NOT_APPLICABLE"]),
+
+  /** Evidence hash (content-addressed test results, audit report, etc.) */
+  evidenceHash: z.string().optional(),
+
+  /** Who verified this check */
+  verifiedBy: z.string().optional(),
+
+  /** When the check was last evaluated */
+  evaluatedAt: z.string().datetime().optional(),
+
+  /** Notes */
+  notes: z.string().optional(),
+});
+
+export type CertificationCheck = z.infer<typeof certificationCheckSchema>;
+
+// =============================================================================
+// CERTIFICATION REQUIREMENTS BY LEVEL
+// =============================================================================
+
+export interface LevelRequirement {
+  id: string;
+  description: string;
+  category: "identity" | "capability" | "testing" | "operational" | "security" | "governance";
+}
+
+export const AC1_REQUIREMENTS: LevelRequirement[] = [
+  { id: "ac1-identity", description: "Agent identity registered on-chain", category: "identity" },
+  { id: "ac1-readonly", description: "Read-only capability tokens verified", category: "capability" },
+  { id: "ac1-logging", description: "Logging and audit trail operational", category: "operational" },
+  { id: "ac1-no-write", description: "No write access to any control system", category: "capability" },
+  { id: "ac1-test-coverage", description: "Functional test suite passes (>95% observation path coverage)", category: "testing" },
+];
+
+export const AC2_REQUIREMENTS: LevelRequirement[] = [
+  ...AC1_REQUIREMENTS,
+  { id: "ac2-accuracy", description: "Recommendation accuracy validated (>90% correct vs historical)", category: "testing" },
+  { id: "ac2-false-positive", description: "False positive rate below configurable threshold", category: "testing" },
+  { id: "ac2-latency", description: "Recommendation latency within SLA (<5s non-critical, <500ms critical)", category: "operational" },
+  { id: "ac2-hitl", description: "Human-in-the-loop confirmation flow verified", category: "governance" },
+  { id: "ac2-override", description: "Operator override mechanism tested and documented", category: "governance" },
+];
+
+export const AC3_REQUIREMENTS: LevelRequirement[] = [
+  ...AC2_REQUIREMENTS,
+  { id: "ac3-envelope", description: "Operational envelope formally specified and verified", category: "operational" },
+  { id: "ac3-trust-tier", description: "Trust tier T2+ achieved in staging environment", category: "operational" },
+  { id: "ac3-safety-tests", description: "Safety function test suite passes (100% safety-critical paths)", category: "testing" },
+  { id: "ac3-fmea", description: "Failure mode analysis documented (FMEA)", category: "testing" },
+  { id: "ac3-estop", description: "Emergency stop response time verified (<100ms)", category: "testing" },
+  { id: "ac3-rollback", description: "Rollback procedure tested for all control actions", category: "operational" },
+  { id: "ac3-shadow", description: "30-day shadow-mode operation with zero safety deviations", category: "operational" },
+];
+
+export const AC4_REQUIREMENTS: LevelRequirement[] = [
+  ...AC3_REQUIREMENTS,
+  { id: "ac4-trust-tier", description: "Trust tier T3+ achieved in production environment", category: "operational" },
+  { id: "ac4-security-audit", description: "Independent security audit passed (ADR-0008 compliance)", category: "security" },
+  { id: "ac4-multi-agent", description: "Multi-agent interaction testing complete", category: "testing" },
+  { id: "ac4-supervised-90d", description: "90-day supervised operation with zero safety deviations", category: "operational" },
+  { id: "ac4-incident-plan", description: "Incident response plan documented and drilled", category: "governance" },
+  { id: "ac4-insurance", description: "Insurance/liability review completed", category: "governance" },
+  { id: "ac4-council", description: "Technical advisory council sign-off", category: "governance" },
+];
+
+export const REQUIREMENTS_BY_LEVEL: Record<CertificationLevel, LevelRequirement[]> = {
+  [CertificationLevel.AC1_OBSERVER]: AC1_REQUIREMENTS,
+  [CertificationLevel.AC2_ADVISOR]: AC2_REQUIREMENTS,
+  [CertificationLevel.AC3_OPERATOR]: AC3_REQUIREMENTS,
+  [CertificationLevel.AC4_AUTONOMOUS]: AC4_REQUIREMENTS,
+};
+
+// =============================================================================
+// CERTIFICATION RECORD (On-Chain Compatible)
+// =============================================================================
+
+export const certificationRecordSchema = z.object({
+  /** Unique certification ID */
+  id: z.string().uuid(),
+
+  /** Agent being certified */
+  agentId: z.string(),
+
+  /** Agent code version at time of certification */
+  agentVersion: z.string(),
+
+  /** Certification level */
+  level: z.enum(["AC1_OBSERVER", "AC2_ADVISOR", "AC3_OPERATOR", "AC4_AUTONOMOUS"]),
+
+  /** Hash of the complete test suite results */
+  testSuiteHash: z.string(),
+
+  /** Hash of the audit report */
+  auditReportHash: z.string().optional(),
+
+  /** Certifiers who signed off */
+  certifiers: z.array(z.object({
+    id: z.string(),
+    name: z.string(),
+    role: z.string(),
+    signature: z.string(),
+    signedAt: z.string().datetime(),
+  })),
+
+  /** Individual check results */
+  checks: z.array(certificationCheckSchema),
+
+  /** Overall status */
+  status: z.enum(["IN_PROGRESS", "CERTIFIED", "FAILED", "EXPIRED", "REVOKED"]),
+
+  /** Issued at */
+  issuedAt: z.string().datetime().optional(),
+
+  /** Expires at */
+  expiresAt: z.string().datetime().optional(),
+
+  /** Revoked flag */
+  revoked: z.boolean().default(false),
+
+  /** Revocation reason */
+  revokedReason: z.string().optional(),
+
+  /** On-chain anchor (if recorded) */
+  onChainAnchor: z.object({
+    txHash: z.string(),
+    blockNumber: z.number().int(),
+    contractAddress: z.string(),
+    anchoredAt: z.string().datetime(),
+  }).optional(),
+
+  /** Metadata */
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type CertificationRecord = z.infer<typeof certificationRecordSchema>;
+
+// =============================================================================
+// RECERTIFICATION TRIGGERS
+// =============================================================================
+
+export const RecertificationTrigger = {
+  CODE_UPDATE: "CODE_UPDATE",
+  ENVELOPE_MODIFIED: "ENVELOPE_MODIFIED",
+  SAFETY_INCIDENT: "SAFETY_INCIDENT",
+  EXPIRY_12_MONTHS: "EXPIRY_12_MONTHS",
+  NEW_DEPLOYMENT_SITE: "NEW_DEPLOYMENT_SITE",
+  INFRASTRUCTURE_CHANGE: "INFRASTRUCTURE_CHANGE",
+} as const;
+
+export type RecertificationTrigger = (typeof RecertificationTrigger)[keyof typeof RecertificationTrigger];
+
+// =============================================================================
+// CERTIFICATION PROCESS STAGES
+// =============================================================================
+
+export const CertificationStage = {
+  SUBMIT: "SUBMIT",
+  REVIEW: "REVIEW",
+  TEST: "TEST",
+  AUDIT: "AUDIT",
+  CERTIFY: "CERTIFY",
+} as const;
+
+export type CertificationStage = (typeof CertificationStage)[keyof typeof CertificationStage];


### PR DESCRIPTION
Implements the certification framework from ADR-0010.

## New Files
- **shared/types/agent-certification.ts**  CertificationLevel (AC1-AC4), level requirements, CertificationRecord schema, recertification triggers
- **server/agents/certification-manager.ts**  Certification lifecycle, check updates, certifier sign-off, revocation, recertification
- **server/__tests__/certification.test.ts**  12 tests covering lifecycle, requirements, revocation, level comparison

## Key Design
- Four certification levels: AC-1 Observer, AC-2 Advisor, AC-3 Operator, AC-4 Autonomous
- Cumulative requirements (AC-3 includes all AC-1 and AC-2 checks)
- SIL/DAL analogues for industry mapping
- Recertification on code update, safety incident, 12-month expiry, new site, infra change
- On-chain compatible record schema with anchor fields

Resolves: 0xSCADA-wp7, 0xSCADA-rd4