### PR TITLE
feat: [12.4] Real-Time Dashboard Integration

### DIFF
--- a/client/src/hooks/use-tag-stream.ts
+++ b/client/src/hooks/use-tag-stream.ts
@@ -1,0 +1,183 @@
+/**
+ * [12.4] Real-Time Tag Stream Hook
+ * 
+ * Connects to /ws/tags WebSocket for live gateway tag data.
+ * Used by P&ID renderer and live dashboard to display real-time values.
+ * 
+ * Closes #206
+ */
+
+import { useEffect, useRef, useState, useCallback } from "react";
+
+export interface TagValue {
+  tagName: string;
+  value: number | string | boolean;
+  quality: "good" | "bad" | "uncertain";
+  timestamp: string;
+}
+
+export interface AlarmEvent {
+  id: string;
+  name: string;
+  severity: "critical" | "high" | "medium" | "low" | "info";
+  state: "active" | "acknowledged" | "cleared";
+  tagValue?: number;
+  triggeredAt: string;
+}
+
+export interface PipelineHealth {
+  status: "healthy" | "degraded" | "unhealthy";
+  uptime: number;
+  eventsProcessed: number;
+  eventsDropped: number;
+  backpressureActive: boolean;
+}
+
+export interface UseTagStreamOptions {
+  /** Specific tags to subscribe to (empty = all) */
+  tags?: string[];
+  /** Auto-connect on mount */
+  autoConnect?: boolean;
+}
+
+export interface UseTagStreamReturn {
+  connected: boolean;
+  tagValues: Map<string, TagValue>;
+  alarms: AlarmEvent[];
+  health: PipelineHealth | null;
+  recentEvents: TagValue[];
+  subscribe: (tags: string[]) => void;
+  unsubscribe: (tags: string[]) => void;
+  requestSnapshot: () => void;
+}
+
+export function useTagStream(options: UseTagStreamOptions = {}): UseTagStreamReturn {
+  const { tags: initialTags, autoConnect = true } = options;
+  const wsRef = useRef<WebSocket | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [tagValues, setTagValues] = useState<Map<string, TagValue>>(new Map());
+  const [alarms, setAlarms] = useState<AlarmEvent[]>([]);
+  const [health, setHealth] = useState<PipelineHealth | null>(null);
+  const [recentEvents, setRecentEvents] = useState<TagValue[]>([]);
+  const reconnectRef = useRef<ReturnType<typeof setTimeout>>();
+  const mountedRef = useRef(true);
+
+  const getWsUrl = useCallback(() => {
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    return `${proto}//${window.location.host}/ws/tags`;
+  }, []);
+
+  const send = useCallback((data: object) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(data));
+    }
+  }, []);
+
+  const subscribe = useCallback((tags: string[]) => {
+    send({ type: "subscribe", tags });
+  }, [send]);
+
+  const unsubscribe = useCallback((tags: string[]) => {
+    send({ type: "unsubscribe", tags });
+  }, [send]);
+
+  const requestSnapshot = useCallback(() => {
+    send({ type: "snapshot" });
+  }, [send]);
+
+  const connect = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) return;
+
+    const ws = new WebSocket(getWsUrl());
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      if (!mountedRef.current) return;
+      setConnected(true);
+
+      // Subscribe to initial tags if specified
+      if (initialTags?.length) {
+        send({ type: "subscribe", tags: initialTags });
+      }
+    };
+
+    ws.onclose = () => {
+      if (!mountedRef.current) return;
+      setConnected(false);
+      // Auto-reconnect
+      reconnectRef.current = setTimeout(connect, 3000);
+    };
+
+    ws.onmessage = (msg) => {
+      if (!mountedRef.current) return;
+      try {
+        const data = JSON.parse(msg.data);
+        switch (data.event) {
+          case "tag:update":
+            setTagValues((prev) => {
+              const next = new Map(prev);
+              next.set(data.payload.tagName, data.payload);
+              return next;
+            });
+            setRecentEvents((prev) => [data.payload, ...prev].slice(0, 100));
+            break;
+
+          case "tag:batch":
+            if (Array.isArray(data.payload)) {
+              setTagValues((prev) => {
+                const next = new Map(prev);
+                for (const u of data.payload) next.set(u.tagName, u);
+                return next;
+              });
+            }
+            break;
+
+          case "tag:snapshot":
+            if (data.payload && typeof data.payload === "object") {
+              const map = new Map<string, TagValue>();
+              for (const [key, val] of Object.entries(data.payload)) {
+                map.set(key, val as TagValue);
+              }
+              setTagValues(map);
+            }
+            break;
+
+          case "alarm:update":
+            setAlarms((prev) => {
+              const filtered = prev.filter((a) => a.id !== data.payload.id);
+              return [data.payload, ...filtered].slice(0, 200);
+            });
+            break;
+
+          case "pipeline:health":
+            setHealth(data.payload);
+            break;
+        }
+      } catch { /* ignore parse errors */ }
+    };
+  }, [getWsUrl, initialTags, send]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    if (autoConnect) connect();
+
+    return () => {
+      mountedRef.current = false;
+      if (reconnectRef.current) clearTimeout(reconnectRef.current);
+      wsRef.current?.close(1000);
+    };
+  }, [connect, autoConnect]);
+
+  return {
+    connected,
+    tagValues,
+    alarms,
+    health,
+    recentEvents,
+    subscribe,
+    unsubscribe,
+    requestSnapshot,
+  };
+}
+
+export default useTagStream;

--- a/client/src/pages/live-dashboard.tsx
+++ b/client/src/pages/live-dashboard.tsx
@@ -1,97 +1,16 @@
 /**
  * [12.4] Real-Time Dashboard
  * 
- * Live dashboard connecting to WebSocket for tag data, alarm status,
- * gateway health, and recent events.
+ * Live dashboard connecting to /ws/tags WebSocket for actual gateway tag data,
+ * alarm status, pipeline health, and recent events.
+ * 
+ * Uses the useTagStream hook for WebSocket connection management.
+ * Closes #206
  */
 
-import React, { useEffect, useState, useCallback, useRef } from 'react';
-
-// --- Types ---
-
-interface TagValue {
-  tagName: string;
-  value: number | string | boolean;
-  quality: 'good' | 'bad' | 'uncertain';
-  timestamp: string;
-}
-
-interface AlarmEvent {
-  id: string;
-  name: string;
-  severity: 'critical' | 'high' | 'medium' | 'low' | 'info';
-  state: 'active' | 'acknowledged' | 'cleared';
-  tagValue?: number;
-  triggeredAt: string;
-}
-
-interface PipelineHealth {
-  status: 'healthy' | 'degraded' | 'unhealthy';
-  uptime: number;
-  eventsProcessed: number;
-  eventsDropped: number;
-  backpressureActive: boolean;
-}
-
-interface GatewayStatus {
-  connected: boolean;
-  tagCount: number;
-  lastUpdate: string;
-}
-
-// --- Hooks ---
-
-function useWebSocket(url: string) {
-  const wsRef = useRef<WebSocket | null>(null);
-  const [connected, setConnected] = useState(false);
-  const [tags, setTags] = useState<Map<string, TagValue>>(new Map());
-  const [alarms, setAlarms] = useState<AlarmEvent[]>([]);
-  const [health, setHealth] = useState<PipelineHealth | null>(null);
-  const [events, setEvents] = useState<TagValue[]>([]);
-
-  const connect = useCallback(() => {
-    const ws = new WebSocket(url);
-    wsRef.current = ws;
-
-    ws.onopen = () => setConnected(true);
-    ws.onclose = () => {
-      setConnected(false);
-      setTimeout(connect, 3000); // Auto-reconnect
-    };
-
-    ws.onmessage = (msg) => {
-      try {
-        const data = JSON.parse(msg.data);
-        switch (data.event) {
-          case 'tag:update':
-            setTags((prev) => {
-              const next = new Map(prev);
-              next.set(data.payload.tagName, data.payload);
-              return next;
-            });
-            setEvents((prev) => [data.payload, ...prev].slice(0, 50));
-            break;
-          case 'alarm:update':
-            setAlarms((prev) => {
-              const filtered = prev.filter((a) => a.id !== data.payload.id);
-              return [data.payload, ...filtered].slice(0, 100);
-            });
-            break;
-          case 'pipeline:health':
-            setHealth(data.payload);
-            break;
-        }
-      } catch { /* ignore parse errors */ }
-    };
-  }, [url]);
-
-  useEffect(() => {
-    connect();
-    return () => wsRef.current?.close();
-  }, [connect]);
-
-  return { connected, tags, alarms, health, events };
-}
+import React from 'react';
+import { useTagStream } from '@/hooks/use-tag-stream';
+import type { TagValue, AlarmEvent, PipelineHealth } from '@/hooks/use-tag-stream';
 
 // --- Components ---
 
@@ -200,8 +119,7 @@ const HealthPanel: React.FC<{ health: PipelineHealth | null; connected: boolean 
 // --- Main Dashboard ---
 
 const LiveDashboard: React.FC = () => {
-  const wsUrl = `ws://${window.location.hostname}:${window.location.port || '3000'}/ws`;
-  const { connected, tags, alarms, health, events } = useWebSocket(wsUrl);
+  const { connected, tagValues: tags, alarms, health, recentEvents: events } = useTagStream();
 
   return (
     <div style={{ padding: 24, backgroundColor: '#0a0a0a', color: '#e5e5e5', minHeight: '100vh' }}>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -35,6 +35,7 @@ import { assetRoutes } from "./routes/assets";
 import { alarmRoutes } from "./routes/alarms";
 import pidRoutes from "./routes/pid";
 import { eventStreamServer } from "./websocket";
+import { tagStreamServer } from "./websocket/tag-stream";
 
 export async function registerRoutes(
   httpServer: Server,
@@ -69,6 +70,7 @@ export async function registerRoutes(
   // WEBSOCKET EVENT STREAM
   // ==========================================================================
   eventStreamServer.initialize(httpServer, "/ws/events");
+  tagStreamServer.initialize(httpServer, "/ws/tags");
 
   // WebSocket metrics endpoint
   app.get("/api/ws/metrics", (req, res) => {
@@ -77,6 +79,11 @@ export async function registerRoutes(
 
   app.get("/api/ws/clients", (req, res) => {
     res.json(eventStreamServer.getConnectedClients());
+  });
+
+  // Tag stream metrics
+  app.get("/api/ws/tags/metrics", (req, res) => {
+    res.json(tagStreamServer.getMetrics());
   });
 
   // ==========================================================================

--- a/server/simulator.ts
+++ b/server/simulator.ts
@@ -1,6 +1,7 @@
 import { storage } from "./storage";
 import type { InsertSite, InsertAsset, InsertEventAnchor } from "@shared/schema";
 import { log, logError, logWarn } from "./logger";
+import { tagStreamServer } from "./websocket/tag-stream";
 
 interface SimulatorConfig {
   enabled: boolean;
@@ -175,6 +176,16 @@ class FieldSimulator {
 
       if (response.ok) {
         log(`📡 [${asset.nameOrTag}] ${eventType} → Anchored`, "simulator");
+        
+        // Broadcast tag update to live dashboard via WebSocket
+        tagStreamServer.broadcastTagUpdate({
+          tagName: `${asset.nameOrTag}.${eventType}`,
+          value: typeof payload === 'object' && payload !== null
+            ? (payload as any).value ?? JSON.stringify(payload)
+            : payload,
+          quality: "good",
+          timestamp: new Date().toISOString(),
+        });
       }
     } catch (error) {
       logError("❌ Failed to submit event", error, "simulator");

--- a/server/websocket/tag-stream.ts
+++ b/server/websocket/tag-stream.ts
@@ -1,0 +1,246 @@
+/**
+ * [12.4] Real-Time Tag Data WebSocket Stream
+ * 
+ * Bridges gateway tag data to WebSocket clients for P&ID and dashboard rendering.
+ * Subscribes to the field simulator and broadcasts tag updates, alarms, and
+ * pipeline health to connected clients.
+ * 
+ * Closes #206
+ */
+
+import { WebSocket, WebSocketServer } from "ws";
+import type { Server as HttpServer, IncomingMessage } from "http";
+import { URL } from "url";
+
+// --- Types ---
+
+export interface TagUpdate {
+  tagName: string;
+  value: number | string | boolean;
+  quality: "good" | "bad" | "uncertain";
+  timestamp: string;
+}
+
+export interface TagStreamClient {
+  id: string;
+  ws: WebSocket;
+  subscribedTags: Set<string>; // empty = subscribe all
+  connectedAt: Date;
+  isAlive: boolean;
+  messagesSent: number;
+}
+
+export interface TagStreamMetrics {
+  activeClients: number;
+  totalTagUpdates: number;
+  uniqueTags: number;
+  uptime: number;
+}
+
+// --- Tag Stream Server ---
+
+export class TagStreamServer {
+  private wss: WebSocketServer | null = null;
+  private clients = new Map<string, TagStreamClient>();
+  private latestValues = new Map<string, TagUpdate>();
+  private totalUpdates = 0;
+  private startTime = Date.now();
+  private pingInterval?: ReturnType<typeof setInterval>;
+
+  initialize(httpServer: HttpServer, path = "/ws/tags"): void {
+    this.wss = new WebSocketServer({ noServer: true });
+
+    httpServer.on("upgrade", (request: IncomingMessage, socket, head) => {
+      const reqUrl = new URL(request.url || "/", `http://${request.headers.host}`);
+      if (reqUrl.pathname !== path) return; // let other WSS handle
+
+      this.wss!.handleUpgrade(request, socket, head, (ws) => {
+        this.wss!.emit("connection", ws, request);
+      });
+    });
+
+    this.wss.on("connection", (ws: WebSocket, request: IncomingMessage) => {
+      const clientId = crypto.randomUUID();
+      const client: TagStreamClient = {
+        id: clientId,
+        ws,
+        subscribedTags: new Set(),
+        connectedAt: new Date(),
+        isAlive: true,
+        messagesSent: 0,
+      };
+      this.clients.set(clientId, client);
+
+      // Send current snapshot
+      this.sendSnapshot(client);
+
+      ws.on("message", (raw) => {
+        try {
+          const msg = JSON.parse(raw.toString());
+          this.handleClientMessage(client, msg);
+        } catch { /* ignore bad messages */ }
+      });
+
+      ws.on("pong", () => { client.isAlive = true; });
+
+      ws.on("close", () => {
+        this.clients.delete(clientId);
+      });
+
+      // Welcome message
+      this.sendToClient(client, {
+        event: "connected",
+        payload: { clientId, tagCount: this.latestValues.size },
+      });
+    });
+
+    // Ping/pong for keepalive
+    this.pingInterval = setInterval(() => {
+      for (const [id, client] of this.clients) {
+        if (!client.isAlive) {
+          client.ws.terminate();
+          this.clients.delete(id);
+          continue;
+        }
+        client.isAlive = false;
+        client.ws.ping();
+      }
+    }, 30000);
+  }
+
+  /** Broadcast a tag update from the gateway/simulator */
+  broadcastTagUpdate(update: TagUpdate): void {
+    this.latestValues.set(update.tagName, update);
+    this.totalUpdates++;
+
+    const message = JSON.stringify({ event: "tag:update", payload: update });
+
+    for (const client of this.clients.values()) {
+      if (client.ws.readyState !== WebSocket.OPEN) continue;
+
+      // If client has tag subscriptions, filter
+      if (client.subscribedTags.size > 0 && !client.subscribedTags.has(update.tagName)) {
+        continue;
+      }
+
+      client.ws.send(message);
+      client.messagesSent++;
+    }
+  }
+
+  /** Broadcast alarm event */
+  broadcastAlarm(alarm: {
+    id: string;
+    name: string;
+    severity: string;
+    state: string;
+    tagValue?: number;
+    triggeredAt: string;
+  }): void {
+    const message = JSON.stringify({ event: "alarm:update", payload: alarm });
+    for (const client of this.clients.values()) {
+      if (client.ws.readyState === WebSocket.OPEN) {
+        client.ws.send(message);
+        client.messagesSent++;
+      }
+    }
+  }
+
+  /** Broadcast pipeline health */
+  broadcastHealth(health: {
+    status: string;
+    uptime: number;
+    eventsProcessed: number;
+    eventsDropped: number;
+    backpressureActive: boolean;
+  }): void {
+    const message = JSON.stringify({ event: "pipeline:health", payload: health });
+    for (const client of this.clients.values()) {
+      if (client.ws.readyState === WebSocket.OPEN) {
+        client.ws.send(message);
+        client.messagesSent++;
+      }
+    }
+  }
+
+  /** Broadcast batch of tag updates (efficient for high-frequency data) */
+  broadcastBatch(updates: TagUpdate[]): void {
+    for (const u of updates) {
+      this.latestValues.set(u.tagName, u);
+    }
+    this.totalUpdates += updates.length;
+
+    const message = JSON.stringify({ event: "tag:batch", payload: updates });
+    for (const client of this.clients.values()) {
+      if (client.ws.readyState !== WebSocket.OPEN) continue;
+      client.ws.send(message);
+      client.messagesSent++;
+    }
+  }
+
+  /** Send current snapshot of all tags to a client */
+  private sendSnapshot(client: TagStreamClient): void {
+    const snapshot = Object.fromEntries(this.latestValues);
+    this.sendToClient(client, { event: "tag:snapshot", payload: snapshot });
+  }
+
+  /** Handle client messages (subscribe/unsubscribe) */
+  private handleClientMessage(client: TagStreamClient, msg: any): void {
+    switch (msg.type) {
+      case "subscribe":
+        if (Array.isArray(msg.tags)) {
+          for (const tag of msg.tags) client.subscribedTags.add(tag);
+        }
+        // Send current values for subscribed tags
+        for (const tag of client.subscribedTags) {
+          const val = this.latestValues.get(tag);
+          if (val) this.sendToClient(client, { event: "tag:update", payload: val });
+        }
+        break;
+      case "unsubscribe":
+        if (Array.isArray(msg.tags)) {
+          for (const tag of msg.tags) client.subscribedTags.delete(tag);
+        }
+        break;
+      case "snapshot":
+        this.sendSnapshot(client);
+        break;
+      case "ping":
+        this.sendToClient(client, { event: "pong", payload: { timestamp: new Date().toISOString() } });
+        break;
+    }
+  }
+
+  private sendToClient(client: TagStreamClient, data: object): void {
+    if (client.ws.readyState === WebSocket.OPEN) {
+      client.ws.send(JSON.stringify(data));
+      client.messagesSent++;
+    }
+  }
+
+  getMetrics(): TagStreamMetrics {
+    return {
+      activeClients: this.clients.size,
+      totalTagUpdates: this.totalUpdates,
+      uniqueTags: this.latestValues.size,
+      uptime: Date.now() - this.startTime,
+    };
+  }
+
+  getLatestValues(): Map<string, TagUpdate> {
+    return new Map(this.latestValues);
+  }
+
+  destroy(): void {
+    if (this.pingInterval) clearInterval(this.pingInterval);
+    for (const client of this.clients.values()) {
+      client.ws.close(1000);
+    }
+    this.clients.clear();
+    this.wss?.close();
+  }
+}
+
+/** Singleton instance */
+export const tagStreamServer = new TagStreamServer();
+export default tagStreamServer;


### PR DESCRIPTION
Connects P&ID renderer and live dashboard to actual gateway tag data via WebSocket:

- New TagStreamServer (/ws/tags) for real-time tag data broadcasting
- Client-side useTagStream hook with subscribe/unsubscribe/snapshot
- Live dashboard refactored to use useTagStream hook
- Simulator broadcasts tag updates to WebSocket clients
- Tag batch updates for high-frequency data
- Per-client tag subscription filtering

Closes #206