### PR TITLE
docs: Architecture & README update for Dual-Time Control Plane (#306)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,65 @@ npx 0xscada tags        # Tag point management
 
 ## ▓▓ ARCHITECTURE
 
+### Dual-Time Control Plane
+
+0xSCADA operates on **two temporal domains** — real-time deterministic control and batch cryptographic anchoring:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                     DUAL-TIME CONTROL PLANE                                │
+│                                                                             │
+│  REAL-TIME DOMAIN (µs)          │          BATCH DOMAIN (s/min)             │
+│  ┌─────────────────────┐        │        ┌─────────────────────┐           │
+│  │   EVENT KERNEL      │        │        │   MERKLE KERNEL     │           │
+│  │  • Ring buffer      │        │        │  • Proof generation │           │
+│  │  • < 50µs latency   │        │        │  • O(log n) verify  │           │
+│  │  • Lock-free        │        │        │  • HSM integration  │           │
+│  │  • PREEMPT_RT       │        │        │  • Batch aggregation│           │
+│  └─────────────────────┘        │        └─────────────────────┘           │
+│            │                    │                    │                     │
+│            ▼                    │                    ▼                     │
+│    ┌─────────────┐              │              ┌─────────────┐             │
+│    │   CONTROL   │              │              │ANCHOR KERNEL│             │
+│    │   LOGIC     │              │              │ • L2 sync   │             │
+│    │ • Safety    │              │              │ • Finality  │             │
+│    │ • Actuators │              │              │ • Gas opt   │             │
+│    │ • Real-time │              │              │ • Byzantine │             │
+│    └─────────────┘              │              └─────────────┘             │
+│                                 │                    │                     │
+└─────────────────────────────────┼────────────────────┼─────────────────────┘
+                                  │                    ▼
+                                  │          ┌─────────────────┐
+                                  │          │   BLOCKCHAIN    │
+                                  │          │   0x5CADA       │
+                                  │          │ • Immutable     │
+                                  │          │ • Audit trails │
+                                  │          │ • Compliance   │
+                                  │          └─────────────────┘
+```
+
+### Three-Kernel Model
+
+**Event Kernel** — Deterministic real-time event processing  
+```
+Hardware IRQ → Ring Buffer → Control Logic → Actuator Response
+     µs            µs            µs              µs
+```
+
+**Merkle Kernel** — Cryptographic proof generation and verification  
+```
+Event Batch → Merkle Tree → Inclusion Proofs → HSM Signing
+     s            s              s               s
+```
+
+**Anchor Kernel** — L2 blockchain state synchronization  
+```
+Merkle Root → Gas Optimization → L2 Submit → Finality Tracking
+     s              s               s            min
+```
+
+### System Architecture
+
 ```
                     ┌─────────────────────────────┐
                     │     0xSCADA PROTOCOL v2.0    │
@@ -144,6 +203,12 @@ npx 0xscada tags        # Tag point management
           │                 ┌─────▼─────┐           ┌─────▼─────┐
           │                 │ PostgreSQL │           │  Contracts │
           │                 │  + Redis   │           │  Solidity  │
+          │                 └───────────┘           └───────────┘
+          │                        │                        │
+          │                 ┌─────▼─────┐           ┌─────▼─────┐
+          │                 │ FLUX STATE│           │  KERNEL   │
+          │                 │ ENGINE     │           │ PREEMPT_RT │
+          │                 │ (World)    │           │ 6.6 LTS    │
           │                 └───────────┘           └───────────┘
           │
     ┌─────▼──────────────────────────────────────────────────────┐

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,212 @@
+# 0xSCADA Roadmap
+
+> **"We write code so that machines may be free."**
+
+This roadmap outlines the evolution of the 0xSCADA decentralized industrial control fabric. Development follows the cypherpunk principles of cryptographic verification, decentralized governance, and transparent infrastructure.
+
+## Current State — v2.0.0 (February 2026)
+
+### 🟢 **PRODUCTION READY**
+
+#### Core Platform
+- ✅ **Web Dashboard** — React 19 + TanStack Query + Radix UI
+- ✅ **API Gateway** — Express + TypeScript with OpenAPI spec
+- ✅ **Database Layer** — PostgreSQL 15 + Drizzle ORM + Redis cache
+- ✅ **Custom Blockchain** — 0x5CADA (380634) Clique PoA, 5s blocks
+- ✅ **Smart Contracts** — Solidity 0.8 with Foundry + Hardhat toolchain
+- ✅ **Docker Stack** — Multi-container with Grafana dashboards
+- ✅ **CLI Tool** — 0xscada agents, alarms, containers, db, gateway, shell, tags
+
+#### Architecture (ADRs 0008–0015)
+- ✅ **Zero-trust agent deployment** (ADR-0008)
+- ✅ **Measured emergence guardrails** (ADR-0009) 
+- ✅ **Agent certification framework** (ADR-0010)
+- ✅ **OT-IT convergence standards** (ADR-0011)
+- ✅ **End-to-end integration** (ADR-0012)
+- ✅ **Autonomous agent architecture** (ADR-0013)
+- ✅ **Production scale architecture** (ADR-0014)
+- ✅ **Flux integration** (ADR-0015) — World state engine connectivity
+
+#### Industrial Integration
+- ✅ **AVEVA Optix** — 12 integration docs (OPC UA, NetLogic, recipes, edge)
+- ✅ **Protocol Support** — Modbus driver, OPC UA patterns
+- ✅ **Code Generation** — ISA-88 blueprints for multiple vendors
+- ✅ **Edge Computing** — Containerized deployment, device plugins
+
+#### Operations
+- ✅ **Kubernetes** — Production-grade orchestration with 16 deployment guides
+- ✅ **GitOps** — ArgoCD continuous delivery
+- ✅ **Observability** — Prometheus + Grafana with pre-built dashboards
+- ✅ **Security** — mTLS, network policies, container security
+- ✅ **SRE Playbooks** — Incident response, scaling, disaster recovery
+
+### 🟡 **IN PROGRESS**
+
+#### Dual-Time Control Plane (ADR-0021)
+- 🔄 **Event Kernel** — Real-time ring buffer, < 50µs latency (Issue #306)
+- 🔄 **Merkle Kernel** — O(log n) proof verification, HSM integration
+- 🔄 **Anchor Kernel** — L2 state sync, finality tracking
+
+#### Real-Time Kernel (Linux 6.6 LTS)
+- 🔄 **PREEMPT_RT Integration** — Deterministic scheduling
+- 🔄 **Custom Modules** — oxscada-event, oxscada-crypto, oxscada-bridge
+- 🔄 **Hardware Acceleration** — SHA-256/Keccak-256 crypto ops
+
+---
+
+## Phase 3: Real-Time Kernel (Q2 2026)
+
+### 🎯 **Primary Goals**
+
+#### Kernel-Space Event Processing
+- **Event Ring Buffer** — Lock-free circular buffer with Netlink interface
+- **Real-Time Scheduling** — SCHED_FIFO threads with priority inheritance
+- **Hardware Integration** — Direct interrupt handling for industrial I/O
+- **Performance Target** — < 50µs event latency (x86_64), < 100µs (ARM64)
+
+#### Cryptographic Kernel Subsystem  
+- **HSM Bridge** — PKCS#11 integration in kernel space
+- **Merkle Operations** — Hardware-accelerated SHA-256/Keccak-256
+- **Proof Cache** — Memory-mapped LRU cache for verification speedup
+- **Batch Processing** — 95-99% gas savings through aggregation
+
+#### L2 State Synchronization
+- **Bidirectional Sync** — Kernel ↔ L2 state import/export
+- **Memory-Mapped Storage** — DMA-optimized state root persistence
+- **Byzantine Tolerance** — Finality tracking with 64-block default depth
+- **Automatic Recovery** — Retry logic with exponential backoff
+
+### 📋 **Deliverables**
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| oxscada-event.ko | `kernel/drivers/oxscada/event/` | Real-time event subsystem |
+| oxscada-crypto.ko | `kernel/drivers/oxscada/crypto/` | Cryptographic operations |
+| oxscada-bridge.ko | `kernel/drivers/oxscada/bridge/` | L2 synchronization |
+| Kernel Config | `kernel/Kconfig.oxscada` | Build-time options |
+| CI/CD Pipeline | `.github/workflows/kernel.yml` | Automated kernel builds |
+
+---
+
+## Phase 4: AI-Native Operations (Q3 2026)
+
+### 🎯 **Primary Goals**
+
+#### Autonomous Agent Framework
+- **Multi-Agent Coordination** — Consensus on equipment state changes
+- **Predictive Maintenance** — ML models for failure prediction
+- **Anomaly Detection** — Real-time pattern recognition on sensor streams
+- **Safety Overrides** — AI-driven emergency response protocols
+
+#### Flux World State Integration
+- **Entity Mapping** — `scada/{equipment-id}` namespace in Flux
+- **Command Protocol** — Bidirectional control via `/control` entities
+- **Cross-Platform State** — Observable by any Flux-connected system
+- **Event Sourcing** — Immutable audit trail of all agent decisions
+
+#### Advanced Analytics
+- **Time-Series Analysis** — Historical trend analysis for optimization
+- **Digital Twins** — Real-time simulation models of physical processes
+- **Energy Optimization** — AI-driven power consumption reduction
+- **Regulatory Compliance** — Automated IEC 62443 / NIST CSF reporting
+
+---
+
+## Phase 5: Decentralized Consensus (Q4 2026)
+
+### 🎯 **Primary Goals**
+
+#### Multi-Site Coordination
+- **Byzantine Consensus** — Cross-site equipment coordination
+- **State Replication** — Distributed state machine across facilities
+- **Network Partitions** — Graceful degradation during connectivity loss
+- **Economic Incentives** — Cryptographic rewards for reliable operation
+
+#### Advanced Cryptography
+- **Zero-Knowledge Proofs** — Privacy-preserving compliance reporting
+- **Multi-Party Computation** — Collaborative analytics without data sharing
+- **Threshold Signatures** — Distributed control authority
+- **Homomorphic Encryption** — Computation on encrypted telemetry
+
+#### Governance Protocol
+- **On-Chain Governance** — Equipment configuration via DAO voting
+- **Stake-Based Security** — Economic bonding for critical infrastructure
+- **Slashing Conditions** — Penalties for malicious or faulty behavior
+- **Decentralized Upgrades** — Consensus-driven protocol evolution
+
+---
+
+## Long-Term Vision (2027+)
+
+### 🌐 **Global Infrastructure Protocol**
+
+- **Universal Compatibility** — Integration with all major industrial vendors
+- **Regulatory Integration** — Native compliance with global industrial standards
+- **Quantum Resistance** — Post-quantum cryptographic primitives
+- **Carbon Accounting** — Blockchain-native emissions tracking
+- **Supply Chain Integration** — End-to-end traceability from raw materials
+
+### 🤖 **Fully Autonomous Operations**
+
+- **Self-Healing Infrastructure** — Automatic failure detection and recovery
+- **Predictive Optimization** — AI-driven efficiency improvements
+- **Zero-Human-Intervention** — Completely autonomous facility operation
+- **Economic Optimization** — Real-time energy and resource markets
+
+---
+
+## Development Process
+
+### Issue Tracking
+- **bd/beads** — Distributed issue tracking system
+- **GitHub Integration** — Sync with conventional issue tracking
+- **Agent Coordination** — AI agents file issues and coordinate work
+
+### Quality Gates
+```bash
+npm run lint          # TypeScript checking
+npm run test          # Unit + integration tests
+npm run test:chaos    # Chaos engineering validation
+bd sync && git push   # Distributed issue sync
+```
+
+### Release Cadence
+- **Nightly** — Automated builds from main branch
+- **Weekly** — Integration-tested releases
+- **Monthly** — Stable releases with full regression testing
+- **Emergency** — Security patches within 48h
+
+---
+
+## Contributing
+
+```diff
++ "Cypherpunks write code."
++ "We solve technical problems with technical solutions."
++ "Privacy is a necessary foundation for an open society."
++
+! Every contribution moves us toward fully decentralized industrial infrastructure.
+```
+
+**Current Priority:** Dual-time control plane implementation (ADR-0021)
+
+See [CLAUDE.md](../CLAUDE.md) for development setup and conventions.
+
+---
+
+<div align="center">
+
+<sub>
+
+**[ ↑ BACK TO TOP ](#0xscada-roadmap) ]**
+
+</sub>
+
+<br/>
+
+```
+> "WHERE ATOMS MEET BITS"
+> 0xSCADA Protocol v2.0.0
+```
+
+</div>

--- a/docs/decisions/ADR-0021-dual-time-control-plane.md
+++ b/docs/decisions/ADR-0021-dual-time-control-plane.md
@@ -1,0 +1,166 @@
+# ADR-0021: Dual-Time Control Plane Architecture
+
+**Status:** Proposed  
+**Date:** 2026-02-27  
+**Deciders:** 0xSCADA Core Team, NickFlach  
+**References:** [ADR-0014 (Production Scale Architecture)](ADR-0014-production-scale-architecture.md), [ADR-0015 (Flux Integration)](ADR-0015-flux-integration.md), [kernel-fork-plan.md](../architecture/kernel-fork-plan.md), [Issue #306](https://github.com/NickFlach/0xSCADA/issues/306)
+
+## Context
+
+Industrial control systems require both **deterministic real-time response** for safety-critical operations and **cryptographic immutability** for audit trails and compliance. These two requirements operate on fundamentally different time horizons:
+
+- **Real-time domain:** Microsecond-level determinism for control loops (PLCs, actuators, safety systems)
+- **Immutable domain:** Batch processing for blockchain anchoring, compliance records, and audit trails
+
+Traditional SCADA systems handle real-time control well but lack cryptographic integrity. Blockchain systems provide immutability but cannot meet real-time control requirements. 0xSCADA bridges this gap through a **dual-time control plane** that separates these concerns while maintaining seamless integration.
+
+The architecture consists of three specialized kernel subsystems, each optimized for its specific temporal and cryptographic requirements.
+
+## Decision
+
+### 1. Three-Kernel Architecture
+
+The 0xSCADA control plane is implemented as three cooperating kernel subsystems:
+
+#### Event Kernel
+- **Purpose:** Real-time event ingestion and deterministic processing
+- **Latency target:** < 50 µs (x86_64), < 100 µs (ARM64)
+- **Implementation:** Kernel-space ring buffer with lock-free publish/subscribe
+- **Location:** `kernel/drivers/oxscada/event/`
+- **Key features:**
+  - PREEMPT_RT scheduling for deterministic timing
+  - Lock-free circular buffer design
+  - Direct hardware interrupt handling
+  - Netlink interface for userspace event injection
+  - `/proc/oxscada/events` monitoring interface
+
+#### Merkle Kernel  
+- **Purpose:** Cryptographic proof generation and verification
+- **Performance target:** O(log n) proof verification
+- **Implementation:** Kernel-space Merkle tree operations with hardware acceleration
+- **Location:** `kernel/drivers/oxscada/crypto/`
+- **Key features:**
+  - SHA-256 / Keccak-256 hardware acceleration hooks
+  - Sparse Merkle tree support
+  - Batch verification for throughput optimization
+  - PKCS#11 HSM bridge integration
+  - Memory-mapped proof cache for performance
+
+#### Anchor Kernel
+- **Purpose:** L2 blockchain state synchronization and anchoring
+- **Consistency model:** Eventually consistent with configurable finality depth
+- **Implementation:** Bidirectional L2 state sync driver
+- **Location:** `kernel/drivers/oxscada/bridge/`
+- **Key features:**
+  - Memory-mapped state root storage
+  - DMA-based batch transfer to userspace
+  - Automatic retry logic with exponential backoff
+  - Finality tracking (default: 64 blocks)
+  - State import verification with proof validation
+
+### 2. Dual-Time Pipeline Flow
+
+The architecture separates time-critical and time-tolerant operations into distinct processing pipelines:
+
+```
+REAL-TIME PIPELINE (Event Kernel)
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│ Sensor/PLC  │───▶│ Event Ring  │───▶│ Control     │
+│ Hardware    │ µs │ Buffer      │ µs │ Logic       │
+│ Interrupts  │    │ (Lock-free) │    │ (RT Sched)  │
+└─────────────┘    └─────────────┘    └─────────────┘
+                           │
+                           ▼ (async)
+BATCH PIPELINE (Merkle + Anchor Kernels)
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│ Event       │───▶│ Merkle Tree │───▶│ L2 Anchor   │
+│ Batching    │ s  │ Generation  │ s  │ Submission  │
+│ (5s/100 ev) │    │ + Proofs    │    │ (Gas Opt)   │
+└─────────────┘    └─────────────┘    └─────────────┘
+```
+
+### 3. Temporal Separation Strategy
+
+| Concern | Time Domain | Kernel | Guarantees |
+|---------|-------------|--------|------------|
+| **Safety Control** | Real-time (µs) | Event | Deterministic latency, preemptible |
+| **Process Monitoring** | Real-time (µs) | Event | Lock-free data structures |
+| **Event Integrity** | Batch (seconds) | Merkle | Cryptographic proofs, O(log n) verification |
+| **Audit Trails** | Batch (seconds) | Merkle + Anchor | Immutable, tamper-evident |
+| **Compliance Records** | Batch (minutes) | Anchor | Blockchain finality, regulatory compliance |
+| **Cross-site Sync** | Eventual (minutes) | Anchor | Byzantine-tolerant consensus |
+
+### 4. Flow Integration Points
+
+#### Event → Merkle Flow
+- Events accumulate in Event Kernel ring buffer
+- Batch threshold triggers (default: 100 events OR 5 seconds)
+- Merkle Kernel consumes batches, computes tree, generates proofs
+- Individual events remain verifiable via inclusion proofs
+
+#### Merkle → Anchor Flow  
+- Merkle roots queued for L2 submission
+- Anchor Kernel handles gas optimization and retry logic
+- L2 transaction confirmation tracked with configurable finality depth
+- State roots imported back for cross-system verification
+
+#### Real-time Bypass
+- Critical control decisions bypass batch pipeline entirely
+- Safety systems operate on Event Kernel data exclusively
+- Immutable records created asynchronously without blocking control
+
+### 5. Configuration Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| **Event Kernel** | | |
+| `EVENT_RING_SIZE` | 65536 | Ring buffer size (power of 2) |
+| `RT_PRIORITY` | 80 | Real-time thread priority (SCHED_FIFO) |
+| `MAX_EVENT_LATENCY_US` | 50 | SLA for event processing (x86_64) |
+| **Merkle Kernel** | | |
+| `BATCH_SIZE_EVENTS` | 100 | Events per Merkle batch |
+| `BATCH_TIMEOUT_MS` | 5000 | Force-flush timeout |
+| `PROOF_CACHE_SIZE` | 1024 | Cached proofs (LRU) |
+| **Anchor Kernel** | | |
+| `FINALITY_DEPTH_BLOCKS` | 64 | Blocks for L2 finality |
+| `ANCHOR_RETRY_COUNT` | 3 | Retry attempts before failure |
+| `STATE_IMPORT_INTERVAL_MS` | 5000 | L2 state polling interval |
+
+## Consequences
+
+### Positive
+- **Real-time guarantees:** Sub-100µs deterministic response for safety-critical control
+- **Immutable integrity:** All events cryptographically anchored without blocking real-time operations
+- **Scalable batching:** 95-99% gas savings through Merkle batch anchoring
+- **Temporal isolation:** Real-time and batch concerns fully separated
+- **Hardware acceleration:** Kernel-space crypto operations with HSM integration
+- **Fault tolerance:** Independent kernel subsystems with graceful degradation
+- **Regulatory compliance:** Immutable audit trails meet IEC 62443 / NIST CSF requirements
+
+### Negative
+- **Complexity increase:** Three kernel subsystems require careful coordination
+- **Development overhead:** Kernel module development is more complex than userspace
+- **Testing challenges:** Real-time validation requires specialized test infrastructure
+- **Platform dependency:** Requires PREEMPT_RT kernel support
+
+### Risks
+- **Kernel stability:** Custom modules could impact system stability (mitigated: extensive testing, gradual rollout)
+- **Performance regression:** Kernel-space processing could introduce overhead (mitigated: benchmarking, profiling)
+- **Maintenance burden:** Kernel modules require ongoing maintenance across kernel versions (mitigated: LTS kernel base)
+
+## Implementation Roadmap
+
+1. **Phase 1:** Event Kernel implementation with ring buffer and Netlink interface
+2. **Phase 2:** Merkle Kernel with O(log n) verification and proof cache
+3. **Phase 3:** Anchor Kernel with L2 state sync and finality tracking
+4. **Phase 4:** Integration testing with full dual-time pipeline validation
+5. **Phase 5:** Production deployment with monitoring and observability
+
+## Related Work
+
+- [Flux Integration (ADR-0015)](ADR-0015-flux-integration.md) — World state engine integration
+- [Production Scale Architecture (ADR-0014)](ADR-0014-production-scale-architecture.md) — Overall system architecture
+- [Kernel Fork Plan](../architecture/kernel-fork-plan.md) — Linux kernel customization strategy
+- [Event Batching](../architecture/event-batching.md) — Merkle batch implementation details
+- [Bidirectional Sync](../architecture/bidirectional-sync.md) — L2 state synchronization
+- [Proof Verification](../architecture/proof-verification.md) — O(log n) verification algorithms


### PR DESCRIPTION
Updates README.md architecture section and adds docs/ROADMAP.md reflecting ADR-0021 Dual-Time Control Plane. Three-kernel model, pipeline diagrams, Flux integration references. Cypherpunk aesthetic maintained.

Closes #306