### PR TITLE
Fix medium QE findings

### DIFF
--- a/server/models/regional-topology.ts
+++ b/server/models/regional-topology.ts
@@ -322,8 +322,11 @@ export function estimateLatencyMs(
       const hops = Math.ceil(distKm / 1000); // Approximate one hop per 1000 km
       return Math.round(propagation * LATENCY_MODEL.routingOverhead + hops * LATENCY_MODEL.perHopLatencyMs);
     }
-    case 'satellite':
-      return Math.round(LATENCY_MODEL.satelliteBaseMs + (Math.random() * LATENCY_MODEL.satelliteJitterMs));
+    case 'satellite': {
+      // Deterministic jitter based on route coordinates to avoid non-determinism in Dijkstra
+      const coordHash = Math.abs(Math.sin(lat1 * 12.9898 + lng1 * 78.233 + lat2 * 37.719 + lng2 * 43.758) * 43758.5453) % 1;
+      return Math.round(LATENCY_MODEL.satelliteBaseMs + (coordHash * LATENCY_MODEL.satelliteJitterMs));
+    }
     case 'microwave': {
       const propagation = distKm / LATENCY_MODEL.microwaveSpeedKmPerMs;
       return Math.round(propagation * 1.1); // Minimal overhead

--- a/server/services/integrity/explainability-monitor.ts
+++ b/server/services/integrity/explainability-monitor.ts
@@ -249,9 +249,11 @@ export class ExplainabilityMonitor extends EventEmitter {
       .update(recordContent + this.lastDecisionHash)
       .digest('hex');
 
+    const seq = this.decisionSequence++;
     const record: DecisionRecord = {
       id,
       timestamp: new Date(),
+      sequence: seq,
       source: params.source,
       action: params.action,
       ruleApplied: params.ruleApplied ?? 'unspecified',
@@ -409,9 +411,11 @@ export class ExplainabilityMonitor extends EventEmitter {
       .update(entryContent + this.lastAuditHash)
       .digest('hex');
 
+    const seq = this.auditSequence++;
     const entry: AuditEntry = {
       id,
       timestamp: new Date(),
+      sequence: seq,
       userId: params.userId,
       action: params.action,
       resource: params.resource,
@@ -484,7 +488,7 @@ export class ExplainabilityMonitor extends EventEmitter {
   /** Verify the integrity of the decision record chain */
   verifyDecisionChain(): { valid: boolean; brokenAt?: string; details: string } {
     const sorted = Array.from(this.decisions.values())
-      .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+      .sort((a, b) => a.sequence - b.sequence);
 
     let previousHash = '0'.repeat(64);
     for (const record of sorted) {

--- a/server/services/spc/capability.ts
+++ b/server/services/spc/capability.ts
@@ -40,6 +40,7 @@ function mean(arr: number[]): number {
 }
 
 function overallStdDev(arr: number[]): number {
+  if (arr.length <= 1) return 0;
   const m = mean(arr);
   return Math.sqrt(arr.reduce((s, v) => s + (v - m) ** 2, 0) / (arr.length - 1));
 }
@@ -71,7 +72,7 @@ export function computeCapability(
   subgroupSize: number,
   specs: SpecificationLimits,
 ): CapabilityIndices {
-  if (values.length === 0) {
+  if (values.length <= 1) {
     return { cp: 0, cpk: 0, pp: 0, ppk: 0, mean: 0, sigmaWithin: 0, sigmaOverall: 0, estimatedDefectRate: 1 };
   }
 

--- a/server/services/spc/control-charts.ts
+++ b/server/services/spc/control-charts.ts
@@ -43,6 +43,7 @@ function mean(arr: number[]): number {
 }
 
 function stdDev(arr: number[]): number {
+  if (arr.length <= 1) return 0;
   const m = mean(arr);
   return Math.sqrt(arr.reduce((s, v) => s + (v - m) ** 2, 0) / (arr.length - 1));
 }


### PR DESCRIPTION
Fix medium QE findings.

- **#372** — ExplainabilityMonitor chain verification: Added sequence numbers to DecisionRecord and AuditEntry for deterministic ordering. verifyDecisionChain now sorts by sequence instead of timestamp.
- **#373** — Non-deterministic satellite latency: Replaced Math.random() with deterministic coordinate-based hash so Dijkstra produces consistent results.
- **#374** — SPC stdDev divide-by-zero: Added guard for single-element arrays (return 0). Also guards computeCapability for ≤1 values.

Note: Issues #363, #365, #368, #369 were already fixed by the critical/high QE PR.

Closes #372, closes #373, closes #374