### PR TITLE
Refactor + low-severity QE fixes

### DIFF
--- a/client/src/components/phi/PhiGauge.tsx
+++ b/client/src/components/phi/PhiGauge.tsx
@@ -118,6 +118,38 @@ function FanoMini({ populatedPoints }: { populatedPoints: Set<number> }) {
   );
 }
 
+/**
+ * Derive populated Fano plane points from partition data.
+ * The 7 points of PG(2,2) map to: 3 quadrant axes (1-3), 3 triality axes (4-6),
+ * and the central classIndex point (7). Points are populated when the corresponding
+ * partition class count meets threshold (>0 for axes, >0 for center).
+ */
+function deriveFanoPoints(data: PhiData): Set<number> {
+  const points = new Set<number>();
+  const q = data.partitions?.quadrant;
+  const t = data.partitions?.triality;
+  const c = data.partitions?.classIndex;
+
+  // Quadrant partition populates points 1, 2, 3 (one per class present, up to 4 classes → 3 outer points)
+  if (q) {
+    if (q.classes >= 1) points.add(1);
+    if (q.classes >= 2) points.add(2);
+    if (q.classes >= 3) points.add(4); // Point 4 (0-indexed 3) — Fano collinear with 1,2
+  }
+  // Triality partition populates points 3, 5, 6
+  if (t) {
+    if (t.classes >= 1) points.add(3);
+    if (t.classes >= 2) points.add(5);
+    if (t.classes >= 3) points.add(6);
+  }
+  // ClassIndex populates center point 7
+  if (c && c.classes > 0) {
+    points.add(7);
+  }
+
+  return points;
+}
+
 export function PhiGauge({ refreshMs = 10000 }: { refreshMs?: number }) {
   const [data, setData] = useState<PhiData | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -155,7 +187,7 @@ export function PhiGauge({ refreshMs = 10000 }: { refreshMs?: number }) {
     <div style={{ padding: 12, background: "#0f172a", borderRadius: 8, border: "1px solid #1e293b", minWidth: 200 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
         <GaugeArc value={data.phi} />
-        <FanoMini populatedPoints={new Set([1, 2, 3, 4, 5, 6, 7].filter((_, i) => i < (data.partitions?.classIndex?.classes || 0)))} />
+        <FanoMini populatedPoints={deriveFanoPoints(data)} />
       </div>
       <div style={{ fontSize: 11, color: "#94a3b8", marginTop: 8 }}>
         <div>Level: <strong style={{ color: phiColor(data.phi) }}>{data.level}</strong></div>

--- a/server/routes/alarms.ts
+++ b/server/routes/alarms.ts
@@ -5,7 +5,7 @@ import { getFluxPublisher } from "../services/flux";
 const router = Router();
 
 // Auth middleware placeholder — same pattern as other protected routes
-function requireAuth(req: any, res: any, next: any) {
+function requireAuth(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) {
   // TODO: implement real auth check (JWT / session validation)
   // For now, allow all requests through (placeholder)
   next();

--- a/server/routes/geometry.ts
+++ b/server/routes/geometry.ts
@@ -29,7 +29,9 @@ function requireAuth(req: Request, res: Response, next: NextFunction): void {
     return;
   }
   // Session-based auth
-  if ((req as any).session?.userId || (req as any).user) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- session types vary by auth middleware
+  const r = req as Request & { session?: { userId?: string }; user?: unknown };
+  if (r.session?.userId || r.user) {
     next();
     return;
   }

--- a/server/services/governance/gate-manager.ts
+++ b/server/services/governance/gate-manager.ts
@@ -19,7 +19,13 @@ import type {
   AuditEntry,
 } from './types';
 import { VerificationPipeline } from '../verification/pipeline';
-import type { VerificationInput, PipelineResult } from '../verification/types';
+import type { VerificationInput, PipelineResult, VerificationPipelineConfig, VerificationSeverity } from '../verification/types';
+
+/** Rank severity for comparison (higher = worse) */
+function severityRank(s: VerificationSeverity): number {
+  const ranks: Record<VerificationSeverity, number> = { info: 0, warning: 1, error: 2, critical: 3 };
+  return ranks[s] ?? 0;
+}
 
 const logger = pino({ name: 'gate-manager' });
 
@@ -29,6 +35,18 @@ const MAX_GATE_INSTANCES = 10000;
 export class GateManager extends EventEmitter implements IGateManager {
   private definitions: Map<string, GateDefinition> = new Map();
   private instances: Map<string, GateInstance> = new Map();
+  /** Cached pipeline instances keyed by serialized config */
+  private pipelineCache: Map<string, VerificationPipeline> = new Map();
+
+  private getOrCreatePipeline(config?: Partial<VerificationPipelineConfig>): VerificationPipeline {
+    const key = config ? JSON.stringify(config) : '__default__';
+    let pipeline = this.pipelineCache.get(key);
+    if (!pipeline) {
+      pipeline = new VerificationPipeline(config);
+      this.pipelineCache.set(key, pipeline);
+    }
+    return pipeline;
+  }
 
   // ─── Gate Definitions ───────────────────────────────────────────────────
 
@@ -70,24 +88,64 @@ export class GateManager extends EventEmitter implements IGateManager {
     // Record initial audit entry
     instance.auditTrail.push(this.createAuditEntry(instanceId, 'submit', 'initial', 'pending', actor));
 
-    // Run automated verification conditions
+    // Run automated verification conditions — ALL of them, not just the first
     if (definition.type === 'automated' || definition.type === 'hybrid') {
       const verificationConditions = definition.conditions.filter(c => c.type === 'verification');
       if (verificationConditions.length > 0) {
-        const pipeline = new VerificationPipeline(verificationConditions[0].verificationConfig);
         const verInput: VerificationInput = {
           id: subject.id,
           data: subject.data,
         };
-        instance.verificationResult = await pipeline.execute(verInput);
+
+        // Execute all verification conditions and aggregate results
+        const results: PipelineResult[] = [];
+        for (const condition of verificationConditions) {
+          const pipeline = this.getOrCreatePipeline(condition.verificationConfig);
+          results.push(await pipeline.execute(verInput));
+        }
+
+        // Use first result as the primary (backward compatible), but aggregate status
+        instance.verificationResult = results[0];
+        if (results.length > 1) {
+          // Store all results in metadata for full visibility
+          instance.metadata = {
+            ...instance.metadata,
+            properties: {
+              ...instance.metadata?.properties,
+              verificationResults: results as unknown as Record<string, unknown>,
+            },
+          };
+          // Aggregate: if ANY result fails, the overall result is a failure
+          const anyFailed = results.some(r => r.status !== 'pass');
+          if (anyFailed && instance.verificationResult.status === 'pass') {
+            // Override the primary result status to reflect aggregate failure
+            instance.verificationResult = {
+              ...instance.verificationResult,
+              status: 'fail',
+              summary: {
+                ...instance.verificationResult.summary,
+                failed: results.reduce((sum, r) => sum + r.summary.failed, 0),
+                passed: results.reduce((sum, r) => sum + r.summary.passed, 0),
+                errors: results.reduce((sum, r) => sum + r.summary.errors, 0),
+                skipped: results.reduce((sum, r) => sum + r.summary.skipped, 0),
+                highestSeverity: results.reduce((worst, r) =>
+                  r.summary.highestSeverity && (!worst || severityRank(r.summary.highestSeverity) > severityRank(worst))
+                    ? r.summary.highestSeverity
+                    : worst,
+                  instance.verificationResult.summary.highestSeverity),
+              },
+            };
+          }
+        }
 
         if (definition.type === 'automated') {
-          // Auto-resolve based on verification result
+          // Auto-resolve based on aggregated verification result
           if (instance.verificationResult.status === 'pass') {
             instance.state = 'approved';
             instance.resolvedAt = new Date().toISOString();
             instance.auditTrail.push(
-              this.createAuditEntry(instanceId, 'approve', 'pending', 'approved', 'system', 'Automated verification passed')
+              this.createAuditEntry(instanceId, 'approve', 'pending', 'approved', 'system',
+                `Automated verification passed (${results.length} condition(s))`)
             );
           } else {
             instance.state = 'rejected';

--- a/server/services/integrity/explainability-monitor.ts
+++ b/server/services/integrity/explainability-monitor.ts
@@ -40,7 +40,7 @@ export interface DecisionRecord {
   /** Input data that led to the decision */
   inputs: Record<string, any>;
   /** Output/result of the decision */
-  output: any;
+  output: unknown;
   /** Confidence score 0-1 */
   confidence: number;
   /** Which verification layers passed */
@@ -80,8 +80,8 @@ export interface AuditEntry {
   action: 'create' | 'modify' | 'delete' | 'approve' | 'reject' | 'acknowledge' | 'login' | 'logout';
   resource: string;
   resourceId: string;
-  oldValue?: any;
-  newValue?: any;
+  oldValue?: unknown;
+  newValue?: unknown;
   reason?: string;
   ipAddress?: string;
   /** Monotonic sequence number for deterministic ordering */
@@ -218,7 +218,7 @@ export class ExplainabilityMonitor extends EventEmitter {
     ruleApplied?: string;
     reasoning: string;
     inputs: Record<string, any>;
-    output: any;
+    output: unknown;
     confidence: number;
     verificationLayers: VerificationLayerResult[];
     signature?: ElectronicSignature;
@@ -389,8 +389,8 @@ export class ExplainabilityMonitor extends EventEmitter {
     action: AuditEntry['action'];
     resource: string;
     resourceId: string;
-    oldValue?: any;
-    newValue?: any;
+    oldValue?: unknown;
+    newValue?: unknown;
     reason?: string;
     ipAddress?: string;
   }): AuditEntry {

--- a/server/services/integrity/paradox-resolver.ts
+++ b/server/services/integrity/paradox-resolver.ts
@@ -31,7 +31,7 @@ export interface ScadaEvent {
   id: string;
   deviceId: string;
   tag: string;
-  value: any;
+  value: unknown;
   timestamp: Date;
   quality: 'good' | 'bad' | 'uncertain';
   source: 'sensor' | 'command' | 'alarm' | 'system';
@@ -78,7 +78,7 @@ export interface Resolution {
   conflictId: string;
   method: ResolutionMethod;
   winner?: ScadaEvent;
-  mergedValue?: any;
+  mergedValue?: unknown;
   rollbackTarget?: string;
   confidence: number;
   reasoning: string;
@@ -89,7 +89,7 @@ export interface ResolvedEvent {
   id: string;
   originalConflictId: string;
   tag: string;
-  resolvedValue: any;
+  resolvedValue: unknown;
   confidence: number;
   method: ResolutionMethod;
   reasoning: string;
@@ -565,7 +565,7 @@ export class ParadoxResolver extends EventEmitter {
     const confidence = bestCount / totalVotes;
 
     // For numeric values, use weighted average of the winning group
-    let finalValue: any;
+    let finalValue: unknown;
     if (winnerBucket.events.every(e => typeof e.value === 'number')) {
       const weights = winnerBucket.events.map(e => e.sensorConfidence ?? this.qualityScore(e));
       const totalWeight = weights.reduce((a, b) => a + b, 0);

--- a/server/services/vendors/emerson-adapter.ts
+++ b/server/services/vendors/emerson-adapter.ts
@@ -12,7 +12,6 @@
  */
 
 import {
-  BaseAdapter,
   ProtocolAdapter,
   AdapterManifest,
   AdapterCapability,
@@ -21,6 +20,14 @@ import {
   ProtocolEndpoint,
   ProtocolConnection,
 } from '@shared/types/services/adapters';
+import { VendorBaseAdapter } from './vendor-base';
+import {
+  MODBUS_FC,
+  MODBUS_EXCEPTION,
+  buildModbusReadRequest,
+  buildModbusWriteSingleRegister as sharedBuildWriteSingle,
+  buildModbusWriteMultipleRegisters as sharedBuildWriteMultiple,
+} from './modbus-utils';
 
 // ─── HART Protocol Constants ──────────────────────────────────────────
 
@@ -118,34 +125,9 @@ export const HART_UNITS = {
   CUBIC_METERS_PER_HOUR: 131,
 } as const;
 
-// ─── Modbus Constants (Emerson-specific) ──────────────────────────────
-
-/** Modbus function codes */
-export const MODBUS_FC = {
-  READ_COILS: 0x01,
-  READ_DISCRETE_INPUTS: 0x02,
-  READ_HOLDING_REGISTERS: 0x03,
-  READ_INPUT_REGISTERS: 0x04,
-  WRITE_SINGLE_COIL: 0x05,
-  WRITE_SINGLE_REGISTER: 0x06,
-  WRITE_MULTIPLE_COILS: 0x0F,
-  WRITE_MULTIPLE_REGISTERS: 0x10,
-  READ_EXCEPTION_STATUS: 0x07,
-  DIAGNOSTICS: 0x08,
-} as const;
-
-/** Modbus exception codes */
-export const MODBUS_EXCEPTION = {
-  ILLEGAL_FUNCTION: 0x01,
-  ILLEGAL_DATA_ADDRESS: 0x02,
-  ILLEGAL_DATA_VALUE: 0x03,
-  SLAVE_DEVICE_FAILURE: 0x04,
-  ACKNOWLEDGE: 0x05,
-  SLAVE_DEVICE_BUSY: 0x06,
-  MEMORY_PARITY_ERROR: 0x08,
-  GATEWAY_PATH_UNAVAILABLE: 0x0A,
-  GATEWAY_TARGET_FAILED: 0x0B,
-} as const;
+// Modbus constants imported from shared modbus-utils.ts
+// Re-export for backward compatibility
+export { MODBUS_FC, MODBUS_EXCEPTION } from './modbus-utils';
 
 export const EMERSON_REGISTER_MAP = {
   HART: {
@@ -402,59 +384,12 @@ function parseHartCmd3Response(data: Buffer): {
   };
 }
 
-// ─── Modbus TCP Frame Encoding ───────────────────────────────────────
+// ─── Modbus TCP Frame Encoding (delegated to shared modbus-utils) ────
 
-let modbusTransactionId = 0;
-
-/** Build Modbus TCP request (MBAP header + PDU) */
-function buildModbusTcpRequest(unitId: number, functionCode: number, startAddr: number, quantity: number): Buffer {
-  const transId = modbusTransactionId & 0xFFFF;
-  modbusTransactionId = (modbusTransactionId + 1) & 0xFFFF;
-  const buf = Buffer.alloc(12);
-  buf.writeUInt16BE(transId, 0);    // Transaction ID
-  buf.writeUInt16BE(0, 2);          // Protocol ID (Modbus)
-  buf.writeUInt16BE(6, 4);          // Length (remaining bytes)
-  buf.writeUInt8(unitId, 6);        // Unit ID
-  buf.writeUInt8(functionCode, 7);  // Function code
-  buf.writeUInt16BE(startAddr, 8);  // Starting address
-  buf.writeUInt16BE(quantity, 10);  // Quantity
-  return buf;
-}
-
-/** Build Modbus TCP write single register */
-function buildModbusWriteSingleRegister(unitId: number, address: number, value: number): Buffer {
-  const transId = modbusTransactionId & 0xFFFF;
-  modbusTransactionId = (modbusTransactionId + 1) & 0xFFFF;
-  const buf = Buffer.alloc(12);
-  buf.writeUInt16BE(transId, 0);
-  buf.writeUInt16BE(0, 2);
-  buf.writeUInt16BE(6, 4);
-  buf.writeUInt8(unitId, 6);
-  buf.writeUInt8(MODBUS_FC.WRITE_SINGLE_REGISTER, 7);
-  buf.writeUInt16BE(address, 8);
-  buf.writeUInt16BE(value, 10);
-  return buf;
-}
-
-/** Build Modbus TCP write multiple registers */
-function buildModbusWriteMultipleRegisters(unitId: number, startAddr: number, values: number[]): Buffer {
-  const transId = modbusTransactionId & 0xFFFF;
-  modbusTransactionId = (modbusTransactionId + 1) & 0xFFFF;
-  const byteCount = values.length * 2;
-  const buf = Buffer.alloc(13 + byteCount);
-  buf.writeUInt16BE(transId, 0);
-  buf.writeUInt16BE(0, 2);
-  buf.writeUInt16BE(7 + byteCount, 4);
-  buf.writeUInt8(unitId, 6);
-  buf.writeUInt8(MODBUS_FC.WRITE_MULTIPLE_REGISTERS, 7);
-  buf.writeUInt16BE(startAddr, 8);
-  buf.writeUInt16BE(values.length, 10);
-  buf.writeUInt8(byteCount, 12);
-  for (let i = 0; i < values.length; i++) {
-    buf.writeUInt16BE(values[i], 13 + i * 2);
-  }
-  return buf;
-}
+/** Alias for backward compatibility */
+const buildModbusTcpRequest = buildModbusReadRequest;
+const buildModbusWriteSingleRegister = sharedBuildWriteSingle;
+const buildModbusWriteMultipleRegisters = sharedBuildWriteMultiple;
 
 /** Parse Modbus TCP response */
 function parseModbusTcpResponse(buf: Buffer): { unitId: number; fc: number; data: Buffer; isException: boolean; exceptionCode?: number } {
@@ -485,7 +420,20 @@ function modbusExceptionToString(code: number): string {
 type EmersonProtocol = 'hart' | 'modbus' | 'deltav';
 
 /** Determine which protocol to use based on address format */
-function routeAddress(address: string): { protocol: EmersonProtocol; parsed: any } {
+/** Parsed address fields from routeAddress */
+interface EmersonParsedAddress {
+  pollingAddress?: number;
+  command?: number;
+  mfr?: number;
+  type?: number;
+  id?: number;
+  area?: string;
+  module?: string;
+  parameter?: string;
+  register?: number;
+}
+
+function routeAddress(address: string): { protocol: EmersonProtocol; parsed: EmersonParsedAddress } {
   // HART: "HART:<pollingAddr>:<command>" or "HART:<mfr>:<type>:<id>:<command>"
   if (address.toUpperCase().startsWith('HART:')) {
     const parts = address.split(':');
@@ -507,7 +455,7 @@ function routeAddress(address: string): { protocol: EmersonProtocol; parsed: any
 
 // ─── Adapter Implementation ──────────────────────────────────────────
 
-export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements ProtocolAdapter {
+export class EmersonVendorAdapter extends VendorBaseAdapter<'protocol'> implements ProtocolAdapter {
   readonly manifest: AdapterManifest & { type: 'protocol' } = {
     id: 'emerson-vendor',
     name: 'Emerson Vendor Adapter',
@@ -521,12 +469,7 @@ export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements Pro
   readonly protocols = ['hart', 'foundation-fieldbus', 'modbus', 'modbus-tcp'];
 
   private connections: Map<string, ProtocolConnection> = new Map();
-  private tagCache: Map<string, { value: any; timestamp: Date; quality: string }> = new Map();
-  private pollingTimers: Map<string, NodeJS.Timeout> = new Map();
   private hartDevices: Map<number, { manufacturerId: number; deviceType: number; deviceId: number; tag: string }> = new Map();
-  private messagesProcessed = 0;
-  private errorsCount = 0;
-  private startTime = 0;
 
   protected async doInitialize(context: AdapterContext): Promise<void> {
     context.logger.info('Initializing Emerson vendor adapter — HART + Modbus + DeltaV');
@@ -619,7 +562,7 @@ export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements Pro
     return tags;
   }
 
-  private async readHartTag(address: string, parsed: any): Promise<AdapterTag> {
+  private async readHartTag(address: string, parsed: EmersonParsedAddress): Promise<AdapterTag> {
     const pollingAddr = parsed.pollingAddress ?? 0;
     const command = parsed.command ?? HART_UNIVERSAL_CMD.READ_PRIMARY_VARIABLE;
 
@@ -633,13 +576,13 @@ export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements Pro
       name: `HART_${pollingAddr}_CMD${command}`,
       dataType: 'number',
       value: cached?.value ?? null,
-      quality: (cached?.quality as any) ?? 'uncertain',
+      quality: (cached?.quality as AdapterTag['quality']) ?? 'uncertain',
       timestamp: cached?.timestamp ?? new Date(),
     };
   }
 
-  private async readModbusTag(address: string, parsed: any): Promise<AdapterTag> {
-    const register = parsed.register;
+  private async readModbusTag(address: string, parsed: EmersonParsedAddress): Promise<AdapterTag> {
+    const register = parsed.register ?? 0;
     const fc = register >= 30000 ? MODBUS_FC.READ_INPUT_REGISTERS : MODBUS_FC.READ_HOLDING_REGISTERS;
     const actualRegister = register >= 40000 ? register - 40001 : register >= 30000 ? register - 30001 : register;
 
@@ -651,12 +594,12 @@ export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements Pro
       address,
       dataType: 'number',
       value: cached?.value ?? null,
-      quality: (cached?.quality as any) ?? 'uncertain',
+      quality: (cached?.quality as AdapterTag['quality']) ?? 'uncertain',
       timestamp: cached?.timestamp ?? new Date(),
     };
   }
 
-  private async readDeltaVTag(address: string, parsed: any): Promise<AdapterTag> {
+  private async readDeltaVTag(address: string, parsed: EmersonParsedAddress): Promise<AdapterTag> {
     // DeltaV uses area/module/parameter addressing
     this.messagesProcessed++;
 
@@ -666,7 +609,7 @@ export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements Pro
       name: `${parsed.area}.${parsed.module}.${parsed.parameter}`,
       dataType: 'number',
       value: cached?.value ?? null,
-      quality: (cached?.quality as any) ?? 'uncertain',
+      quality: (cached?.quality as AdapterTag['quality']) ?? 'uncertain',
       timestamp: cached?.timestamp ?? new Date(),
     };
   }
@@ -685,8 +628,9 @@ export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements Pro
           break;
         }
         case 'modbus': {
-          const register = parsed.register >= 40000 ? parsed.register - 40001 : parsed.register;
-          const request = buildModbusWriteSingleRegister(EMERSON_CONNECTION_PARAMS.modbus.unitId, register, Number(tag.value));
+          const reg = parsed.register ?? 0;
+          const writeAddr = reg >= 40000 ? reg - 40001 : reg;
+          const request = buildModbusWriteSingleRegister(EMERSON_CONNECTION_PARAMS.modbus.unitId, writeAddr, Number(tag.value));
           this.messagesProcessed++;
           break;
         }
@@ -702,9 +646,9 @@ export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements Pro
 
   // ─── Discovery ─────────────────────────────────────────────────────
 
-  async discoverDevices(): Promise<any[]> {
+  async discoverDevices(): Promise<Record<string, unknown>[]> {
     this.context?.logger.info('Discovering Emerson devices via HART polling and Modbus scan');
-    const devices: any[] = [];
+    const devices: Record<string, unknown>[] = [];
 
     // HART: Poll addresses 0-15 with Command 0
     for (let addr = 0; addr <= 15; addr++) {
@@ -724,7 +668,7 @@ export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements Pro
 
   // ─── Diagnostics ───────────────────────────────────────────────────
 
-  async getDeviceInfo(deviceId: string): Promise<any> {
+  async getDeviceInfo(deviceId: string): Promise<Record<string, unknown>> {
     // HART Command 0 + Command 13 (Read Tag) + Command 15 (Device Info)
     const frame0 = encodeHartShortFrame(parseInt(deviceId) || 0, HART_UNIVERSAL_CMD.READ_UNIQUE_ID);
     const frame13 = encodeHartShortFrame(parseInt(deviceId) || 0, HART_UNIVERSAL_CMD.READ_TAG);
@@ -733,7 +677,7 @@ export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements Pro
     return { deviceId, vendor: 'Emerson', models: EMERSON_MODELS };
   }
 
-  async getDeviceDiagnostics(deviceId: string): Promise<any> {
+  async getDeviceDiagnostics(deviceId: string): Promise<Record<string, unknown>> {
     // HART Command 48 — Read Additional Device Status
     const frame48 = encodeHartShortFrame(parseInt(deviceId) || 0, HART_COMMON_CMD.READ_ADDITIONAL_DEVICE_STATUS);
     this.messagesProcessed++;
@@ -746,17 +690,17 @@ export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements Pro
   }
 
   /** Send HART pass-through command */
-  async sendHartCommand(pollingAddress: number, command: number, data?: Buffer): Promise<any> {
+  async sendHartCommand(pollingAddress: number, command: number, data?: Buffer): Promise<Record<string, unknown>> {
     const frame = encodeHartShortFrame(pollingAddress, command, data);
     this.messagesProcessed++;
     return {};
   }
 
   /** Read all 4 dynamic variables via HART Command 3 */
-  async readDynamicVariables(pollingAddress: number): Promise<any> {
+  async readDynamicVariables(pollingAddress: number): Promise<Record<string, unknown>> {
     const frame = encodeHartShortFrame(pollingAddress, HART_UNIVERSAL_CMD.READ_DYNAMIC_VARIABLES_AND_CURRENT);
     this.messagesProcessed++;
-    return null;
+    return {};
   }
 
   /** Perform loop current trim (Command 45/46) */
@@ -770,43 +714,20 @@ export class EmersonVendorAdapter extends BaseAdapter<'protocol'> implements Pro
 
   // ─── Polling ───────────────────────────────────────────────────────
 
-  startPolling(addresses: string[], tier: keyof typeof EMERSON_POLLING, callback: (tags: AdapterTag[]) => void): string {
-    const interval = EMERSON_POLLING[tier];
-    const key = `poll_${tier}_${Date.now()}`;
-    const timer = setInterval(async () => {
-      try {
-        const tags = await this.readTags(addresses);
-        callback(tags);
-      } catch (err) {
-        this.context?.logger.error(`Emerson polling error (${tier}):`, err);
-        this.errorsCount++;
-      }
-    }, interval);
-    this.pollingTimers.set(key, timer);
-    return key;
+  startPollingByTier(addresses: string[], tier: keyof typeof EMERSON_POLLING, callback: (tags: AdapterTag[]) => void): string {
+    return this.startPolling(addresses, EMERSON_POLLING[tier], callback, tier);
   }
 
-  stopPolling(key: string): void {
-    const timer = this.pollingTimers.get(key);
-    if (timer) {
-      clearInterval(timer);
-      this.pollingTimers.delete(key);
-    }
-  }
-
-  protected async getMetrics() {
+  protected async getMetrics(): Promise<Record<string, unknown>> {
+    const base = await super.getMetrics();
     return {
+      ...base,
       connectionsActive: this.connections.size,
-      messagesProcessed: this.messagesProcessed,
-      errorsCount: this.errorsCount,
-      uptime: Date.now() - this.startTime,
-      cachedTags: this.tagCache.size,
       hartDevicesKnown: this.hartDevices.size,
-      activePollers: this.pollingTimers.size,
     };
   }
 
-  protected async getDiagnostics() {
+  protected async getDiagnostics(): Promise<Record<string, unknown>> {
     return {
       registerMap: EMERSON_REGISTER_MAP,
       connectionParams: EMERSON_CONNECTION_PARAMS,

--- a/server/services/vendors/modbus-utils.ts
+++ b/server/services/vendors/modbus-utils.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared Modbus TCP Utilities
+ * Issue #370: Extract duplicated Modbus framing from vendor adapters
+ */
+
+/** Standard Modbus function codes */
+export const MODBUS_FC = {
+  READ_COILS: 0x01,
+  READ_DISCRETE_INPUTS: 0x02,
+  READ_HOLDING_REGISTERS: 0x03,
+  READ_INPUT_REGISTERS: 0x04,
+  WRITE_SINGLE_COIL: 0x05,
+  WRITE_SINGLE_REGISTER: 0x06,
+  WRITE_MULTIPLE_COILS: 0x0F,
+  WRITE_MULTIPLE_REGISTERS: 0x10,
+  READ_EXCEPTION_STATUS: 0x07,
+  DIAGNOSTICS: 0x08,
+  READ_DEVICE_IDENTIFICATION: 0x2B,
+} as const;
+
+/** Modbus exception codes */
+export const MODBUS_EXCEPTION = {
+  ILLEGAL_FUNCTION: 0x01,
+  ILLEGAL_DATA_ADDRESS: 0x02,
+  ILLEGAL_DATA_VALUE: 0x03,
+  SLAVE_DEVICE_FAILURE: 0x04,
+  ACKNOWLEDGE: 0x05,
+  SLAVE_DEVICE_BUSY: 0x06,
+  MEMORY_PARITY_ERROR: 0x08,
+  GATEWAY_PATH_UNAVAILABLE: 0x0A,
+  GATEWAY_TARGET_FAILED: 0x0B,
+} as const;
+
+let modbusTransactionId = 0;
+
+function nextTransactionId(): number {
+  const id = modbusTransactionId & 0xFFFF;
+  modbusTransactionId = (modbusTransactionId + 1) & 0xFFFF;
+  return id;
+}
+
+/**
+ * Encode a Modbus TCP (MBAP) request frame.
+ * Generic form: MBAP header + function code + payload.
+ */
+export function encodeModbusTcpRequest(unitId: number, functionCode: number, payload: Buffer): Buffer {
+  const transId = nextTransactionId();
+  const mbapHeader = Buffer.alloc(7);
+  mbapHeader.writeUInt16BE(transId, 0);            // Transaction ID
+  mbapHeader.writeUInt16BE(0x0000, 2);              // Protocol ID (Modbus = 0)
+  mbapHeader.writeUInt16BE(1 + 1 + payload.length, 4); // Length (Unit ID + FC + payload)
+  mbapHeader.writeUInt8(unitId, 6);                 // Unit Identifier
+
+  const pdu = Buffer.alloc(1 + payload.length);
+  pdu.writeUInt8(functionCode, 0);
+  payload.copy(pdu, 1);
+
+  return Buffer.concat([mbapHeader, pdu]);
+}
+
+/** Build Modbus TCP read request (FC01/02/03/04) */
+export function buildModbusReadRequest(unitId: number, fc: number, startAddress: number, quantity: number): Buffer {
+  const payload = Buffer.alloc(4);
+  payload.writeUInt16BE(startAddress, 0);
+  payload.writeUInt16BE(quantity, 2);
+  return encodeModbusTcpRequest(unitId, fc, payload);
+}
+
+/** Build Modbus TCP write single register (FC06) */
+export function buildModbusWriteSingleRegister(unitId: number, address: number, value: number): Buffer {
+  const payload = Buffer.alloc(4);
+  payload.writeUInt16BE(address, 0);
+  payload.writeUInt16BE(value & 0xFFFF, 2);
+  return encodeModbusTcpRequest(unitId, MODBUS_FC.WRITE_SINGLE_REGISTER, payload);
+}
+
+/** Build Modbus TCP write single coil (FC05) */
+export function buildModbusWriteSingleCoil(unitId: number, address: number, value: boolean): Buffer {
+  const payload = Buffer.alloc(4);
+  payload.writeUInt16BE(address, 0);
+  payload.writeUInt16BE(value ? 0xFF00 : 0x0000, 2);
+  return encodeModbusTcpRequest(unitId, MODBUS_FC.WRITE_SINGLE_COIL, payload);
+}
+
+/** Build Modbus TCP write multiple registers (FC16) */
+export function buildModbusWriteMultipleRegisters(unitId: number, startAddress: number, values: number[]): Buffer {
+  const byteCount = values.length * 2;
+  const payload = Buffer.alloc(5 + byteCount);
+  payload.writeUInt16BE(startAddress, 0);
+  payload.writeUInt16BE(values.length, 2);
+  payload.writeUInt8(byteCount, 4);
+  for (let i = 0; i < values.length; i++) {
+    payload.writeUInt16BE(values[i] & 0xFFFF, 5 + i * 2);
+  }
+  return encodeModbusTcpRequest(unitId, MODBUS_FC.WRITE_MULTIPLE_REGISTERS, payload);
+}
+
+/** Build Modbus TCP write multiple coils (FC15) */
+export function buildModbusWriteMultipleCoils(unitId: number, startAddress: number, values: boolean[]): Buffer {
+  const byteCount = Math.ceil(values.length / 8);
+  const payload = Buffer.alloc(5 + byteCount);
+  payload.writeUInt16BE(startAddress, 0);
+  payload.writeUInt16BE(values.length, 2);
+  payload.writeUInt8(byteCount, 4);
+  for (let i = 0; i < values.length; i++) {
+    if (values[i]) {
+      payload[5 + Math.floor(i / 8)] |= (1 << (i % 8));
+    }
+  }
+  return encodeModbusTcpRequest(unitId, MODBUS_FC.WRITE_MULTIPLE_COILS, payload);
+}

--- a/server/services/vendors/rockwell-adapter.ts
+++ b/server/services/vendors/rockwell-adapter.ts
@@ -9,7 +9,6 @@
  */
 
 import {
-  BaseAdapter,
   ProtocolAdapter,
   AdapterManifest,
   AdapterCapability,
@@ -18,6 +17,7 @@ import {
   ProtocolEndpoint,
   ProtocolConnection
 } from '@shared/types/services/adapters';
+import { VendorBaseAdapter } from './vendor-base';
 
 // ─── CIP Protocol Constants ───────────────────────────────────────────
 
@@ -183,7 +183,7 @@ interface CipConnection {
   originatorSerialNumber: number;
   rpi: number;
   endpoint: ProtocolEndpoint;
-  socket: any; // TCP socket
+  socket: import('net').Socket | null;
   keepAliveTimer?: NodeJS.Timeout;
   lastActivity: Date;
   sequenceCount: number;
@@ -402,7 +402,7 @@ function parseCipReadResponse(data: Buffer): { status: number; typeCode: number;
 }
 
 /** Marshal a JS value into a CIP typed buffer */
-function marshalCipValue(value: any, cipType: number): Buffer {
+function marshalCipValue(value: unknown, cipType: number): Buffer {
   switch (cipType) {
     case ROCKWELL_REGISTER_MAP.DATA_TYPES.BOOL: {
       const b = Buffer.alloc(1);
@@ -452,7 +452,7 @@ function marshalCipValue(value: any, cipType: number): Buffer {
 }
 
 /** Unmarshal raw bytes into a JS value based on CIP type code */
-function unmarshalCipValue(typeCode: number, data: Buffer): any {
+function unmarshalCipValue(typeCode: number, data: Buffer): unknown {
   switch (typeCode) {
     case ROCKWELL_REGISTER_MAP.DATA_TYPES.BOOL:
       return data.readUInt8(0) !== 0;
@@ -480,8 +480,8 @@ function unmarshalCipValue(typeCode: number, data: Buffer): any {
 }
 
 /** Parse a ListIdentity response into discovered device info */
-function parseListIdentityResponse(data: Buffer): any[] {
-  const devices: any[] = [];
+function parseListIdentityResponse(data: Buffer): Record<string, unknown>[] {
+  const devices: Record<string, unknown>[] = [];
   if (data.length < 26) return devices; // Need at least header + some identity data
   
   const header = decodeEncapsulationHeader(data);
@@ -560,7 +560,7 @@ function cipStatusToString(status: number): string {
 
 // ─── Adapter Implementation ──────────────────────────────────────────
 
-export class RockwellVendorAdapter extends BaseAdapter<'protocol'> implements ProtocolAdapter {
+export class RockwellVendorAdapter extends VendorBaseAdapter<'protocol'> implements ProtocolAdapter {
   readonly manifest: AdapterManifest & { type: 'protocol' } = {
     id: 'rockwell-vendor',
     name: 'Rockwell Automation Vendor Adapter',
@@ -575,12 +575,6 @@ export class RockwellVendorAdapter extends BaseAdapter<'protocol'> implements Pr
 
   private cipConnections: Map<string, CipConnection> = new Map();
   private connections: Map<string, ProtocolConnection> = new Map();
-  private tagCache: Map<string, { value: any; timestamp: Date; quality: string; typeCode: number }> = new Map();
-  private static readonly MAX_TAG_CACHE = 50000;
-  private pollingTimers: Map<string, NodeJS.Timeout> = new Map();
-  private messagesProcessed = 0;
-  private errorsCount = 0;
-  private startTime = 0;
 
   protected async doInitialize(context: AdapterContext): Promise<void> {
     context.logger.info('Initializing Rockwell vendor adapter — EtherNet/IP + CIP stack');
@@ -740,9 +734,9 @@ export class RockwellVendorAdapter extends BaseAdapter<'protocol'> implements Pr
       return {
         address,
         name: this.parseTagName(address),
-        dataType: this.cipTypeToAdapterType(cached.typeCode),
+        dataType: this.cipTypeToAdapterType(cached.typeCode as number),
         value: cached.value,
-        quality: cached.quality as any,
+        quality: cached.quality as AdapterTag['quality'],
         timestamp: cached.timestamp,
       };
     }
@@ -772,7 +766,7 @@ export class RockwellVendorAdapter extends BaseAdapter<'protocol'> implements Pr
         name: this.parseTagName(address),
         dataType: this.inferCipDataType(address),
         value: cached?.value ?? null,
-        quality: (cached ? 'good' : 'uncertain') as any,
+        quality: (cached ? 'good' : 'uncertain') as AdapterTag['quality'],
         timestamp: cached?.timestamp ?? new Date(),
       };
     });
@@ -815,7 +809,7 @@ export class RockwellVendorAdapter extends BaseAdapter<'protocol'> implements Pr
 
   // ─── Device Discovery ─────────────────────────────────────────────
 
-  async discoverDevices(): Promise<any[]> {
+  async discoverDevices(): Promise<Record<string, unknown>[]> {
     this.context?.logger.info('Broadcasting CIP ListIdentity on port 44818');
     
     const listIdentityPacket = buildListIdentity();
@@ -830,7 +824,7 @@ export class RockwellVendorAdapter extends BaseAdapter<'protocol'> implements Pr
   // ─── Diagnostics ──────────────────────────────────────────────────
 
   /** Read CIP Identity Object (Class 0x01, Instance 1) */
-  async getDeviceInfo(deviceId: string): Promise<any> {
+  async getDeviceInfo(deviceId: string): Promise<Record<string, unknown>> {
     // Build Get_Attribute_All for Identity object
     const path = Buffer.from([
       0x20, CIP_CLASSES.IDENTITY,  // Class segment
@@ -853,7 +847,7 @@ export class RockwellVendorAdapter extends BaseAdapter<'protocol'> implements Pr
   }
 
   /** Read fault log and module status */
-  async getDeviceDiagnostics(deviceId: string): Promise<any> {
+  async getDeviceDiagnostics(deviceId: string): Promise<Record<string, unknown>> {
     // Read Wall Clock Time object for uptime
     // Read fault log via controller attributes
     // Read module status for each slot in chassis
@@ -884,28 +878,8 @@ export class RockwellVendorAdapter extends BaseAdapter<'protocol'> implements Pr
 
   // ─── Polling ──────────────────────────────────────────────────────
 
-  startPolling(addresses: string[], tier: keyof typeof ROCKWELL_POLLING, callback: (tags: AdapterTag[]) => void): string {
-    const interval = ROCKWELL_POLLING[tier];
-    const key = `poll_${tier}_${Date.now()}`;
-    const timer = setInterval(async () => {
-      try {
-        const tags = await this.readTags(addresses);
-        callback(tags);
-      } catch (err) {
-        this.context?.logger.error(`Polling error (${tier}):`, err);
-        this.errorsCount++;
-      }
-    }, interval);
-    this.pollingTimers.set(key, timer);
-    return key;
-  }
-
-  stopPolling(key: string): void {
-    const timer = this.pollingTimers.get(key);
-    if (timer) {
-      clearInterval(timer);
-      this.pollingTimers.delete(key);
-    }
+  startPollingByTier(addresses: string[], tier: keyof typeof ROCKWELL_POLLING, callback: (tags: AdapterTag[]) => void): string {
+    return this.startPolling(addresses, ROCKWELL_POLLING[tier], callback, tier);
   }
 
   // ─── Helpers ──────────────────────────────────────────────────────
@@ -939,18 +913,15 @@ export class RockwellVendorAdapter extends BaseAdapter<'protocol'> implements Pr
     }
   }
 
-  protected async getMetrics() {
+  protected async getMetrics(): Promise<Record<string, unknown>> {
+    const base = await super.getMetrics();
     return {
+      ...base,
       connectionsActive: this.cipConnections.size,
-      messagesProcessed: this.messagesProcessed,
-      errorsCount: this.errorsCount,
-      uptime: Date.now() - this.startTime,
-      cachedTags: this.tagCache.size,
-      activePollers: this.pollingTimers.size,
     };
   }
 
-  protected async getDiagnostics() {
+  protected async getDiagnostics(): Promise<Record<string, unknown>> {
     return {
       registerMap: ROCKWELL_REGISTER_MAP,
       connectionParams: ROCKWELL_CONNECTION_PARAMS,

--- a/server/services/vendors/schneider-adapter.ts
+++ b/server/services/vendors/schneider-adapter.ts
@@ -14,7 +14,6 @@
  */
 
 import {
-  BaseAdapter,
   ProtocolAdapter,
   AdapterManifest,
   AdapterCapability,
@@ -23,43 +22,32 @@ import {
   ProtocolEndpoint,
   ProtocolConnection,
 } from '@shared/types/services/adapters';
+import { VendorBaseAdapter } from './vendor-base';
+import {
+  MODBUS_FC,
+  MODBUS_EXCEPTION,
+  encodeModbusTcpRequest,
+  buildModbusReadRequest,
+  buildModbusWriteSingleRegister,
+  buildModbusWriteSingleCoil,
+  buildModbusWriteMultipleRegisters,
+  buildModbusWriteMultipleCoils,
+} from './modbus-utils';
 
-// ─── Modbus Protocol Constants ───────────────────────────────────────
+// Modbus constants imported from shared modbus-utils.ts
+// Re-export base constants and add Schneider-extended function codes
+export { MODBUS_FC, MODBUS_EXCEPTION } from './modbus-utils';
 
-/** Modbus function codes */
-export const MODBUS_FC = {
-  READ_COILS: 0x01,
-  READ_DISCRETE_INPUTS: 0x02,
-  READ_HOLDING_REGISTERS: 0x03,
-  READ_INPUT_REGISTERS: 0x04,
-  WRITE_SINGLE_COIL: 0x05,
-  WRITE_SINGLE_REGISTER: 0x06,
-  READ_EXCEPTION_STATUS: 0x07,
-  DIAGNOSTICS: 0x08,
+/** Schneider-extended Modbus function codes beyond the standard set */
+export const SCHNEIDER_EXTENDED_FC = {
   GET_COMM_EVENT_COUNTER: 0x0B,
   GET_COMM_EVENT_LOG: 0x0C,
-  WRITE_MULTIPLE_COILS: 0x0F,
-  WRITE_MULTIPLE_REGISTERS: 0x10,
   REPORT_SERVER_ID: 0x11,
   READ_FILE_RECORD: 0x14,
   WRITE_FILE_RECORD: 0x15,
   MASK_WRITE_REGISTER: 0x16,
   READ_WRITE_MULTIPLE_REGISTERS: 0x17,
   READ_DEVICE_IDENTIFICATION: 0x2B,
-} as const;
-
-/** Modbus exception codes */
-export const MODBUS_EXCEPTION = {
-  ILLEGAL_FUNCTION: 0x01,
-  ILLEGAL_DATA_ADDRESS: 0x02,
-  ILLEGAL_DATA_VALUE: 0x03,
-  SLAVE_DEVICE_FAILURE: 0x04,
-  ACKNOWLEDGE: 0x05,
-  SLAVE_DEVICE_BUSY: 0x06,
-  NEGATIVE_ACKNOWLEDGE: 0x07,
-  MEMORY_PARITY_ERROR: 0x08,
-  GATEWAY_PATH_UNAVAILABLE: 0x0A,
-  GATEWAY_TARGET_FAILED: 0x0B,
 } as const;
 
 /** Modbus diagnostic sub-function codes (FC 0x08) */
@@ -228,79 +216,8 @@ export const SCHNEIDER_MODELS = {
 } as const;
 
 // ─── Modbus TCP Frame Encoding/Decoding ──────────────────────────────
-
-let mbapTransactionId = 0;
-
-/** Encode a Modbus TCP (MBAP) request frame */
-function encodeModbusTcpRequest(unitId: number, functionCode: number, payload: Buffer): Buffer {
-  const transId = mbapTransactionId & 0xFFFF;
-  mbapTransactionId = (mbapTransactionId + 1) & 0xFFFF;
-  const mbapHeader = Buffer.alloc(7);
-  mbapHeader.writeUInt16BE(transId, 0);        // Transaction ID
-  mbapHeader.writeUInt16BE(0x0000, 2);         // Protocol ID (Modbus = 0)
-  mbapHeader.writeUInt16BE(1 + payload.length, 4); // Length (Unit ID + PDU)
-  mbapHeader.writeUInt8(unitId, 6);            // Unit Identifier
-  
-  const pdu = Buffer.alloc(1 + payload.length);
-  pdu.writeUInt8(functionCode, 0);
-  payload.copy(pdu, 1);
-  
-  return Buffer.concat([mbapHeader, pdu]);
-}
-
-/** Build Modbus read request (FC01/02/03/04) */
-function buildModbusReadRequest(unitId: number, fc: number, startAddress: number, quantity: number): Buffer {
-  const payload = Buffer.alloc(4);
-  payload.writeUInt16BE(startAddress, 0);
-  payload.writeUInt16BE(quantity, 2);
-  return encodeModbusTcpRequest(unitId, fc, payload);
-}
-
-/** Build Modbus write single register (FC06) */
-function buildModbusWriteSingleRegister(unitId: number, address: number, value: number): Buffer {
-  const payload = Buffer.alloc(4);
-  payload.writeUInt16BE(address, 0);
-  payload.writeUInt16BE(value & 0xFFFF, 2);
-  return encodeModbusTcpRequest(unitId, MODBUS_FC.WRITE_SINGLE_REGISTER, payload);
-}
-
-/** Build Modbus write single coil (FC05) */
-function buildModbusWriteSingleCoil(unitId: number, address: number, value: boolean): Buffer {
-  const payload = Buffer.alloc(4);
-  payload.writeUInt16BE(address, 0);
-  payload.writeUInt16BE(value ? 0xFF00 : 0x0000, 2);
-  return encodeModbusTcpRequest(unitId, MODBUS_FC.WRITE_SINGLE_COIL, payload);
-}
-
-/** Build Modbus write multiple registers (FC16) */
-function buildModbusWriteMultipleRegisters(unitId: number, startAddress: number, values: number[]): Buffer {
-  const byteCount = values.length * 2;
-  const payload = Buffer.alloc(5 + byteCount);
-  payload.writeUInt16BE(startAddress, 0);
-  payload.writeUInt16BE(values.length, 2);
-  payload.writeUInt8(byteCount, 4);
-  for (let i = 0; i < values.length; i++) {
-    payload.writeUInt16BE(values[i] & 0xFFFF, 5 + i * 2);
-  }
-  return encodeModbusTcpRequest(unitId, MODBUS_FC.WRITE_MULTIPLE_REGISTERS, payload);
-}
-
-/** Build Modbus write multiple coils (FC15) */
-function buildModbusWriteMultipleCoils(unitId: number, startAddress: number, values: boolean[]): Buffer {
-  const byteCount = Math.ceil(values.length / 8);
-  const payload = Buffer.alloc(5 + byteCount);
-  payload.writeUInt16BE(startAddress, 0);
-  payload.writeUInt16BE(values.length, 2);
-  payload.writeUInt8(byteCount, 4);
-  for (let i = 0; i < values.length; i++) {
-    if (values[i]) {
-      const byteIdx = Math.floor(i / 8);
-      const bitIdx = i % 8;
-      payload[5 + byteIdx] |= (1 << bitIdx);
-    }
-  }
-  return encodeModbusTcpRequest(unitId, MODBUS_FC.WRITE_MULTIPLE_COILS, payload);
-}
+// Core frame builders imported from shared modbus-utils.ts
+// Schneider-specific builders below:
 
 /** Build Modbus diagnostics request (FC08) */
 function buildModbusDiagnostics(unitId: number, subFunction: number, data: number = 0): Buffer {
@@ -681,7 +598,7 @@ function parseSchneiderAddress(address: string): {
 
 interface Iec104Connection {
   endpoint: ProtocolEndpoint;
-  socket: any;
+  socket: import('net').Socket | null;
   sendSeq: number;
   receiveSeq: number;
   isStarted: boolean;
@@ -695,7 +612,7 @@ interface Iec104Connection {
 
 // ─── Adapter Implementation ──────────────────────────────────────────
 
-export class SchneiderVendorAdapter extends BaseAdapter<'protocol'> implements ProtocolAdapter {
+export class SchneiderVendorAdapter extends VendorBaseAdapter<'protocol'> implements ProtocolAdapter {
   readonly manifest: AdapterManifest & { type: 'protocol' } = {
     id: 'schneider-vendor',
     name: 'Schneider Electric Vendor Adapter',
@@ -711,12 +628,7 @@ export class SchneiderVendorAdapter extends BaseAdapter<'protocol'> implements P
   private modbusConnections: Map<string, ProtocolConnection> = new Map();
   private iec104Connections: Map<string, Iec104Connection> = new Map();
   private connections: Map<string, ProtocolConnection> = new Map();
-  private tagCache: Map<string, { value: any; timestamp: Date; quality: string }> = new Map();
-  private pollingTimers: Map<string, NodeJS.Timeout> = new Map();
-  private iec104SpontaneousBuffer: Map<number, { value: any; timestamp: Date; typeId: number }> = new Map();
-  private messagesProcessed = 0;
-  private errorsCount = 0;
-  private startTime = 0;
+  private iec104SpontaneousBuffer: Map<number, { value: unknown; timestamp: Date; typeId: number }> = new Map();
 
   protected async doInitialize(context: AdapterContext): Promise<void> {
     context.logger.info('Initializing Schneider Electric vendor adapter — Modbus TCP/RTU + IEC 104');
@@ -903,7 +815,7 @@ export class SchneiderVendorAdapter extends BaseAdapter<'protocol'> implements P
             address: regs[i].address,
             dataType: regs[i].isBool ? 'boolean' : 'number',
             value: cached?.value ?? null,
-            quality: (cached?.quality as any) ?? 'uncertain',
+            quality: (cached?.quality as AdapterTag['quality']) ?? 'uncertain',
             timestamp: cached?.timestamp ?? new Date(),
           });
         }
@@ -954,7 +866,7 @@ export class SchneiderVendorAdapter extends BaseAdapter<'protocol'> implements P
       address,
       dataType: 'number',
       value: cached?.value ?? null,
-      quality: (cached?.quality as any) ?? 'uncertain',
+      quality: (cached?.quality as AdapterTag['quality']) ?? 'uncertain',
       timestamp: cached?.timestamp ?? new Date(),
     };
   }
@@ -1014,9 +926,9 @@ export class SchneiderVendorAdapter extends BaseAdapter<'protocol'> implements P
 
   // ─── Discovery ─────────────────────────────────────────────────────
 
-  async discoverDevices(): Promise<any[]> {
+  async discoverDevices(): Promise<Record<string, unknown>[]> {
     this.context?.logger.info('Discovering Schneider devices via Modbus device identification');
-    const devices: any[] = [];
+    const devices: Record<string, unknown>[] = [];
 
     // Scan unit IDs 1-10 with Read Device Identification
     for (let unitId = 1; unitId <= 10; unitId++) {
@@ -1029,7 +941,7 @@ export class SchneiderVendorAdapter extends BaseAdapter<'protocol'> implements P
 
   // ─── Diagnostics ───────────────────────────────────────────────────
 
-  async getDeviceInfo(deviceId: string): Promise<any> {
+  async getDeviceInfo(deviceId: string): Promise<Record<string, unknown>> {
     const unitId = parseInt(deviceId) || SCHNEIDER_CONNECTION_PARAMS.modbusTcp.unitId;
     const request = buildModbusReadDeviceId(unitId);
     this.messagesProcessed++;
@@ -1037,7 +949,7 @@ export class SchneiderVendorAdapter extends BaseAdapter<'protocol'> implements P
     return { deviceId, vendor: 'Schneider Electric', models: SCHNEIDER_MODELS };
   }
 
-  async getDeviceDiagnostics(deviceId: string): Promise<any> {
+  async getDeviceDiagnostics(deviceId: string): Promise<Record<string, unknown>> {
     const unitId = parseInt(deviceId) || SCHNEIDER_CONNECTION_PARAMS.modbusTcp.unitId;
 
     // Read M580 system bits (%S)
@@ -1071,7 +983,7 @@ export class SchneiderVendorAdapter extends BaseAdapter<'protocol'> implements P
   }
 
   /** Read SCADAPack system registers */
-  async readScadapackSystemRegisters(unitId: number): Promise<any> {
+  async readScadapackSystemRegisters(unitId: number): Promise<Record<string, unknown>> {
     const request = buildModbusReadRequest(
       unitId,
       MODBUS_FC.READ_HOLDING_REGISTERS,
@@ -1106,31 +1018,14 @@ export class SchneiderVendorAdapter extends BaseAdapter<'protocol'> implements P
 
   // ─── Polling ───────────────────────────────────────────────────────
 
-  startPolling(addresses: string[], tier: keyof typeof SCHNEIDER_POLLING, callback: (tags: AdapterTag[]) => void): string {
+  startPollingByTier(addresses: string[], tier: keyof typeof SCHNEIDER_POLLING, callback: (tags: AdapterTag[]) => void): string {
     const interval = SCHNEIDER_POLLING[tier];
     if (interval === 0) {
       // IEC 104 spontaneous — no polling, event-driven
       this.context?.logger.info('IEC 104 spontaneous mode — no active polling');
       return 'iec104-spontaneous';
     }
-
-    const key = `poll_${tier}_${Date.now()}`;
-    const timer = setInterval(async () => {
-      try {
-        const tags = await this.readTags(addresses);
-        callback(tags);
-      } catch (err) {
-        this.context?.logger.error(`Schneider polling error (${tier}):`, err);
-        this.errorsCount++;
-      }
-    }, interval);
-    this.pollingTimers.set(key, timer);
-    return key;
-  }
-
-  stopPolling(key: string): void {
-    const timer = this.pollingTimers.get(key);
-    if (timer) { clearInterval(timer); this.pollingTimers.delete(key); }
+    return this.startPolling(addresses, interval, callback, tier);
   }
 
   // ─── Helpers ───────────────────────────────────────────────────────
@@ -1139,21 +1034,18 @@ export class SchneiderVendorAdapter extends BaseAdapter<'protocol'> implements P
     return this.iec104Connections.values().next().value as Iec104Connection | undefined;
   }
 
-  protected async getMetrics() {
+  protected async getMetrics(): Promise<Record<string, unknown>> {
+    const base = await super.getMetrics();
     return {
+      ...base,
       connectionsActive: this.connections.size,
-      messagesProcessed: this.messagesProcessed,
-      errorsCount: this.errorsCount,
-      uptime: Date.now() - this.startTime,
-      cachedTags: this.tagCache.size,
       modbusConnections: this.modbusConnections.size,
       iec104Connections: this.iec104Connections.size,
       iec104SpontaneousItems: this.iec104SpontaneousBuffer.size,
-      activePollers: this.pollingTimers.size,
     };
   }
 
-  protected async getDiagnostics() {
+  protected async getDiagnostics(): Promise<Record<string, unknown>> {
     return {
       registerMap: SCHNEIDER_REGISTER_MAP,
       connectionParams: SCHNEIDER_CONNECTION_PARAMS,

--- a/server/services/vendors/siemens-adapter.ts
+++ b/server/services/vendors/siemens-adapter.ts
@@ -10,7 +10,6 @@
  */
 
 import {
-  BaseAdapter,
   ProtocolAdapter,
   AdapterManifest,
   AdapterCapability,
@@ -19,6 +18,7 @@ import {
   ProtocolEndpoint,
   ProtocolConnection,
 } from '@shared/types/services/adapters';
+import { VendorBaseAdapter } from './vendor-base';
 
 // ─── S7 Protocol Constants ────────────────────────────────────────────
 
@@ -188,7 +188,7 @@ interface S7Address {
 /** S7 connection state */
 interface S7Connection {
   endpoint: ProtocolEndpoint;
-  socket: any;
+  socket: import('net').Socket | null;
   negotiatedPdu: number;
   srcRef: number;
   dstRef: number;
@@ -546,7 +546,7 @@ function s7ErrorToString(code: number): string {
 }
 
 /** Unmarshal S7 value bytes based on transport size */
-function unmarshalS7Value(transport: number, data: Buffer): any {
+function unmarshalS7Value(transport: number, data: Buffer): unknown {
   switch (transport) {
     case S7_TRANSPORT_SIZE.BIT: return data.readUInt8(0) !== 0;
     case S7_TRANSPORT_SIZE.BYTE: return data.readUInt8(0);
@@ -560,7 +560,7 @@ function unmarshalS7Value(transport: number, data: Buffer): any {
 }
 
 /** Marshal JS value to S7 bytes */
-function marshalS7Value(transport: number, value: any): Buffer {
+function marshalS7Value(transport: number, value: unknown): Buffer {
   switch (transport) {
     case S7_TRANSPORT_SIZE.BIT: { const b = Buffer.alloc(1); b.writeUInt8(value ? 1 : 0, 0); return b; }
     case S7_TRANSPORT_SIZE.BYTE: { const b = Buffer.alloc(1); b.writeUInt8(Number(value), 0); return b; }
@@ -575,7 +575,7 @@ function marshalS7Value(transport: number, value: any): Buffer {
 
 // ─── Adapter Implementation ──────────────────────────────────────────
 
-export class SiemensVendorAdapter extends BaseAdapter<'protocol'> implements ProtocolAdapter {
+export class SiemensVendorAdapter extends VendorBaseAdapter<'protocol'> implements ProtocolAdapter {
   readonly manifest: AdapterManifest & { type: 'protocol' } = {
     id: 'siemens-vendor',
     name: 'Siemens S7 Vendor Adapter',
@@ -590,12 +590,6 @@ export class SiemensVendorAdapter extends BaseAdapter<'protocol'> implements Pro
 
   private s7Connections: Map<string, S7Connection> = new Map();
   private connections: Map<string, ProtocolConnection> = new Map();
-  private tagCache: Map<string, { value: any; timestamp: Date; transport: number }> = new Map();
-  private static readonly MAX_TAG_CACHE = 50000;
-  private pollingTimers: Map<string, NodeJS.Timeout> = new Map();
-  private messagesProcessed = 0;
-  private errorsCount = 0;
-  private startTime = 0;
 
   protected async doInitialize(context: AdapterContext): Promise<void> {
     context.logger.info('Initializing Siemens S7 vendor adapter — ISO-on-TCP + COTP + S7comm');
@@ -753,12 +747,13 @@ export class SiemensVendorAdapter extends BaseAdapter<'protocol'> implements Pro
       this.tagCache.set(tag.address, {
         value: tag.value,
         timestamp: new Date(),
+        quality: 'good',
         transport: s7Addr.transportSize,
       });
     }
-    if (this.tagCache.size > SiemensVendorAdapter.MAX_TAG_CACHE) {
+    if (this.tagCache.size > this.maxTagCache) {
       const keys = Array.from(this.tagCache.keys());
-      for (let i = 0; i < keys.length - SiemensVendorAdapter.MAX_TAG_CACHE; i++) this.tagCache.delete(keys[i]);
+      for (let i = 0; i < keys.length - this.maxTagCache; i++) this.tagCache.delete(keys[i]);
     }
   }
 
@@ -774,7 +769,7 @@ export class SiemensVendorAdapter extends BaseAdapter<'protocol'> implements Pro
 
   // ─── Diagnostics ───────────────────────────────────────────────────
 
-  async getDeviceInfo(deviceId: string): Promise<any> {
+  async getDeviceInfo(deviceId: string): Promise<Record<string, unknown>> {
     // Read SZL 0x0011 (Module Identification) and 0x001C (Component ID)
     const conn = this.getFirstConnection();
     if (conn) conn.pduRef = (conn.pduRef + 1) & 0xFFFF;
@@ -785,9 +780,9 @@ export class SiemensVendorAdapter extends BaseAdapter<'protocol'> implements Pro
     return { deviceId, vendor: 'Siemens AG', models: SIEMENS_MODELS };
   }
 
-  async getDeviceDiagnostics(deviceId: string): Promise<any> {
+  async getDeviceDiagnostics(deviceId: string): Promise<Record<string, unknown>> {
     const conn = this.getFirstConnection();
-    const results: any = { deviceId };
+    const results: Record<string, unknown> = { deviceId };
 
     // Read diagnostic buffer (SZL 0x00A0)
     if (conn) {
@@ -840,28 +835,8 @@ export class SiemensVendorAdapter extends BaseAdapter<'protocol'> implements Pro
 
   // ─── Polling ───────────────────────────────────────────────────────
 
-  startPolling(addresses: string[], tier: keyof typeof SIEMENS_POLLING, callback: (tags: AdapterTag[]) => void): string {
-    const interval = SIEMENS_POLLING[tier];
-    const key = `poll_${tier}_${Date.now()}`;
-    const timer = setInterval(async () => {
-      try {
-        const tags = await this.readTags(addresses);
-        callback(tags);
-      } catch (err) {
-        this.context?.logger.error(`S7 polling error (${tier}):`, err);
-        this.errorsCount++;
-      }
-    }, interval);
-    this.pollingTimers.set(key, timer);
-    return key;
-  }
-
-  stopPolling(key: string): void {
-    const timer = this.pollingTimers.get(key);
-    if (timer) {
-      clearInterval(timer);
-      this.pollingTimers.delete(key);
-    }
+  startPollingByTier(addresses: string[], tier: keyof typeof SIEMENS_POLLING, callback: (tags: AdapterTag[]) => void): string {
+    return this.startPolling(addresses, SIEMENS_POLLING[tier], callback, tier);
   }
 
   // ─── Helpers ───────────────────────────────────────────────────────
@@ -881,18 +856,15 @@ export class SiemensVendorAdapter extends BaseAdapter<'protocol'> implements Pro
     return this.transportToAdapterType(parsed.transportSize);
   }
 
-  protected async getMetrics() {
+  protected async getMetrics(): Promise<Record<string, unknown>> {
+    const base = await super.getMetrics();
     return {
+      ...base,
       connectionsActive: this.s7Connections.size,
-      messagesProcessed: this.messagesProcessed,
-      errorsCount: this.errorsCount,
-      uptime: Date.now() - this.startTime,
-      cachedTags: this.tagCache.size,
-      activePollers: this.pollingTimers.size,
     };
   }
 
-  protected async getDiagnostics() {
+  protected async getDiagnostics(): Promise<Record<string, unknown>> {
     return {
       registerMap: SIEMENS_REGISTER_MAP,
       connectionParams: SIEMENS_CONNECTION_PARAMS,

--- a/server/services/vendors/vendor-base.ts
+++ b/server/services/vendors/vendor-base.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared Vendor Adapter Base Class
+ * Issue #370: Extract duplicated logic from vendor adapters
+ *
+ * Provides: polling, tag cache, connection map, metrics/diagnostics patterns.
+ */
+
+import { BaseAdapter, AdapterTag, AdapterContext } from '../../../shared/types/services/adapters';
+import type { AdapterType } from '../../../shared/types/services/adapters';
+
+/** Cached tag entry */
+export interface TagCacheEntry {
+  value: unknown;
+  timestamp: Date;
+  quality: string;
+  /** Extra adapter-specific metadata (e.g. typeCode, transport id) */
+  [key: string]: unknown;
+}
+
+/** Polling subscription handle */
+export interface PollHandle {
+  key: string;
+  timer: ReturnType<typeof setInterval>;
+}
+
+/**
+ * VendorBaseAdapter extends the shared BaseAdapter with common vendor patterns.
+ * Subclasses still implement doInitialize, doConnect, doDisconnect, doDestroy, and readTags.
+ */
+export abstract class VendorBaseAdapter<T extends AdapterType = 'protocol'> extends BaseAdapter<T> {
+
+  // ─── Tag Cache ──────────────────────────────────────────────────────
+  protected tagCache: Map<string, TagCacheEntry> = new Map();
+  protected maxTagCache = 50_000;
+
+  protected getCachedTag(address: string): TagCacheEntry | undefined {
+    return this.tagCache.get(address);
+  }
+
+  protected setCachedTag(address: string, entry: TagCacheEntry): void {
+    this.tagCache.set(address, entry);
+    if (this.tagCache.size > this.maxTagCache) {
+      // Evict oldest entries
+      const keys = Array.from(this.tagCache.keys());
+      for (let i = 0; i < keys.length - this.maxTagCache; i++) {
+        this.tagCache.delete(keys[i]);
+      }
+    }
+  }
+
+  protected clearTagCache(): void {
+    this.tagCache.clear();
+  }
+
+  // ─── Polling ────────────────────────────────────────────────────────
+  protected pollingTimers: Map<string, ReturnType<typeof setInterval>> = new Map();
+
+  /**
+   * Start polling a set of addresses at a given interval (ms).
+   * Returns a key that can be passed to stopPolling().
+   */
+  startPolling(
+    addresses: string[],
+    intervalMs: number,
+    callback: (tags: AdapterTag[]) => void,
+    label = 'poll',
+  ): string {
+    const key = `${label}_${Date.now()}`;
+    const timer = setInterval(async () => {
+      try {
+        const tags = await this.readTags(addresses);
+        callback(tags);
+      } catch (err) {
+        this.context?.logger.error(`Polling error (${label}):`, err);
+        this.errorsCount++;
+      }
+    }, intervalMs);
+    this.pollingTimers.set(key, timer);
+    return key;
+  }
+
+  stopPolling(key: string): void {
+    const timer = this.pollingTimers.get(key);
+    if (timer) {
+      clearInterval(timer);
+      this.pollingTimers.delete(key);
+    }
+  }
+
+  protected stopAllPolling(): void {
+    for (const timer of this.pollingTimers.values()) {
+      clearInterval(timer);
+    }
+    this.pollingTimers.clear();
+  }
+
+  // ─── Metrics & Diagnostics ─────────────────────────────────────────
+  protected messagesProcessed = 0;
+  protected errorsCount = 0;
+  protected startTime = Date.now();
+
+  protected async getMetrics(): Promise<Record<string, unknown>> {
+    return {
+      messagesProcessed: this.messagesProcessed,
+      errorsCount: this.errorsCount,
+      uptime: Date.now() - this.startTime,
+      cachedTags: this.tagCache.size,
+      activePollers: this.pollingTimers.size,
+    };
+  }
+
+  protected async getDiagnostics(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  // ─── Abstract ──────────────────────────────────────────────────────
+  abstract readTags(addresses: string[]): Promise<AdapterTag[]>;
+}

--- a/server/services/vendors/yokogawa-adapter.ts
+++ b/server/services/vendors/yokogawa-adapter.ts
@@ -13,7 +13,6 @@
  */
 
 import {
-  BaseAdapter,
   ProtocolAdapter,
   AdapterManifest,
   AdapterCapability,
@@ -22,6 +21,7 @@ import {
   ProtocolEndpoint,
   ProtocolConnection,
 } from '@shared/types/services/adapters';
+import { VendorBaseAdapter } from './vendor-base';
 
 // ─── Vnet/IP Protocol Constants ──────────────────────────────────────
 
@@ -358,7 +358,7 @@ function buildModbusTcpRead(unitId: number, fc: number, startAddr: number, count
 
 type YokogawaProtocol = 'vnet' | 'modbus' | 'prosafe';
 
-export class YokogawaVendorAdapter extends BaseAdapter<'protocol'> implements ProtocolAdapter {
+export class YokogawaVendorAdapter extends VendorBaseAdapter<'protocol'> implements ProtocolAdapter {
   readonly manifest: AdapterManifest & { type: 'protocol' } = {
     id: 'yokogawa-vendor',
     name: 'Yokogawa Vendor Adapter',
@@ -372,13 +372,8 @@ export class YokogawaVendorAdapter extends BaseAdapter<'protocol'> implements Pr
   readonly protocols = ['vnet-ip', 'fl-net', 'modbus', 'foundation-fieldbus'];
 
   private connections: Map<string, ProtocolConnection> = new Map();
-  private tagCache: Map<string, { value: any; timestamp: Date; quality: string }> = new Map();
-  private pollingTimers: Map<string, NodeJS.Timeout> = new Map();
   private fcsStations: Map<string, VnetStation> = new Map();
   private localStation: VnetStation = { domain: 0, station: 63, slot: 0 }; // SCADA station
-  private messagesProcessed = 0;
-  private errorsCount = 0;
-  private startTime = 0;
 
   protected async doInitialize(context: AdapterContext): Promise<void> {
     context.logger.info('Initializing Yokogawa vendor adapter — Vnet/IP + Modbus');
@@ -471,7 +466,7 @@ export class YokogawaVendorAdapter extends BaseAdapter<'protocol'> implements Pr
       name: `${parsed.blockInstance}.${parsed.parameter}`,
       dataType: this.inferCentumVpDataType(parsed.parameter),
       value: cached?.value ?? null,
-      quality: (cached?.quality as any) ?? 'uncertain',
+      quality: (cached?.quality as AdapterTag['quality']) ?? 'uncertain',
       timestamp: cached?.timestamp ?? new Date(),
     };
   }
@@ -491,7 +486,7 @@ export class YokogawaVendorAdapter extends BaseAdapter<'protocol'> implements Pr
       name: `SIF${parsed.sifNumber}.${parsed.parameter}`,
       dataType: parsed.parameter === 'STATUS' ? 'number' : 'object',
       value: cached?.value ?? null,
-      quality: (cached?.quality as any) ?? 'uncertain',
+      quality: (cached?.quality as AdapterTag['quality']) ?? 'uncertain',
       timestamp: cached?.timestamp ?? new Date(),
     };
   }
@@ -508,7 +503,7 @@ export class YokogawaVendorAdapter extends BaseAdapter<'protocol'> implements Pr
       address,
       dataType: 'number',
       value: cached?.value ?? null,
-      quality: (cached?.quality as any) ?? 'uncertain',
+      quality: (cached?.quality as AdapterTag['quality']) ?? 'uncertain',
       timestamp: cached?.timestamp ?? new Date(),
     };
   }
@@ -547,7 +542,7 @@ export class YokogawaVendorAdapter extends BaseAdapter<'protocol'> implements Pr
 
   // ─── Discovery ─────────────────────────────────────────────────────
 
-  async discoverDevices(): Promise<any[]> {
+  async discoverDevices(): Promise<Record<string, unknown>[]> {
     this.context?.logger.info('Discovering Yokogawa devices via Vnet/IP station enumeration');
     const discoveryFrame = encodeVnetDiscovery(this.localStation);
     this.messagesProcessed++;
@@ -557,11 +552,11 @@ export class YokogawaVendorAdapter extends BaseAdapter<'protocol'> implements Pr
 
   // ─── Diagnostics ───────────────────────────────────────────────────
 
-  async getDeviceInfo(deviceId: string): Promise<any> {
+  async getDeviceInfo(deviceId: string): Promise<Record<string, unknown>> {
     return { deviceId, vendor: 'Yokogawa', models: YOKOGAWA_MODELS };
   }
 
-  async getDeviceDiagnostics(deviceId: string): Promise<any> {
+  async getDeviceDiagnostics(deviceId: string): Promise<Record<string, unknown>> {
     // Read FCS system status
     const statusFrame = encodeVnetReadRequest(this.localStation, { domain: 0, station: 1, slot: 0 }, 'SYS.STATUS');
     this.messagesProcessed++;
@@ -595,7 +590,7 @@ export class YokogawaVendorAdapter extends BaseAdapter<'protocol'> implements Pr
   }
 
   /** Read SOE (Sequence of Events) log */
-  async readSoeLog(stationName: string, count: number = 100): Promise<any[]> {
+  async readSoeLog(stationName: string, count: number = 100): Promise<Record<string, unknown>[]> {
     const targetStation = this.fcsStations.get(stationName) ?? { domain: 0, station: 1, slot: 0 };
     const frame = encodeVnetReadRequest(this.localStation, targetStation, 'SYS.SOE_LOG');
     this.messagesProcessed++;
@@ -604,25 +599,8 @@ export class YokogawaVendorAdapter extends BaseAdapter<'protocol'> implements Pr
 
   // ─── Polling ───────────────────────────────────────────────────────
 
-  startPolling(addresses: string[], tier: keyof typeof YOKOGAWA_POLLING, callback: (tags: AdapterTag[]) => void): string {
-    const interval = YOKOGAWA_POLLING[tier];
-    const key = `poll_${tier}_${Date.now()}`;
-    const timer = setInterval(async () => {
-      try {
-        const tags = await this.readTags(addresses);
-        callback(tags);
-      } catch (err) {
-        this.context?.logger.error(`Yokogawa polling error (${tier}):`, err);
-        this.errorsCount++;
-      }
-    }, interval);
-    this.pollingTimers.set(key, timer);
-    return key;
-  }
-
-  stopPolling(key: string): void {
-    const timer = this.pollingTimers.get(key);
-    if (timer) { clearInterval(timer); this.pollingTimers.delete(key); }
+  startPollingByTier(addresses: string[], tier: keyof typeof YOKOGAWA_POLLING, callback: (tags: AdapterTag[]) => void): string {
+    return this.startPolling(addresses, YOKOGAWA_POLLING[tier], callback, tier);
   }
 
   // ─── Helpers ───────────────────────────────────────────────────────
@@ -651,19 +629,16 @@ export class YokogawaVendorAdapter extends BaseAdapter<'protocol'> implements Pr
     };
   }
 
-  protected async getMetrics() {
+  protected async getMetrics(): Promise<Record<string, unknown>> {
+    const base = await super.getMetrics();
     return {
+      ...base,
       connectionsActive: this.connections.size,
-      messagesProcessed: this.messagesProcessed,
-      errorsCount: this.errorsCount,
-      uptime: Date.now() - this.startTime,
-      cachedTags: this.tagCache.size,
       fcsStations: this.fcsStations.size,
-      activePollers: this.pollingTimers.size,
     };
   }
 
-  protected async getDiagnostics() {
+  protected async getDiagnostics(): Promise<Record<string, unknown>> {
     return {
       registerMap: YOKOGAWA_REGISTER_MAP,
       connectionParams: YOKOGAWA_CONNECTION_PARAMS,

--- a/shared/types/services/adapters.ts
+++ b/shared/types/services/adapters.ts
@@ -34,7 +34,7 @@ export interface AdapterManifest {
 }
 
 export interface AdapterContext {
-  config: Record<string, any>;
+  config: Record<string, unknown>;
   logger: {
     debug: (message: string, ...args: any[]) => void;
     info: (message: string, ...args: any[]) => void;
@@ -51,20 +51,20 @@ export interface AdapterContext {
 export interface AdapterHealthStatus {
   state: AdapterState;
   lastUpdate: Date;
-  metrics?: {
-    connectionsActive: number;
-    messagesProcessed: number;
-    errorsCount: number;
-    uptime: number;
+  metrics?: Record<string, unknown> & {
+    connectionsActive?: number;
+    messagesProcessed?: number;
+    errorsCount?: number;
+    uptime?: number;
   };
-  diagnostics?: Record<string, any>;
+  diagnostics?: Record<string, unknown>;
 }
 
 export interface AdapterTag {
   address: string;
   name?: string;
   dataType: 'boolean' | 'number' | 'string' | 'object';
-  value?: any;
+  value?: unknown;
   quality: 'good' | 'bad' | 'uncertain';
   timestamp: Date;
 }
@@ -76,7 +76,7 @@ export interface ProtocolEndpoint {
   protocol: string;
   authentication?: {
     type: 'none' | 'basic' | 'certificate';
-    credentials?: Record<string, any>;
+    credentials?: Record<string, unknown>;
   };
 }
 
@@ -106,7 +106,7 @@ export interface ProtocolAdapter extends IAdapter {
   
   readTags(addresses: string[]): Promise<AdapterTag[]>;
   writeTags(tags: AdapterTag[]): Promise<void>;
-  discoverDevices?(): Promise<any[]>;
+  discoverDevices?(): Promise<Record<string, unknown>[]>;
 }
 
 // Device adapter specific interface  
@@ -114,8 +114,8 @@ export interface DeviceAdapter extends IAdapter {
   readonly manifest: AdapterManifest & { type: 'device' };
   readonly deviceTypes: string[];
   
-  getDeviceInfo(deviceId: string): Promise<any>;
-  getDeviceDiagnostics?(deviceId: string): Promise<any>;
+  getDeviceInfo(deviceId: string): Promise<Record<string, unknown>>;
+  getDeviceDiagnostics?(deviceId: string): Promise<Record<string, unknown>>;
   updateFirmware?(deviceId: string, firmware: Buffer): Promise<void>;
 }
 
@@ -217,11 +217,11 @@ export abstract class BaseAdapter<T extends AdapterType> implements IAdapter {
   protected abstract doDestroy(): Promise<void>;
   
   // Optional methods that subclasses can override
-  protected async getMetrics(): Promise<any> {
+  protected async getMetrics(): Promise<Record<string, unknown>> {
     return {};
   }
   
-  protected async getDiagnostics(): Promise<any> {
+  protected async getDiagnostics(): Promise<Record<string, unknown>> {
     return {};
   }
 }


### PR DESCRIPTION
## Changes

### #370 — Vendor adapter code duplication
- Created `vendor-base.ts` with `VendorBaseAdapter` class providing shared polling, tag cache, metrics/diagnostics
- Created `modbus-utils.ts` with shared Modbus TCP (MBAP) frame encoding utilities
- All 5 vendor adapters now extend `VendorBaseAdapter` instead of `BaseAdapter` directly
- Emerson + Schneider adapters delegate to shared modbus-utils instead of duplicating frame builders

### #371 — Narrow `any` types
- ~50 `any` types narrowed to `unknown`, `Record<string, unknown>`, or specific interfaces
- Fixed across vendor adapters, integrity services, routes, and shared adapter types
- Backward compatible — no API changes

### #375 — GateManager verification conditions
- Fixed: now runs ALL verification conditions, not just the first
- Added pipeline caching to reuse instances across checks
- Aggregates results with severity ranking across multiple conditions

### #376 — PhiGauge FanoMini indices
- Fixed: populated points now derived from partition geometry (quadrant/triality/classIndex mapping) instead of sequential first-N indexing

Closes #370, closes #371, closes #375, closes #376