### PR TITLE
feat: NATS event publishing for SCADA events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "hardhat": "^3.1.10",
         "ioredis": "^5.3.0",
         "lucide-react": "^0.344.0",
+        "nats": "^2.29.3",
         "openapi-types": "^12.1.0",
         "pg": "^8.11.0",
         "pino": "^8.17.0",
@@ -6849,6 +6850,18 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
+    "node_modules/nats": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/nats/-/nats-2.29.3.tgz",
+      "integrity": "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "nkeys.js": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -6856,6 +6869,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nkeys.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nkeys.js/-/nkeys.js-1.1.0.tgz",
+      "integrity": "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tweetnacl": "1.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/node-abi": {
@@ -9216,6 +9241,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "hardhat": "^3.1.10",
     "ioredis": "^5.3.0",
     "lucide-react": "^0.344.0",
+    "nats": "^2.29.3",
     "openapi-types": "^12.1.0",
     "pg": "^8.11.0",
     "pino": "^8.17.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -184,6 +184,10 @@ app.use((req, res, next) => {
       const { startFluxIntegration } = await import("./services/flux");
       startFluxIntegration();
 
+      // Connect to NATS for SCADA event publishing
+      const { natsPublisher } = await import("./services/nats");
+      await natsPublisher.connect();
+
       // Start periodic health monitoring (every 30 s)
       healthManager.startPeriodicCheck(30_000);
     },

--- a/server/services/nats/index.ts
+++ b/server/services/nats/index.ts
@@ -1,0 +1,41 @@
+import { connect, NatsConnection, StringCodec } from "nats";
+import { log, logError, logWarn } from "../../logger";
+
+const sc = StringCodec();
+
+class NatsPublisher {
+  private nc: NatsConnection | null = null;
+  private url: string;
+
+  constructor() {
+    this.url = process.env.NATS_URL || "nats://swarm.ninja-portal.com:4222";
+  }
+
+  async connect() {
+    try {
+      this.nc = await connect({ servers: this.url });
+      log(`✅ NATS connected to ${this.url}`, "nats");
+    } catch (err) {
+      logError(`❌ NATS connection failed (${this.url})`, err as Error);
+    }
+  }
+
+  publish(subject: string, data: object) {
+    if (!this.nc) return;
+    try {
+      this.nc.publish(subject, sc.encode(JSON.stringify(data)));
+    } catch (err) {
+      logWarn(`NATS publish failed on ${subject}: ${err}`, "nats");
+    }
+  }
+
+  async close() {
+    if (this.nc) {
+      await this.nc.drain();
+      this.nc = null;
+      log("NATS disconnected", "nats");
+    }
+  }
+}
+
+export const natsPublisher = new NatsPublisher();

--- a/server/simulator.ts
+++ b/server/simulator.ts
@@ -1,6 +1,7 @@
 import { log, logError, logWarn } from "./logger";
 import { tagStreamServer } from "./websocket/tag-stream";
 import { getFluxPublisher } from "./services/flux";
+import { natsPublisher } from "./services/nats";
 
 interface SimulatorConfig {
   enabled: boolean;
@@ -113,6 +114,20 @@ class FieldSimulator {
           timestamp: new Date().toISOString(),
         });
       } catch { /* WebSocket not connected — that's fine */ }
+
+      // Publish to NATS for blockchain anchoring
+      try {
+        natsPublisher.publish("scada.events", {
+          asset: asset.nameOrTag,
+          event_type: eventType,
+          site_id: asset.siteId,
+          site_name: asset.siteName,
+          asset_type: asset.assetType,
+          timestamp: new Date().toISOString(),
+          payload: payload,
+          details: details,
+        });
+      } catch { /* NATS not connected — that's fine */ }
     } catch (error) {
       logError("❌ Failed to generate event", error as any);
     }


### PR DESCRIPTION
## Summary
Adds NATS integration for publishing SCADA simulator events to a NATS subject (scada.events) for downstream blockchain anchoring.

## Changes
- **package.json**: Added 
ats v2.29.3
- **server/services/nats/index.ts**: New NatsPublisher class — connects to configurable NATS server, publishes JSON events, graceful error handling
- **server/index.ts**: Wire NATS connection into server startup
- **server/simulator.ts**: Publish simulator events to \scada.events\ subject

## Config
- Set \NATS_URL\ env var (defaults to \
ats://swarm.ninja-portal.com:4222\)
- Non-blocking: if NATS is unavailable, events are silently dropped