### PR TITLE
fix(blockchain): implement ValidatorHealthMonitor against the real oxscada RPC :9090 (#442)

### DIFF
--- a/docs/blockchain/validator-monitoring.md
+++ b/docs/blockchain/validator-monitoring.md
@@ -2,7 +2,37 @@
 
 ## Overview
 
-The validator health monitor (`server/blockchain/validator-health.ts`) tracks validator node status, block production, peer connections, and sync status, alerting on degraded performance.
+The validator health monitor (`server/blockchain/validator-health.ts`) polls
+**oxscada validator nodes** (0xSCADA-node) over their HTTP JSON-RPC surface and
+alerts on degraded validators.
+
+An oxscada node serves RPC on port **9090** (not Tendermint's 26657 — see
+issue #442) with three endpoints:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /status` | Node status: height, role, peers, mempool, Kuramoto phase data |
+| `GET /events` | Last 50 bridged SCADA events |
+| `GET /health` | Liveness: `{"ok":true}` |
+
+The authoritative `/status` schema lives in `0xSCADA-node/src/rpc.rs`:
+
+```json
+{
+  "node_id": "hex",
+  "height": 1042,
+  "role": "validator",
+  "order_parameter": 0.97,
+  "mean_phase": 1.234,
+  "local_phase": 1.229,
+  "peer_phases": [
+    { "node_id": "hex", "phase": 1.24, "natural_freq": 0.5, "last_updated": 1748810000 }
+  ],
+  "peers": 2,
+  "mempool": 7,
+  "uptime_ticks": 123456
+}
+```
 
 ## Quick Start
 
@@ -13,13 +43,13 @@ const monitor = new ValidatorHealthMonitor();
 
 monitor.addNode({
   name: 'validator-1',
-  rpcUrl: 'http://localhost:26657',
+  rpcUrl: 'http://localhost:9090',
   checkIntervalMs: 30000,
   thresholds: {
-    minPeers: 3,
-    maxBlocksBehind: 10,
-    maxBlockAgeSec: 120,
-    minUptimePercent: 95,
+    minPeers: 1,            // 0 peers is always critical
+    minOrderParameter: 0.8, // Kuramoto coherence floor
+    maxHeightLag: 10,       // blocks behind the highest observed height
+    maxStalledChecks: 3,    // checks without height progress
   },
 });
 
@@ -30,19 +60,38 @@ monitor.onAlert((alert, node) => {
 monitor.startMonitoring();
 ```
 
-## Monitored Metrics
+## Monitored Conditions
 
-| Metric | Threshold | Severity |
-|--------|-----------|----------|
-| Peer count | < minPeers | warning/critical (0 peers = critical) |
-| Block age | > maxBlockAgeSec | warning/critical (3x = critical) |
-| Sync status | catching_up = true | info |
-| Uptime | < minUptimePercent | warning |
-| Reachability | connection failure | critical |
+| Condition | Alert code | Severity |
+|-----------|------------|----------|
+| RPC unreachable / HTTP error | `unreachable` | critical |
+| `/status` shape mismatch (schema drift) | `bad-status-shape` | critical |
+| Zero connected peers | `no-peers` | critical |
+| Peers below `minPeers` | `low-peers` | warning |
+| Kuramoto order parameter below `minOrderParameter` | `decoherent` | warning |
+| Height trails cluster max by more than `maxHeightLag` | `height-lag` | warning |
+| Height unchanged for `maxStalledChecks` checks | `height-stalled` | warning |
+| Node returned to health | `recovered` | info |
+
+## Prometheus Metrics
+
+Exported through the shared registry (`server/metrics/prometheus.ts`,
+`scada_` prefix) and served at `/metrics`, all labeled by `validator`:
+
+- `scada_blockchain_validator_up` — 1 when reachable and parseable, else 0
+- `scada_blockchain_validator_height`
+- `scada_blockchain_validator_peers`
+- `scada_blockchain_validator_mempool_size`
+- `scada_blockchain_validator_order_parameter` — Kuramoto coherence (0–1)
+- `scada_blockchain_validator_last_seen_timestamp_seconds`
+
+Dashboards: point Grafana at these series; alert on
+`scada_blockchain_validator_up == 0` and
+`scada_blockchain_validator_order_parameter < 0.8`.
 
 ## Alert Severities
 
-- **info** — Informational, no action needed (e.g., node syncing)
+- **info** — Informational, no action needed (e.g. recovery)
 - **warning** — Degraded, investigate soon
 - **critical** — Action required immediately
 
@@ -60,9 +109,10 @@ monitor.onAlert((alert, node) => {
 ## API
 
 - `addNode(config)` — Register a validator node
+- `removeNode(name)` — Unregister and stop monitoring a node
 - `startMonitoring(name?)` — Start periodic checks
 - `stopMonitoring(name?)` — Stop checks
-- `checkNode(name)` — Manual health check
+- `checkNode(name)` — Manual health check (returns the node status)
 - `getStatus(name)` — Get last known status
 - `getAllStatuses()` — All node statuses
 - `getUnhealthyNodes()` — Only unhealthy nodes

--- a/server/blockchain/__tests__/validator-health.test.ts
+++ b/server/blockchain/__tests__/validator-health.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ValidatorHealthMonitor,
+  parseOxscadaStatus,
+  DEFAULT_THRESHOLDS,
+  type FetchLike,
+  type OxscadaStatus,
+  type ValidatorAlert,
+} from '../validator-health';
+import { registry } from '../../metrics/prometheus';
+
+/** Representative payload captured from oxscada `GET /status` (0xSCADA-node/src/rpc.rs). */
+function oxscadaStatusFixture(overrides: Partial<OxscadaStatus> = {}): OxscadaStatus {
+  return {
+    node_id: 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90',
+    height: 1042,
+    role: 'validator',
+    order_parameter: 0.97,
+    mean_phase: 1.234,
+    local_phase: 1.229,
+    peer_phases: [
+      { node_id: 'ffee', phase: 1.24, natural_freq: 0.5, last_updated: 1748810000 },
+      { node_id: 'ddcc', phase: 1.22, natural_freq: 0.5, last_updated: 1748810001 },
+    ],
+    peers: 2,
+    mempool: 7,
+    uptime_ticks: 123456,
+    ...overrides,
+  };
+}
+
+function fetchReturning(payload: unknown): FetchLike {
+  return async () => ({ ok: true, status: 200, json: async () => payload });
+}
+
+function fetchFailing(): FetchLike {
+  return async () => {
+    throw new Error('ECONNREFUSED');
+  };
+}
+
+describe('parseOxscadaStatus', () => {
+  it('accepts a representative oxscada /status payload', () => {
+    const parsed = parseOxscadaStatus(oxscadaStatusFixture());
+    expect(parsed.height).toBe(1042);
+    expect(parsed.order_parameter).toBeCloseTo(0.97);
+    expect(parsed.peer_phases).toHaveLength(2);
+    expect(parsed.peer_phases[0].node_id).toBe('ffee');
+  });
+
+  it('rejects a Tendermint-style :26657 status payload', () => {
+    // The shape ValidatorHealthMonitor used to (incorrectly) target — issue #442
+    const tendermint = {
+      jsonrpc: '2.0',
+      id: -1,
+      result: {
+        node_info: { id: 'abc', network: 'test' },
+        sync_info: { latest_block_height: '100', catching_up: false },
+      },
+    };
+    expect(() => parseOxscadaStatus(tendermint)).toThrow(/peer_phases|node_id/);
+  });
+
+  it('rejects payloads with missing or mistyped fields', () => {
+    expect(() => parseOxscadaStatus(null)).toThrow(/not an object/);
+    expect(() => parseOxscadaStatus({ ...oxscadaStatusFixture(), height: '1042' })).toThrow(
+      /"height" is not a number/
+    );
+    expect(() => parseOxscadaStatus({ ...oxscadaStatusFixture(), peer_phases: 'none' })).toThrow(
+      /peer_phases/
+    );
+    const badPeer = oxscadaStatusFixture();
+    (badPeer.peer_phases as unknown[])[0] = { node_id: 1, phase: 0, natural_freq: 0, last_updated: 0 };
+    expect(() => parseOxscadaStatus(badPeer)).toThrow(/peer_phases\[0\]/);
+  });
+});
+
+describe('ValidatorHealthMonitor', () => {
+  let alerts: Array<{ alert: ValidatorAlert; node: string }>;
+
+  beforeEach(() => {
+    alerts = [];
+  });
+
+  function collect(monitor: ValidatorHealthMonitor): void {
+    monitor.onAlert((alert, node) => alerts.push({ alert, node }));
+  }
+
+  it('marks a healthy node healthy and populates Prometheus gauges', async () => {
+    const monitor = new ValidatorHealthMonitor(fetchReturning(oxscadaStatusFixture()));
+    collect(monitor);
+    monitor.addNode({ name: 'v1', rpcUrl: 'http://localhost:9090' });
+
+    const status = await monitor.checkNode('v1');
+
+    expect(status.healthy).toBe(true);
+    expect(status.reachable).toBe(true);
+    expect(status.status?.height).toBe(1042);
+    expect(alerts).toHaveLength(0);
+
+    // Issue #442 verification: gauges hold non-default values after a poll
+    const label = { validator: 'v1' };
+    expect(registry.gauge('blockchain_validator_up', '').get(label)).toBe(1);
+    expect(registry.gauge('blockchain_validator_height', '').get(label)).toBe(1042);
+    expect(registry.gauge('blockchain_validator_peers', '').get(label)).toBe(2);
+    expect(registry.gauge('blockchain_validator_mempool_size', '').get(label)).toBe(7);
+    expect(registry.gauge('blockchain_validator_order_parameter', '').get(label)).toBeCloseTo(0.97);
+    expect(registry.gauge('blockchain_validator_last_seen_timestamp_seconds', '').get(label)).toBeGreaterThan(0);
+  });
+
+  it('raises a critical unreachable alert and zeroes the up gauge on connection failure', async () => {
+    const monitor = new ValidatorHealthMonitor(fetchFailing());
+    collect(monitor);
+    monitor.addNode({ name: 'down', rpcUrl: 'http://localhost:9090' });
+
+    const status = await monitor.checkNode('down');
+
+    expect(status.healthy).toBe(false);
+    expect(status.reachable).toBe(false);
+    expect(status.consecutiveFailures).toBe(1);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].alert.severity).toBe('critical');
+    expect(alerts[0].alert.code).toBe('unreachable');
+    expect(registry.gauge('blockchain_validator_up', '').get({ validator: 'down' })).toBe(0);
+  });
+
+  it('flags an unexpected /status shape distinctly from unreachability', async () => {
+    const monitor = new ValidatorHealthMonitor(fetchReturning({ totally: 'wrong' }));
+    collect(monitor);
+    monitor.addNode({ name: 'drifted', rpcUrl: 'http://localhost:9090' });
+
+    await monitor.checkNode('drifted');
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].alert.code).toBe('bad-status-shape');
+  });
+
+  it('alerts critical on zero peers and warning below minPeers', async () => {
+    const zeroPeers = new ValidatorHealthMonitor(fetchReturning(oxscadaStatusFixture({ peers: 0 })));
+    collect(zeroPeers);
+    zeroPeers.addNode({ name: 'isolated', rpcUrl: 'http://x:9090' });
+    await zeroPeers.checkNode('isolated');
+    expect(alerts.some(a => a.alert.code === 'no-peers' && a.alert.severity === 'critical')).toBe(true);
+
+    alerts = [];
+    const lowPeers = new ValidatorHealthMonitor(fetchReturning(oxscadaStatusFixture({ peers: 1 })));
+    collect(lowPeers);
+    lowPeers.addNode({ name: 'sparse', rpcUrl: 'http://x:9090', thresholds: { minPeers: 3 } });
+    await lowPeers.checkNode('sparse');
+    expect(alerts.some(a => a.alert.code === 'low-peers' && a.alert.severity === 'warning')).toBe(true);
+  });
+
+  it('alerts when the Kuramoto order parameter drops below threshold', async () => {
+    const monitor = new ValidatorHealthMonitor(
+      fetchReturning(oxscadaStatusFixture({ order_parameter: 0.42 }))
+    );
+    collect(monitor);
+    monitor.addNode({ name: 'decoherent', rpcUrl: 'http://x:9090' });
+
+    const status = await monitor.checkNode('decoherent');
+
+    expect(status.healthy).toBe(false);
+    expect(alerts.some(a => a.alert.code === 'decoherent')).toBe(true);
+    expect(DEFAULT_THRESHOLDS.minOrderParameter).toBeGreaterThan(0.42);
+  });
+
+  it('flags a node trailing the highest observed cluster height', async () => {
+    let calls = 0;
+    const fetchPerNode: FetchLike = async url => {
+      calls++;
+      const payload = url.includes('ahead')
+        ? oxscadaStatusFixture({ height: 500 })
+        : oxscadaStatusFixture({ height: 100 });
+      return { ok: true, status: 200, json: async () => payload };
+    };
+    const monitor = new ValidatorHealthMonitor(fetchPerNode);
+    collect(monitor);
+    monitor.addNode({ name: 'ahead', rpcUrl: 'http://ahead:9090' });
+    monitor.addNode({ name: 'behind', rpcUrl: 'http://behind:9090' });
+
+    await monitor.checkNode('ahead');
+    const behind = await monitor.checkNode('behind');
+
+    expect(calls).toBe(2);
+    expect(behind.healthy).toBe(false);
+    expect(alerts.some(a => a.node === 'behind' && a.alert.code === 'height-lag')).toBe(true);
+  });
+
+  it('flags a stalled height after maxStalledChecks unchanged polls', async () => {
+    const monitor = new ValidatorHealthMonitor(
+      fetchReturning(oxscadaStatusFixture({ height: 777 }))
+    );
+    collect(monitor);
+    monitor.addNode({
+      name: 'stalled',
+      rpcUrl: 'http://x:9090',
+      thresholds: { maxStalledChecks: 2 },
+    });
+
+    await monitor.checkNode('stalled'); // establishes baseline height
+    await monitor.checkNode('stalled'); // stalledChecks = 1
+    const third = await monitor.checkNode('stalled'); // stalledChecks = 2 → alert
+
+    expect(third.stalledChecks).toBe(2);
+    expect(alerts.some(a => a.alert.code === 'height-stalled')).toBe(true);
+  });
+
+  it('emits a recovery info alert when a node returns to health', async () => {
+    let failing = true;
+    const flappingFetch: FetchLike = async () => {
+      if (failing) throw new Error('ECONNREFUSED');
+      return { ok: true, status: 200, json: async () => oxscadaStatusFixture() };
+    };
+    const monitor = new ValidatorHealthMonitor(flappingFetch);
+    collect(monitor);
+    monitor.addNode({ name: 'flappy', rpcUrl: 'http://x:9090' });
+
+    failing = false;
+    await monitor.checkNode('flappy'); // healthy baseline (lastSeenHealthy set)
+    failing = true;
+    await monitor.checkNode('flappy'); // outage
+    failing = false;
+    const recovered = await monitor.checkNode('flappy');
+
+    expect(recovered.healthy).toBe(true);
+    expect(alerts.some(a => a.alert.code === 'recovered' && a.alert.severity === 'info')).toBe(true);
+  });
+
+  it('summarizes healthy and unhealthy nodes', async () => {
+    const fetchPerNode: FetchLike = async url => {
+      if (url.includes('bad')) throw new Error('ECONNREFUSED');
+      return { ok: true, status: 200, json: async () => oxscadaStatusFixture() };
+    };
+    const monitor = new ValidatorHealthMonitor(fetchPerNode);
+    monitor.addNode({ name: 'good', rpcUrl: 'http://good:9090' });
+    monitor.addNode({ name: 'bad', rpcUrl: 'http://bad:9090' });
+
+    await monitor.checkNode('good');
+    await monitor.checkNode('bad');
+
+    expect(monitor.getSummary()).toEqual({ total: 2, healthy: 1, unhealthy: 1 });
+    expect(monitor.getUnhealthyNodes().map(s => s.name)).toEqual(['bad']);
+  });
+
+  it('rejects duplicate registration and unknown node checks', async () => {
+    const monitor = new ValidatorHealthMonitor(fetchReturning(oxscadaStatusFixture()));
+    monitor.addNode({ name: 'v1', rpcUrl: 'http://x:9090' });
+    expect(() => monitor.addNode({ name: 'v1', rpcUrl: 'http://y:9090' })).toThrow(/already registered/);
+    await expect(monitor.checkNode('nope')).rejects.toThrow(/unknown validator/);
+  });
+});

--- a/server/blockchain/validator-health.ts
+++ b/server/blockchain/validator-health.ts
@@ -1,0 +1,466 @@
+/**
+ * Validator Node Health Monitoring
+ *
+ * Polls oxscada validator nodes (0xSCADA-node) over their HTTP JSON-RPC
+ * surface — `GET /status`, `GET /health` on port 9090 by default — and
+ * raises alerts on degraded validators.
+ *
+ * Note this is NOT a Tendermint RPC (:26657) client: oxscada nodes expose a
+ * purpose-built status shape (Kuramoto phase data, mempool, uptime ticks).
+ * See 0xSCADA-node/src/rpc.rs for the authoritative response schema.
+ */
+
+import { registry } from '../metrics/prometheus';
+
+// ============================================================================
+// oxscada RPC response shapes (mirror 0xSCADA-node/src/rpc.rs)
+// ============================================================================
+
+export interface OxscadaPeerPhase {
+  node_id: string;
+  phase: number;
+  natural_freq: number;
+  last_updated: number;
+}
+
+export interface OxscadaStatus {
+  node_id: string;
+  height: number;
+  role: string;
+  /** Kuramoto order parameter r ∈ [0, 1]; 1 = fully phase-coherent validator set */
+  order_parameter: number;
+  mean_phase: number;
+  local_phase: number;
+  peer_phases: OxscadaPeerPhase[];
+  peers: number;
+  mempool: number;
+  uptime_ticks: number;
+}
+
+/**
+ * Strict parse of an oxscada `/status` payload. Throws with a field-specific
+ * message on any shape mismatch so schema drift surfaces immediately instead
+ * of as NaN gauges.
+ */
+export function parseOxscadaStatus(raw: unknown): OxscadaStatus {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('status payload is not an object');
+  }
+  const obj = raw as Record<string, unknown>;
+
+  const str = (field: string): string => {
+    if (typeof obj[field] !== 'string') {
+      throw new Error(`status field "${field}" is not a string`);
+    }
+    return obj[field] as string;
+  };
+  const num = (field: string): number => {
+    if (typeof obj[field] !== 'number' || Number.isNaN(obj[field] as number)) {
+      throw new Error(`status field "${field}" is not a number`);
+    }
+    return obj[field] as number;
+  };
+
+  if (!Array.isArray(obj.peer_phases)) {
+    throw new Error('status field "peer_phases" is not an array');
+  }
+  const peerPhases: OxscadaPeerPhase[] = (obj.peer_phases as unknown[]).map((p, i) => {
+    if (typeof p !== 'object' || p === null) {
+      throw new Error(`peer_phases[${i}] is not an object`);
+    }
+    const pp = p as Record<string, unknown>;
+    for (const f of ['phase', 'natural_freq', 'last_updated'] as const) {
+      if (typeof pp[f] !== 'number') {
+        throw new Error(`peer_phases[${i}].${f} is not a number`);
+      }
+    }
+    if (typeof pp.node_id !== 'string') {
+      throw new Error(`peer_phases[${i}].node_id is not a string`);
+    }
+    return {
+      node_id: pp.node_id,
+      phase: pp.phase as number,
+      natural_freq: pp.natural_freq as number,
+      last_updated: pp.last_updated as number,
+    };
+  });
+
+  return {
+    node_id: str('node_id'),
+    height: num('height'),
+    role: str('role'),
+    order_parameter: num('order_parameter'),
+    mean_phase: num('mean_phase'),
+    local_phase: num('local_phase'),
+    peer_phases: peerPhases,
+    peers: num('peers'),
+    mempool: num('mempool'),
+    uptime_ticks: num('uptime_ticks'),
+  };
+}
+
+// ============================================================================
+// Monitor configuration
+// ============================================================================
+
+export interface ValidatorThresholds {
+  /** Minimum connected peers before warning (0 peers is always critical) */
+  minPeers: number;
+  /** Minimum Kuramoto order parameter before the validator set counts as decoherent */
+  minOrderParameter: number;
+  /** Blocks a node may trail the highest observed height before warning */
+  maxHeightLag: number;
+  /** Consecutive checks without height progress before warning */
+  maxStalledChecks: number;
+}
+
+export const DEFAULT_THRESHOLDS: ValidatorThresholds = {
+  minPeers: 1,
+  minOrderParameter: 0.8,
+  maxHeightLag: 10,
+  maxStalledChecks: 3,
+};
+
+export interface ValidatorNodeConfig {
+  name: string;
+  /** Base URL of the oxscada RPC server, e.g. http://localhost:9090 */
+  rpcUrl: string;
+  checkIntervalMs?: number;
+  thresholds?: Partial<ValidatorThresholds>;
+}
+
+export type AlertSeverity = 'info' | 'warning' | 'critical';
+
+export interface ValidatorAlert {
+  severity: AlertSeverity;
+  code:
+    | 'unreachable'
+    | 'bad-status-shape'
+    | 'no-peers'
+    | 'low-peers'
+    | 'decoherent'
+    | 'height-lag'
+    | 'height-stalled'
+    | 'recovered';
+  message: string;
+  at: number;
+}
+
+export interface ValidatorNodeStatus {
+  name: string;
+  rpcUrl: string;
+  healthy: boolean;
+  reachable: boolean;
+  lastChecked: number | null;
+  lastSeenHealthy: number | null;
+  consecutiveFailures: number;
+  stalledChecks: number;
+  status: OxscadaStatus | null;
+  alerts: ValidatorAlert[];
+}
+
+export type AlertHandler = (alert: ValidatorAlert, nodeName: string) => void;
+
+/** Injectable for tests; defaults to global fetch (Node 18+). */
+export type FetchLike = (url: string, init?: { signal?: AbortSignal }) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}>;
+
+// ============================================================================
+// Prometheus gauges (label: validator name)
+// ============================================================================
+
+const validatorUp = registry.gauge(
+  'blockchain_validator_up',
+  'Whether the oxscada validator RPC is reachable and parseable (1/0)',
+  ['validator']
+);
+const validatorHeight = registry.gauge(
+  'blockchain_validator_height',
+  'Latest ledger height reported by the validator',
+  ['validator']
+);
+const validatorPeers = registry.gauge(
+  'blockchain_validator_peers',
+  'Connected peer count reported by the validator',
+  ['validator']
+);
+const validatorMempool = registry.gauge(
+  'blockchain_validator_mempool_size',
+  'Mempool size reported by the validator',
+  ['validator']
+);
+const validatorOrderParameter = registry.gauge(
+  'blockchain_validator_order_parameter',
+  'Kuramoto order parameter (phase coherence, 0-1) reported by the validator',
+  ['validator']
+);
+const validatorLastSeen = registry.gauge(
+  'blockchain_validator_last_seen_timestamp_seconds',
+  'Unix time of the last successful status poll for the validator',
+  ['validator']
+);
+
+// ============================================================================
+// Monitor
+// ============================================================================
+
+interface NodeState {
+  config: ValidatorNodeConfig;
+  thresholds: ValidatorThresholds;
+  status: ValidatorNodeStatus;
+  lastHeight: number | null;
+  timer: ReturnType<typeof setInterval> | null;
+}
+
+const DEFAULT_CHECK_INTERVAL_MS = 30_000;
+const FETCH_TIMEOUT_MS = 10_000;
+
+export class ValidatorHealthMonitor {
+  private nodes = new Map<string, NodeState>();
+  private alertHandlers: AlertHandler[] = [];
+  private fetchImpl: FetchLike;
+
+  constructor(fetchImpl?: FetchLike) {
+    this.fetchImpl = fetchImpl ?? (fetch as unknown as FetchLike);
+  }
+
+  addNode(config: ValidatorNodeConfig): void {
+    if (this.nodes.has(config.name)) {
+      throw new Error(`validator "${config.name}" is already registered`);
+    }
+    this.nodes.set(config.name, {
+      config,
+      thresholds: { ...DEFAULT_THRESHOLDS, ...config.thresholds },
+      status: {
+        name: config.name,
+        rpcUrl: config.rpcUrl,
+        healthy: false,
+        reachable: false,
+        lastChecked: null,
+        lastSeenHealthy: null,
+        consecutiveFailures: 0,
+        stalledChecks: 0,
+        status: null,
+        alerts: [],
+      },
+      lastHeight: null,
+      timer: null,
+    });
+  }
+
+  removeNode(name: string): void {
+    this.stopMonitoring(name);
+    this.nodes.delete(name);
+  }
+
+  onAlert(handler: AlertHandler): void {
+    this.alertHandlers.push(handler);
+  }
+
+  startMonitoring(name?: string): void {
+    for (const node of this.selectNodes(name)) {
+      if (node.timer) continue;
+      const interval = node.config.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS;
+      node.timer = setInterval(() => {
+        void this.checkNode(node.config.name);
+      }, interval);
+      // Never keep the process alive just for monitoring
+      node.timer.unref?.();
+      void this.checkNode(node.config.name);
+    }
+  }
+
+  stopMonitoring(name?: string): void {
+    for (const node of this.selectNodes(name)) {
+      if (node.timer) {
+        clearInterval(node.timer);
+        node.timer = null;
+      }
+    }
+  }
+
+  async checkNode(name: string): Promise<ValidatorNodeStatus> {
+    const node = this.nodes.get(name);
+    if (!node) {
+      throw new Error(`unknown validator "${name}"`);
+    }
+
+    const now = Date.now();
+    node.status.lastChecked = now;
+    const alerts: ValidatorAlert[] = [];
+
+    let parsed: OxscadaStatus | null = null;
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      try {
+        const res = await this.fetchImpl(`${node.config.rpcUrl.replace(/\/$/, '')}/status`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`/status returned HTTP ${res.status}`);
+        }
+        parsed = parseOxscadaStatus(await res.json());
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const shapeError = message.startsWith('status field') || message.startsWith('peer_phases');
+      node.status.reachable = false;
+      node.status.consecutiveFailures++;
+      alerts.push({
+        severity: 'critical',
+        code: shapeError ? 'bad-status-shape' : 'unreachable',
+        message: `${name}: ${shapeError ? 'unexpected /status shape' : 'status poll failed'} (${message})`,
+        at: now,
+      });
+    }
+
+    if (parsed) {
+      const wasUnhealthy = !node.status.healthy && node.status.lastSeenHealthy !== null;
+      node.status.reachable = true;
+      node.status.consecutiveFailures = 0;
+      node.status.status = parsed;
+
+      // Height progress tracking
+      if (node.lastHeight !== null && parsed.height <= node.lastHeight) {
+        node.status.stalledChecks++;
+      } else {
+        node.status.stalledChecks = 0;
+      }
+      node.lastHeight = parsed.height;
+
+      alerts.push(...this.evaluate(node, parsed, now));
+
+      const healthyNow = alerts.every(a => a.severity === 'info');
+      if (healthyNow) {
+        node.status.lastSeenHealthy = now;
+        if (wasUnhealthy) {
+          alerts.push({
+            severity: 'info',
+            code: 'recovered',
+            message: `${name}: validator healthy again`,
+            at: now,
+          });
+        }
+      }
+
+      validatorUp.set(1, { validator: name });
+      validatorHeight.set(parsed.height, { validator: name });
+      validatorPeers.set(parsed.peers, { validator: name });
+      validatorMempool.set(parsed.mempool, { validator: name });
+      validatorOrderParameter.set(parsed.order_parameter, { validator: name });
+      validatorLastSeen.set(now / 1000, { validator: name });
+    } else {
+      validatorUp.set(0, { validator: name });
+    }
+
+    node.status.healthy =
+      node.status.reachable && alerts.every(a => a.severity === 'info');
+    node.status.alerts = alerts;
+
+    for (const alert of alerts) {
+      for (const handler of this.alertHandlers) {
+        handler(alert, name);
+      }
+    }
+
+    return { ...node.status };
+  }
+
+  private evaluate(node: NodeState, status: OxscadaStatus, now: number): ValidatorAlert[] {
+    const t = node.thresholds;
+    const alerts: ValidatorAlert[] = [];
+
+    if (status.peers === 0) {
+      alerts.push({
+        severity: 'critical',
+        code: 'no-peers',
+        message: `${node.config.name}: validator has no connected peers`,
+        at: now,
+      });
+    } else if (status.peers < t.minPeers) {
+      alerts.push({
+        severity: 'warning',
+        code: 'low-peers',
+        message: `${node.config.name}: ${status.peers} peers (minimum ${t.minPeers})`,
+        at: now,
+      });
+    }
+
+    if (status.order_parameter < t.minOrderParameter) {
+      alerts.push({
+        severity: 'warning',
+        code: 'decoherent',
+        message: `${node.config.name}: Kuramoto order parameter ${status.order_parameter.toFixed(3)} below ${t.minOrderParameter}`,
+        at: now,
+      });
+    }
+
+    const maxHeight = this.highestKnownHeight();
+    if (maxHeight !== null && maxHeight - status.height > t.maxHeightLag) {
+      alerts.push({
+        severity: 'warning',
+        code: 'height-lag',
+        message: `${node.config.name}: height ${status.height} trails cluster max ${maxHeight} by more than ${t.maxHeightLag}`,
+        at: now,
+      });
+    }
+
+    if (node.status.stalledChecks >= t.maxStalledChecks) {
+      alerts.push({
+        severity: 'warning',
+        code: 'height-stalled',
+        message: `${node.config.name}: height ${status.height} unchanged for ${node.status.stalledChecks} checks`,
+        at: now,
+      });
+    }
+
+    return alerts;
+  }
+
+  private highestKnownHeight(): number | null {
+    let max: number | null = null;
+    for (const node of this.nodes.values()) {
+      const h = node.status.status?.height;
+      if (typeof h === 'number' && (max === null || h > max)) {
+        max = h;
+      }
+    }
+    return max;
+  }
+
+  getStatus(name: string): ValidatorNodeStatus | undefined {
+    const node = this.nodes.get(name);
+    return node ? { ...node.status } : undefined;
+  }
+
+  getAllStatuses(): ValidatorNodeStatus[] {
+    return Array.from(this.nodes.values(), n => ({ ...n.status }));
+  }
+
+  getUnhealthyNodes(): ValidatorNodeStatus[] {
+    return this.getAllStatuses().filter(s => !s.healthy);
+  }
+
+  getSummary(): { total: number; healthy: number; unhealthy: number } {
+    const all = this.getAllStatuses();
+    const healthy = all.filter(s => s.healthy).length;
+    return { total: all.length, healthy, unhealthy: all.length - healthy };
+  }
+
+  private selectNodes(name?: string): NodeState[] {
+    if (name === undefined) {
+      return Array.from(this.nodes.values());
+    }
+    const node = this.nodes.get(name);
+    if (!node) {
+      throw new Error(`unknown validator "${name}"`);
+    }
+    return [node];
+  }
+}


### PR DESCRIPTION
Fixes #442

## Key finding

The issue framed this as "rewrite the monitor to target :9090" — but `server/blockchain/validator-health.ts` (referenced by `docs/blockchain/validator-monitoring.md`) **never existed in the repo**. Only the doc did, describing a Tendermint-style `:26657` client. So this is a fresh implementation against the real surface, not a port change.

## What this adds

`server/blockchain/validator-health.ts` — polls oxscada nodes on `:9090` per the authoritative schema in `0xSCADA-node/src/rpc.rs`:

- **Strict `/status` parser** mirroring `rpc.rs` field-for-field. Schema drift raises a distinct `bad-status-shape` critical alert instead of silently producing NaN gauges (same failure mode #440 warns about on the NATS side).
- **Alerts**: `unreachable`, `no-peers` (critical) / `low-peers` (warning), `decoherent` (Kuramoto order parameter below threshold — feeds #453's coherence indicator), `height-lag` (vs highest observed cluster height), `height-stalled`, `recovered`.
- **Prometheus gauges** via the existing shared registry, labeled by validator: `scada_blockchain_validator_{up,height,peers,mempool_size,order_parameter,last_seen_timestamp_seconds}`.
- Doc rewritten for the real endpoint set (`/status`, `/events`, `/health`), thresholds, alert codes, and metric names.

## Acceptance criteria from #442

- [x] Monitor targets the oxscada RPC surface (`:9090`, `/status`)
- [x] `docs/blockchain/validator-monitoring.md` updated
- [x] Smoke test parsing the `/status` response shape (fixture captured from `rpc.rs`, plus rejection tests for the old Tendermint shape)
- [x] Gauges populate with non-default values — asserted directly in tests
- [ ] Grafana dashboards / alert configs — **none exist in this repo** (no `ops/` dir); the doc lists the series names and suggested alert rules. Dashboard JSON belongs with #460's `ops/grafana/` work.

## Tests

13 vitest tests in `server/blockchain/__tests__/validator-health.test.ts`, all passing; `tsc --noEmit` clean for the new files.

## Design notes for #453 (Validator Dashboard)

The dashboard issue expects this data layer. `ValidatorHealthMonitor` exposes `getAllStatuses()` including raw `OxscadaStatus` (with `peer_phases` for the Kuramoto view) and per-node alert lists — ready to wrap in an `/api/blockchain/validators` route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)