### PR TITLE
docs: disambiguate Resonant Consensus — archive the unadopted BLS proposal (#441)

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,9 @@ Prometheus metrics exposed at `/metrics` on all services.
 90+ documents across the `docs/` directory:
 
 ### Architecture
-Bidirectional sync · Chiral network topology · Decentralized orchestration · Event batching · HSM integration · L2 kernel integration · Resonant consensus · Resonant scheduler · Sublinear solver · Proof verification
+Bidirectional sync · Chiral network topology · Decentralized orchestration · Event batching · HSM integration · L2 kernel integration · Resonant scheduler · Sublinear solver · Proof verification
+
+> Consensus: the shipping "Resonant Consensus" protocol (Kuramoto-BFT) is specified in [0xSCADA-node ADR-0001](https://github.com/NickFlach/0xSCADA-node/blob/main/docs/adr/ADR-0001-resonant-consensus.md). An earlier BLS-based proposal by the same name was not adopted and is archived at `docs/archive/resonant-consensus-bls-proposal.md`.
 
 ### ADRs (0008–0025)
 `0008` Zero-trust agents · `0009` Emergence guardrails · `0010` Agent certification · `0011` OT-IT convergence · `0012` End-to-end integration · `0013` Autonomous agents · `0014` Production scale · `0022` Constellation unification · `0023` Evolutionary paradox resolution · `0024` Sublinear decoherence prediction · `0025` Living Fano dashboard

--- a/docs/archive/resonant-consensus-bls-proposal.md
+++ b/docs/archive/resonant-consensus-bls-proposal.md
@@ -1,4 +1,15 @@
-# Resonant Consensus Protocol: Signal → Resonance → Emergence
+# Proposal: Resonant-BLS Consensus Variant (NOT ADOPTED)
+
+> **ARCHIVED 2026-07-21 — this design was never implemented.**
+>
+> Two unrelated protocols historically shared the name "Resonant Consensus"
+> (issue #441). The canonical protocol — the one implemented and shipping in
+> the Rust validator node — is **Kuramoto-BFT**: phase-coupled oscillators
+> with Raft fallback and ed25519 attestations. Its spec is
+> [0xSCADA-node ADR-0001](https://github.com/NickFlach/0xSCADA-node/blob/main/docs/adr/ADR-0001-resonant-consensus.md).
+>
+> The BLS-aggregate-signature, `2f+1`-threshold design below is kept only as
+> a historical proposal. Do not build against it.
 
 > Issue #144: [Protocol] Design resonant consensus
 

--- a/docs/decisions/ADR-0012-end-to-end-integration.md
+++ b/docs/decisions/ADR-0012-end-to-end-integration.md
@@ -75,7 +75,7 @@ Wave 2 will build on this integrated foundation:
 
 - **AI/ML Anomaly Detection** — Feed historian data into ML models for predictive maintenance
 - **Autonomous Agent Governance** — Agents that can propose and execute operational changes within guardrails (ADR-0007, ADR-0009)
-- **Advanced Consensus** — Resonant consensus and sublinear solver integration for multi-site coordination
+- **Advanced Consensus** — Resonant consensus (Kuramoto-BFT, shipped in 0xSCADA-node — see its ADR-0001) and sublinear solver integration for multi-site coordination
 - **Digital Twin Simulation** — Use the unified pipeline to drive real-time digital twin models
 - **Federated Learning** — Cross-site model training without centralizing sensitive process data
 

--- a/docs/decisions/ADR-0016-rust-unikernel.md
+++ b/docs/decisions/ADR-0016-rust-unikernel.md
@@ -74,7 +74,7 @@ Every 0xSCADA-OS node is simultaneously:
 1. **A SCADA controller** — reads sensors, drives actuators, runs control logic
 2. **A Flux entity** — publishes state to the world graph, subscribes to peers, reacts to cross-network events
 3. **An Ethereum attestor** — batches events into Merkle roots, anchors to L2, verifies proofs from peers
-4. **A consensus participant** — resonant consensus (RCP) for local cluster agreement
+4. **A consensus participant** — resonant consensus (Kuramoto-BFT, see 0xSCADA-node ADR-0001) for local cluster agreement
 5. **A chiral network node** — Byzantine-resistant routing with L-path/R-path separation
 
 The SIN forms when nodes discover each other via Flux and establish chiral routing relationships. There is no central coordinator. The network self-organizes via gossip + resonant consensus.
@@ -171,7 +171,7 @@ No ethers.js, no JSON-RPC proxy. The kernel speaks Ethereum natively:
 - secp256k1, Keccak-256, RLP encoding
 - Merkle tree construction + proof verification
 - Batch anchor submission to L2
-- Resonant consensus protocol (signal → resonance → emergence)
+- Resonant consensus protocol (Kuramoto-BFT — see 0xSCADA-node ADR-0001)
 - Bidirectional state sync
 
 ### Phase 4: Production Hardening (Weeks 27+)
@@ -229,7 +229,7 @@ No ethers.js, no JSON-RPC proxy. The kernel speaks Ethereum natively:
 
 ## References
 
-- Existing docs: `kernel-fork-plan.md`, `chiral-network-stack.md`, `resonant-consensus.md`, `resonant-scheduler.md`, `l2-kernel-integration.md`, `bidirectional-sync.md`, `decentralized-orchestration.md`
+- Existing docs: `kernel-fork-plan.md`, `chiral-network-stack.md`, `archive/resonant-consensus-bls-proposal.md` (archived proposal — canonical spec is 0xSCADA-node ADR-0001), `resonant-scheduler.md`, `l2-kernel-integration.md`, `bidirectional-sync.md`, `decentralized-orchestration.md`
 - Rust OS resources: [Writing an OS in Rust (phil-opp)](https://os.phil-opp.com/), [Redox OS](https://www.redox-os.org/), [Theseus OS](https://github.com/theseus-os/Theseus)
 - smoltcp: https://github.com/smoltcp-rs/smoltcp
 - Flux: https://flux.eckman-tech.com


### PR DESCRIPTION
Fixes #441

Confirms **Kuramoto-BFT** (implemented in Rust in 0xSCADA-node, specified in its ADR-0001) as the canonical "Resonant Consensus". The BLS-aggregate-signature `2f+1` design was paper only.

- `docs/architecture/resonant-consensus.md` → `docs/archive/resonant-consensus-bls-proposal.md`, retitled "Proposal: Resonant-BLS Consensus Variant (NOT ADOPTED)" with a sunset banner pointing at the canonical spec
- Cross-references updated: README architecture list, ADR-0012 future-work bullet, ADR-0016 (SIN role, Phase 3 roadmap line, references list)
- Verification per the issue: `grep -i "resonant consensus"` outside the archive now yields only hits that point at 0xSCADA-node ADR-0001 or generic term usage

Companion PR in 0xSCADA-node adds the disambiguation note at the top of ADR-0001 itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)