### PR TITLE
fix(contracts): drop misleading Payment.txHash field (#448) [stacked on #473]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+Notable changes to the 0xSCADA contracts and platform.
+
+## Unreleased
+
+### Changed (on-chain state shape)
+
+- **`BountyPayment.Payment` struct: removed the `txHash` field** (#448).
+  It was documented as "transaction hash for reference" but actually stored
+  `blockhash(block.number - 1)` — the previous block's hash, which identifies
+  nothing about the payment. A transaction cannot know its own hash on-chain;
+  consumers needing the real payment tx hash should take it from the
+  `BountyPaid` event log. No deployed instances existed (the contract did not
+  compile before #449's fix), so no live-state migration is required.
+
+### Fixed
+
+- **`BountyPayment` payout functions now follow strict
+  checks-effects-interactions** (#449): status, payment record, and
+  `totalPaidOut` are finalized before any external transfer, in both
+  `payBounty` and `payBountyMultiple`. Latent compile error in
+  `payBountyMultiple` fixed (invalid `address payable[]` → `address[]`
+  assignment).

--- a/contracts/BountyPayment.sol
+++ b/contracts/BountyPayment.sol
@@ -64,13 +64,15 @@ contract BountyPayment is AccessControl, ReentrancyGuard {
         address createdBy;          // Who registered the bounty
     }
 
+    // The paying transaction's own hash is unknowable on-chain; consumers
+    // needing it should read it from the BountyPaid event log. A former
+    // `txHash` field here actually held blockhash(block.number - 1) — see #448.
     struct Payment {
         uint256 issueNumber;
         uint256 prNumber;           // GitHub PR number
         address[] recipients;       // Support multi-recipient payments
         uint256[] amounts;          // Amount per recipient
         uint256 paidAt;             // Timestamp of payment
-        bytes32 txHash;             // Transaction hash for reference
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -303,8 +305,7 @@ contract BountyPayment is AccessControl, ReentrancyGuard {
             prNumber: prNumber,
             recipients: recipients,
             amounts: amounts,
-            paidAt: block.timestamp,
-            txHash: blockhash(block.number - 1) // Approximate tx hash
+            paidAt: block.timestamp
         });
 
         totalPaidOut += bounty.amount;
@@ -380,8 +381,7 @@ contract BountyPayment is AccessControl, ReentrancyGuard {
             prNumber: prNumber,
             recipients: recipientAddrs,
             amounts: amounts,
-            paidAt: block.timestamp,
-            txHash: blockhash(block.number - 1)
+            paidAt: block.timestamp
         });
 
         totalPaidOut += totalAmount;


### PR DESCRIPTION
Fixes #448

**Stacked on #473** (same lines; merge #473 first — this PR's base is that branch and it will retarget to `main` automatically when #473 merges and its branch is deleted).

## Decision: drop the field

Of the issue's three options (rename to `priorBlockHash` / emit event with real context / drop), dropping is correct:

- `blockhash(block.number - 1)` identifies **nothing** about the payment — renaming it keeps a useless field in on-chain state forever
- The real payment tx hash is already available the only place it can be: the `BountyPaid` **event log** (a transaction cannot know its own hash on-chain)
- No consumer reads `Payment.txHash` — grepped `client/`, `scripts/`, `docs/`, `.github/` (the `txHash` hits in `openapi.yaml` are unrelated anchor-pipeline APIs)
- **No deployed instance exists**: the contract didn't compile before #473's fix, so the "on-chain state shape" migration risk flagged in the issue is moot

A comment on the struct records why the field is gone, and `CHANGELOG.md` (new) carries the migration note per the issue's acceptance criteria.

## Verification

9/9 forge tests pass on this branch (`forge test --match-contract BountyPaymentTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)