### PR TITLE
fix(server): Redis-backed sliding-window rate limiter for multi-replica deployments (#447)

### DIFF
--- a/helm/oxscada/templates/configmap.yaml
+++ b/helm/oxscada/templates/configmap.yaml
@@ -9,3 +9,6 @@ data:
   SERVER_PORT: "{{ .Values.server.port }}"
   GATEWAY_PORT: "{{ .Values.gateway.port }}"
   CLIENT_PORT: "{{ .Values.client.port }}"
+  RATE_LIMITER_BACKEND: "{{ .Values.rateLimiter.backend }}"
+  REDIS_HOST: "{{ .Values.redis.host }}"
+  REDIS_PORT: "{{ .Values.redis.port }}"

--- a/helm/oxscada/values.yaml
+++ b/helm/oxscada/values.yaml
@@ -45,6 +45,16 @@ gateway:
       cpu: 500m
       memory: 256Mi
 
+# Required in production whenever server.replicaCount > 1: the in-memory
+# rate limiter is per-pod, so callers can multiply their limit by routing
+# to different replicas (issue #447). "redis" gives one shared limit.
+rateLimiter:
+  backend: redis
+
+redis:
+  host: oxscada-redis
+  port: 6379
+
 postgresql:
   enabled: true
   auth:

--- a/server/middleware/__tests__/rate-limiter.test.ts
+++ b/server/middleware/__tests__/rate-limiter.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  SlidingWindowRateLimiter,
+  RedisSlidingWindowRateLimiter,
+  createRateLimiter,
+  type RedisClientLike,
+  type RedisPipelineLike,
+} from '../rate-limiter';
+import { rateLimitMiddleware } from '../api-gateway';
+
+/**
+ * In-process fake of the ioredis subset the Redis backend uses. One store
+ * can back several client instances — the multi-replica scenario.
+ */
+class FakeRedisStore {
+  sets = new Map<string, Map<string, number>>();
+
+  client(): RedisClientLike {
+    const store = this;
+    return {
+      pipeline(): RedisPipelineLike {
+        const ops: Array<() => unknown> = [];
+        const pipe = {
+          zremrangebyscore(key: string, min: number | string, max: number | string) {
+            ops.push(() => {
+              const set = store.sets.get(key);
+              if (!set) return 0;
+              let removed = 0;
+              for (const [member, score] of set) {
+                if (score >= Number(min) && score <= Number(max)) {
+                  set.delete(member);
+                  removed++;
+                }
+              }
+              return removed;
+            });
+            return pipe;
+          },
+          zadd(key: string, score: number, member: string) {
+            ops.push(() => {
+              let set = store.sets.get(key);
+              if (!set) {
+                set = new Map();
+                store.sets.set(key, set);
+              }
+              set.set(member, score);
+              return 1;
+            });
+            return pipe;
+          },
+          zcard(key: string) {
+            ops.push(() => store.sets.get(key)?.size ?? 0);
+            return pipe;
+          },
+          zrange(key: string, start: number, stop: number, _ws: 'WITHSCORES') {
+            ops.push(() => {
+              const set = store.sets.get(key);
+              if (!set) return [];
+              const sorted = [...set.entries()].sort((a, b) => a[1] - b[1]);
+              const slice = sorted.slice(start, stop === -1 ? undefined : stop + 1);
+              return slice.flatMap(([member, score]) => [member, String(score)]);
+            });
+            return pipe;
+          },
+          pexpire(_key: string, _ms: number) {
+            ops.push(() => 1);
+            return pipe;
+          },
+          async exec() {
+            return ops.map(op => [null, op()] as [Error | null, unknown]);
+          },
+        };
+        return pipe as RedisPipelineLike;
+      },
+      async zcount(key: string, min: number | string, _max: number | string) {
+        const set = store.sets.get(key);
+        if (!set) return 0;
+        let n = 0;
+        for (const score of set.values()) {
+          if (score >= Number(min)) n++;
+        }
+        return n;
+      },
+    };
+  }
+}
+
+function failingRedis(): RedisClientLike {
+  return {
+    pipeline(): RedisPipelineLike {
+      const pipe = {
+        zremrangebyscore: () => pipe,
+        zadd: () => pipe,
+        zcard: () => pipe,
+        zrange: () => pipe,
+        pexpire: () => pipe,
+        exec: async () => {
+          throw new Error('ECONNREFUSED');
+        },
+      };
+      return pipe as unknown as RedisPipelineLike;
+    },
+    zcount: async () => {
+      throw new Error('ECONNREFUSED');
+    },
+  };
+}
+
+// --- Backend contract (both implementations) ---
+
+describe.each([
+  ['memory', () => new SlidingWindowRateLimiter({ windowMs: 1000, maxRequests: 5 })],
+  [
+    'redis',
+    () => new RedisSlidingWindowRateLimiter({ windowMs: 1000, maxRequests: 5 }, new FakeRedisStore().client()),
+  ],
+] as const)('rate limiter contract (%s backend)', (_name, makeLimiter) => {
+  it('allows requests up to the limit and blocks beyond it', async () => {
+    const limiter = makeLimiter();
+    for (let i = 0; i < 5; i++) {
+      const r = await limiter.check('k');
+      expect(r.allowed).toBe(true);
+    }
+    const blocked = await limiter.check('k');
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    limiter.destroy();
+  });
+
+  it('tracks keys independently', async () => {
+    const limiter = makeLimiter();
+    for (let i = 0; i < 5; i++) await limiter.check('a');
+    expect((await limiter.check('a')).allowed).toBe(false);
+    expect((await limiter.check('b')).allowed).toBe(true);
+    limiter.destroy();
+  });
+
+  it('honors per-call override limits', async () => {
+    const limiter = makeLimiter();
+    expect((await limiter.check('k', 1)).allowed).toBe(true);
+    expect((await limiter.check('k', 1)).allowed).toBe(false);
+    limiter.destroy();
+  });
+
+  it('frees the window after windowMs', async () => {
+    vi.useFakeTimers();
+    try {
+      const limiter = makeLimiter();
+      for (let i = 0; i < 6; i++) await limiter.check('k');
+      expect((await limiter.check('k')).allowed).toBe(false);
+      vi.advanceTimersByTime(1500);
+      expect((await limiter.check('k')).allowed).toBe(true);
+      limiter.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// --- Multi-replica behavior (the actual #447 bug) ---
+
+describe('multi-replica limiting', () => {
+  it('memory backend leaks limit across replicas (documents the bug)', async () => {
+    const podA = new SlidingWindowRateLimiter({ windowMs: 1000, maxRequests: 10 });
+    const podB = new SlidingWindowRateLimiter({ windowMs: 1000, maxRequests: 10 });
+    for (let i = 0; i < 10; i++) expect(podA.check('client').allowed).toBe(true);
+    expect(podA.check('client').allowed).toBe(false);
+    // Same caller, different pod: fresh window. This is the failure mode.
+    expect(podB.check('client').allowed).toBe(true);
+    podA.destroy();
+    podB.destroy();
+  });
+
+  it('redis backend enforces one shared limit: 11th call over a 10-limit window 429s on instance B', async () => {
+    const shared = new FakeRedisStore();
+    const podA = new RedisSlidingWindowRateLimiter({ windowMs: 10_000, maxRequests: 10 }, shared.client());
+    const podB = new RedisSlidingWindowRateLimiter({ windowMs: 10_000, maxRequests: 10 }, shared.client());
+
+    for (let i = 0; i < 10; i++) {
+      expect((await podA.check('client')).allowed).toBe(true);
+    }
+    const eleventh = await podB.check('client');
+    expect(eleventh.allowed).toBe(false);
+    expect(eleventh.remaining).toBe(0);
+    podA.destroy();
+    podB.destroy();
+  });
+});
+
+// --- Degradation ---
+
+describe('redis failure degradation', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to in-memory limiting and warns once', async () => {
+    const limiter = new RedisSlidingWindowRateLimiter({ windowMs: 1000, maxRequests: 2 }, failingRedis());
+
+    expect((await limiter.check('k')).allowed).toBe(true);
+    expect((await limiter.check('k')).allowed).toBe(true);
+    // Still limited — by the fallback — rather than failing open entirely
+    expect((await limiter.check('k')).allowed).toBe(false);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    limiter.destroy();
+  });
+});
+
+// --- Factory ---
+
+describe('createRateLimiter', () => {
+  const originalEnv = process.env.RATE_LIMITER_BACKEND;
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.RATE_LIMITER_BACKEND;
+    else process.env.RATE_LIMITER_BACKEND = originalEnv;
+  });
+
+  it('defaults to memory', () => {
+    delete process.env.RATE_LIMITER_BACKEND;
+    const limiter = createRateLimiter({ windowMs: 1000, maxRequests: 5 });
+    expect(limiter).toBeInstanceOf(SlidingWindowRateLimiter);
+    limiter.destroy();
+  });
+
+  it('selects redis via env', () => {
+    process.env.RATE_LIMITER_BACKEND = 'redis';
+    const limiter = createRateLimiter(
+      { windowMs: 1000, maxRequests: 5 },
+      { redisClient: new FakeRedisStore().client() }
+    );
+    expect(limiter).toBeInstanceOf(RedisSlidingWindowRateLimiter);
+    limiter.destroy();
+  });
+
+  it('explicit option beats env', () => {
+    process.env.RATE_LIMITER_BACKEND = 'redis';
+    const limiter = createRateLimiter({ windowMs: 1000, maxRequests: 5 }, { backend: 'memory' });
+    expect(limiter).toBeInstanceOf(SlidingWindowRateLimiter);
+    limiter.destroy();
+  });
+});
+
+// --- Middleware over the Redis backend ---
+
+describe('rateLimitMiddleware with redis backend', () => {
+  function mockRes() {
+    const res: any = {
+      headers: {} as Record<string, string>,
+      statusCode: 0,
+      body: undefined as unknown,
+      setHeader(k: string, v: string) {
+        this.headers[k] = v;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: unknown) {
+        this.body = payload;
+      },
+    };
+    return res;
+  }
+
+  it('returns 429 with rate-limit headers once the shared window is exhausted', async () => {
+    const shared = new FakeRedisStore();
+    const mw = rateLimitMiddleware(
+      { windowMs: 10_000, maxRequests: 3 },
+      { backend: 'redis', redisClient: shared.client() }
+    );
+    const req = { ip: '10.0.0.1', method: 'GET', path: '/api/tags', headers: {} } as any;
+
+    for (let i = 0; i < 3; i++) {
+      const res = mockRes();
+      const next = vi.fn();
+      await mw(req, res, next);
+      expect(next).toHaveBeenCalled();
+    }
+
+    const res = mockRes();
+    const next = vi.fn();
+    await mw(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(429);
+    expect(res.headers['X-RateLimit-Remaining']).toBe('0');
+    expect((res.body as any).retryAfter).toBeGreaterThan(0);
+  });
+});

--- a/server/middleware/api-gateway.ts
+++ b/server/middleware/api-gateway.ts
@@ -11,16 +11,25 @@
 import { Request, Response, NextFunction, Router, Express } from 'express';
 import crypto from 'crypto';
 import { z, ZodSchema } from 'zod';
+import {
+  createRateLimiter,
+  type CreateRateLimiterOptions,
+  type RateLimitConfig,
+} from './rate-limiter';
+
+// Limiter implementations live in ./rate-limiter (issue #447); re-exported
+// here so existing imports keep working.
+export {
+  SlidingWindowRateLimiter,
+  RedisSlidingWindowRateLimiter,
+  createRateLimiter,
+  type RateLimitConfig,
+  type RateLimitResult,
+  type RateLimiter,
+  type RateLimiterBackendName,
+} from './rate-limiter';
 
 // --- Types ---
-
-export interface RateLimitConfig {
-  windowMs: number;
-  maxRequests: number;
-  keyExtractor?: (req: Request) => string;
-  /** Per-route overrides keyed by "METHOD /path" */
-  routeOverrides?: Record<string, { windowMs?: number; maxRequests: number }>;
-}
 
 export interface ApiKeyRecord {
   key: string;
@@ -50,61 +59,6 @@ const DEFAULT_CONFIG: ApiGatewayConfig = {
   publicRoutes: ['/api/health', '/api/healthz', '/api/readyz'],
 };
 
-// --- Sliding Window Rate Limiter ---
-
-interface WindowEntry {
-  count: number;
-  resetAt: number;
-}
-
-export class SlidingWindowRateLimiter {
-  private windows = new Map<string, WindowEntry>();
-  private cleanupTimer?: ReturnType<typeof setInterval>;
-
-  constructor(private config: RateLimitConfig) {
-    this.cleanupTimer = setInterval(() => this.cleanup(), config.windowMs * 2);
-  }
-
-  check(key: string, overrideMax?: number): { allowed: boolean; remaining: number; resetAt: number } {
-    const now = Date.now();
-    const max = overrideMax ?? this.config.maxRequests;
-    let entry = this.windows.get(key);
-
-    if (!entry || now >= entry.resetAt) {
-      entry = { count: 0, resetAt: now + this.config.windowMs };
-      this.windows.set(key, entry);
-    }
-
-    entry.count++;
-    const remaining = Math.max(0, max - entry.count);
-
-    return {
-      allowed: entry.count <= max,
-      remaining,
-      resetAt: entry.resetAt,
-    };
-  }
-
-  /** Get current count for a key without incrementing */
-  peek(key: string): number {
-    const entry = this.windows.get(key);
-    if (!entry || Date.now() >= entry.resetAt) return 0;
-    return entry.count;
-  }
-
-  private cleanup(): void {
-    const now = Date.now();
-    for (const [key, entry] of this.windows) {
-      if (now >= entry.resetAt) this.windows.delete(key);
-    }
-  }
-
-  destroy(): void {
-    if (this.cleanupTimer) clearInterval(this.cleanupTimer);
-    this.windows.clear();
-  }
-}
-
 // --- Middleware Functions ---
 
 /** Inject a unique request ID */
@@ -118,11 +72,11 @@ export function requestIdMiddleware() {
 }
 
 /** Rate limiting middleware with per-route overrides */
-export function rateLimitMiddleware(config: RateLimitConfig) {
-  const limiter = new SlidingWindowRateLimiter(config);
+export function rateLimitMiddleware(config: RateLimitConfig, limiterOptions?: CreateRateLimiterOptions) {
+  const limiter = createRateLimiter(config, limiterOptions);
   const keyFn = config.keyExtractor || ((req: Request) => req.ip || 'unknown');
 
-  return (req: Request, res: Response, next: NextFunction): void => {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const key = keyFn(req);
     const routeKey = `${req.method} ${req.path}`;
 
@@ -143,7 +97,16 @@ export function rateLimitMiddleware(config: RateLimitConfig) {
       maxRequests = apiKeyRecord.rateLimit;
     }
 
-    const result = limiter.check(key, maxRequests);
+    let result;
+    try {
+      result = await limiter.check(key, maxRequests);
+    } catch (err) {
+      // Backends degrade internally; anything reaching here is unexpected —
+      // fail open rather than take down the API path.
+      console.error('[rate-limiter] check failed unexpectedly, allowing request:', err);
+      next();
+      return;
+    }
 
     res.setHeader('X-RateLimit-Limit', maxRequests.toString());
     res.setHeader('X-RateLimit-Remaining', result.remaining.toString());

--- a/server/middleware/rate-limiter.ts
+++ b/server/middleware/rate-limiter.ts
@@ -1,0 +1,230 @@
+/**
+ * Rate limiter backends (issue #447)
+ *
+ * Two implementations of the same contract:
+ *
+ * - SlidingWindowRateLimiter — process-local Map. Fine for a single
+ *   replica; with N replicas each pod has its own windows, so a caller can
+ *   multiply the effective limit by spraying requests across pods.
+ * - RedisSlidingWindowRateLimiter — true sliding window over a shared
+ *   Redis sorted set, giving one consistent limit across all replicas.
+ *   On Redis failure it degrades to an internal in-memory limiter
+ *   (per-replica limiting beats either blocking all traffic or none).
+ *
+ * Select via RATE_LIMITER_BACKEND=memory|redis (default memory) or the
+ * explicit factory options.
+ */
+
+import crypto from 'crypto';
+import type { Request } from 'express';
+import { getRedisClient } from '../services/cache/redis-client';
+
+// --- Types ---
+
+export interface RateLimitConfig {
+  windowMs: number;
+  maxRequests: number;
+  keyExtractor?: (req: Request) => string;
+  /** Per-route overrides keyed by "METHOD /path" */
+  routeOverrides?: Record<string, { windowMs?: number; maxRequests: number }>;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+}
+
+/** Common contract; memory backend is sync, Redis backend async. */
+export interface RateLimiter {
+  check(key: string, overrideMax?: number): RateLimitResult | Promise<RateLimitResult>;
+  peek(key: string): number | Promise<number>;
+  destroy(): void;
+}
+
+export type RateLimiterBackendName = 'memory' | 'redis';
+
+// --- In-memory backend ---
+
+interface WindowEntry {
+  count: number;
+  resetAt: number;
+}
+
+export class SlidingWindowRateLimiter implements RateLimiter {
+  private windows = new Map<string, WindowEntry>();
+  private cleanupTimer?: ReturnType<typeof setInterval>;
+
+  constructor(private config: RateLimitConfig) {
+    this.cleanupTimer = setInterval(() => this.cleanup(), config.windowMs * 2);
+    this.cleanupTimer.unref?.();
+  }
+
+  check(key: string, overrideMax?: number): RateLimitResult {
+    const now = Date.now();
+    const max = overrideMax ?? this.config.maxRequests;
+    let entry = this.windows.get(key);
+
+    if (!entry || now >= entry.resetAt) {
+      entry = { count: 0, resetAt: now + this.config.windowMs };
+      this.windows.set(key, entry);
+    }
+
+    entry.count++;
+    const remaining = Math.max(0, max - entry.count);
+
+    return {
+      allowed: entry.count <= max,
+      remaining,
+      resetAt: entry.resetAt,
+    };
+  }
+
+  /** Get current count for a key without incrementing */
+  peek(key: string): number {
+    const entry = this.windows.get(key);
+    if (!entry || Date.now() >= entry.resetAt) return 0;
+    return entry.count;
+  }
+
+  private cleanup(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.windows) {
+      if (now >= entry.resetAt) this.windows.delete(key);
+    }
+  }
+
+  destroy(): void {
+    if (this.cleanupTimer) clearInterval(this.cleanupTimer);
+    this.windows.clear();
+  }
+}
+
+// --- Redis backend ---
+
+/**
+ * Structural subset of ioredis used by the Redis backend; lets tests inject
+ * a fake without a live server.
+ */
+export interface RedisPipelineLike {
+  zremrangebyscore(key: string, min: number | string, max: number | string): this;
+  zadd(key: string, score: number, member: string): this;
+  zcard(key: string): this;
+  zrange(key: string, start: number, stop: number, withScores: 'WITHSCORES'): this;
+  pexpire(key: string, ms: number): this;
+  exec(): Promise<Array<[error: Error | null, result: unknown]> | null>;
+}
+
+export interface RedisClientLike {
+  pipeline(): RedisPipelineLike;
+  zcount(key: string, min: number | string, max: number | string): Promise<number>;
+}
+
+const KEY_NAMESPACE = 'ratelimit:';
+
+export class RedisSlidingWindowRateLimiter implements RateLimiter {
+  private fallback: SlidingWindowRateLimiter;
+  private fallbackWarned = false;
+
+  constructor(
+    private config: RateLimitConfig,
+    private client?: RedisClientLike
+  ) {
+    this.fallback = new SlidingWindowRateLimiter(config);
+  }
+
+  private async getClient(): Promise<RedisClientLike> {
+    if (this.client) return this.client;
+    this.client = (await getRedisClient()) as unknown as RedisClientLike;
+    return this.client;
+  }
+
+  async check(key: string, overrideMax?: number): Promise<RateLimitResult> {
+    const max = overrideMax ?? this.config.maxRequests;
+    const windowMs = this.config.windowMs;
+    const now = Date.now();
+    const redisKey = KEY_NAMESPACE + key;
+    // Member must be unique per request so concurrent hits in the same ms
+    // all count.
+    const member = `${now}-${crypto.randomUUID()}`;
+
+    try {
+      const client = await this.getClient();
+      const replies = await client
+        .pipeline()
+        .zremrangebyscore(redisKey, 0, now - windowMs)
+        .zadd(redisKey, now, member)
+        .zcard(redisKey)
+        .zrange(redisKey, 0, 0, 'WITHSCORES')
+        .pexpire(redisKey, windowMs)
+        .exec();
+
+      if (!replies) throw new Error('redis pipeline returned null');
+      for (const [err] of replies) {
+        if (err) throw err;
+      }
+
+      const count = Number(replies[2][1]);
+      // Rejected requests stay in the set on purpose: a client hammering the
+      // endpoint keeps its own window full rather than sliding it free.
+      const oldest = replies[3][1] as string[] | undefined;
+      const oldestScore = oldest && oldest.length >= 2 ? Number(oldest[1]) : now;
+      return {
+        allowed: count <= max,
+        remaining: Math.max(0, max - count),
+        resetAt: oldestScore + windowMs,
+      };
+    } catch (err) {
+      if (!this.fallbackWarned) {
+        this.fallbackWarned = true;
+        console.warn(
+          `[rate-limiter] Redis unavailable, degrading to per-replica in-memory limiting: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+      return this.fallback.check(key, overrideMax);
+    }
+  }
+
+  async peek(key: string): Promise<number> {
+    const now = Date.now();
+    try {
+      const client = await this.getClient();
+      return await client.zcount(KEY_NAMESPACE + key, now - this.config.windowMs, '+inf');
+    } catch {
+      return this.fallback.peek(key);
+    }
+  }
+
+  destroy(): void {
+    this.fallback.destroy();
+  }
+}
+
+// --- Factory ---
+
+export interface CreateRateLimiterOptions {
+  backend?: RateLimiterBackendName;
+  redisClient?: RedisClientLike;
+}
+
+export function createRateLimiter(
+  config: RateLimitConfig,
+  options: CreateRateLimiterOptions = {}
+): RateLimiter {
+  const requested =
+    options.backend ?? (process.env.RATE_LIMITER_BACKEND as RateLimiterBackendName | undefined) ?? 'memory';
+
+  switch (requested) {
+    case 'redis':
+      return new RedisSlidingWindowRateLimiter(config, options.redisClient);
+    case 'memory':
+      return new SlidingWindowRateLimiter(config);
+    default:
+      console.warn(
+        `[rate-limiter] Unknown RATE_LIMITER_BACKEND "${requested}", using in-memory backend`
+      );
+      return new SlidingWindowRateLimiter(config);
+  }
+}


### PR DESCRIPTION
Fixes #447

## The bug

`SlidingWindowRateLimiter` keeps windows in a process-local `Map`; the Helm chart deploys `server.replicaCount: 2`, so each pod enforces its own limit and a caller doubles its budget by hitting the other pod. (The chart also didn't deploy or configure Redis at all, despite `server/services/cache/redis-client.ts` existing.)

## The fix

`RedisSlidingWindowRateLimiter` — a **true sliding window** over a shared sorted set. Design choices worth noting:

- **Pipeline (`zremrangebyscore` → `zadd` → `zcard` → oldest-entry → `pexpire`) instead of a Lua script**: count-after-add gives the same enforcement property, works on Redis Cluster, and is testable without embedding a Lua interpreter. Rejected requests intentionally stay in the set, so a hammering client keeps its own window full.
- **Degradation, not fail-open**: if Redis is unreachable, the backend falls back to an internal in-memory limiter with a single warning — per-replica limiting beats letting everything through or 500ing the API path.
- The old limiter code moved to `server/middleware/rate-limiter.ts`; `api-gateway.ts` re-exports everything, so the existing imports (vite, static, swagger, certifications routes, fuzz tests) and the existing test suite are untouched and still green.

## Acceptance criteria

- [x] Redis-backed sliding-window limiter (sorted-set approach)
- [x] Config toggle: `RATE_LIMITER_BACKEND=memory|redis` (default `memory`; explicit factory option wins over env)
- [x] Existing limiter unit tests pass against both backends — shared contract suite runs parameterized over both
- [x] Multi-instance test: **11 calls over a 10-limit window trigger 429 on instance B** (two limiter instances sharing one store; the memory backend's cross-replica leak is also pinned by a test documenting the bug)
- [x] Helm `values.yaml` documents the prod requirement; `rateLimiter.backend: redis` default + `REDIS_HOST`/`REDIS_PORT`/`RATE_LIMITER_BACKEND` wired into the configmap

## Verification

- 25/25 middleware tests pass (15 new + 10 pre-existing api-gateway)
- Full node suite: 1116 passed; the only failing *file* is `test/integrity/e2e-pipeline.test.ts`, which shells out to `openssl` (not installed on this machine) — pre-existing environmental failure, all its tests skipped, unrelated to this change
- `tsc --noEmit` clean for the touched files

Note: the Redis fake in tests implements the exact ioredis structural subset (`RedisPipelineLike`); a live-Redis CI job (service container) would be a good follow-up once CI runs one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)