### PR TITLE
fix(bridge): canonical NATS wire schema for scada.events, fixture-pinned across repos (#440)

### DIFF
--- a/docs/architecture/event-anchor-bridge.md
+++ b/docs/architecture/event-anchor-bridge.md
@@ -50,6 +50,39 @@ Batch₃.root ─┘
 | aggregateRoots | false | Buffer and aggregate roots |
 | maxAggregateCount | 10 | Max roots before force-flush |
 
+## NATS Wire Schema (0xSCADA-node path)
+
+Alongside the L2 contract path above, events are published over NATS to the
+Rust validator node (`0xSCADA-node`), which anchors them via Kuramoto-BFT
+consensus. The canonical wire schema for subject **`scada.events`** is
+defined once, in **`shared/wire-schema/scada-event.ts`** (issue #440), and
+consumed by `0xSCADA-node/src/bridge.rs` (`ScadaEvent`).
+
+Field names are **snake_case by contract**:
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `asset` | string | yes | Asset name/tag, e.g. `TR-MAIN-01` |
+| `event_type` | string | yes | e.g. `BREAKER_TRIP` |
+| `site_id` | string | yes | Site identifier |
+| `timestamp` | string | yes | ISO 8601 |
+| `payload` | any JSON | no | blake3-hashed by the node into the anchor merkle root |
+| `site_name`, `asset_type`, `details` | string | no | Context only; ignored by the node |
+
+Rules:
+
+- **Publish only through `natsPublisher.publishScadaEvent()`** — it validates
+  against the schema and drops (loudly) anything that would fail to parse on
+  the Rust side. Never hand-roll the payload.
+- The legacy camelCase `AnchorableEvent` shape (`server/bridge/event-anchor.ts`)
+  does **not** parse as this schema; convert with `fromAnchorableEvent()`.
+  The Rust side carries transitional `#[serde(alias)]` attributes for
+  camelCase stragglers — they will be removed.
+- The contract is pinned by **twin fixtures** asserted byte-for-byte on both
+  sides: `shared/wire-schema/__tests__/scada-event.test.ts` and the
+  `test_canonical_wire_fixture` test in `0xSCADA-node/src/bridge.rs`.
+  Changing the schema means changing both fixtures in the same commit pair.
+
 ## Implementation
 
 See `server/bridge/event-anchor-bridge.ts`.

--- a/server/services/nats/index.ts
+++ b/server/services/nats/index.ts
@@ -1,5 +1,10 @@
 import { connect, NatsConnection, StringCodec } from "nats";
 import { log, logError, logWarn } from "../../logger";
+import {
+  SCADA_EVENTS_SUBJECT,
+  buildScadaEventWire,
+  type ScadaEventWire,
+} from "../../../shared/wire-schema/scada-event";
 
 const sc = StringCodec();
 
@@ -27,6 +32,22 @@ class NatsPublisher {
     } catch (err) {
       logWarn(`NATS publish failed on ${subject}: ${err}`, "nats");
     }
+  }
+
+  /**
+   * Publish a SCADA event on the canonical `scada.events` wire schema
+   * (issue #440). Validation failures are loud: a payload the Rust node
+   * cannot parse must never leave this process silently.
+   */
+  publishScadaEvent(event: ScadaEventWire) {
+    let wire: ScadaEventWire;
+    try {
+      wire = buildScadaEventWire(event);
+    } catch (err) {
+      logError(err as Error, "NATS scada.events payload violates the wire schema — dropped");
+      return;
+    }
+    this.publish(SCADA_EVENTS_SUBJECT, wire);
   }
 
   async close() {

--- a/server/simulator.ts
+++ b/server/simulator.ts
@@ -115,9 +115,9 @@ class FieldSimulator {
         });
       } catch { /* WebSocket not connected — that's fine */ }
 
-      // Publish to NATS for blockchain anchoring
+      // Publish to NATS for blockchain anchoring (canonical wire schema, #440)
       try {
-        natsPublisher.publish("scada.events", {
+        natsPublisher.publishScadaEvent({
           asset: asset.nameOrTag,
           event_type: eventType,
           site_id: asset.siteId,

--- a/shared/wire-schema/__tests__/scada-event.test.ts
+++ b/shared/wire-schema/__tests__/scada-event.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  scadaEventWireSchema,
+  buildScadaEventWire,
+  fromAnchorableEvent,
+  SCADA_EVENTS_SUBJECT,
+  type LegacyAnchorableEvent,
+} from '../scada-event';
+
+/**
+ * Twin contract fixture (issue #440): the byte-identical JSON also asserted
+ * by `0xSCADA-node/src/bridge.rs` test `test_canonical_wire_fixture`.
+ * If you change it here, change it there in the same commit.
+ */
+const CANONICAL_FIXTURE = `{"asset":"TR-MAIN-01","event_type":"BREAKER_TRIP","site_id":"site-1","timestamp":"2026-03-15T22:00:00Z","payload":{"voltage":138.5},"site_name":"Substation Alpha","asset_type":"BREAKER","details":"Breaker tripped on overcurrent"}`;
+
+describe('scada.events wire schema (#440)', () => {
+  it('uses the subject the Rust node subscribes to', () => {
+    expect(SCADA_EVENTS_SUBJECT).toBe('scada.events');
+  });
+
+  it('accepts the canonical twin fixture', () => {
+    const parsed = scadaEventWireSchema.parse(JSON.parse(CANONICAL_FIXTURE));
+    expect(parsed.asset).toBe('TR-MAIN-01');
+    expect(parsed.event_type).toBe('BREAKER_TRIP');
+    expect(parsed.site_id).toBe('site-1');
+    expect(parsed.timestamp).toBe('2026-03-15T22:00:00Z');
+  });
+
+  it('round-trips the canonical fixture byte-identically', () => {
+    // Key order is preserved by JSON.parse/stringify for these shapes, so a
+    // schema-validated re-serialization must equal the fixture exactly —
+    // this is what pins both repos to the same bytes.
+    const wire = buildScadaEventWire(JSON.parse(CANONICAL_FIXTURE));
+    expect(JSON.stringify(wire)).toBe(CANONICAL_FIXTURE);
+  });
+
+  it('REJECTS the legacy camelCase AnchorableEvent serialization (the #440 drift)', () => {
+    const legacy = {
+      id: 'evt-1',
+      timestamp: '2026-03-15T22:00:00Z',
+      eventType: 'BREAKER_TRIP',
+      siteId: 'site-1',
+      severity: 'critical',
+      message: 'Breaker tripped',
+    };
+    const result = scadaEventWireSchema.safeParse(legacy);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown extra fields (strict contract)', () => {
+    const withExtra = { ...JSON.parse(CANONICAL_FIXTURE), sneaky_new_field: 1 };
+    expect(scadaEventWireSchema.safeParse(withExtra).success).toBe(false);
+  });
+
+  it('rejects missing required fields and bad timestamps', () => {
+    const base = JSON.parse(CANONICAL_FIXTURE);
+    for (const field of ['asset', 'event_type', 'site_id', 'timestamp']) {
+      const broken = { ...base };
+      delete broken[field];
+      expect(scadaEventWireSchema.safeParse(broken).success).toBe(false);
+    }
+    expect(
+      scadaEventWireSchema.safeParse({ ...base, timestamp: 'yesterday' }).success
+    ).toBe(false);
+  });
+
+  it('converts the legacy AnchorableEvent shape via fromAnchorableEvent', () => {
+    const legacy: LegacyAnchorableEvent = {
+      id: 'evt-1',
+      timestamp: new Date('2026-03-15T22:00:00Z'),
+      eventType: 'BREAKER_TRIP',
+      siteId: 'site-1',
+      severity: 'critical',
+      message: 'Breaker tripped',
+      data: { voltage: 138.5 },
+    };
+    const wire = fromAnchorableEvent(legacy, 'TR-MAIN-01');
+    expect(wire.asset).toBe('TR-MAIN-01');
+    expect(wire.event_type).toBe('BREAKER_TRIP');
+    expect(wire.site_id).toBe('site-1');
+    expect(wire.timestamp).toBe('2026-03-15T22:00:00.000Z');
+    expect(wire.details).toBe('Breaker tripped');
+    expect(wire.payload).toEqual({ voltage: 138.5, severity: 'critical', id: 'evt-1' });
+  });
+});

--- a/shared/wire-schema/scada-event.ts
+++ b/shared/wire-schema/scada-event.ts
@@ -1,0 +1,80 @@
+/**
+ * Canonical NATS wire schema for `scada.events` (issue #440)
+ *
+ * This is the single source of truth for the payload the TS server publishes
+ * and the Rust node (`0xSCADA-node/src/bridge.rs` `ScadaEvent`) consumes.
+ * Field names are snake_case BY CONTRACT — the Rust consumer derives
+ * serde with snake_case fields, and a camelCase payload deserializes to
+ * nothing (see the drift this issue fixed).
+ *
+ * Rules:
+ * - Every field added here must either be added to the Rust struct or be
+ *   safe for serde to ignore (extras are ignored by default).
+ * - The contract is pinned by twin fixtures asserted byte-for-byte on both
+ *   sides: `shared/wire-schema/__tests__/scada-event.test.ts` (TS) and
+ *   `0xSCADA-node/src/bridge.rs` tests (Rust).
+ */
+
+import { z } from 'zod';
+
+/** NATS subject the Rust node subscribes to. */
+export const SCADA_EVENTS_SUBJECT = 'scada.events';
+
+export const scadaEventWireSchema = z
+  .object({
+    /** Asset name or tag, e.g. "TR-MAIN-01" */
+    asset: z.string().min(1),
+    /** Event type, e.g. "BREAKER_TRIP" */
+    event_type: z.string().min(1),
+    /** Site identifier */
+    site_id: z.string().min(1),
+    /** ISO 8601 timestamp */
+    timestamp: z.string().datetime({ offset: true }),
+    /** Arbitrary event payload; blake3-hashed by the node into the anchor merkle root */
+    payload: z.unknown().optional(),
+    /** Optional context — ignored by the Rust consumer */
+    site_name: z.string().optional(),
+    asset_type: z.string().optional(),
+    details: z.string().optional(),
+  })
+  // strict() so accidental camelCase or new unagreed fields fail at the
+  // publisher instead of silently vanishing at the consumer
+  .strict();
+
+export type ScadaEventWire = z.infer<typeof scadaEventWireSchema>;
+
+/** Validate an event against the wire contract; throws ZodError on drift. */
+export function buildScadaEventWire(event: ScadaEventWire): ScadaEventWire {
+  return scadaEventWireSchema.parse(event);
+}
+
+/**
+ * Legacy camelCase event shape (`server/bridge/event-anchor.ts`
+ * AnchorableEvent). Publishing this shape raw is exactly the bug #440
+ * describes — convert with {@link fromAnchorableEvent} instead.
+ */
+export interface LegacyAnchorableEvent {
+  id: string;
+  timestamp: Date | string;
+  eventType: string;
+  siteId: string;
+  severity: 'info' | 'warning' | 'alarm' | 'critical';
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+/** Map the legacy camelCase shape onto the canonical wire schema. */
+export function fromAnchorableEvent(
+  event: LegacyAnchorableEvent,
+  asset: string
+): ScadaEventWire {
+  return buildScadaEventWire({
+    asset,
+    event_type: event.eventType,
+    site_id: event.siteId,
+    timestamp:
+      event.timestamp instanceof Date ? event.timestamp.toISOString() : event.timestamp,
+    payload: { ...event.data, severity: event.severity, id: event.id },
+    details: event.message,
+  });
+}


### PR DESCRIPTION
Fixes #440

## Reality check on the issue

The issue (filed June 1) cites `AnchorableEvent` in `server/bridge/event-anchor.ts` as the NATS publisher. Since then the CLI-restore merge added `server/services/nats/index.ts` + `server/simulator.ts`, and the simulator **already publishes snake_case** matching the Rust `ScadaEvent`. So live traffic parses today — but only by convention: the payload was an untyped inline object, the camelCase `AnchorableEvent` type sits right next to it as a drift trap, and nothing pinned the two repos to the same bytes. One silent rename and events vanish at the consumer with no error anywhere.

## What this adds

- **`shared/wire-schema/scada-event.ts`** — zod schema as the single source of truth. `strict()`, so camelCase or unagreed new fields fail **at the publisher**, not silently at the consumer.
- **`natsPublisher.publishScadaEvent()`** — the only sanctioned publish path; validates and drops loudly (`logError`) on violations. Simulator now goes through it.
- **`fromAnchorableEvent()`** — mapper for the legacy camelCase shape.
- **Twin contract fixture**: one byte-identical JSON asserted in `shared/wire-schema/__tests__/scada-event.test.ts` *and* in `0xSCADA-node/src/bridge.rs` (`test_canonical_wire_fixture`, companion PR). This is the cross-repo "e2e round-trip" pin — a broker-based TS→NATS→Rust test needs a live NATS + cargo in CI, which doesn't exist yet; the twin fixture gives the same drift protection at the schema layer.
- `docs/architecture/event-anchor-bridge.md` — canonical wire schema documented (field table, rules, fixture policy).

## Acceptance criteria

- [x] Shared schema extracted (JSON; `shared/wire-schema/` as the issue proposed)
- [x] `#[serde(alias)]` transitional net on the Rust side — companion PR in 0xSCADA-node
- [x] Canonical wire schema documented in `docs/architecture/event-anchor-bridge.md`
- [x] Round-trip pinned via twin byte-identical fixtures on both sides (in lieu of broker e2e; see above)

## Tests

7/7 wire-schema tests (fixture accept + byte-identical round-trip, camelCase rejection, strict unknown-field rejection, required-field/timestamp guards, legacy converter). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)