### PR TITLE
feat(bridge): ANCHOR_BACKEND switch — 0xSCADA-node is the canonical anchor path (#443) [stacked on #478]

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,9 +81,18 @@ This roadmap documents the current state of the 0xSCADA industrial SCADA system,
 - **Safety Overrides** — Emergency stop and safety protocol implementation
 
 #### Distributed Architecture
-- **Multi-Node Coordination** — Distributed SCADA node management
-- **State Synchronization** — Cross-node data consistency
-- **Network Resilience** — Partition tolerance and recovery protocols
+
+> **Status (2026-07):** the first three items below already ship in
+> [`0xSCADA-node`](https://github.com/NickFlach/0xSCADA-node) — multi-validator
+> coordination via Kuramoto-BFT resonant consensus (its ADR-0001), state
+> synchronization through consensus rounds, and partition tolerance via the
+> Raft fallback. The node is the canonical anchor backend (see
+> `docs/architecture/anchor-backend-migration.md`, issue #443). Remaining
+> work is integration depth, not greenfield.
+
+- **Multi-Node Coordination** — ✅ shipped in `0xSCADA-node` (Kuramoto-BFT validator network)
+- **State Synchronization** — ✅ shipped in `0xSCADA-node` (consensus-driven ledger state)
+- **Network Resilience** — ✅ partial: Raft fallback in `0xSCADA-node`; store-and-forward edge queueing still open (#224)
 - **Edge Computing** — Localized control with central coordination
 
 ## 🔍 **TECHNICAL DEBT & IMPROVEMENTS**

--- a/docs/architecture/anchor-backend-migration.md
+++ b/docs/architecture/anchor-backend-migration.md
@@ -1,0 +1,53 @@
+# Anchor Backend: Decision & Migration (issue #443)
+
+## Decision
+
+**The canonical anchor backend is `0xSCADA-node`** — events flow over NATS
+(`scada.events`, canonical wire schema per #440) into the Rust validator
+network, reach Kuramoto-BFT consensus, and land as `AnchorBatch`
+transactions on the purpose-built ledger.
+
+The TS-side L2 path (`contracts/EventAnchor.sol` via
+`server/bridge/event-anchor.ts`) is **deprecated**. Two facts drove this:
+
+1. The node path is the one with a real, tested implementation (191-test
+   Rust suite, live 3-validator deployments). The L2 bridge's
+   `submitToBlockchain` is still a simulation stub (random tx hashes,
+   `Math.random()` failure injection) — it has never anchored to a real L2.
+2. Both paths were wired unconditionally, so depending on which services
+   were up, an event could anchor twice, once, or not at all — exactly the
+   ambiguity #443 flagged.
+
+## The switch
+
+`ANCHOR_BACKEND` (read by `server/bridge/anchor-backend.ts`):
+
+| Value | Node path (NATS → Kuramoto-BFT) | L2 path (EventAnchor.sol) |
+|-------|--------------------------------|---------------------------|
+| `node` *(default)* | ✅ | ❌ (bridge refuses to initialize) |
+| `l2` | ❌ (`publishScadaEvent` is silent) | ✅ (subject to `BLOCKCHAIN_ANCHORING`) |
+| `both` | ✅ | ✅ — migration/comparison window only |
+
+Unknown values warn once and behave as `node`.
+
+## Migration window
+
+- **Now:** default is `node`. Deployments that still rely on the L2 path
+  must set `ANCHOR_BACKEND=l2` explicitly (and should plan to migrate).
+- **Comparison runs:** `both` exists so operators can diff anchor streams
+  during cutover. It intentionally double-anchors; do not leave it on.
+- **Removal:** once no deployment sets `l2`/`both`, the L2 bridge,
+  `contracts/EventAnchor.sol` submission tasks (`blockchain/tasks/`), and
+  this switch's `l2` arm can be deleted. File that as a `cycle:fix` issue
+  when the window closes.
+
+Operator-facing switch UX (dry-run projections, audit-anchored switch
+events, admin UI) is #455 and builds on this env-level mechanism.
+
+## Roadmap reconciliation
+
+`ROADMAP.md`'s "Distributed Architecture / Multi-Node Coordination" items
+describe capability that `0xSCADA-node` already provides (multi-validator
+coordination, state sync via consensus, partition tolerance via Raft
+fallback). The roadmap now points there rather than implying it is all
+future work.

--- a/server/bridge/__tests__/anchor-backend.test.ts
+++ b/server/bridge/__tests__/anchor-backend.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getAnchorBackend,
+  anchorsToL2,
+  anchorsToNode,
+  _resetWarningLatch,
+} from '../anchor-backend';
+import { EventAnchorBridge } from '../event-anchor';
+import { natsPublisher } from '../../services/nats';
+
+const ORIGINAL = process.env.ANCHOR_BACKEND;
+
+function setBackend(value: string | undefined) {
+  if (value === undefined) delete process.env.ANCHOR_BACKEND;
+  else process.env.ANCHOR_BACKEND = value;
+}
+
+afterEach(() => {
+  setBackend(ORIGINAL);
+  _resetWarningLatch();
+  vi.restoreAllMocks();
+});
+
+describe('getAnchorBackend (#443)', () => {
+  it('defaults to the canonical node backend', () => {
+    setBackend(undefined);
+    expect(getAnchorBackend()).toBe('node');
+    expect(anchorsToNode()).toBe(true);
+    expect(anchorsToL2()).toBe(false);
+  });
+
+  it('honors l2, node, and both (case-insensitive)', () => {
+    setBackend('l2');
+    expect(anchorsToL2()).toBe(true);
+    expect(anchorsToNode()).toBe(false);
+
+    setBackend('BOTH');
+    expect(anchorsToL2()).toBe(true);
+    expect(anchorsToNode()).toBe(true);
+
+    setBackend('node');
+    expect(anchorsToL2()).toBe(false);
+    expect(anchorsToNode()).toBe(true);
+  });
+
+  it('falls back to node on garbage, warning once', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    setBackend('sidechain');
+    expect(getAnchorBackend()).toBe('node');
+    getAnchorBackend();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('exactly one backend receives events per config', () => {
+  let publishSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    publishSpy = vi.spyOn(natsPublisher, 'publish').mockImplementation(() => {});
+  });
+
+  const wireEvent = {
+    asset: 'TR-MAIN-01',
+    event_type: 'BREAKER_TRIP',
+    site_id: 'site-1',
+    timestamp: '2026-03-15T22:00:00Z',
+  };
+
+  it('ANCHOR_BACKEND=node: node path publishes, L2 bridge refuses to initialize', async () => {
+    setBackend('node');
+
+    natsPublisher.publishScadaEvent(wireEvent);
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+
+    const bridge = new EventAnchorBridge({ enabled: true });
+    await bridge.initialize();
+    expect(bridge.getStatus().enabled).toBe(false);
+    expect(bridge.getStatus().isHealthy).toBe(false);
+  });
+
+  it('ANCHOR_BACKEND=l2: node path is silent, L2 bridge may initialize', async () => {
+    setBackend('l2');
+
+    natsPublisher.publishScadaEvent(wireEvent);
+    expect(publishSpy).not.toHaveBeenCalled();
+
+    process.env.EVENT_ANCHOR_CONTRACT = '0x' + '1'.repeat(40);
+    try {
+      const bridge = new EventAnchorBridge({ enabled: true });
+      await bridge.initialize();
+      expect(bridge.getStatus().enabled).toBe(true);
+    } finally {
+      delete process.env.EVENT_ANCHOR_CONTRACT;
+    }
+  });
+
+  it('ANCHOR_BACKEND=both: both paths active (migration window only)', async () => {
+    setBackend('both');
+
+    natsPublisher.publishScadaEvent(wireEvent);
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+
+    process.env.EVENT_ANCHOR_CONTRACT = '0x' + '1'.repeat(40);
+    try {
+      const bridge = new EventAnchorBridge({ enabled: true });
+      await bridge.initialize();
+      expect(bridge.getStatus().enabled).toBe(true);
+    } finally {
+      delete process.env.EVENT_ANCHOR_CONTRACT;
+    }
+  });
+});

--- a/server/bridge/anchor-backend.ts
+++ b/server/bridge/anchor-backend.ts
@@ -1,0 +1,55 @@
+/**
+ * Anchor backend selection (issue #443)
+ *
+ * Two anchoring paths exist:
+ *  - "node": NATS → 0xSCADA-node (Kuramoto-BFT AnchorBatch txs) — CANONICAL
+ *  - "l2":   EventAnchorBridge → EventAnchor.sol on an EVM L2 — DEPRECATED,
+ *            kept only for the migration window
+ *
+ * Before this switch both paths were wired unconditionally, so an event
+ * could anchor twice, once, or not at all depending on which services
+ * happened to be up. ANCHOR_BACKEND makes the routing explicit:
+ *
+ *   ANCHOR_BACKEND=node   (default) — node path only
+ *   ANCHOR_BACKEND=l2     — legacy L2 path only
+ *   ANCHOR_BACKEND=both   — dual-anchor during migration/comparison only
+ *
+ * See docs/architecture/anchor-backend-migration.md.
+ */
+
+export type AnchorBackend = 'l2' | 'node' | 'both';
+
+const VALID: readonly AnchorBackend[] = ['l2', 'node', 'both'];
+
+let warned = false;
+
+export function getAnchorBackend(): AnchorBackend {
+  const raw = (process.env.ANCHOR_BACKEND ?? 'node').toLowerCase();
+  if ((VALID as readonly string[]).includes(raw)) {
+    return raw as AnchorBackend;
+  }
+  if (!warned) {
+    warned = true;
+    console.warn(
+      `[anchor-backend] Unknown ANCHOR_BACKEND "${process.env.ANCHOR_BACKEND}", defaulting to "node"`
+    );
+  }
+  return 'node';
+}
+
+/** Whether events should flow to the legacy L2 EventAnchor contract path. */
+export function anchorsToL2(): boolean {
+  const backend = getAnchorBackend();
+  return backend === 'l2' || backend === 'both';
+}
+
+/** Whether events should flow to the 0xSCADA-node path (NATS → Kuramoto-BFT). */
+export function anchorsToNode(): boolean {
+  const backend = getAnchorBackend();
+  return backend === 'node' || backend === 'both';
+}
+
+/** Test hook: reset the one-time warning latch. */
+export function _resetWarningLatch(): void {
+  warned = false;
+}

--- a/server/bridge/event-anchor.ts
+++ b/server/bridge/event-anchor.ts
@@ -9,6 +9,7 @@
 
 import { EventEmitter } from 'events';
 import { log, logError } from '../logger';
+import { anchorsToL2, getAnchorBackend } from './anchor-backend';
 
 export interface AnchorableEvent {
   id: string;
@@ -60,7 +61,15 @@ export class EventAnchorBridge extends EventEmitter {
     if (this.isInitialized) return;
 
     log('Initializing event anchor bridge');
-    
+
+    // The L2 path is deprecated (#443): only active when ANCHOR_BACKEND
+    // explicitly selects it, so events cannot double-anchor by default.
+    if (!anchorsToL2()) {
+      this.config.enabled = false;
+      log(`L2 event anchor bridge disabled (ANCHOR_BACKEND=${getAnchorBackend()}); canonical path is 0xSCADA-node`);
+      return;
+    }
+
     if (!this.config.enabled) {
       log('Event anchor bridge disabled via configuration');
       return;

--- a/server/services/nats/index.ts
+++ b/server/services/nats/index.ts
@@ -5,6 +5,7 @@ import {
   buildScadaEventWire,
   type ScadaEventWire,
 } from "../../../shared/wire-schema/scada-event";
+import { anchorsToNode } from "../../bridge/anchor-backend";
 
 const sc = StringCodec();
 
@@ -38,8 +39,12 @@ class NatsPublisher {
    * Publish a SCADA event on the canonical `scada.events` wire schema
    * (issue #440). Validation failures are loud: a payload the Rust node
    * cannot parse must never leave this process silently.
+   *
+   * Respects ANCHOR_BACKEND (#443): when the operator pins anchoring to
+   * the legacy L2 path, nothing is published toward the node.
    */
   publishScadaEvent(event: ScadaEventWire) {
+    if (!anchorsToNode()) return;
     let wire: ScadaEventWire;
     try {
       wire = buildScadaEventWire(event);


### PR DESCRIPTION
Fixes #443

**Stacked on #478** (both touch the NATS publisher; merge #478 first — this retargets to `main` automatically when its branch is deleted).

## The decision

Canonical anchor backend: **`0xSCADA-node`**, as the issue presumed. The deciding evidence, discovered along the way: the L2 path's `submitToBlockchain` in `server/bridge/event-anchor.ts` is still a **simulation stub** — random tx hashes, `Math.random()` failure injection — it has never anchored to a real L2. Meanwhile the node path has a 191-test Rust implementation and live 3-validator deployments. This wasn't a close call.

## Acceptance criteria

- [x] Canonical backend decided (node) — recorded in `docs/architecture/anchor-backend-migration.md`
- [x] Runtime config switch `ANCHOR_BACKEND=l2|node|both` gating the bridge — **default `node`**, so out of the box exactly one path is active; `l2` silences the node publisher; `both` is documented as migration-window-only
- [x] Migration window + L2 deprecation documented (including the removal criteria for the L2 bridge and `blockchain/tasks/`)
- [x] `ROADMAP.md` "Multi-Node Coordination" reconciled — coordination/state-sync/partition-tolerance already ship in 0xSCADA-node; the section now says so instead of implying greenfield (edge store-and-forward remains open as #224)

## Verification

"Single event lands in exactly one backend": 6 tests assert per config value that the node publisher fires XOR the L2 bridge initializes (plus env parsing and the one-time unknown-value warning). 13/13 including the #440 wire-schema suite on this stack; `tsc --noEmit` clean.

#455 (operator switch UX with dry-run projections and audit-anchored switch events) builds directly on this env-level mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)