### PR TITLE
test(integrity): #445 gate — PKCS#11 signer is a stub; software path gets its first real tests

### DIFF
--- a/docs/security/hsm-signing.md
+++ b/docs/security/hsm-signing.md
@@ -1,0 +1,46 @@
+# HSM / Merkle-Root Signing: Provider Matrix & Status
+
+> Gate verification record for issue #445 (2026-07-21). The HSM/PKCS#11
+> path was specified in #291–292, both closed in the 2026-02-15 bulk-close
+> without verification. This document records what actually exists.
+
+## Provider matrix
+
+| Mode (`HSMConfig.mode`) | Status | Evidence |
+|--------------------------|--------|----------|
+| `software` | ✅ **Implemented & tested** | `SoftwareSigner` — Node crypto, RSA-2048, PKCS#8/SPKI PEM persisted under `keyPath` (default `.keys/`). Round-trip suite: `server/integrity/__tests__/hsm.test.ts` |
+| `pkcs11` | ❌ **Stub — throws on every call** | `PKCS11Signer` (`server/integrity/hsm.ts:263-305`): `initialize`/`sign`/`verify`/`getPublicKey`/`listKeys` all raise `not yet implemented`. Implementation tracked in **#482** |
+| `hardware` | ❌ Not implemented | Factory throws (`hsm.ts:319`) |
+
+No PKCS#11 provider (SoftHSMv2 or vendor HSM) has ever been exercised
+against this codebase. Any deployment configured with `mode: 'pkcs11'`
+fails at startup.
+
+## What actually runs in production paths
+
+`server/integrity/resilience.ts` instantiates `MerkleRootSigner` for both
+its **primary** and **fallback** signers from configuration. With the
+PKCS#11 stub, the only viable configuration today is software/software —
+i.e. the "HSM-backed" integrity pipeline is software-key signing with a
+software-key fallback. Threat-model accordingly: the signing key lives as
+a PEM file on the server filesystem.
+
+## Test coverage (added by the #445 gate)
+
+`server/integrity/__tests__/hsm.test.ts`:
+
+- Software round-trip: key-gen → sign → verify
+- Tamper detection (modified root, modified signature)
+- Key persistence across signer instances (same `keyPath`)
+- Unknown-key error path; `MerkleRootSigner` facade
+- **PKCS#11 status pin** — asserts the stub throws `not yet implemented`.
+  When #482 lands a real implementation this test fails on purpose:
+  update this matrix and replace the pin with SoftHSMv2 round-trip tests.
+
+## Planned CI verification (with #482)
+
+- SoftHSMv2 as a GitHub Actions service container (ubuntu runner)
+- Token init + RSA key-gen via `pkcs11-tool`, then a vitest suite running
+  `MerkleRootSigner` with `mode: 'pkcs11'` against
+  `/usr/lib/softhsm/libsofthsm2.so`
+- Provider matrix updated with each provider actually validated

--- a/server/integrity/__tests__/hsm.test.ts
+++ b/server/integrity/__tests__/hsm.test.ts
@@ -1,0 +1,133 @@
+/**
+ * HSM signing path verification (issue #445).
+ *
+ * The software signer gets a real round-trip suite (it previously had zero
+ * working coverage — the only references lived in the openssl-gated e2e
+ * file whose tests are all skipped). The PKCS#11 signer is pinned as
+ * not-implemented: if someone lands a real implementation, these tests
+ * fail loudly and the provider matrix in docs/security/hsm-signing.md must
+ * be updated (#482 tracks the implementation).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  SoftwareSigner,
+  PKCS11Signer,
+  HSMSignerFactory,
+  MerkleRootSigner,
+  type HSMConfig,
+} from '../hsm';
+
+let keyDir: string;
+
+beforeAll(() => {
+  keyDir = mkdtempSync(join(tmpdir(), 'hsm-test-'));
+});
+
+afterAll(() => {
+  rmSync(keyDir, { recursive: true, force: true });
+});
+
+function softwareConfig(): HSMConfig {
+  return { mode: 'software', algorithm: 'RS256', keyPath: keyDir };
+}
+
+describe('SoftwareSigner round-trip (#445)', () => {
+  it('generates a default key, signs, and verifies a merkle root', async () => {
+    const signer = new SoftwareSigner(softwareConfig());
+    await signer.initialize();
+
+    const root = 'a'.repeat(64);
+    const result = await signer.sign(root);
+
+    expect(result.signature).toMatch(/^[0-9a-f]+$/);
+    expect(result.algorithm).toBe('RS256');
+    expect(result.keyId).toBe('default');
+    expect(result.merkleRoot).toBe(root);
+
+    const verification = await signer.verify(root, result);
+    expect(verification.valid).toBe(true);
+    await signer.cleanup();
+  });
+
+  it('rejects a tampered merkle root and a tampered signature', async () => {
+    const signer = new SoftwareSigner(softwareConfig());
+    await signer.initialize();
+
+    const root = 'b'.repeat(64);
+    const result = await signer.sign(root);
+
+    const tamperedRoot = await signer.verify('c'.repeat(64), result);
+    expect(tamperedRoot.valid).toBe(false);
+
+    const tamperedSig = await signer.verify(root, {
+      ...result,
+      signature: result.signature.replace(/^../, 'ff'),
+    });
+    expect(tamperedSig.valid).toBe(false);
+    await signer.cleanup();
+  });
+
+  it('persists keys to disk and reloads them across instances', async () => {
+    const first = new SoftwareSigner(softwareConfig());
+    await first.initialize();
+    const root = 'd'.repeat(64);
+    const signed = await first.sign(root);
+    const publicKey = await first.getPublicKey();
+    await first.cleanup();
+
+    // Same keyPath → the reloaded default key must verify the old signature
+    const second = new SoftwareSigner(softwareConfig());
+    await second.initialize();
+    expect(await second.getPublicKey()).toBe(publicKey);
+    const verification = await second.verify(root, signed);
+    expect(verification.valid).toBe(true);
+    await second.cleanup();
+  });
+
+  it('throws on signing with an unknown key', async () => {
+    const signer = new SoftwareSigner(softwareConfig());
+    await signer.initialize();
+    await expect(signer.sign('e'.repeat(64), 'nope')).rejects.toThrow(/Key not found/);
+    await signer.cleanup();
+  });
+
+  it('works through the MerkleRootSigner facade', async () => {
+    const facade = new MerkleRootSigner(softwareConfig());
+    const root = 'f'.repeat(64);
+    const signed = await facade.signMerkleRoot(root);
+    const verification = await facade.verifyMerkleRootSignature(root, signed);
+    expect(verification.valid).toBe(true);
+    expect((await facade.listKeys()).length).toBeGreaterThan(0);
+    await facade.cleanup();
+  });
+});
+
+describe('PKCS#11 signer status pin (#445 → #482)', () => {
+  it('is a stub: every operation throws not-implemented', async () => {
+    const signer = new PKCS11Signer({
+      mode: 'pkcs11',
+      algorithm: 'RS256',
+      pkcs11Library: '/usr/lib/softhsm/libsofthsm2.so',
+      slot: 0,
+      pin: '1234',
+    });
+
+    await expect(signer.initialize()).rejects.toThrow(/not yet implemented/);
+    await expect(signer.sign('root')).rejects.toThrow(/not yet implemented/);
+    await expect(signer.getPublicKey()).rejects.toThrow(/not yet implemented/);
+    await expect(signer.listKeys()).rejects.toThrow(/not yet implemented/);
+  });
+
+  it('factory routes modes correctly and rejects hardware mode', () => {
+    expect(HSMSignerFactory.createSigner(softwareConfig())).toBeInstanceOf(SoftwareSigner);
+    expect(
+      HSMSignerFactory.createSigner({ mode: 'pkcs11', algorithm: 'RS256' })
+    ).toBeInstanceOf(PKCS11Signer);
+    expect(() =>
+      HSMSignerFactory.createSigner({ mode: 'hardware', algorithm: 'RS256' })
+    ).toThrow(/not implemented/);
+  });
+});


### PR DESCRIPTION
Fixes #445 · Files #482

## Gate verdict

The HSM/PKCS#11 signing path specified in bulk-closed #291–292 **does not exist**. `PKCS11Signer` (`server/integrity/hsm.ts:263-305`) throws `not yet implemented` from every method. No PKCS#11 provider — SoftHSMv2 or otherwise — has ever been exercised against this codebase; a deployment configured `mode: 'pkcs11'` fails at startup.

Sharper finding: `server/integrity/resilience.ts` instantiates both its **primary and fallback** signers from the same factory, so the only viable configuration today is software/software. The "HSM-backed" integrity pipeline is software-key signing (RSA-2048 PEM on the server filesystem) with a software-key fallback. The provider matrix doc says this plainly for threat-modeling.

## What this PR adds

- `server/integrity/__tests__/hsm.test.ts` (7 tests) — the signing path previously had **zero working coverage** (its only references live in the openssl-gated e2e file whose tests are all skipped):
  - software round-trip (key-gen → sign → verify), tamper detection on both root and signature, key persistence across instances, unknown-key error, `MerkleRootSigner` facade
  - **PKCS#11 status pin**: asserts the stub throws — a future partial implementation cannot land silently; the failing pin forces the provider matrix to be updated
- `docs/security/hsm-signing.md` — provider matrix (software ✅ / pkcs11 ❌ stub / hardware ❌), what actually runs in production paths, and the SoftHSMv2 CI plan that becomes possible once #482 implements the signer

## Why no SoftHSMv2 CI job here

The issue's verification asked for a SoftHSMv2 round-trip in CI — there is nothing to round-trip against; the class throws before touching any provider. That criterion moves to #482 (implementation), exactly per the issue's own contingency: *"If the path is missing/stubbed, file a cycle:build follow-up with the gap."*

7/7 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)