### PR TITLE
[13.1] Predictive Maintenance Engine (ADR-0013)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -97,6 +97,30 @@ export async function registerRoutes(
     predictiveMaintenanceService.ingestTagUpdate(update)
   );
 
+  // Start the periodic analysis sweep here — services/initializeServices()
+  // has no callers at startup, so registering there alone never runs it.
+  void predictiveMaintenanceService.initialize();
+
+  // Surface predictive alerts on the alarm WebSocket channel so they reach
+  // operators, not just the REST API.
+  predictiveMaintenanceService.on("alert", (alert) => {
+    void import("./websocket/cached-event-bridge").then(({ cachedEventBridge }) =>
+      cachedEventBridge.publishAlarm({
+        id: alert.id,
+        name: `Predictive: ${alert.tagId}`,
+        tagId: alert.tagId,
+        severity: alert.severity,
+        state: "active",
+        message: alert.message,
+        tagValue: undefined,
+        triggeredAt: new Date(alert.timestamp).toISOString(),
+        timestamp: new Date(alert.timestamp).toISOString(),
+        source: "predictive-maintenance",
+        recommendation: alert.recommendation,
+      })
+    ).catch(() => { /* alarm fan-out failure must not break alerting */ });
+  });
+
   // WebSocket metrics endpoint
   app.get("/api/ws/metrics", (req, res) => {
     res.json({

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -37,6 +37,8 @@ import pidRoutes from "./routes/pid";
 import { fluxRoutes } from "./routes/flux";
 import { gatewayRoutes } from "./routes/gateway";
 import { intelligenceRoutes } from "./routes/intelligence";
+import { predictiveRoutes } from "./routes/predictive";
+import { predictiveMaintenanceService } from "./services/predictive";
 import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
@@ -68,6 +70,7 @@ export async function registerRoutes(
   
   // P1 Wiring: Intelligence, Governance, and Security modules
   app.use("/api/intelligence", intelligenceRoutes);
+  app.use("/api/predictive", predictiveRoutes);  // ADR-0013 [13.1] (#212)
   app.use("/api/governance", governanceRoutes);
   app.use("/api/security", securityRoutes);
   app.use("/api/geometry", geometryRoutes(getFluxPublisher()));
@@ -88,6 +91,11 @@ export async function registerRoutes(
   // WebSocket servers initialize if available
   try { tagStreamServer?.initialize(httpServer, "/ws/tags"); } catch {}
   try { unifiedStreamServer?.initialize(httpServer, "/ws"); } catch {}  // unified endpoint (#255)
+
+  // Feed live tag updates into the predictive maintenance engine (#212)
+  tagStreamServer.onTagUpdate((update) =>
+    predictiveMaintenanceService.ingestTagUpdate(update)
+  );
 
   // WebSocket metrics endpoint
   app.get("/api/ws/metrics", (req, res) => {

--- a/server/routes/predictive.ts
+++ b/server/routes/predictive.ts
@@ -8,6 +8,7 @@
  */
 
 import { Router } from "express";
+import type { Request, Response, NextFunction, RequestHandler } from "express";
 import { z } from "zod";
 import { fromZodError } from "zod-validation-error";
 import { predictiveMaintenanceService } from "../services/predictive";
@@ -16,10 +17,38 @@ import type { SeverityLevel } from "@shared/types/predictive";
 const router = Router();
 const engine = predictiveMaintenanceService.engine;
 
+// Auth middleware placeholder — same pattern as other protected routes
+function requireAuth(req: Request, res: Response, next: NextFunction) {
+  // TODO: implement real auth check (JWT / session validation)
+  next();
+}
+router.use(requireAuth);
+
+/** Express 4 does not catch async rejections — wrap every async handler */
+function asyncHandler(
+  fn: (req: Request, res: Response) => Promise<unknown>
+): RequestHandler {
+  return (req, res) => {
+    fn(req, res).catch((error) => {
+      if (!res.headersSent) {
+        res.status(500).json({ error: "Internal error" });
+      }
+      console.error("[predictive] handler error:", error);
+    });
+  };
+}
+
 // ── Schemas ────────────────────────────────────────────────────────────────
 
+/** Must match the engine's history window — larger minSamples can never be met */
+const MAX_WINDOW = 1000;
+/** Reject data stamped further than this into the future */
+const MAX_FUTURE_SKEW_MS = 60 * 60 * 1000;
+/** New tags rejected once the engine tracks this many (DoS guard) */
+const MAX_TRACKED_TAGS = 500;
+
 const IngestSchema = z.object({
-  tagId: z.string().min(1),
+  tagId: z.string().min(1).max(256),
   points: z
     .array(
       z.object({
@@ -35,17 +64,19 @@ const SeveritySchema = z.enum(["info", "warning", "critical", "emergency"]);
 
 const ThresholdsSchema = z
   .object({
-    minSamples: z.number().int().min(3).max(100_000),
+    minSamples: z.number().int().min(3).max(MAX_WINDOW),
     zScoreThreshold: z.number().positive(),
     ewmaAlpha: z.number().gt(0).lte(1),
     ewmaL: z.number().positive(),
     iqrMultiplier: z.number().positive(),
-    ensembleWeights: z.record(z.number().min(0)),
-    severityThresholds: z.object({
-      warning: z.number().min(0).max(1),
-      critical: z.number().min(0).max(1),
-      emergency: z.number().min(0).max(1),
-    }),
+    ensembleWeights: z.record(z.number().min(0).finite()),
+    severityThresholds: z
+      .object({
+        warning: z.number().min(0).max(1),
+        critical: z.number().min(0).max(1),
+        emergency: z.number().min(0).max(1),
+      })
+      .partial(),
     failureLimits: z.object({
       low: z.number().optional(),
       high: z.number().optional(),
@@ -63,36 +94,61 @@ const AlertQuerySchema = z.object({
 
 // ── Ingestion & analysis ───────────────────────────────────────────────────
 
-router.post("/ingest", async (req, res) => {
-  const parsed = IngestSchema.safeParse(req.body);
-  if (!parsed.success) {
-    return res.status(400).json({ error: fromZodError(parsed.error).message });
-  }
-  const { tagId, points } = parsed.data;
-  engine.ingestSeries(tagId, points);
-  const assessment = await engine.analyze(tagId);
-  res.json({ ingested: points.length, assessment });
-});
+router.post(
+  "/ingest",
+  asyncHandler(async (req, res) => {
+    const parsed = IngestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: fromZodError(parsed.error).message });
+    }
+    const { tagId, points } = parsed.data;
 
-router.get("/analyze/:tagId", async (req, res) => {
-  const assessment = await engine.analyze(req.params.tagId);
-  if (!assessment) {
-    return res.status(404).json({
-      error: "Insufficient data for analysis",
-      required: engine.getThresholds(req.params.tagId).minSamples,
-      available: engine.getHistory(req.params.tagId).length,
+    const isNewTag = engine.getHistory(tagId).length === 0;
+    if (isNewTag && engine.getStatus().trackedTags >= MAX_TRACKED_TAGS) {
+      return res.status(429).json({
+        error: `Tracked-tag limit (${MAX_TRACKED_TAGS}) reached; new tags rejected`,
+      });
+    }
+
+    const cutoff = Date.now() + MAX_FUTURE_SKEW_MS;
+    const usable = points.filter((p) => p.timestamp <= cutoff);
+    engine.ingestSeries(tagId, usable);
+    const assessment = await engine.analyze(tagId);
+    res.json({
+      ingested: usable.length,
+      rejectedFuturePoints: points.length - usable.length,
+      assessment,
     });
-  }
-  res.json(assessment);
-});
+  })
+);
 
-router.get("/prediction/:tagId", async (req, res) => {
-  const prediction = await engine.predictFailure(req.params.tagId);
-  if (!prediction) {
-    return res.status(404).json({ error: "Insufficient data for prediction" });
-  }
-  res.json(prediction);
-});
+// Read-only analysis — alert generation happens on ingest and in the sweep,
+// never from a GET.
+router.get(
+  "/analyze/:tagId",
+  asyncHandler(async (req, res) => {
+    const assessment = await engine.analyze(req.params.tagId, { generateAlerts: false });
+    if (!assessment) {
+      return res.status(404).json({
+        error: "Insufficient data for analysis",
+        required: engine.getThresholds(req.params.tagId).minSamples,
+        available: engine.getHistory(req.params.tagId).length,
+      });
+    }
+    res.json(assessment);
+  })
+);
+
+router.get(
+  "/prediction/:tagId",
+  asyncHandler(async (req, res) => {
+    const prediction = await engine.predictFailure(req.params.tagId);
+    if (!prediction) {
+      return res.status(404).json({ error: "Insufficient data for prediction" });
+    }
+    res.json(prediction);
+  })
+);
 
 // ── Tags & thresholds ──────────────────────────────────────────────────────
 
@@ -109,8 +165,50 @@ router.put("/thresholds/:tagId", (req, res) => {
   if (!parsed.success) {
     return res.status(400).json({ error: fromZodError(parsed.error).message });
   }
-  const updated = engine.setThresholds(req.params.tagId, parsed.data);
-  res.json(updated);
+  const overrides = parsed.data;
+
+  // Cross-field checks run against the merged result so partial updates
+  // can't sneak an inconsistent final configuration past validation.
+  const current = engine.getThresholds(req.params.tagId);
+  const merged = {
+    ...current,
+    ...overrides,
+    severityThresholds: { ...current.severityThresholds, ...overrides.severityThresholds },
+    failureLimits: overrides.failureLimits ?? current.failureLimits,
+  };
+  const { warning, critical, emergency } = merged.severityThresholds;
+  if (!(warning <= critical && critical <= emergency)) {
+    return res.status(400).json({
+      error: "severityThresholds must satisfy warning <= critical <= emergency",
+    });
+  }
+  if (
+    merged.failureLimits?.low !== undefined &&
+    merged.failureLimits?.high !== undefined &&
+    merged.failureLimits.low >= merged.failureLimits.high
+  ) {
+    return res.status(400).json({ error: "failureLimits.low must be below failureLimits.high" });
+  }
+  if (overrides.ensembleWeights) {
+    const known = new Set(engine.getDetectors().map((d) => d.name));
+    const unknown = Object.keys(overrides.ensembleWeights).filter((k) => !known.has(k));
+    if (unknown.length > 0) {
+      return res.status(400).json({
+        error: `Unknown detectors in ensembleWeights: ${unknown.join(", ")}`,
+      });
+    }
+    const mergedWeights = { ...current.ensembleWeights, ...overrides.ensembleWeights };
+    if (!Object.values(mergedWeights).some((w) => w > 0)) {
+      return res.status(400).json({ error: "ensembleWeights must include a positive weight" });
+    }
+  }
+  if (merged.minSamples > MAX_WINDOW) {
+    return res.status(400).json({
+      error: `minSamples cannot exceed the ${MAX_WINDOW}-point history window`,
+    });
+  }
+
+  res.json(engine.setThresholds(req.params.tagId, overrides));
 });
 
 // ── Alerts ─────────────────────────────────────────────────────────────────
@@ -136,9 +234,12 @@ router.post("/alerts/:alertId/acknowledge", (req, res) => {
 
 // ── Status ─────────────────────────────────────────────────────────────────
 
-router.get("/status", async (_req, res) => {
-  const health = await predictiveMaintenanceService.healthCheck();
-  res.json({ ...engine.getStatus(), ...health });
-});
+router.get(
+  "/status",
+  asyncHandler(async (_req, res) => {
+    const health = await predictiveMaintenanceService.healthCheck();
+    res.json({ ...engine.getStatus(), ...health });
+  })
+);
 
 export { router as predictiveRoutes };

--- a/server/routes/predictive.ts
+++ b/server/routes/predictive.ts
@@ -1,0 +1,144 @@
+/**
+ * Predictive Maintenance API
+ * ADR-0013 [13.1] — Issue #212
+ *
+ * REST surface for the predictive maintenance engine: tag ingestion,
+ * on-demand analysis, per-tag threshold configuration, alerts, and
+ * trend-based failure prediction.
+ */
+
+import { Router } from "express";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+import { predictiveMaintenanceService } from "../services/predictive";
+import type { SeverityLevel } from "@shared/types/predictive";
+
+const router = Router();
+const engine = predictiveMaintenanceService.engine;
+
+// ── Schemas ────────────────────────────────────────────────────────────────
+
+const IngestSchema = z.object({
+  tagId: z.string().min(1),
+  points: z
+    .array(
+      z.object({
+        timestamp: z.number().finite(),
+        value: z.number().finite(),
+      })
+    )
+    .min(1)
+    .max(10_000),
+});
+
+const SeveritySchema = z.enum(["info", "warning", "critical", "emergency"]);
+
+const ThresholdsSchema = z
+  .object({
+    minSamples: z.number().int().min(3).max(100_000),
+    zScoreThreshold: z.number().positive(),
+    ewmaAlpha: z.number().gt(0).lte(1),
+    ewmaL: z.number().positive(),
+    iqrMultiplier: z.number().positive(),
+    ensembleWeights: z.record(z.number().min(0)),
+    severityThresholds: z.object({
+      warning: z.number().min(0).max(1),
+      critical: z.number().min(0).max(1),
+      emergency: z.number().min(0).max(1),
+    }),
+    failureLimits: z.object({
+      low: z.number().optional(),
+      high: z.number().optional(),
+    }),
+  })
+  .partial();
+
+const AlertQuerySchema = z.object({
+  severity: SeveritySchema.optional(),
+  acknowledged: z
+    .enum(["true", "false"])
+    .transform((v) => v === "true")
+    .optional(),
+});
+
+// ── Ingestion & analysis ───────────────────────────────────────────────────
+
+router.post("/ingest", async (req, res) => {
+  const parsed = IngestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const { tagId, points } = parsed.data;
+  engine.ingestSeries(tagId, points);
+  const assessment = await engine.analyze(tagId);
+  res.json({ ingested: points.length, assessment });
+});
+
+router.get("/analyze/:tagId", async (req, res) => {
+  const assessment = await engine.analyze(req.params.tagId);
+  if (!assessment) {
+    return res.status(404).json({
+      error: "Insufficient data for analysis",
+      required: engine.getThresholds(req.params.tagId).minSamples,
+      available: engine.getHistory(req.params.tagId).length,
+    });
+  }
+  res.json(assessment);
+});
+
+router.get("/prediction/:tagId", async (req, res) => {
+  const prediction = await engine.predictFailure(req.params.tagId);
+  if (!prediction) {
+    return res.status(404).json({ error: "Insufficient data for prediction" });
+  }
+  res.json(prediction);
+});
+
+// ── Tags & thresholds ──────────────────────────────────────────────────────
+
+router.get("/tags", (_req, res) => {
+  res.json({ tags: engine.getTrackedTags() });
+});
+
+router.get("/thresholds/:tagId", (req, res) => {
+  res.json(engine.getThresholds(req.params.tagId));
+});
+
+router.put("/thresholds/:tagId", (req, res) => {
+  const parsed = ThresholdsSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const updated = engine.setThresholds(req.params.tagId, parsed.data);
+  res.json(updated);
+});
+
+// ── Alerts ─────────────────────────────────────────────────────────────────
+
+router.get("/alerts", (req, res) => {
+  const parsed = AlertQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const { severity, acknowledged } = parsed.data;
+  res.json({
+    alerts: engine.getAlerts({ severity: severity as SeverityLevel | undefined, acknowledged }),
+  });
+});
+
+router.post("/alerts/:alertId/acknowledge", (req, res) => {
+  const ok = engine.acknowledgeAlert(req.params.alertId);
+  if (!ok) {
+    return res.status(404).json({ error: `Alert ${req.params.alertId} not found` });
+  }
+  res.json({ acknowledged: true });
+});
+
+// ── Status ─────────────────────────────────────────────────────────────────
+
+router.get("/status", async (_req, res) => {
+  const health = await predictiveMaintenanceService.healthCheck();
+  res.json({ ...engine.getStatus(), ...health });
+});
+
+export { router as predictiveRoutes };

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -62,6 +62,10 @@ export { optimizationService } from './optimization';
 export * from './spc';
 export { spcService } from './spc';
 
+// ── Predictive Maintenance Service (ADR-0013 [13.1], #212) ───────────────────
+export * from './predictive';
+export { predictiveMaintenanceService } from './predictive';
+
 // ── Layer 2 Rollup Service ───────────────────────────────────────────────────
 export * from './l2-rollup';
 export { l2RollupService } from './l2-rollup';
@@ -80,7 +84,8 @@ export async function initializeServices(): Promise<void> {
     { name: 'Ubiquity', service: () => import('./ubiquity').then(m => m.ubiquityService.initialize()) },
     { name: 'Layer 2 Rollup', service: () => import('./l2-rollup').then(m => m.l2RollupService.initialize()) },
     { name: 'Optimization', service: () => import('./optimization').then(m => m.optimizationService.initialize()) },
-    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) }
+    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) },
+    { name: 'Predictive Maintenance', service: () => import('./predictive').then(m => m.predictiveMaintenanceService.initialize()) }
   ];
 
   for (const { name, service } of services) {
@@ -171,6 +176,14 @@ export async function getServicesHealthStatus(): Promise<{
         return await spcService.healthCheck();
       } catch {
         return { healthy: false, message: 'SPC service not available' };
+      }
+    },
+    predictive: async () => {
+      try {
+        const { predictiveMaintenanceService } = await import('./predictive');
+        return await predictiveMaintenanceService.healthCheck();
+      } catch {
+        return { healthy: false, message: 'Predictive maintenance service not available' };
       }
     }
   };

--- a/server/services/predictive/__tests__/predictive-maintenance.test.ts
+++ b/server/services/predictive/__tests__/predictive-maintenance.test.ts
@@ -3,7 +3,7 @@
  * ADR-0013 [13.1] — Issue #212
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { AnomalyDetector, TimeSeriesPoint } from '@shared/types/predictive';
 import {
   quantile,
@@ -390,5 +390,176 @@ describe('PredictiveMaintenanceService', () => {
     expect((await service.healthCheck()).healthy).toBe(true);
     await service.shutdown();
     expect((await service.healthCheck()).healthy).toBe(false);
+  });
+});
+
+// ── Review regressions (PR #493 adversarial review) ───────────────────────
+
+describe('constant decimal series (float rounding residue)', () => {
+  it('never flags flat non-integer signals at any window size', async () => {
+    for (const value of [0.1, 0.4, 1.3, 1.5]) {
+      for (const n of [10, 15, 20, 50]) {
+        const flat = series(Array(n).fill(value));
+        expect(ewmaDetector(flat, 0.3, 3).anomalous, `ewma v=${value} n=${n}`).toBe(false);
+        expect(ewmaDetector(flat, 0.3, 3).score, `ewma score v=${value} n=${n}`).toBe(0);
+        expect(zScoreDetector(flat, 3).score, `z score v=${value} n=${n}`).toBe(0);
+      }
+    }
+    const engine = new PredictiveMaintenanceEngine();
+    for (let i = 0; i < 40; i++) engine.ingestPoint('flat', i * 1000, 0.4);
+    const result = await engine.analyze('flat');
+    expect(result!.severity).toBe('info');
+    expect(engine.getAlerts()).toHaveLength(0);
+  });
+});
+
+describe('ensemble abstention', () => {
+  it('renormalizes over detectors that actually ran', async () => {
+    // 4 samples: IQR abstains (insufficient); z-score + EWMA both saturate.
+    const engine = new PredictiveMaintenanceEngine();
+    engine.setThresholds('fast', { minSamples: 4 });
+    engine.ingestSeries('fast', series([100, 100, 100, 180]));
+    const result = await engine.analyze('fast');
+    expect(result!.ensembleScore).toBeCloseTo(1);
+    expect(result!.severity).toBe('emergency');
+  });
+});
+
+describe('IQR score contract', () => {
+  it('scores exactly 1 at the Tukey fence and grades inside it', () => {
+    const base = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+    // q1=12.5, q3=17.5, iqr=5, fence=17.5+7.5=25
+    const atFence = iqrDetector(series([...base, 25]), 1.5);
+    expect(atFence.score).toBeCloseTo(1, 5);
+    const inside = iqrDetector(series([...base, 21]), 1.5);
+    expect(inside.anomalous).toBe(false);
+    expect(inside.score).toBeGreaterThan(0);
+    expect(inside.score).toBeLessThan(1);
+  });
+});
+
+describe('EWMA statistic formulation (drift detection)', () => {
+  it('flags a sustained small shift that no single point would trigger', () => {
+    // Sustained +2 shift: the EWMA statistic accumulates and crosses its
+    // control limit even though the latest point stays well inside 3 sigma
+    // of the (shift-contaminated) process mean — a per-point test misses it.
+    const baseline = Array.from({ length: 40 }, (_, i) => 50 + Math.sin(i));
+    const shifted = Array.from({ length: 8 }, (_, i) => 52 + Math.sin(40 + i));
+    const all = [...baseline, ...shifted];
+    const result = ewmaDetector(series(all), 0.3, 3);
+    expect(result.anomalous).toBe(true);
+
+    const base = all.slice(0, -1);
+    const m = base.reduce((a, b) => a + b, 0) / base.length;
+    const sd = Math.sqrt(
+      base.reduce((s, x) => s + (x - m) ** 2, 0) / (base.length - 1)
+    );
+    expect(Math.abs(all[all.length - 1] - m)).toBeLessThan(3 * sd);
+  });
+});
+
+describe('per-tag threshold overrides drive analysis outcomes', () => {
+  it('a desensitized tag stays info while a default tag alarms on the same data', async () => {
+    const engine = new PredictiveMaintenanceEngine();
+    engine.setThresholds('desensitized', {
+      zScoreThreshold: 100_000,
+      ewmaL: 100_000,
+      iqrMultiplier: 100_000,
+    });
+    const data = [...Array.from({ length: 30 }, (_, i) => 10 + Math.sin(i)), 500];
+    engine.ingestSeries('desensitized', series(data));
+    engine.ingestSeries('default', series(data));
+
+    const desensitized = await engine.analyze('desensitized');
+    const standard = await engine.analyze('default');
+    expect(standard!.severity).not.toBe('info');
+    expect(desensitized!.severity).toBe('info');
+    expect(engine.getAlerts().every((a) => a.tagId === 'default')).toBe(true);
+  });
+});
+
+describe('alert cooldown (wall clock)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('re-alerts after the window and is immune to future-dated data', async () => {
+    vi.useFakeTimers();
+    const engine = new PredictiveMaintenanceEngine({ alertCooldownMs: 60_000 });
+    // Future-dated spike data must not permanently mute the tag
+    const farFuture = Date.now() + 365 * 24 * 3600 * 1000;
+    for (let i = 0; i < 30; i++) engine.ingestPoint('t', farFuture + i * 1000, 10);
+    engine.ingestPoint('t', farFuture + 31_000, 500);
+
+    await engine.analyze('t');
+    await engine.analyze('t');
+    expect(engine.getAlerts()).toHaveLength(1); // within cooldown
+
+    vi.advanceTimersByTime(61_000);
+    await engine.analyze('t');
+    expect(engine.getAlerts()).toHaveLength(2); // wall-clock window elapsed
+  });
+});
+
+describe('bounded state', () => {
+  it('caps retained alerts at maxAlerts', async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = new PredictiveMaintenanceEngine({ maxAlerts: 3, alertCooldownMs: 0 });
+      for (let i = 0; i < 30; i++) engine.ingestPoint('t', i * 1000, 10);
+      for (let k = 0; k < 6; k++) {
+        engine.ingestPoint('t', 31_000 + k, 500 + k);
+        await engine.analyze('t');
+        vi.advanceTimersByTime(1);
+      }
+      expect(engine.getAlerts().length).toBeLessThanOrEqual(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('evicts the least-recently-updated tag beyond maxTrackedTags', () => {
+    const engine = new PredictiveMaintenanceEngine({ maxTrackedTags: 3 });
+    for (const tag of ['a', 'b', 'c']) engine.ingestPoint(tag, 0, 1);
+    engine.ingestPoint('a', 1000, 2); // refresh a — b is now oldest
+    engine.ingestPoint('d', 2000, 1);
+    const tags = engine.getTrackedTags().map((t) => t.tagId);
+    expect(tags).toHaveLength(3);
+    expect(tags).not.toContain('b');
+    expect(tags).toEqual(expect.arrayContaining(['a', 'c', 'd']));
+  });
+});
+
+describe('resilient sweeps', () => {
+  it('keeps analyzing other tags when an alert listener throws', async () => {
+    const engine = new PredictiveMaintenanceEngine();
+    engine.on('alert', () => {
+      throw new Error('listener boom');
+    });
+    const errors: unknown[] = [];
+    engine.on('analyze-error', (e) => errors.push(e));
+
+    // 'a' alarms (listener throws); 'z' must still be analyzed after it
+    engine.ingestSeries('a', series([...Array(30).fill(10), 500]));
+    engine.ingestSeries('z', series(Array(30).fill(10)));
+    const results = await engine.analyzeAll();
+
+    expect(results.map((r) => r.tagId)).toEqual(expect.arrayContaining(['a', 'z']));
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('ingestion quality guards', () => {
+  it('skips non-good quality readings and empty-string values', () => {
+    const service = new PredictiveMaintenanceService();
+    service.ingestTagUpdate({ tagName: 'q', value: 10, timestamp: 1000, quality: 'bad' });
+    service.ingestTagUpdate({ tagName: 'q', value: 11, timestamp: 2000, quality: 'uncertain' });
+    service.ingestTagUpdate({ tagName: 'q', value: '', timestamp: 3000 });
+    service.ingestTagUpdate({ tagName: 'q', value: '   ', timestamp: 4000 });
+    service.ingestTagUpdate({ tagName: 'q', value: 12, timestamp: 5000, quality: 'good' });
+    service.ingestTagUpdate({ tagName: 'q', value: 13, timestamp: 6000 });
+
+    const history = service.engine.getHistory('q');
+    expect(history.map((p) => p.value)).toEqual([12, 13]);
   });
 });

--- a/server/services/predictive/__tests__/predictive-maintenance.test.ts
+++ b/server/services/predictive/__tests__/predictive-maintenance.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Predictive Maintenance Engine tests
+ * ADR-0013 [13.1] — Issue #212
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { AnomalyDetector, TimeSeriesPoint } from '@shared/types/predictive';
+import {
+  quantile,
+  computeZScore,
+  zScoreDetector,
+  ewmaDetector,
+  iqrDetector,
+  ensembleScore,
+  classifySeverity,
+  estimateTrend,
+  estimateHoursToLimit,
+} from '../detectors';
+import { PredictiveMaintenanceEngine } from '../engine';
+import { PredictiveMaintenanceService } from '../index';
+
+function series(values: number[], intervalMs = 1000): TimeSeriesPoint[] {
+  return values.map((value, i) => ({ timestamp: i * intervalMs, value }));
+}
+
+// ── Statistics primitives ─────────────────────────────────────────────────
+
+describe('quantile', () => {
+  it('interpolates linearly between sample points', () => {
+    expect(quantile([1, 2, 3, 4], 0.25)).toBeCloseTo(1.75);
+    expect(quantile([1, 2, 3, 4], 0.5)).toBeCloseTo(2.5);
+    expect(quantile([1, 2, 3, 4], 1)).toBe(4);
+  });
+
+  it('handles unsorted input', () => {
+    expect(quantile([4, 1, 3, 2], 0.5)).toBeCloseTo(2.5);
+  });
+});
+
+describe('computeZScore', () => {
+  it('returns 0 for constant values', () => {
+    const result = computeZScore([5, 5, 5, 5, 5]);
+    expect(result.zScore).toBe(0);
+    expect(result.mean).toBe(5);
+  });
+
+  it('treats a deviation from a zero-variance baseline as infinite', () => {
+    const result = computeZScore([10, 10, 10, 10, 50]);
+    expect(result.zScore).toBe(Infinity);
+  });
+
+  it('measures the latest value against the preceding baseline', () => {
+    const result = computeZScore([10, 12, 11, 9, 10, 11, 10, 12, 9, 30]);
+    expect(result.mean).toBeCloseTo(10.44, 1);
+    expect(result.zScore).toBeGreaterThan(3);
+  });
+});
+
+// ── Detectors ─────────────────────────────────────────────────────────────
+
+describe('zScoreDetector', () => {
+  it('flags a spike at the end of the series', () => {
+    const values = Array.from({ length: 49 }, (_, i) => 10 + Math.sin(i) * 2);
+    const result = zScoreDetector(series([...values, 100]), 3);
+    expect(result.anomalous).toBe(true);
+    expect(result.score).toBe(1);
+    expect(result.detector).toBe('z-score');
+  });
+
+  it('passes normal data', () => {
+    const values = Array.from({ length: 50 }, (_, i) => 10 + Math.sin(i) * 2);
+    const result = zScoreDetector(series(values), 3);
+    expect(result.anomalous).toBe(false);
+  });
+});
+
+describe('ewmaDetector', () => {
+  it('detects a sudden jump', () => {
+    const values = Array.from({ length: 30 }, (_, i) => 50 + Math.sin(i));
+    const result = ewmaDetector(series([...values, 200]), 0.3, 3);
+    expect(result.anomalous).toBe(true);
+  });
+
+  it('passes a steady signal', () => {
+    const values = Array.from({ length: 30 }, (_, i) => 50 + Math.sin(i));
+    const result = ewmaDetector(series(values), 0.3, 3);
+    expect(result.anomalous).toBe(false);
+  });
+
+  it('uses sigma-scaled limits so units do not matter', () => {
+    const small = Array.from({ length: 30 }, (_, i) => 0.5 + Math.sin(i) * 0.01);
+    const result = ewmaDetector(series([...small, 2]), 0.3, 3);
+    expect(result.anomalous).toBe(true);
+  });
+
+  it('reports insufficient data for tiny series', () => {
+    const result = ewmaDetector(series([1, 2]), 0.3, 3);
+    expect(result.anomalous).toBe(false);
+    expect(result.details.insufficient).toBe(true);
+  });
+});
+
+describe('iqrDetector', () => {
+  it('detects outliers beyond the fences', () => {
+    const values = Array.from({ length: 30 }, (_, i) => 10 + (i % 5));
+    const result = iqrDetector(series([...values, 100]), 1.5);
+    expect(result.anomalous).toBe(true);
+    expect(result.score).toBeGreaterThan(0);
+  });
+
+  it('passes values inside the fences', () => {
+    const values = Array.from({ length: 30 }, (_, i) => 10 + (i % 5));
+    const result = iqrDetector(series([...values, 12]), 1.5);
+    expect(result.anomalous).toBe(false);
+  });
+});
+
+// ── Ensemble & severity ───────────────────────────────────────────────────
+
+describe('ensembleScore', () => {
+  it('computes a weighted average', () => {
+    const results = [
+      { detector: 'z-score', score: 1, anomalous: true, details: {} },
+      { detector: 'ewma', score: 0, anomalous: false, details: {} },
+    ];
+    expect(ensembleScore(results, { 'z-score': 3, ewma: 1 })).toBeCloseTo(0.75);
+  });
+
+  it('defaults unlisted detectors to weight 1', () => {
+    const results = [
+      { detector: 'custom-ml', score: 0.5, anomalous: true, details: {} },
+    ];
+    expect(ensembleScore(results, {})).toBeCloseTo(0.5);
+  });
+
+  it('returns 0 for no results', () => {
+    expect(ensembleScore([], {})).toBe(0);
+  });
+});
+
+describe('classifySeverity', () => {
+  const t = { warning: 0.4, critical: 0.7, emergency: 0.9 };
+  it('classifies at each boundary', () => {
+    expect(classifySeverity(0.1, t)).toBe('info');
+    expect(classifySeverity(0.4, t)).toBe('warning');
+    expect(classifySeverity(0.7, t)).toBe('critical');
+    expect(classifySeverity(0.95, t)).toBe('emergency');
+  });
+});
+
+// ── Trend estimation ──────────────────────────────────────────────────────
+
+describe('estimateTrend', () => {
+  it('recovers the slope of a linear ramp', () => {
+    // 1 unit per minute = 60 units/hour
+    const points = Array.from({ length: 30 }, (_, i) => ({
+      timestamp: i * 60_000,
+      value: 100 + i,
+    }));
+    const trend = estimateTrend(points)!;
+    expect(trend.slopePerHour).toBeCloseTo(60);
+    expect(trend.rSquared).toBeCloseTo(1);
+  });
+
+  it('returns zero slope for flat data', () => {
+    const trend = estimateTrend(series([5, 5, 5, 5, 5]))!;
+    expect(trend.slopePerHour).toBeCloseTo(0);
+  });
+});
+
+describe('estimateHoursToLimit', () => {
+  it('projects time to a high limit', () => {
+    const trend = { slopePerHour: 60, latestFitted: 129, rSquared: 1 };
+    const result = estimateHoursToLimit(trend, { high: 189 })!;
+    expect(result.hours).toBeCloseTo(1);
+    expect(result.limit).toBe(189);
+  });
+
+  it('projects time to a low limit on a falling trend', () => {
+    const trend = { slopePerHour: -10, latestFitted: 50, rSquared: 1 };
+    const result = estimateHoursToLimit(trend, { low: 20 })!;
+    expect(result.hours).toBeCloseTo(3);
+  });
+
+  it('returns null when not trending toward a limit', () => {
+    const trend = { slopePerHour: -10, latestFitted: 50, rSquared: 1 };
+    expect(estimateHoursToLimit(trend, { high: 100 })).toBeNull();
+  });
+
+  it('returns 0 hours when already past the limit', () => {
+    const trend = { slopePerHour: 5, latestFitted: 120, rSquared: 1 };
+    expect(estimateHoursToLimit(trend, { high: 100 })!.hours).toBe(0);
+  });
+});
+
+// ── Engine ────────────────────────────────────────────────────────────────
+
+describe('PredictiveMaintenanceEngine', () => {
+  it('returns null for insufficient data', async () => {
+    const engine = new PredictiveMaintenanceEngine();
+    engine.ingestPoint('x', 0, 10);
+    expect(await engine.analyze('x')).toBeNull();
+  });
+
+  it('detects a spike, classifies severity, and emits an alert', async () => {
+    const engine = new PredictiveMaintenanceEngine();
+    const onAlert = vi.fn();
+    engine.on('alert', onAlert);
+
+    for (let i = 0; i < 50; i++) engine.ingestPoint('temp-1', i * 1000, 25 + Math.sin(i));
+    engine.ingestPoint('temp-1', 50_000, 200);
+
+    const result = await engine.analyze('temp-1');
+    expect(result).not.toBeNull();
+    expect(result!.severity).not.toBe('info');
+    expect(result!.detectorResults.length).toBe(3);
+    expect(onAlert).toHaveBeenCalledTimes(1);
+
+    const alerts = engine.getAlerts();
+    expect(alerts.length).toBe(1);
+    expect(alerts[0].detectors.length).toBeGreaterThan(0);
+    expect(alerts[0].recommendation).toBeTruthy();
+  });
+
+  it('suppresses duplicate alerts within the cooldown window', async () => {
+    const engine = new PredictiveMaintenanceEngine({ alertCooldownMs: 60_000 });
+    for (let i = 0; i < 50; i++) engine.ingestPoint('t', i * 1000, 10);
+    engine.ingestPoint('t', 50_000, 500);
+
+    await engine.analyze('t');
+    await engine.analyze('t');
+    expect(engine.getAlerts().length).toBe(1);
+  });
+
+  it('acknowledges alerts and filters by acknowledged state', async () => {
+    const engine = new PredictiveMaintenanceEngine();
+    for (let i = 0; i < 50; i++) engine.ingestPoint('t', i * 1000, 10);
+    engine.ingestPoint('t', 50_000, 500);
+    await engine.analyze('t');
+
+    const [alert] = engine.getAlerts();
+    expect(engine.acknowledgeAlert(alert.id)).toBe(true);
+    expect(engine.getAlerts({ acknowledged: false })).toHaveLength(0);
+    expect(engine.getAlerts({ acknowledged: true })).toHaveLength(1);
+    expect(engine.acknowledgeAlert('nope')).toBe(false);
+  });
+
+  it('merges per-tag threshold overrides onto defaults', () => {
+    const engine = new PredictiveMaintenanceEngine();
+    const updated = engine.setThresholds('tag-a', {
+      zScoreThreshold: 4,
+      severityThresholds: { warning: 0.5, critical: 0.8, emergency: 0.95 },
+    });
+    expect(updated.zScoreThreshold).toBe(4);
+    expect(updated.iqrMultiplier).toBe(1.5); // default preserved
+    expect(engine.getThresholds('tag-a').severityThresholds.warning).toBe(0.5);
+    // unconfigured tags fall back to defaults
+    expect(engine.getThresholds('tag-b').zScoreThreshold).toBe(3);
+  });
+
+  it('runs registered ML detectors alongside statistical ones', async () => {
+    const engine = new PredictiveMaintenanceEngine();
+    const mlDetector: AnomalyDetector = {
+      name: 'custom-ml',
+      kind: 'ml',
+      detect: async () => ({
+        detector: 'custom-ml',
+        score: 1,
+        anomalous: true,
+        details: { model: 'v1' },
+      }),
+    };
+    engine.registerDetector(mlDetector);
+    expect(engine.getDetectors().map((d) => d.name)).toContain('custom-ml');
+
+    for (let i = 0; i < 20; i++) engine.ingestPoint('t', i * 1000, 10 + Math.sin(i));
+    const result = await engine.analyze('t');
+    expect(result!.detectorResults.map((d) => d.detector)).toContain('custom-ml');
+
+    expect(engine.unregisterDetector('custom-ml')).toBe(true);
+  });
+
+  it('surfaces detector failures without breaking analysis', async () => {
+    const engine = new PredictiveMaintenanceEngine();
+    const onError = vi.fn();
+    engine.on('detector-error', onError);
+    engine.registerDetector({
+      name: 'broken',
+      kind: 'ml',
+      detect: () => {
+        throw new Error('model unavailable');
+      },
+    });
+
+    for (let i = 0; i < 20; i++) engine.ingestPoint('t', i * 1000, 10 + Math.sin(i));
+    const result = await engine.analyze('t');
+    expect(result).not.toBeNull();
+    expect(result!.detectorResults.length).toBe(3); // built-ins still ran
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ detector: 'broken', tagId: 't' })
+    );
+  });
+
+  it('bounds history to the sliding window', () => {
+    const engine = new PredictiveMaintenanceEngine({ maxHistorySize: 100 });
+    for (let i = 0; i < 250; i++) engine.ingestPoint('t', i * 1000, i);
+    const history = engine.getHistory('t');
+    expect(history.length).toBe(100);
+    expect(history[0].value).toBe(150);
+  });
+
+  it('ignores non-finite inputs', () => {
+    const engine = new PredictiveMaintenanceEngine();
+    engine.ingestPoint('t', 0, NaN);
+    engine.ingestPoint('t', NaN, 5);
+    engine.ingestPoint('t', 0, Infinity);
+    expect(engine.getHistory('t')).toHaveLength(0);
+  });
+
+  it('predicts hours until a failure limit on a rising trend', async () => {
+    const engine = new PredictiveMaintenanceEngine();
+    engine.setThresholds('bearing-temp', { failureLimits: { high: 189 } });
+    // 1 unit/minute ramp: 100 → 129 over 30 minutes, limit 60 units away
+    for (let i = 0; i < 30; i++) engine.ingestPoint('bearing-temp', i * 60_000, 100 + i);
+
+    const prediction = await engine.predictFailure('bearing-temp');
+    expect(prediction).not.toBeNull();
+    expect(prediction!.estimatedHoursToLimit).toBeCloseTo(1, 1);
+    expect(prediction!.limit).toBe(189);
+    expect(prediction!.trendSlopePerHour).toBeCloseTo(60);
+    expect(prediction!.confidence).toBeCloseTo(1);
+    expect(prediction!.failureProbability).toBeGreaterThan(0.9);
+    // prediction must not generate alerts as a side effect
+    expect(engine.getAlerts()).toHaveLength(0);
+  });
+
+  it('reports tracked tags and status', () => {
+    const engine = new PredictiveMaintenanceEngine();
+    for (let i = 0; i < 5; i++) engine.ingestPoint('a', i, i);
+    engine.ingestPoint('b', 0, 1);
+
+    const tags = engine.getTrackedTags();
+    expect(tags).toHaveLength(2);
+    expect(tags.find((t) => t.tagId === 'a')!.samples).toBe(5);
+
+    const status = engine.getStatus();
+    expect(status.trackedTags).toBe(2);
+    expect(status.totalSamples).toBe(6);
+    expect(status.detectors.map((d) => d.name)).toEqual(['z-score', 'ewma', 'iqr']);
+
+    engine.clearHistory('a');
+    expect(engine.getTrackedTags()).toHaveLength(1);
+  });
+});
+
+// ── Service wrapper ───────────────────────────────────────────────────────
+
+describe('PredictiveMaintenanceService', () => {
+  it('ingests numeric tag updates and skips non-numeric values', () => {
+    const service = new PredictiveMaintenanceService();
+    service.ingestTagUpdate({ tagName: 'pump.flow', value: 42.5, timestamp: 1000 });
+    service.ingestTagUpdate({ tagName: 'pump.flow', value: '43.1', timestamp: '1970-01-01T00:00:02.000Z' });
+    service.ingestTagUpdate({ tagName: 'pump.flow', value: 'running', timestamp: 3000 });
+    service.ingestTagUpdate({ tagName: 'pump.flow', value: true, timestamp: 4000 });
+    service.ingestTagUpdate({ tagName: 'pump.flow', value: 44, timestamp: 'not-a-date' });
+
+    const history = service.engine.getHistory('pump.flow');
+    expect(history).toHaveLength(2);
+    expect(history[1].value).toBeCloseTo(43.1);
+    expect(history[1].timestamp).toBe(2000);
+  });
+
+  it('re-emits engine alerts', async () => {
+    const service = new PredictiveMaintenanceService();
+    const onAlert = vi.fn();
+    service.on('alert', onAlert);
+
+    for (let i = 0; i < 50; i++) {
+      service.ingestTagUpdate({ tagName: 't', value: 10, timestamp: i * 1000 });
+    }
+    service.ingestTagUpdate({ tagName: 't', value: 500, timestamp: 50_000 });
+    await service.engine.analyze('t');
+    expect(onAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports health based on initialization', async () => {
+    const service = new PredictiveMaintenanceService();
+    expect((await service.healthCheck()).healthy).toBe(false);
+    await service.initialize();
+    expect((await service.healthCheck()).healthy).toBe(true);
+    await service.shutdown();
+    expect((await service.healthCheck()).healthy).toBe(false);
+  });
+});

--- a/server/services/predictive/detectors.ts
+++ b/server/services/predictive/detectors.ts
@@ -1,0 +1,274 @@
+/**
+ * Statistical Anomaly Detectors
+ * ADR-0013 [13.1] — Issue #212
+ *
+ * Pure statistical detectors (z-score, EWMA, IQR) over tag time-series.
+ * Each detector tests the latest point against a baseline built from the
+ * preceding window, and implements the shared AnomalyDetector contract so
+ * ML models can be registered alongside them.
+ */
+
+import type {
+  AnomalyDetector,
+  DetectorResult,
+  SeverityLevel,
+  SeverityThresholds,
+  TagThresholds,
+  TimeSeriesPoint,
+} from '@shared/types/predictive';
+
+// ── Statistics primitives ─────────────────────────────────────────────────
+
+export function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+/** Sample standard deviation (n-1 denominator) */
+export function stdDev(values: number[]): number {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  const variance = values.reduce((sum, v) => sum + (v - m) ** 2, 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+/** Quantile with linear interpolation (q in 0..1) over an unsorted sample */
+export function quantile(values: number[], q: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const pos = (sorted.length - 1) * q;
+  const base = Math.floor(pos);
+  const rest = pos - base;
+  if (base + 1 < sorted.length) {
+    return sorted[base] + rest * (sorted[base + 1] - sorted[base]);
+  }
+  return sorted[base];
+}
+
+/**
+ * Z-score of the latest value against the baseline of all preceding values.
+ * A zero-variance baseline with a deviating latest value is treated as an
+ * infinite z-score (score 1).
+ */
+export function computeZScore(values: number[]): {
+  mean: number;
+  stdDev: number;
+  zScore: number;
+} {
+  if (values.length < 3) {
+    return { mean: values[0] ?? 0, stdDev: 0, zScore: 0 };
+  }
+  const baseline = values.slice(0, -1);
+  const latest = values[values.length - 1];
+  const m = mean(baseline);
+  const sd = stdDev(baseline);
+  if (sd === 0) {
+    return { mean: m, stdDev: 0, zScore: latest === m ? 0 : Infinity };
+  }
+  return { mean: m, stdDev: sd, zScore: Math.abs(latest - m) / sd };
+}
+
+// ── Detector functions ────────────────────────────────────────────────────
+
+export function zScoreDetector(series: TimeSeriesPoint[], threshold: number): DetectorResult {
+  const values = series.map((p) => p.value);
+  const { zScore, mean: m, stdDev: sd } = computeZScore(values);
+  return {
+    detector: 'z-score',
+    score: Math.min(zScore / threshold, 1),
+    anomalous: zScore > threshold,
+    details: { zScore, mean: m, stdDev: sd, threshold },
+  };
+}
+
+/**
+ * EWMA control-chart detector. The EWMA statistic z_i = α·x_i + (1−α)·z_{i−1}
+ * is run over the whole series and its final value is compared against the
+ * process mean of the preceding baseline, with asymptotic control limits of
+ * width L·σ·√(α/(2−α)). Thresholds are in sigma units, so the detector works
+ * for tags of any engineering scale and catches sustained drift that
+ * point-wise detectors miss.
+ */
+export function ewmaDetector(series: TimeSeriesPoint[], alpha: number, L: number): DetectorResult {
+  if (series.length < 3) {
+    return { detector: 'ewma', score: 0, anomalous: false, details: { insufficient: true } };
+  }
+
+  const values = series.map((p) => p.value);
+  const baseline = values.slice(0, -1);
+  const processMean = mean(baseline);
+  const sd = stdDev(baseline);
+
+  let ewma = values[0];
+  for (let i = 1; i < values.length; i++) {
+    ewma = alpha * values[i] + (1 - alpha) * ewma;
+  }
+
+  const deviation = Math.abs(ewma - processMean);
+
+  if (sd === 0) {
+    const anomalous = deviation > 0;
+    return {
+      detector: 'ewma',
+      score: anomalous ? 1 : 0,
+      anomalous,
+      details: { ewma, processMean, deviation, alpha, L, controlLimit: 0 },
+    };
+  }
+
+  const controlLimit = L * sd * Math.sqrt(alpha / (2 - alpha));
+  return {
+    detector: 'ewma',
+    score: Math.min(deviation / controlLimit, 1),
+    anomalous: deviation > controlLimit,
+    details: { ewma, processMean, deviation, alpha, L, controlLimit },
+  };
+}
+
+export function iqrDetector(series: TimeSeriesPoint[], multiplier: number): DetectorResult {
+  if (series.length < 5) {
+    return { detector: 'iqr', score: 0, anomalous: false, details: { insufficient: true } };
+  }
+
+  const baseline = series.slice(0, -1).map((p) => p.value);
+  const latest = series[series.length - 1].value;
+
+  const q1 = quantile(baseline, 0.25);
+  const q3 = quantile(baseline, 0.75);
+  const iqr = q3 - q1;
+  const lowerBound = q1 - multiplier * iqr;
+  const upperBound = q3 + multiplier * iqr;
+  const outsideRange = latest < lowerBound || latest > upperBound;
+
+  let score = 0;
+  if (outsideRange) {
+    if (iqr === 0) {
+      score = 1;
+    } else {
+      const distance = latest < lowerBound ? lowerBound - latest : latest - upperBound;
+      score = Math.min(distance / iqr, 1);
+    }
+  }
+
+  return {
+    detector: 'iqr',
+    score,
+    anomalous: outsideRange,
+    details: { q1, q3, iqr, lowerBound, upperBound, latest, multiplier },
+  };
+}
+
+// ── AnomalyDetector implementations ──────────────────────────────────────
+
+export const builtinDetectors: AnomalyDetector[] = [
+  {
+    name: 'z-score',
+    kind: 'statistical',
+    detect: (series, cfg) => zScoreDetector(series, cfg.zScoreThreshold),
+  },
+  {
+    name: 'ewma',
+    kind: 'statistical',
+    detect: (series, cfg) => ewmaDetector(series, cfg.ewmaAlpha, cfg.ewmaL),
+  },
+  {
+    name: 'iqr',
+    kind: 'statistical',
+    detect: (series, cfg) => iqrDetector(series, cfg.iqrMultiplier),
+  },
+];
+
+// ── Ensemble scoring ─────────────────────────────────────────────────────
+
+export function ensembleScore(
+  results: DetectorResult[],
+  weights: Record<string, number>
+): number {
+  let totalWeight = 0;
+  let weightedSum = 0;
+
+  for (const r of results) {
+    const w = weights[r.detector] ?? 1;
+    weightedSum += r.score * w;
+    totalWeight += w;
+  }
+
+  return totalWeight === 0 ? 0 : weightedSum / totalWeight;
+}
+
+export function classifySeverity(score: number, thresholds: SeverityThresholds): SeverityLevel {
+  if (score >= thresholds.emergency) return 'emergency';
+  if (score >= thresholds.critical) return 'critical';
+  if (score >= thresholds.warning) return 'warning';
+  return 'info';
+}
+
+// ── Trend estimation (alert before failure) ──────────────────────────────
+
+export interface TrendEstimate {
+  /** Least-squares slope in value units per hour */
+  slopePerHour: number;
+  /** Fitted value at the latest timestamp */
+  latestFitted: number;
+  /** R² of the fit — 0 when the data has no linear structure */
+  rSquared: number;
+}
+
+const MS_PER_HOUR = 3_600_000;
+
+export function estimateTrend(series: TimeSeriesPoint[]): TrendEstimate | null {
+  if (series.length < 3) return null;
+
+  const t0 = series[0].timestamp;
+  const xs = series.map((p) => (p.timestamp - t0) / MS_PER_HOUR);
+  const ys = series.map((p) => p.value);
+
+  const mx = mean(xs);
+  const my = mean(ys);
+  let sxx = 0;
+  let sxy = 0;
+  let syy = 0;
+  for (let i = 0; i < xs.length; i++) {
+    sxx += (xs[i] - mx) ** 2;
+    sxy += (xs[i] - mx) * (ys[i] - my);
+    syy += (ys[i] - my) ** 2;
+  }
+  if (sxx === 0) return null;
+
+  const slope = sxy / sxx;
+  const intercept = my - slope * mx;
+  const rSquared = syy === 0 ? 0 : (sxy * sxy) / (sxx * syy);
+
+  return {
+    slopePerHour: slope,
+    latestFitted: intercept + slope * xs[xs.length - 1],
+    rSquared,
+  };
+}
+
+/**
+ * Hours until the fitted trend crosses a failure limit, or null when the
+ * series is not trending toward either limit.
+ */
+export function estimateHoursToLimit(
+  trend: TrendEstimate,
+  limits: { low?: number; high?: number }
+): { hours: number; limit: number } | null {
+  const { slopePerHour, latestFitted } = trend;
+  if (slopePerHour === 0) return null;
+
+  if (limits.high !== undefined && slopePerHour > 0 && latestFitted < limits.high) {
+    return { hours: (limits.high - latestFitted) / slopePerHour, limit: limits.high };
+  }
+  if (limits.low !== undefined && slopePerHour < 0 && latestFitted > limits.low) {
+    return { hours: (limits.low - latestFitted) / slopePerHour, limit: limits.low };
+  }
+  // Already at/past a limit and still heading away from safe range
+  if (limits.high !== undefined && slopePerHour > 0 && latestFitted >= limits.high) {
+    return { hours: 0, limit: limits.high };
+  }
+  if (limits.low !== undefined && slopePerHour < 0 && latestFitted <= limits.low) {
+    return { hours: 0, limit: limits.low };
+  }
+  return null;
+}

--- a/server/services/predictive/detectors.ts
+++ b/server/services/predictive/detectors.ts
@@ -19,6 +19,18 @@ import type {
 
 // ── Statistics primitives ─────────────────────────────────────────────────
 
+/**
+ * Relative tolerance treating floating-point rounding residue as zero.
+ * Means/EWMAs of constant decimal series (e.g. 0.4 repeated) land a few ulp
+ * away from the constant; without this guard that residue registers as an
+ * anomaly with score 1 on a perfectly flat signal.
+ */
+const REL_EPS = 1e-9;
+
+function epsFor(...magnitudes: number[]): number {
+  return REL_EPS * Math.max(...magnitudes.map(Math.abs), Number.MIN_VALUE);
+}
+
 export function mean(values: number[]): number {
   if (values.length === 0) return 0;
   return values.reduce((a, b) => a + b, 0) / values.length;
@@ -62,8 +74,9 @@ export function computeZScore(values: number[]): {
   const latest = values[values.length - 1];
   const m = mean(baseline);
   const sd = stdDev(baseline);
-  if (sd === 0) {
-    return { mean: m, stdDev: 0, zScore: latest === m ? 0 : Infinity };
+  const eps = epsFor(m, latest);
+  if (sd <= eps) {
+    return { mean: m, stdDev: 0, zScore: Math.abs(latest - m) <= eps ? 0 : Infinity };
   }
   return { mean: m, stdDev: sd, zScore: Math.abs(latest - m) / sd };
 }
@@ -77,7 +90,14 @@ export function zScoreDetector(series: TimeSeriesPoint[], threshold: number): De
     detector: 'z-score',
     score: Math.min(zScore / threshold, 1),
     anomalous: zScore > threshold,
-    details: { zScore, mean: m, stdDev: sd, threshold },
+    // Infinity is not JSON-representable — report it as an explicit flag
+    details: {
+      zScore: Number.isFinite(zScore) ? zScore : null,
+      zScoreInfinite: !Number.isFinite(zScore),
+      mean: m,
+      stdDev: sd,
+      threshold,
+    },
   };
 }
 
@@ -105,9 +125,10 @@ export function ewmaDetector(series: TimeSeriesPoint[], alpha: number, L: number
   }
 
   const deviation = Math.abs(ewma - processMean);
+  const eps = epsFor(ewma, processMean);
 
-  if (sd === 0) {
-    const anomalous = deviation > 0;
+  if (sd <= eps) {
+    const anomalous = deviation > eps;
     return {
       detector: 'ewma',
       score: anomalous ? 1 : 0,
@@ -116,7 +137,7 @@ export function ewmaDetector(series: TimeSeriesPoint[], alpha: number, L: number
     };
   }
 
-  const controlLimit = L * sd * Math.sqrt(alpha / (2 - alpha));
+  const controlLimit = Math.max(L * sd * Math.sqrt(alpha / (2 - alpha)), eps);
   return {
     detector: 'ewma',
     score: Math.min(deviation / controlLimit, 1),
@@ -140,14 +161,15 @@ export function iqrDetector(series: TimeSeriesPoint[], multiplier: number): Dete
   const upperBound = q3 + multiplier * iqr;
   const outsideRange = latest < lowerBound || latest > upperBound;
 
+  // Score contract: 0 inside the quartiles, exactly 1 at the Tukey fence,
+  // saturating beyond it — same "1.0 == at threshold" semantics as the
+  // other detectors so ensemble weighting stays comparable.
   let score = 0;
-  if (outsideRange) {
-    if (iqr === 0) {
-      score = 1;
-    } else {
-      const distance = latest < lowerBound ? lowerBound - latest : latest - upperBound;
-      score = Math.min(distance / iqr, 1);
-    }
+  if (iqr === 0) {
+    score = outsideRange ? 1 : 0;
+  } else {
+    const displacement = Math.max(0, q1 - latest, latest - q3);
+    score = Math.min(displacement / (multiplier * iqr), 1);
   }
 
   return {
@@ -188,6 +210,10 @@ export function ensembleScore(
   let weightedSum = 0;
 
   for (const r of results) {
+    // An insufficient-data result is an abstention, not a "normal" vote —
+    // renormalize over the detectors that actually ran, otherwise a small
+    // window mathematically caps the ensemble below the top severities.
+    if (r.details.insufficient === true) continue;
     const w = weights[r.detector] ?? 1;
     weightedSum += r.score * w;
     totalWeight += w;

--- a/server/services/predictive/engine.ts
+++ b/server/services/predictive/engine.ts
@@ -1,0 +1,321 @@
+/**
+ * Predictive Maintenance Engine
+ * ADR-0013 [13.1] — Issue #212
+ *
+ * Ingests tag time-series, runs an ensemble of anomaly detectors
+ * (z-score, EWMA, IQR by default — ML models pluggable via the
+ * AnomalyDetector contract), classifies severity against per-tag
+ * thresholds, and generates alerts before failures using trend-based
+ * time-to-limit estimation.
+ */
+
+import { EventEmitter } from 'events';
+import type {
+  AnomalyAssessment,
+  AnomalyDetector,
+  DetectorResult,
+  MaintenancePrediction,
+  PredictiveAlert,
+  SeverityLevel,
+  TagThresholds,
+  TimeSeriesPoint,
+} from '@shared/types/predictive';
+import {
+  builtinDetectors,
+  classifySeverity,
+  ensembleScore,
+  estimateHoursToLimit,
+  estimateTrend,
+} from './detectors';
+
+export const DEFAULT_THRESHOLDS: Omit<TagThresholds, 'tagId'> = {
+  minSamples: 10,
+  zScoreThreshold: 3,
+  ewmaAlpha: 0.3,
+  ewmaL: 3,
+  iqrMultiplier: 1.5,
+  ensembleWeights: { 'z-score': 0.4, ewma: 0.35, iqr: 0.25 },
+  severityThresholds: { warning: 0.4, critical: 0.7, emergency: 0.9 },
+};
+
+export interface EngineOptions {
+  /** Points retained per tag (sliding window) */
+  maxHistorySize?: number;
+  /** Alerts retained before the oldest are dropped */
+  maxAlerts?: number;
+  /** Suppress repeat alerts for the same tag+severity within this window */
+  alertCooldownMs?: number;
+}
+
+export class PredictiveMaintenanceEngine extends EventEmitter {
+  private readonly maxHistorySize: number;
+  private readonly maxAlerts: number;
+  private readonly alertCooldownMs: number;
+
+  private detectors: Map<string, AnomalyDetector> = new Map();
+  private thresholds: Map<string, TagThresholds> = new Map();
+  private history: Map<string, TimeSeriesPoint[]> = new Map();
+  private alerts: PredictiveAlert[] = [];
+  private lastAlertAt: Map<string, number> = new Map(); // key: tagId:severity
+  private alertCounter = 0;
+
+  constructor(options: EngineOptions = {}) {
+    super();
+    this.maxHistorySize = options.maxHistorySize ?? 1000;
+    this.maxAlerts = options.maxAlerts ?? 500;
+    this.alertCooldownMs = options.alertCooldownMs ?? 5 * 60 * 1000;
+    for (const d of builtinDetectors) {
+      this.detectors.set(d.name, d);
+    }
+  }
+
+  // ── Detector registry (ML integration point) ─────────────────────────
+
+  registerDetector(detector: AnomalyDetector): void {
+    this.detectors.set(detector.name, detector);
+  }
+
+  unregisterDetector(name: string): boolean {
+    return this.detectors.delete(name);
+  }
+
+  getDetectors(): Array<Pick<AnomalyDetector, 'name' | 'kind'>> {
+    return Array.from(this.detectors.values()).map(({ name, kind }) => ({ name, kind }));
+  }
+
+  // ── Per-tag threshold configuration ──────────────────────────────────
+
+  setThresholds(tagId: string, overrides: Partial<Omit<TagThresholds, 'tagId'>>): TagThresholds {
+    const base = this.thresholds.get(tagId) ?? { ...DEFAULT_THRESHOLDS, tagId };
+    const merged: TagThresholds = {
+      ...base,
+      ...overrides,
+      ensembleWeights: { ...base.ensembleWeights, ...overrides.ensembleWeights },
+      severityThresholds: { ...base.severityThresholds, ...overrides.severityThresholds },
+      tagId,
+    };
+    this.thresholds.set(tagId, merged);
+    return merged;
+  }
+
+  getThresholds(tagId: string): TagThresholds {
+    return this.thresholds.get(tagId) ?? { ...DEFAULT_THRESHOLDS, tagId };
+  }
+
+  // ── Ingestion ────────────────────────────────────────────────────────
+
+  ingestPoint(tagId: string, timestamp: number, value: number): void {
+    if (!Number.isFinite(timestamp) || !Number.isFinite(value)) return;
+    let series = this.history.get(tagId);
+    if (!series) {
+      series = [];
+      this.history.set(tagId, series);
+    }
+    series.push({ timestamp, value });
+    if (series.length > this.maxHistorySize) {
+      series.splice(0, series.length - this.maxHistorySize);
+    }
+  }
+
+  ingestSeries(tagId: string, points: TimeSeriesPoint[]): void {
+    for (const p of points) this.ingestPoint(tagId, p.timestamp, p.value);
+  }
+
+  // ── Analysis ─────────────────────────────────────────────────────────
+
+  async analyze(
+    tagId: string,
+    options: { generateAlerts?: boolean } = {}
+  ): Promise<AnomalyAssessment | null> {
+    const series = this.history.get(tagId);
+    const cfg = this.getThresholds(tagId);
+    if (!series || series.length < cfg.minSamples) return null;
+
+    const detectorResults: DetectorResult[] = [];
+    for (const detector of this.detectors.values()) {
+      try {
+        detectorResults.push(await detector.detect(series, cfg));
+      } catch (error) {
+        this.emit('detector-error', {
+          detector: detector.name,
+          tagId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    if (detectorResults.length === 0) return null;
+
+    const ensemble = ensembleScore(detectorResults, cfg.ensembleWeights);
+    const severity = classifySeverity(ensemble, cfg.severityThresholds);
+    const latest = series[series.length - 1];
+
+    const assessment: AnomalyAssessment = {
+      tagId,
+      timestamp: latest.timestamp,
+      value: latest.value,
+      detectorResults,
+      ensembleScore: ensemble,
+      severity,
+      description: this.describeAnomaly(tagId, severity, detectorResults),
+    };
+
+    if (severity !== 'info' && options.generateAlerts !== false) {
+      this.generateAlert(assessment);
+    }
+
+    return assessment;
+  }
+
+  async analyzeAll(): Promise<AnomalyAssessment[]> {
+    const results: AnomalyAssessment[] = [];
+    for (const tagId of this.history.keys()) {
+      const result = await this.analyze(tagId);
+      if (result) results.push(result);
+    }
+    return results;
+  }
+
+  // ── Failure prediction (alert before failure) ────────────────────────
+
+  async predictFailure(tagId: string): Promise<MaintenancePrediction | null> {
+    const series = this.history.get(tagId);
+    const cfg = this.getThresholds(tagId);
+    if (!series || series.length < cfg.minSamples) return null;
+
+    const trend = estimateTrend(series);
+    if (!trend) return null;
+
+    const toLimit = cfg.failureLimits
+      ? estimateHoursToLimit(trend, cfg.failureLimits)
+      : null;
+
+    const assessment = await this.analyze(tagId, { generateAlerts: false });
+    const anomalyScore = assessment?.ensembleScore ?? 0;
+
+    // Blend current anomaly level with trend certainty; an imminent limit
+    // crossing dominates the probability.
+    let failureProbability = anomalyScore;
+    if (toLimit) {
+      const urgency = toLimit.hours <= 0 ? 1 : Math.min(24 / (toLimit.hours + 24), 1);
+      failureProbability = Math.min(1, Math.max(anomalyScore, urgency * trend.rSquared));
+    }
+
+    return {
+      tagId,
+      failureProbability,
+      estimatedHoursToLimit: toLimit ? Math.max(0, toLimit.hours) : null,
+      trendSlopePerHour: trend.slopePerHour,
+      limit: toLimit?.limit ?? null,
+      recommendedAction: this.getRecommendation(
+        classifySeverity(failureProbability, cfg.severityThresholds)
+      ),
+      confidence: trend.rSquared,
+    };
+  }
+
+  // ── Alerts ───────────────────────────────────────────────────────────
+
+  getAlerts(filter?: { severity?: SeverityLevel; acknowledged?: boolean }): PredictiveAlert[] {
+    let alerts = [...this.alerts];
+    if (filter?.severity) alerts = alerts.filter((a) => a.severity === filter.severity);
+    if (filter?.acknowledged !== undefined) {
+      alerts = alerts.filter((a) => a.acknowledged === filter.acknowledged);
+    }
+    return alerts;
+  }
+
+  acknowledgeAlert(alertId: string): boolean {
+    const alert = this.alerts.find((a) => a.id === alertId);
+    if (!alert) return false;
+    alert.acknowledged = true;
+    return true;
+  }
+
+  // ── History access ───────────────────────────────────────────────────
+
+  getHistory(tagId: string): TimeSeriesPoint[] {
+    return this.history.get(tagId) ?? [];
+  }
+
+  getTrackedTags(): Array<{ tagId: string; samples: number; latest: TimeSeriesPoint | null }> {
+    return Array.from(this.history.entries()).map(([tagId, series]) => ({
+      tagId,
+      samples: series.length,
+      latest: series[series.length - 1] ?? null,
+    }));
+  }
+
+  clearHistory(tagId: string): void {
+    this.history.delete(tagId);
+  }
+
+  getStatus(): {
+    trackedTags: number;
+    totalSamples: number;
+    detectors: Array<Pick<AnomalyDetector, 'name' | 'kind'>>;
+    activeAlerts: number;
+    totalAlerts: number;
+  } {
+    let totalSamples = 0;
+    for (const series of this.history.values()) totalSamples += series.length;
+    return {
+      trackedTags: this.history.size,
+      totalSamples,
+      detectors: this.getDetectors(),
+      activeAlerts: this.alerts.filter((a) => !a.acknowledged).length,
+      totalAlerts: this.alerts.length,
+    };
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────
+
+  private generateAlert(assessment: AnomalyAssessment): void {
+    const cooldownKey = `${assessment.tagId}:${assessment.severity}`;
+    const last = this.lastAlertAt.get(cooldownKey);
+    if (last !== undefined && assessment.timestamp - last < this.alertCooldownMs) {
+      return;
+    }
+    this.lastAlertAt.set(cooldownKey, assessment.timestamp);
+
+    const alert: PredictiveAlert = {
+      id: `PMA-${++this.alertCounter}`,
+      tagId: assessment.tagId,
+      severity: assessment.severity,
+      score: assessment.ensembleScore,
+      message: assessment.description,
+      timestamp: assessment.timestamp,
+      detectors: assessment.detectorResults.filter((d) => d.anomalous).map((d) => d.detector),
+      acknowledged: false,
+      recommendation: this.getRecommendation(assessment.severity),
+    };
+
+    this.alerts.push(alert);
+    if (this.alerts.length > this.maxAlerts) {
+      this.alerts.splice(0, this.alerts.length - this.maxAlerts);
+    }
+    this.emit('alert', alert);
+  }
+
+  private describeAnomaly(
+    tagId: string,
+    severity: SeverityLevel,
+    detectors: DetectorResult[]
+  ): string {
+    const triggered = detectors.filter((d) => d.anomalous).map((d) => d.detector);
+    if (triggered.length === 0) return `Tag ${tagId}: nominal`;
+    return `Tag ${tagId}: ${severity} anomaly detected by ${triggered.join(', ')}`;
+  }
+
+  private getRecommendation(severity: SeverityLevel): string {
+    switch (severity) {
+      case 'emergency':
+        return 'Immediate inspection required. Consider shutting down affected equipment.';
+      case 'critical':
+        return 'Schedule urgent maintenance within 24 hours.';
+      case 'warning':
+        return 'Monitor closely. Schedule inspection within 1 week.';
+      default:
+        return 'No action required.';
+    }
+  }
+}

--- a/server/services/predictive/engine.ts
+++ b/server/services/predictive/engine.ts
@@ -17,9 +17,17 @@ import type {
   MaintenancePrediction,
   PredictiveAlert,
   SeverityLevel,
+  SeverityThresholds,
   TagThresholds,
   TimeSeriesPoint,
 } from '@shared/types/predictive';
+
+/** Threshold overrides — nested objects may be partial; they merge over the base */
+export type ThresholdOverrides = Partial<
+  Omit<TagThresholds, 'tagId' | 'severityThresholds'>
+> & {
+  severityThresholds?: Partial<SeverityThresholds>;
+};
 import {
   builtinDetectors,
   classifySeverity,
@@ -45,15 +53,21 @@ export interface EngineOptions {
   maxAlerts?: number;
   /** Suppress repeat alerts for the same tag+severity within this window */
   alertCooldownMs?: number;
+  /** Tags tracked before the least-recently-updated is evicted */
+  maxTrackedTags?: number;
 }
 
 export class PredictiveMaintenanceEngine extends EventEmitter {
   private readonly maxHistorySize: number;
   private readonly maxAlerts: number;
   private readonly alertCooldownMs: number;
+  private readonly maxTrackedTags: number;
+  /** Distinguishes alert ids across process restarts */
+  private readonly bootId: string;
 
   private detectors: Map<string, AnomalyDetector> = new Map();
   private thresholds: Map<string, TagThresholds> = new Map();
+  /** Insertion order doubles as recency order — refreshed on every ingest */
   private history: Map<string, TimeSeriesPoint[]> = new Map();
   private alerts: PredictiveAlert[] = [];
   private lastAlertAt: Map<string, number> = new Map(); // key: tagId:severity
@@ -64,6 +78,8 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
     this.maxHistorySize = options.maxHistorySize ?? 1000;
     this.maxAlerts = options.maxAlerts ?? 500;
     this.alertCooldownMs = options.alertCooldownMs ?? 5 * 60 * 1000;
+    this.maxTrackedTags = options.maxTrackedTags ?? 500;
+    this.bootId = Date.now().toString(36);
     for (const d of builtinDetectors) {
       this.detectors.set(d.name, d);
     }
@@ -85,7 +101,7 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
 
   // ── Per-tag threshold configuration ──────────────────────────────────
 
-  setThresholds(tagId: string, overrides: Partial<Omit<TagThresholds, 'tagId'>>): TagThresholds {
+  setThresholds(tagId: string, overrides: ThresholdOverrides): TagThresholds {
     const base = this.thresholds.get(tagId) ?? { ...DEFAULT_THRESHOLDS, tagId };
     const merged: TagThresholds = {
       ...base,
@@ -107,14 +123,18 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
   ingestPoint(tagId: string, timestamp: number, value: number): void {
     if (!Number.isFinite(timestamp) || !Number.isFinite(value)) return;
     let series = this.history.get(tagId);
-    if (!series) {
+    if (series) {
+      // Refresh recency: Map insertion order is the eviction order
+      this.history.delete(tagId);
+    } else {
       series = [];
-      this.history.set(tagId, series);
     }
+    this.history.set(tagId, series);
     series.push({ timestamp, value });
     if (series.length > this.maxHistorySize) {
       series.splice(0, series.length - this.maxHistorySize);
     }
+    this.evictStaleTags();
   }
 
   ingestSeries(tagId: string, points: TimeSeriesPoint[]): void {
@@ -127,9 +147,13 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
     tagId: string,
     options: { generateAlerts?: boolean } = {}
   ): Promise<AnomalyAssessment | null> {
-    const series = this.history.get(tagId);
+    const live = this.history.get(tagId);
     const cfg = this.getThresholds(tagId);
-    if (!series || series.length < cfg.minSamples) return null;
+    if (!live || live.length < cfg.minSamples) return null;
+    // Snapshot before any await — the live series mutates while async
+    // detectors run, and every detector (and the alert) must describe the
+    // same window.
+    const series = live.slice();
 
     const detectorResults: DetectorResult[] = [];
     for (const detector of this.detectors.values()) {
@@ -168,9 +192,18 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
 
   async analyzeAll(): Promise<AnomalyAssessment[]> {
     const results: AnomalyAssessment[] = [];
-    for (const tagId of this.history.keys()) {
-      const result = await this.analyze(tagId);
-      if (result) results.push(result);
+    for (const tagId of Array.from(this.history.keys())) {
+      try {
+        const result = await this.analyze(tagId);
+        if (result) results.push(result);
+      } catch (error) {
+        // One tag's failure (including a throwing 'alert' listener) must
+        // not starve the remaining tags of analysis.
+        this.emit('analyze-error', {
+          tagId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
     return results;
   }
@@ -247,6 +280,19 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
 
   clearHistory(tagId: string): void {
     this.history.delete(tagId);
+    for (const severity of ['warning', 'critical', 'emergency'] as const) {
+      this.lastAlertAt.delete(`${tagId}:${severity}`);
+    }
+  }
+
+  /** Evict least-recently-updated tags beyond the tracked-tag cap */
+  private evictStaleTags(): void {
+    while (this.history.size > this.maxTrackedTags) {
+      const oldest = this.history.keys().next().value as string | undefined;
+      if (oldest === undefined) return;
+      this.clearHistory(oldest);
+      this.emit('tag-evicted', { tagId: oldest });
+    }
   }
 
   getStatus(): {
@@ -270,15 +316,19 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
   // ── Private ──────────────────────────────────────────────────────────
 
   private generateAlert(assessment: AnomalyAssessment): void {
+    // Cooldown is an operator-facing rate limit, so it runs on wall clock —
+    // keying it on data timestamps would let one future-dated point mute a
+    // tag+severity permanently.
     const cooldownKey = `${assessment.tagId}:${assessment.severity}`;
+    const now = Date.now();
     const last = this.lastAlertAt.get(cooldownKey);
-    if (last !== undefined && assessment.timestamp - last < this.alertCooldownMs) {
+    if (last !== undefined && now - last < this.alertCooldownMs) {
       return;
     }
-    this.lastAlertAt.set(cooldownKey, assessment.timestamp);
+    this.lastAlertAt.set(cooldownKey, now);
 
     const alert: PredictiveAlert = {
-      id: `PMA-${++this.alertCounter}`,
+      id: `PMA-${this.bootId}-${++this.alertCounter}`,
       tagId: assessment.tagId,
       severity: assessment.severity,
       score: assessment.ensembleScore,
@@ -293,7 +343,15 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
     if (this.alerts.length > this.maxAlerts) {
       this.alerts.splice(0, this.alerts.length - this.maxAlerts);
     }
-    this.emit('alert', alert);
+    try {
+      this.emit('alert', alert);
+    } catch (error) {
+      // A throwing listener must not abort the caller's analysis loop
+      this.emit('analyze-error', {
+        tagId: alert.tagId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private describeAnomaly(

--- a/server/services/predictive/index.ts
+++ b/server/services/predictive/index.ts
@@ -19,6 +19,8 @@ export interface TagUpdateInput {
   tagName: string;
   value: number | string | boolean;
   timestamp: string | number;
+  /** OPC-style quality flag — only 'good' (or absent) readings are ingested */
+  quality?: 'good' | 'bad' | 'uncertain';
 }
 
 export class PredictiveMaintenanceService extends EventEmitter {
@@ -48,10 +50,13 @@ export class PredictiveMaintenanceService extends EventEmitter {
 
   /**
    * Feed a live tag update into the engine. Non-numeric values are ignored —
-   * the statistical detectors only apply to analog signals.
+   * the statistical detectors only apply to analog signals — and non-good
+   * quality readings are excluded so failed sensors can't poison baselines.
    */
   ingestTagUpdate(update: TagUpdateInput): void {
+    if (update.quality !== undefined && update.quality !== 'good') return;
     if (typeof update.value === 'boolean') return;
+    if (typeof update.value === 'string' && update.value.trim() === '') return;
     const value = typeof update.value === 'number' ? update.value : Number(update.value);
     if (!Number.isFinite(value)) return;
     const timestamp =

--- a/server/services/predictive/index.ts
+++ b/server/services/predictive/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Predictive Maintenance Service
+ * ADR-0013 [13.1] — Issue #212
+ *
+ * Wraps the PredictiveMaintenanceEngine as a singleton service: consumes
+ * live tag updates (numeric values only), runs a periodic analysis sweep,
+ * and re-emits engine alerts for downstream consumers (WebSocket, alarms).
+ */
+
+import { EventEmitter } from 'events';
+
+export * from './detectors';
+export * from './engine';
+
+import { PredictiveMaintenanceEngine } from './engine';
+import type { PredictiveAlert } from '@shared/types/predictive';
+
+export interface TagUpdateInput {
+  tagName: string;
+  value: number | string | boolean;
+  timestamp: string | number;
+}
+
+export class PredictiveMaintenanceService extends EventEmitter {
+  readonly engine = new PredictiveMaintenanceEngine();
+
+  private initialized = false;
+  private sweepTimer: NodeJS.Timeout | null = null;
+  private sweepIntervalMs: number;
+
+  constructor(sweepIntervalMs = 30_000) {
+    super();
+    this.sweepIntervalMs = sweepIntervalMs;
+    this.engine.on('alert', (alert: PredictiveAlert) => this.emit('alert', alert));
+    this.engine.on('detector-error', (err) => this.emit('detector-error', err));
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+    this.sweepTimer = setInterval(() => {
+      void this.engine.analyzeAll().catch(() => {
+        /* per-detector errors already surface via 'detector-error' */
+      });
+    }, this.sweepIntervalMs);
+    this.sweepTimer.unref?.();
+  }
+
+  /**
+   * Feed a live tag update into the engine. Non-numeric values are ignored —
+   * the statistical detectors only apply to analog signals.
+   */
+  ingestTagUpdate(update: TagUpdateInput): void {
+    if (typeof update.value === 'boolean') return;
+    const value = typeof update.value === 'number' ? update.value : Number(update.value);
+    if (!Number.isFinite(value)) return;
+    const timestamp =
+      typeof update.timestamp === 'number'
+        ? update.timestamp
+        : new Date(update.timestamp).getTime();
+    if (!Number.isFinite(timestamp)) return;
+    this.engine.ingestPoint(update.tagName, timestamp, value);
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+    this.initialized = false;
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
+    const status = this.engine.getStatus();
+    return {
+      healthy: this.initialized,
+      message: this.initialized
+        ? `Predictive maintenance running: ${status.trackedTags} tags, ${status.activeAlerts} active alerts`
+        : 'Predictive maintenance service not initialized',
+    };
+  }
+}
+
+export const predictiveMaintenanceService = new PredictiveMaintenanceService();

--- a/server/simulator.ts
+++ b/server/simulator.ts
@@ -103,13 +103,24 @@ class FieldSimulator {
         ...(typeof payload === 'object' ? payload : { value: payload }),
       });
 
-      // Broadcast tag update to live dashboard via WebSocket
+      // Broadcast tag update to live dashboard via WebSocket. Prefer any
+      // numeric measurement in the payload (current, newValue, ...) so
+      // numeric consumers like predictive maintenance receive real data
+      // instead of a JSON blob string (#212).
       try {
+        const numeric =
+          typeof payload === 'object' && payload !== null
+            ? [payload.value, payload.current, payload.newValue].find(
+                (v: unknown) => typeof v === 'number' && Number.isFinite(v)
+              )
+            : undefined;
         tagStreamServer.broadcastTagUpdate({
           tagName: `${asset.nameOrTag}.${eventType}`,
-          value: typeof payload === 'object' && payload !== null
-            ? (payload as any).value ?? JSON.stringify(payload)
-            : payload,
+          value:
+            numeric ??
+            (typeof payload === 'object' && payload !== null
+              ? JSON.stringify(payload)
+              : payload),
           quality: "good",
           timestamp: new Date().toISOString(),
         });

--- a/server/websocket/tag-stream.ts
+++ b/server/websocket/tag-stream.ts
@@ -46,6 +46,24 @@ export class TagStreamServer {
   private totalUpdates = 0;
   private startTime = Date.now();
   private pingInterval?: ReturnType<typeof setInterval>;
+  private updateListeners: Array<(update: TagUpdate) => void> = [];
+
+  /**
+   * Register a server-side listener for every tag update flowing through the
+   * stream (e.g. predictive maintenance ingestion). Listener errors are
+   * swallowed so a consumer can never break broadcasting.
+   */
+  onTagUpdate(listener: (update: TagUpdate) => void): void {
+    this.updateListeners.push(listener);
+  }
+
+  private notifyListeners(update: TagUpdate): void {
+    for (const listener of this.updateListeners) {
+      try {
+        listener(update);
+      } catch { /* consumer error — never disrupt broadcasting */ }
+    }
+  }
 
   initialize(httpServer: HttpServer, path = "/ws/tags"): void {
     this.wss = new WebSocketServer({ noServer: true });
@@ -112,6 +130,7 @@ export class TagStreamServer {
   broadcastTagUpdate(update: TagUpdate): void {
     this.latestValues.set(update.tagName, update);
     this.totalUpdates++;
+    this.notifyListeners(update);
 
     const message = JSON.stringify({ event: "tag:update", payload: update });
 
@@ -167,6 +186,7 @@ export class TagStreamServer {
   broadcastBatch(updates: TagUpdate[]): void {
     for (const u of updates) {
       this.latestValues.set(u.tagName, u);
+      this.notifyListeners(u);
     }
     this.totalUpdates += updates.length;
 

--- a/shared/types/predictive.ts
+++ b/shared/types/predictive.ts
@@ -1,0 +1,104 @@
+/**
+ * Predictive Maintenance Types
+ * ADR-0013 [13.1] — Issue #212
+ *
+ * Anomaly detection on tag time-series with ensemble scoring,
+ * configurable per-tag thresholds, and severity-rated alerts.
+ */
+
+export type SeverityLevel = 'info' | 'warning' | 'critical' | 'emergency';
+
+export interface TimeSeriesPoint {
+  timestamp: number;
+  value: number;
+}
+
+export interface DetectorResult {
+  detector: string;
+  /** Normalized 0..1 — saturates at 1 when the detector threshold is reached */
+  score: number;
+  anomalous: boolean;
+  details: Record<string, unknown>;
+}
+
+/**
+ * ML-ready detector contract.
+ *
+ * Built-in statistical detectors (z-score, EWMA, IQR) and future ML models
+ * implement the same interface; `detect` may be async so remote/model
+ * inference can be plugged in without changing the engine.
+ */
+export interface AnomalyDetector {
+  readonly name: string;
+  readonly kind: 'statistical' | 'ml';
+  detect(
+    series: TimeSeriesPoint[],
+    config: TagThresholds
+  ): DetectorResult | Promise<DetectorResult>;
+}
+
+export interface SeverityThresholds {
+  warning: number;
+  critical: number;
+  emergency: number;
+}
+
+/** Engineering limits used for time-to-failure trend estimation */
+export interface FailureLimits {
+  low?: number;
+  high?: number;
+}
+
+export interface TagThresholds {
+  tagId: string;
+  /** Minimum samples in the window before analysis runs */
+  minSamples: number;
+  zScoreThreshold: number;
+  /** EWMA smoothing factor (0..1) */
+  ewmaAlpha: number;
+  /** EWMA control limit width in sigma units */
+  ewmaL: number;
+  iqrMultiplier: number;
+  /** Weight per detector name — unlisted detectors default to weight 1 */
+  ensembleWeights: Record<string, number>;
+  severityThresholds: SeverityThresholds;
+  failureLimits?: FailureLimits;
+}
+
+export interface AnomalyAssessment {
+  tagId: string;
+  timestamp: number;
+  value: number;
+  detectorResults: DetectorResult[];
+  ensembleScore: number;
+  severity: SeverityLevel;
+  description: string;
+}
+
+export interface MaintenancePrediction {
+  tagId: string;
+  /** 0..1 — current ensemble anomaly score blended with trend confidence */
+  failureProbability: number;
+  /** Hours until the trend crosses a failure limit; null if not trending toward one */
+  estimatedHoursToLimit: number | null;
+  /** Least-squares slope of the window, in value units per hour */
+  trendSlopePerHour: number;
+  /** The failure limit the trend is heading toward, if any */
+  limit: number | null;
+  recommendedAction: string;
+  /** R² of the linear fit — how well the trend explains the data */
+  confidence: number;
+}
+
+export interface PredictiveAlert {
+  id: string;
+  tagId: string;
+  severity: SeverityLevel;
+  score: number;
+  message: string;
+  timestamp: number;
+  detectors: string[];
+  acknowledged: boolean;
+  recommendation: string;
+  prediction?: MaintenancePrediction | null;
+}


### PR DESCRIPTION
Closes #212

Rebuilds the Predictive Maintenance Engine from ADR-0013 [13.1]. (The original Wave 2 implementation from PR #220 was lost in the later repo restructure, commit 6f9d9219c — this reimplements it against the current codebase structure and improves on it.)

## What's included

**Statistical detectors** (`server/services/predictive/detectors.ts`)
- **Z-score**: latest value vs. baseline of the preceding window (sample std, zero-variance handled)
- **EWMA control chart**: the EWMA statistic vs. asymptotic limits `L·σ·√(α/(2−α))` — sigma-scaled, so it works for tags of any engineering unit and catches sustained drift
- **IQR**: Tukey fences with linearly-interpolated quantiles
- Weighted **ensemble scoring** → severity classification (info / warning / critical / emergency)

**ML-ready interface**
- All detectors implement a shared `AnomalyDetector` contract (`detect` may be async); ML models register via `engine.registerDetector()` and participate in the ensemble with configurable weights. Detector failures surface as `detector-error` events without breaking analysis.

**Engine** (`server/services/predictive/engine.ts`)
- Per-tag configurable thresholds merged over defaults (detector params, ensemble weights, severity bands, failure limits)
- Sliding-window history per tag, bounded alert store, per-tag alert cooldown, acknowledgement
- **Alert before failures**: least-squares trend estimation projects hours until a configured failure limit is crossed (`predictFailure`), with R²-based confidence

**Integration**
- `PredictiveMaintenanceService` singleton wired into the services registry (init + health check)
- Live tag updates feed the engine via a new `TagStreamServer.onTagUpdate()` hook; a periodic sweep analyzes all tracked tags
- REST API at `/api/predictive` (ingest, analyze, thresholds, alerts, prediction, status), zod-validated

## Testing

- 37 new unit tests (detector math, ensemble, trend projection, engine behavior, service wrapper)
- Full suite: 1156 tests / 40 files pass; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)