### PR TITLE
fix(evolutionary): ADR-0023 ParadoxResolver blockers B1/B2/B3 + majors + first test suite (#491)

### DIFF
--- a/server/services/integrity/__tests__/paradox-resolver.test.ts
+++ b/server/services/integrity/__tests__/paradox-resolver.test.ts
@@ -96,6 +96,26 @@ describe('ParadoxResolver voting hardening (#491 B3)', () => {
     expect(res.mergedValue as number).toBeLessThan(150);
   });
 
+  it('a 2-2 vote tie is broken deterministically by insertion order', async () => {
+    const r = new ParadoxResolver({ simultaneousWindowMs: 100000 });
+    r.registerProcessAreaRules(areaRules({ preferredStrategy: 'voting', minVotingQuorum: 4 }));
+    const now = Date.now();
+    // Two devices vote 10, two vote 20 — an even split.
+    await r.ingestEvent(evt({ deviceId: 'd1', value: 10, timestamp: new Date(now) }));
+    await r.ingestEvent(evt({ deviceId: 'd2', value: 10, timestamp: new Date(now + 1) }));
+    await r.ingestEvent(evt({ deviceId: 'd3', value: 20, timestamp: new Date(now + 2) }));
+    await r.ingestEvent(evt({ deviceId: 'd4', value: 20, timestamp: new Date(now + 3) }));
+    const c = conflict([
+      evt({ deviceId: 'd1', value: 10 }),
+      evt({ id: 'e2', deviceId: 'd3', value: 20 }),
+    ]);
+    const res = await r.resolve(c);
+    expect(res.method).toBe('voting');
+    // Strict `>` keeps the first bucket seen (value 10) on a tie.
+    expect(res.mergedValue as number).toBeCloseTo(10, 5);
+    expect(res.confidence).toBeCloseTo(0.5, 5); // 2 of 4
+  });
+
   it('zero-confidence winning readings do not produce a NaN merged value', async () => {
     const r = new ParadoxResolver({ simultaneousWindowMs: 100000, qualityWeight: 1.0 });
     r.registerProcessAreaRules(areaRules({ preferredStrategy: 'voting', minVotingQuorum: 3 }));
@@ -151,6 +171,23 @@ describe('ParadoxResolver auto-resolve config (#491 minor)', () => {
     // The area opted in explicitly → auto-resolution should have fired despite
     // autoResolveLowSeverity=false globally.
     expect(resolvedEvents.length).toBeGreaterThan(0);
+  });
+
+  it('a registered area that OMITS autoResolveSeverity defers to the global switch (off → no auto-resolve)', async () => {
+    // autoResolveSeverity is optional (#451): an area with rules but no explicit
+    // threshold must fall through to the global kill-switch, not auto-resolve.
+    const r = new ParadoxResolver({ autoResolveLowSeverity: false, simultaneousWindowMs: 100000 });
+    r.registerProcessAreaRules(areaRules({
+      processArea: 'deferring-area',
+      preferredStrategy: 'temporal_priority',
+      autoResolveSeverity: undefined, // explicitly no per-area threshold
+    }));
+    const resolved: unknown[] = [];
+    r.on('resolved', res => resolved.push(res));
+    const now = Date.now();
+    await r.ingestEvent(evt({ tag: 'LT-3', deviceId: 'd1', value: 10, timestamp: new Date(now), processArea: 'deferring-area' }));
+    await r.ingestEvent(evt({ tag: 'LT-3', deviceId: 'd2', value: 99, timestamp: new Date(now + 5), processArea: 'deferring-area' }));
+    expect(resolved.length).toBe(0);
   });
 
   it('with the global flag off and no area rule, conflicts are NOT auto-resolved', async () => {

--- a/server/services/integrity/__tests__/paradox-resolver.test.ts
+++ b/server/services/integrity/__tests__/paradox-resolver.test.ts
@@ -1,0 +1,165 @@
+/**
+ * ParadoxResolver voting/quorum/config tests (#491 B3 + minors).
+ * The resolver previously had zero tests.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ParadoxResolver,
+  type ScadaEvent,
+  type ConflictDetection,
+  type ProcessAreaRules,
+} from '../paradox-resolver';
+
+function evt(overrides: Partial<ScadaEvent> = {}): ScadaEvent {
+  return {
+    id: `e_${Math.random().toString(36).slice(2)}`,
+    deviceId: 'dev-1',
+    tag: 'TT-101',
+    value: 100,
+    timestamp: new Date('2026-03-15T00:00:00Z'),
+    quality: 'good',
+    source: 'sensor',
+    logicalClock: 1,
+    vectorClock: {},
+    ...overrides,
+  };
+}
+
+function conflict(events: ScadaEvent[], area = 'area-1'): ConflictDetection {
+  return {
+    conflictId: `c_${Math.random().toString(36).slice(2)}`,
+    type: 'simultaneous_reading',
+    events,
+    severity: 'medium',
+    detectedAt: new Date(),
+    description: 'test',
+    processArea: area,
+  };
+}
+
+function areaRules(overrides: Partial<ProcessAreaRules> = {}): ProcessAreaRules {
+  return {
+    processArea: 'area-1',
+    preferredStrategy: 'voting',
+    minVotingQuorum: 3,
+    physicsConstraints: [],
+    sensorPriority: [],
+    autoResolveSeverity: 'low',
+    deviceConfidenceOverrides: {},
+    ...overrides,
+  };
+}
+
+describe('ParadoxResolver voting hardening (#491 B3)', () => {
+  it('does NOT crash when preferredStrategy=voting and the tag window is empty', async () => {
+    const r = new ParadoxResolver();
+    r.registerProcessAreaRules(areaRules({ preferredStrategy: 'voting', minVotingQuorum: 3 }));
+    const c = conflict([evt({ deviceId: 'd1' }), evt({ id: 'e2', deviceId: 'd2', value: 101 })]);
+    // No events were ingested → tagEventWindow is empty for this tag.
+    const res = await r.resolve(c);
+    expect(res).toBeDefined();
+    // Falls back to confidence weighting rather than throwing / voting with 0.
+    expect(res.method).toBe('confidence_weighted');
+    expect(Number.isFinite(res.confidence)).toBe(true);
+  });
+
+  it('enforces quorum: below minVotingQuorum distinct devices falls back to confidence weighting', async () => {
+    const r = new ParadoxResolver();
+    r.registerProcessAreaRules(areaRules({ preferredStrategy: 'voting', minVotingQuorum: 3 }));
+    // Ingest two devices only (quorum is 3)
+    await r.ingestEvent(evt({ deviceId: 'd1', value: 100, timestamp: new Date(Date.now()) }));
+    const c = conflict([
+      evt({ deviceId: 'd1', value: 100 }),
+      evt({ id: 'e2', deviceId: 'd2', value: 100 }),
+    ]);
+    const res = await r.resolve(c);
+    expect(res.method).toBe('confidence_weighted');
+  });
+
+  it('genuine 3-device majority resolves by voting with a finite merged value', async () => {
+    const r = new ParadoxResolver({ simultaneousWindowMs: 100000 });
+    r.registerProcessAreaRules(areaRules({ preferredStrategy: 'voting', minVotingQuorum: 3 }));
+    const now = Date.now();
+    // 3 distinct devices, two agree ≈100, one says 200
+    await r.ingestEvent(evt({ deviceId: 'd1', value: 100, timestamp: new Date(now) }));
+    await r.ingestEvent(evt({ deviceId: 'd2', value: 100.4, timestamp: new Date(now + 1) }));
+    await r.ingestEvent(evt({ deviceId: 'd3', value: 200, timestamp: new Date(now + 2) }));
+    const c = conflict([
+      evt({ deviceId: 'd1', value: 100 }),
+      evt({ id: 'e2', deviceId: 'd3', value: 200 }),
+    ]);
+    const res = await r.resolve(c);
+    expect(res.method).toBe('voting');
+    expect(typeof res.mergedValue).toBe('number');
+    expect(Number.isFinite(res.mergedValue as number)).toBe(true);
+    // Majority (100 bucket) should win over the single 200.
+    expect(res.mergedValue as number).toBeLessThan(150);
+  });
+
+  it('zero-confidence winning readings do not produce a NaN merged value', async () => {
+    const r = new ParadoxResolver({ simultaneousWindowMs: 100000, qualityWeight: 1.0 });
+    r.registerProcessAreaRules(areaRules({ preferredStrategy: 'voting', minVotingQuorum: 3 }));
+    const now = Date.now();
+    // All three devices agree on 50 but report sensorConfidence 0 and bad quality
+    await r.ingestEvent(evt({ deviceId: 'd1', value: 50, sensorConfidence: 0, quality: 'bad', timestamp: new Date(now) }));
+    await r.ingestEvent(evt({ deviceId: 'd2', value: 50, sensorConfidence: 0, quality: 'bad', timestamp: new Date(now + 1) }));
+    await r.ingestEvent(evt({ deviceId: 'd3', value: 50, sensorConfidence: 0, quality: 'bad', timestamp: new Date(now + 2) }));
+    const c = conflict([
+      evt({ deviceId: 'd1', value: 50, sensorConfidence: 0, quality: 'bad' }),
+      evt({ id: 'e2', deviceId: 'd2', value: 50, sensorConfidence: 0, quality: 'bad' }),
+    ]);
+    const res = await r.resolve(c);
+    expect(res.method).toBe('voting');
+    expect(Number.isFinite(res.mergedValue as number)).toBe(true);
+    expect(res.mergedValue as number).toBeCloseTo(50, 5);
+  });
+});
+
+describe('ParadoxResolver confidence weighting NaN guard (#491 minor)', () => {
+  it('a NaN sensorConfidence does not poison the weighted merge', async () => {
+    const r = new ParadoxResolver();
+    const c = conflict([
+      evt({ deviceId: 'd1', value: 10, sensorConfidence: NaN }),
+      evt({ id: 'e2', deviceId: 'd2', value: 12, sensorConfidence: NaN }),
+    ]);
+    const res = await r.resolve(c);
+    expect(res.method).toBe('confidence_weighted');
+    expect(Number.isFinite(res.confidence)).toBe(true);
+    if (res.mergedValue !== undefined) {
+      expect(Number.isFinite(res.mergedValue as number)).toBe(true);
+    }
+  });
+});
+
+describe('ParadoxResolver auto-resolve config (#491 minor)', () => {
+  it('an area with explicit autoResolveSeverity auto-resolves even when the global flag is off', async () => {
+    const r = new ParadoxResolver({ autoResolveLowSeverity: false, simultaneousWindowMs: 100000 });
+    r.registerProcessAreaRules(areaRules({
+      processArea: 'critical-area',
+      preferredStrategy: 'temporal_priority',
+      autoResolveSeverity: 'critical',
+    }));
+
+    const resolvedEvents: unknown[] = [];
+    r.on('resolved', res => resolvedEvents.push(res));
+
+    // Two conflicting sensor readings in the critical area (medium severity ≤ critical)
+    const now = Date.now();
+    await r.ingestEvent(evt({ tag: 'PT-1', deviceId: 'd1', value: 10, timestamp: new Date(now), processArea: 'critical-area' }));
+    await r.ingestEvent(evt({ tag: 'PT-1', deviceId: 'd2', value: 99, timestamp: new Date(now + 5), processArea: 'critical-area' }));
+
+    // The area opted in explicitly → auto-resolution should have fired despite
+    // autoResolveLowSeverity=false globally.
+    expect(resolvedEvents.length).toBeGreaterThan(0);
+  });
+
+  it('with the global flag off and no area rule, conflicts are NOT auto-resolved', async () => {
+    const r = new ParadoxResolver({ autoResolveLowSeverity: false, simultaneousWindowMs: 100000 });
+    const resolved: unknown[] = [];
+    r.on('resolved', res => resolved.push(res));
+    const now = Date.now();
+    await r.ingestEvent(evt({ tag: 'FT-9', deviceId: 'd1', value: 10, timestamp: new Date(now) }));
+    await r.ingestEvent(evt({ tag: 'FT-9', deviceId: 'd2', value: 99, timestamp: new Date(now + 5) }));
+    expect(resolved.length).toBe(0);
+  });
+});

--- a/server/services/integrity/evolutionary/__tests__/evolution.test.ts
+++ b/server/services/integrity/evolutionary/__tests__/evolution.test.ts
@@ -57,10 +57,12 @@ describe('seedable RNG (#451)', () => {
     for (const x of seqA) expect(x).toBeGreaterThanOrEqual(0), expect(x).toBeLessThan(1);
   });
 
-  it('shuffleInPlace touches every position and preserves the multiset', () => {
+  it('shuffleInPlace preserves the multiset and actually reorders (not a no-op)', () => {
     const src = [1, 2, 3, 4, 5, 6, 7, 8];
     const out = shuffleInPlace([...src], mulberry32(7));
     expect([...out].sort((a, b) => a - b)).toEqual(src);
+    // A `return arr` no-op would leave order unchanged — require movement.
+    expect(out).not.toEqual(src);
   });
 });
 
@@ -156,12 +158,23 @@ describe('EvolutionEngine', () => {
 
   it('selectResolutionGenome explores non-best genomes under exploration pressure (#451 M3)', () => {
     const engine = new EvolutionEngine(registry, fitness, { seed: 9, populationSize: 10, explorationRate: 1.0 });
-    const pop = engine.initializePopulation('a');
-    // With explorationRate 1.0 every pick is random — over many draws we should
-    // touch more than just the single best genome.
+    engine.initializePopulation('a');
+    // With explorationRate 1.0 every pick is random — over 40 draws on a pop of
+    // 10 the exploration should reach most of the population, not just the best.
     const seen = new Set<string>();
     for (let i = 0; i < 40; i++) seen.add(engine.selectResolutionGenome('a')!.id);
-    expect(seen.size).toBeGreaterThan(1);
+    expect(seen.size).toBeGreaterThanOrEqual(5);
+  });
+
+  it('never crosses over into an empty genome (verification-workflow finding)', () => {
+    const engine = new EvolutionEngine(registry, fitness, { seed: 13 });
+    const p1 = new ResolutionGenome({ primitives: [{ primitiveId: 'A', weight: 1 }] });
+    const p2 = new ResolutionGenome({ primitives: [{ primitiveId: 'B', weight: 1 }] });
+    // cut1=0 + cut2=len (=1) is the empty-child case; exercise many draws.
+    for (let i = 0; i < 300; i++) {
+      const child = (engine as any).crossover(p1, p2) as ResolutionGenome;
+      expect(child.primitives.length).toBeGreaterThanOrEqual(1);
+    }
   });
 
   it('crossover can inherit the last gene of parent1 (#451 M6)', () => {
@@ -202,8 +215,44 @@ describe('EvolutionEngine', () => {
     (engine as any).resolutionCounters.set('a', 0);
     expect(() => engine.evolve('a')).not.toThrow();
     const stats = engine.getStats('a')!;
-    expect(stats.diversityScore).toBeGreaterThanOrEqual(0);
+    // Diversity is (unique signatures / population size); post-evolve the pop
+    // is no longer perfectly homogeneous but stays a proper ratio in (0, 1].
+    expect(stats.diversityScore).toBeGreaterThan(0);
     expect(stats.diversityScore).toBeLessThanOrEqual(1);
+  });
+
+  it('computeDiversity reports the concrete ratio for a homogeneous population', () => {
+    const engine = new EvolutionEngine(registry, fitness, { seed: 8 });
+    const g = new ResolutionGenome({ primitives: [{ primitiveId: 'vote', weight: 1 }], processAreaAffinity: 'a' });
+    (engine as any).populations.set('a', Array.from({ length: 6 }, () => g.clone()));
+    (engine as any).generations.set('a', 0);
+    (engine as any).resolutionCounters.set('a', 0);
+    // 1 unique signature across 6 identical genomes → 1/6.
+    expect(engine.getStats('a')!.diversityScore).toBeCloseTo(1 / 6, 5);
+  });
+
+  it('serialize → deserialize round-trips a genome, and evaluate skips unknown primitive ids', () => {
+    const g = new ResolutionGenome({
+      primitives: [{ primitiveId: 'confidence_weight', weight: 1.5 }, { primitiveId: 'DOES_NOT_EXIST', weight: 2 }],
+      generation: 3,
+      ancestry: ['x', 'y'],
+      processAreaAffinity: 'area-1',
+    });
+    g.recordFitness(0.7);
+    const round = ResolutionGenome.deserialize(g.serialize());
+    expect(round.id).toBe(g.id);
+    expect(round.primitives).toEqual(g.primitives);
+    expect(round.generation).toBe(3);
+    expect(round.ancestry).toEqual(['x', 'y']);
+    expect(round.fitnessHistory).toEqual([0.7]);
+
+    // Unknown primitive id is silently skipped, not a crash; the known one still counts.
+    const ev = round.evaluate(
+      { conflict: conflict([evt({ sensorConfidence: 0.9 }), evt({ id: 'e2', value: 101, sensorConfidence: 0.8 })]) } as any,
+      new PrimitiveRegistry().getMap(),
+    );
+    expect(ev.primitivesEvaluated).toBe(1);
+    expect(Number.isFinite(ev.score)).toBe(true);
   });
 });
 

--- a/server/services/integrity/evolutionary/__tests__/evolution.test.ts
+++ b/server/services/integrity/evolutionary/__tests__/evolution.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Edge-case + regression suite for the ADR-0023 evolutionary resolver (#491).
+ * The subsystem previously had zero tests. These encode the CORRECT behavior
+ * for the blockers/majors identified in the #451 review.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { EvolutionEngine } from '../evolution-engine';
+import { FitnessEvaluator } from '../fitness';
+import { SafetyGuard } from '../safety-guard';
+import { PrimitiveRegistry } from '../registry';
+import { ResolutionGenome } from '../genome';
+import { EvolutionaryResolver } from '../evolutionary-resolver';
+import { mulberry32, shuffleInPlace } from '../rng';
+import { ParadoxResolver, type ConflictDetection, type ScadaEvent } from '../../paradox-resolver';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function evt(overrides: Partial<ScadaEvent> = {}): ScadaEvent {
+  return {
+    id: `e_${Math.random().toString(36).slice(2)}`,
+    deviceId: 'dev-1',
+    tag: 'TT-101',
+    value: 100,
+    timestamp: new Date('2026-03-15T00:00:00Z'),
+    quality: 'good',
+    source: 'sensor',
+    logicalClock: 1,
+    vectorClock: {},
+    ...overrides,
+  };
+}
+
+function conflict(events: ScadaEvent[], area = 'area-1'): ConflictDetection {
+  return {
+    conflictId: `c_${Math.random().toString(36).slice(2)}`,
+    type: 'simultaneous_reading',
+    events,
+    severity: 'medium',
+    detectedAt: new Date(),
+    description: 'test conflict',
+    processArea: area,
+  };
+}
+
+// ─── RNG ──────────────────────────────────────────────────────────────────
+
+describe('seedable RNG (#451)', () => {
+  it('same seed → identical stream; different seed → different', () => {
+    const a = mulberry32(42);
+    const b = mulberry32(42);
+    const c = mulberry32(43);
+    const seqA = Array.from({ length: 8 }, () => a());
+    const seqB = Array.from({ length: 8 }, () => b());
+    const seqC = Array.from({ length: 8 }, () => c());
+    expect(seqA).toEqual(seqB);
+    expect(seqA).not.toEqual(seqC);
+    for (const x of seqA) expect(x).toBeGreaterThanOrEqual(0), expect(x).toBeLessThan(1);
+  });
+
+  it('shuffleInPlace touches every position and preserves the multiset', () => {
+    const src = [1, 2, 3, 4, 5, 6, 7, 8];
+    const out = shuffleInPlace([...src], mulberry32(7));
+    expect([...out].sort((a, b) => a - b)).toEqual(src);
+  });
+});
+
+// ─── FitnessEvaluator ─────────────────────────────────────────────────────
+
+describe('FitnessEvaluator', () => {
+  it('getFitnessForGenome falls back to the genome fitnessHistory when records are pruned (#451 M2)', () => {
+    const fitness = new FitnessEvaluator();
+    const g = new ResolutionGenome({ id: 'g1', primitives: [] });
+    g.recordFitness(0.9);
+    g.recordFitness(0.85);
+    // No evaluator records for g1 → must use the genome's own history, not 0
+    expect(fitness.getFitness('g1')).toBe(0);
+    expect(fitness.getFitnessForGenome(g)).toBeGreaterThan(0.5);
+  });
+
+  it('clamps NaN/Infinity fitness inputs to 0 (does not poison ranking)', () => {
+    const fitness = new FitnessEvaluator();
+    const g = new ResolutionGenome({ id: 'gNaN', primitives: [] });
+    const evalObj = { score: NaN, primitiveResults: [], primitivesEvaluated: 0, reasoning: '' };
+    const raw = fitness.evaluate(g, { conflictId: 'c', method: 'confidence_weighted', confidence: NaN, reasoning: '', resolvedAt: new Date() }, evalObj as any);
+    expect(Number.isFinite(raw)).toBe(true);
+    expect(raw).toBe(0);
+  });
+
+  it('recordValidation adjusts the latest record within [0,1]', () => {
+    const fitness = new FitnessEvaluator();
+    const g = new ResolutionGenome({ id: 'gv', primitives: [] });
+    const evalObj = { score: 0.5, primitiveResults: [], primitivesEvaluated: 1, reasoning: '' };
+    fitness.evaluate(g, { conflictId: 'c', method: 'confidence_weighted', confidence: 0.5, reasoning: '', resolvedAt: new Date() }, evalObj as any);
+    const before = fitness.getFitness('gv');
+    fitness.recordValidation('gv', true);
+    expect(fitness.getFitness('gv')).toBeGreaterThan(before);
+    expect(fitness.getFitness('gv')).toBeLessThanOrEqual(1);
+  });
+});
+
+// ─── EvolutionEngine ──────────────────────────────────────────────────────
+
+describe('EvolutionEngine', () => {
+  let registry: PrimitiveRegistry;
+  let fitness: FitnessEvaluator;
+
+  beforeEach(() => {
+    registry = new PrimitiveRegistry();
+    fitness = new FitnessEvaluator();
+  });
+
+  it('is deterministic under a fixed seed', () => {
+    const mk = () =>
+      new EvolutionEngine(new PrimitiveRegistry(), new FitnessEvaluator(), { seed: 123, populationSize: 10 });
+    const e1 = mk();
+    const e2 = mk();
+    const p1 = e1.initializePopulation('a').map(g => g.primitives.map(p => p.primitiveId).join(','));
+    const p2 = e2.initializePopulation('a').map(g => g.primitives.map(p => p.primitiveId).join(','));
+    expect(p1).toEqual(p2);
+  });
+
+  it('preserves elite fitness identity across a generation (#451 M2)', () => {
+    const engine = new EvolutionEngine(registry, fitness, { seed: 1, populationSize: 8, eliteCount: 2 });
+    const pop = engine.initializePopulation('a');
+    // Give the first genome a strong, repeated fitness signal
+    const star = pop[0];
+    for (let i = 0; i < 5; i++) {
+      fitness.evaluate(star, { conflictId: 'c', method: 'confidence_weighted', confidence: 0.95, reasoning: '', resolvedAt: new Date() }, { score: 0.95, primitiveResults: [], primitivesEvaluated: 1, reasoning: '' } as any);
+    }
+    const starFitnessBefore = fitness.getFitnessForGenome(star);
+    expect(starFitnessBefore).toBeGreaterThan(0.8);
+
+    const newPop = engine.evolve('a');
+    // The elite (same object/id) must still be present with its fitness intact
+    const survivor = newPop.find(g => g.id === star.id);
+    expect(survivor).toBeDefined();
+    expect(fitness.getFitnessForGenome(survivor!)).toBeGreaterThan(0.8);
+    // getStats bestFitness must be non-zero (was always 0 before the fix)
+    expect(engine.getStats('a')!.bestFitness).toBeGreaterThan(0.8);
+  });
+
+  it('getBestGenome returns the genome with the highest fitness', () => {
+    const engine = new EvolutionEngine(registry, fitness, { seed: 5, populationSize: 6 });
+    const pop = engine.initializePopulation('a');
+    const target = pop[3];
+    fitness.evaluate(target, { conflictId: 'c', method: 'confidence_weighted', confidence: 0.99, reasoning: '', resolvedAt: new Date() }, { score: 0.99, primitiveResults: [], primitivesEvaluated: 1, reasoning: '' } as any);
+    expect(engine.getBestGenome('a')!.id).toBe(target.id);
+  });
+
+  it('single-genome population: evolve and select do not crash', () => {
+    const engine = new EvolutionEngine(registry, fitness, { seed: 2, populationSize: 1, eliteCount: 1 });
+    engine.initializePopulation('a');
+    expect(() => engine.evolve('a')).not.toThrow();
+    expect(engine.selectResolutionGenome('a')).not.toBeNull();
+  });
+
+  it('selectResolutionGenome explores non-best genomes under exploration pressure (#451 M3)', () => {
+    const engine = new EvolutionEngine(registry, fitness, { seed: 9, populationSize: 10, explorationRate: 1.0 });
+    const pop = engine.initializePopulation('a');
+    // With explorationRate 1.0 every pick is random — over many draws we should
+    // touch more than just the single best genome.
+    const seen = new Set<string>();
+    for (let i = 0; i < 40; i++) seen.add(engine.selectResolutionGenome('a')!.id);
+    expect(seen.size).toBeGreaterThan(1);
+  });
+
+  it('crossover can inherit the last gene of parent1 (#451 M6)', () => {
+    const engine = new EvolutionEngine(registry, fitness, { seed: 3 });
+    const p1 = new ResolutionGenome({ primitives: [
+      { primitiveId: 'AA', weight: 1 },
+      { primitiveId: 'BB', weight: 1 },
+      { primitiveId: 'ZZ_LAST', weight: 1 },
+    ]});
+    const p2 = new ResolutionGenome({ primitives: [{ primitiveId: 'P2ONLY', weight: 1 }] });
+    // Over many crossovers the exclusive tail gene of parent1 must appear at
+    // least once (impossible when cuts are sampled [0, len-1]).
+    let sawLast = false;
+    for (let i = 0; i < 200 && !sawLast; i++) {
+      const child = (engine as any).crossover(p1, p2) as ResolutionGenome;
+      if (child.primitives.some(p => p.primitiveId === 'ZZ_LAST')) sawLast = true;
+    }
+    expect(sawLast).toBe(true);
+  });
+
+  it('mutation never empties a genome and keeps weights in range', () => {
+    const engine = new EvolutionEngine(registry, fitness, { seed: 11 });
+    const g = new ResolutionGenome({ primitives: [{ primitiveId: 'temporal_weight', weight: 1 }] });
+    for (let i = 0; i < 100; i++) (engine as any).mutate(g);
+    expect(g.primitives.length).toBeGreaterThanOrEqual(1);
+    for (const p of g.primitives) {
+      expect(p.weight).toBeGreaterThanOrEqual(0.1);
+      expect(p.weight).toBeLessThanOrEqual(3.0);
+    }
+  });
+
+  it('all-identical population still evolves without error and reports diversity', () => {
+    const engine = new EvolutionEngine(registry, fitness, { seed: 4, populationSize: 6 });
+    const genome = new ResolutionGenome({ primitives: [{ primitiveId: 'vote', weight: 1 }], processAreaAffinity: 'a' });
+    // Force a homogeneous population
+    (engine as any).populations.set('a', Array.from({ length: 6 }, () => genome.clone()));
+    (engine as any).generations.set('a', 0);
+    (engine as any).resolutionCounters.set('a', 0);
+    expect(() => engine.evolve('a')).not.toThrow();
+    const stats = engine.getStats('a')!;
+    expect(stats.diversityScore).toBeGreaterThanOrEqual(0);
+    expect(stats.diversityScore).toBeLessThanOrEqual(1);
+  });
+});
+
+// ─── SafetyGuard novelty budget ───────────────────────────────────────────
+
+describe('SafetyGuard novelty budget (#451 B1)', () => {
+  it('does NOT deadlock after the first experimental resolution', () => {
+    const fitness = new FitnessEvaluator();
+    const guard = new SafetyGuard(fitness, { noveltyBudget: 0.3, maturityGeneration: 5, confidenceFloor: 0.3 });
+    const experimental = new ResolutionGenome({ id: 'exp', primitives: [], generation: 0 });
+    const goodEval = { score: 0.9, primitiveResults: [], primitivesEvaluated: 1, reasoning: 'ok' };
+
+    let allowed = 0;
+    for (let i = 0; i < 100; i++) {
+      const d = guard.checkResolution(experimental, goodEval as any, 'a');
+      if (d.allowed) allowed++;
+    }
+    // The old accounting allowed exactly 1. Correct behavior lets ~30% through.
+    expect(allowed).toBeGreaterThan(10);
+    // And it must respect the budget ceiling (never runaway to all-allowed).
+    expect(allowed).toBeLessThan(60);
+    // Steady-state ratio should hover around the budget.
+    expect(guard.getNoveltyRatio()).toBeLessThanOrEqual(0.35);
+  });
+
+  it('mature genomes are never novelty-blocked', () => {
+    const guard = new SafetyGuard(new FitnessEvaluator(), { noveltyBudget: 0.3, maturityGeneration: 5 });
+    const mature = new ResolutionGenome({ id: 'mat', primitives: [], generation: 10 });
+    const goodEval = { score: 0.9, primitiveResults: [], primitivesEvaluated: 1, reasoning: 'ok' };
+    for (let i = 0; i < 50; i++) {
+      expect(guard.checkResolution(mature, goodEval as any, 'a').allowed).toBe(true);
+    }
+  });
+
+  it('confidence floor still blocks low-confidence evolved strategies', () => {
+    const guard = new SafetyGuard(new FitnessEvaluator(), { confidenceFloor: 0.3 });
+    const g = new ResolutionGenome({ id: 'low', primitives: [], generation: 10 });
+    const lowEval = { score: 0.1, primitiveResults: [], primitivesEvaluated: 1, reasoning: 'weak' };
+    const d = guard.checkResolution(g, lowEval as any, 'a');
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/below floor/);
+  });
+
+  it('kill switch blocks everything', () => {
+    const guard = new SafetyGuard(new FitnessEvaluator());
+    guard.activateKillSwitch();
+    const g = new ResolutionGenome({ id: 'k', primitives: [], generation: 10 });
+    expect(guard.checkResolution(g, { score: 0.99, primitiveResults: [], primitivesEvaluated: 1, reasoning: '' } as any, 'a').allowed).toBe(false);
+  });
+});
+
+// ─── EvolutionaryResolver end-to-end ──────────────────────────────────────
+
+describe('EvolutionaryResolver (#451 B1/B2 integration)', () => {
+  it('a genome blocked by the confidence floor records its OWN low fitness, not the static fallbacks (#451 B2)', async () => {
+    // Discriminating setup: a genome that always evaluates LOW while the static
+    // resolver handles the same (good-quality) conflict with HIGH confidence.
+    // The B2 bug credited the blocked genome with the static HIGH confidence,
+    // inverting selection. Correct behavior records the genome's own LOW score.
+    const base = new ParadoxResolver();
+    const resolver = new EvolutionaryResolver(base, {
+      evolution: { seed: 1, populationSize: 4, explorationRate: 0 }, // always the (only) genome
+      safety: { confidenceFloor: 0.9, maturityGeneration: 5 }, // floor forces a block
+    });
+    const fitness = resolver.getFitnessEvaluator();
+    const engine = resolver.getEngine();
+
+    // A custom primitive that always scores 0.01 → genome eval ≈ 0.01, well
+    // below the 0.9 floor → always blocked.
+    resolver.getRegistry().add({
+      id: 'always_low',
+      name: 'Always Low',
+      description: 'test primitive',
+      evaluate: () => ({ score: 0.01, weight: 1, reasoning: 'always low' }),
+    });
+    const weak = new ResolutionGenome({
+      id: 'weak',
+      primitives: [{ primitiveId: 'always_low', weight: 1 }],
+      generation: 10,
+      processAreaAffinity: 'area-1',
+    });
+    (engine as any).populations.set('area-1', [weak]);
+    (engine as any).generations.set('area-1', 0);
+    (engine as any).resolutionCounters.set('area-1', 0);
+
+    // GOOD events → the static resolver resolves with HIGH confidence (~0.9).
+    const goodEvents = [
+      evt({ deviceId: 'd1', quality: 'good', sensorConfidence: 0.9 }),
+      evt({ id: 'e2', deviceId: 'd2', value: 101, quality: 'good', sensorConfidence: 0.9 }),
+    ];
+
+    let out;
+    for (let i = 0; i < 5; i++) {
+      out = await resolver.resolveConflict(conflict(
+        goodEvents.map((e, k) => ({ ...e, id: `g${i}_${k}` })),
+      ));
+    }
+
+    // It was blocked (fell back to static)…
+    expect(out!.usedEvolved).toBe(false);
+    expect(out!.safetyDecision.allowed).toBe(false);
+    // …the static fallback is highly confident on these good readings…
+    expect(out!.resolution.confidence).toBeGreaterThan(0.7);
+    // …but the genome's recorded fitness reflects ITS OWN weak eval, not that.
+    // (Under the B2 bug this would be ~0.99 — the static confidence.)
+    expect(fitness.getFitnessForGenome(weak)).toBeLessThan(0.3);
+  });
+
+  it('resolveConflict returns a valid resolution and does not throw on a fresh area', async () => {
+    const base = new ParadoxResolver();
+    const resolver = new EvolutionaryResolver(base, { evolution: { seed: 2, populationSize: 4 } });
+    const events = [evt({ deviceId: 'd1' }), evt({ id: 'e2', deviceId: 'd2', value: 105 })];
+    const out = await resolver.resolveConflict(conflict(events));
+    expect(out.resolution).toBeDefined();
+    expect(out.resolution.conflictId).toBeDefined();
+  });
+
+  it('evolution eventually triggers over a long run (no permanent stall) (#451 B1)', async () => {
+    const base = new ParadoxResolver();
+    let evolved = 0;
+    const resolver = new EvolutionaryResolver(base, {
+      evolution: { seed: 7, populationSize: 6, resolutionsPerCycle: 20 },
+      safety: { maturityGeneration: 2, noveltyBudget: 0.3, confidenceFloor: 0.2 },
+    });
+    resolver.on('evolution_complete', () => { evolved++; });
+    const events = [evt({ deviceId: 'd1', sensorConfidence: 0.8 }), evt({ id: 'e2', deviceId: 'd2', value: 101, sensorConfidence: 0.75 })];
+    for (let i = 0; i < 200; i++) {
+      await resolver.resolveConflict(conflict([
+        { ...events[0], id: `a${i}` },
+        { ...events[1], id: `b${i}` },
+      ]));
+    }
+    // With blocked resolutions counting toward the cycle, generations advance.
+    expect(evolved).toBeGreaterThan(0);
+    const status = resolver.getStatus();
+    expect(status.processAreas[0].generation).toBeGreaterThan(0);
+  });
+});

--- a/server/services/integrity/evolutionary/evolution-engine.ts
+++ b/server/services/integrity/evolutionary/evolution-engine.ts
@@ -16,6 +16,7 @@
 import { ResolutionGenome, WeightedPrimitive } from './genome';
 import { PrimitiveRegistry } from './registry';
 import { FitnessEvaluator } from './fitness';
+import { mulberry32, shuffleInPlace, type Rng } from './rng';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -36,6 +37,16 @@ export interface EvolutionConfig {
   minWeight: number;
   /** Number of resolved paradoxes before triggering evolution (default 100) */
   resolutionsPerCycle: number;
+  /**
+   * Fraction of resolutions that pick a random (non-best) genome so the whole
+   * population accrues fitness, not just the incumbent best (#451 M3). Default 0.2.
+   */
+  explorationRate: number;
+  /**
+   * Optional seed for reproducible/auditable evolution (#451). When set, all
+   * randomness draws from a seeded stream; otherwise Math.random is used.
+   */
+  seed?: number;
 }
 
 export interface PopulationStats {
@@ -66,6 +77,7 @@ const DEFAULT_EVOLUTION_CONFIG: EvolutionConfig = {
   maxWeight: 3.0,
   minWeight: 0.1,
   resolutionsPerCycle: 100,
+  explorationRate: 0.2,
 };
 
 // ─── Evolution Engine ───────────────────────────────────────────────────────
@@ -74,6 +86,7 @@ export class EvolutionEngine {
   private config: EvolutionConfig;
   private registry: PrimitiveRegistry;
   private fitnessEval: FitnessEvaluator;
+  private rng: Rng;
 
   /** processArea → population of genomes */
   private populations: Map<string, ResolutionGenome[]> = new Map();
@@ -93,6 +106,7 @@ export class EvolutionEngine {
     this.config = { ...DEFAULT_EVOLUTION_CONFIG, ...config };
     this.registry = registry;
     this.fitnessEval = fitnessEval;
+    this.rng = this.config.seed !== undefined ? mulberry32(this.config.seed) : Math.random;
   }
 
   // ─── Population Management ──────────────────────────────────────
@@ -135,10 +149,10 @@ export class EvolutionEngine {
     if (!pop || pop.length === 0) return null;
 
     let best = pop[0];
-    let bestFitness = this.fitnessEval.getFitness(best.id);
+    let bestFitness = this.fitnessEval.getFitnessForGenome(best);
 
     for (let i = 1; i < pop.length; i++) {
-      const f = this.fitnessEval.getFitness(pop[i].id);
+      const f = this.fitnessEval.getFitnessForGenome(pop[i]);
       if (f > bestFitness) {
         bestFitness = f;
         best = pop[i];
@@ -146,6 +160,20 @@ export class EvolutionEngine {
     }
 
     return best;
+  }
+
+  /**
+   * Select a genome to resolve the next conflict. Epsilon-greedy (#451 M3):
+   * with probability `explorationRate`, return a random population member so
+   * the whole population accrues fitness records; otherwise the current best.
+   */
+  selectResolutionGenome(processArea: string): ResolutionGenome | null {
+    const pop = this.populations.get(processArea);
+    if (!pop || pop.length === 0) return null;
+    if (pop.length > 1 && this.rng() < this.config.explorationRate) {
+      return pop[Math.floor(this.rng() * pop.length)];
+    }
+    return this.getBestGenome(processArea);
   }
 
   /**
@@ -171,8 +199,10 @@ export class EvolutionEngine {
     // 1. Sort by fitness (descending)
     const ranked = this.rankByFitness(population);
 
-    // 2. Elitism: preserve top genomes
-    const elites = ranked.slice(0, this.config.eliteCount).map(g => g.clone());
+    // 2. Elitism: preserve top genomes BY REFERENCE (#451 M2). Keeping the
+    //    same object (and id) means their accumulated fitness records survive
+    //    the pruneInactive below, so ranking is meaningful next generation.
+    const elites = ranked.slice(0, this.config.eliteCount);
     for (const elite of elites) {
       elite.generation = gen;
     }
@@ -184,7 +214,7 @@ export class EvolutionEngine {
     for (let i = 0; i < targetSize; i++) {
       let child: ResolutionGenome;
 
-      if (Math.random() < this.config.crossoverRate && population.length >= 2) {
+      if (this.rng() < this.config.crossoverRate && population.length >= 2) {
         // Crossover
         const parent1 = this.tournamentSelect(ranked);
         const parent2 = this.tournamentSelect(ranked);
@@ -196,7 +226,7 @@ export class EvolutionEngine {
       }
 
       // Mutation
-      if (Math.random() < this.config.mutationRate) {
+      if (this.rng() < this.config.mutationRate) {
         this.mutate(child);
       }
 
@@ -208,7 +238,8 @@ export class EvolutionEngine {
     // 4. Build new population
     const newPopulation = [...elites, ...offspring];
 
-    // 5. Prune fitness records for retired genomes
+    // 5. Prune fitness records for retired genomes (elites' ids are retained
+    //    because they were preserved by reference above)
     const activeIds = new Set(newPopulation.map(g => g.id));
     const pruned = this.fitnessEval.pruneInactive(activeIds);
 
@@ -227,7 +258,7 @@ export class EvolutionEngine {
         elitesPreserved: elites.length,
         offspringCreated: offspring.length,
         genomesPruned: pruned,
-        bestFitness: this.fitnessEval.getFitness(newPopulation[0]?.id ?? ''),
+        bestFitness: newPopulation[0] ? this.fitnessEval.getFitnessForGenome(newPopulation[0]) : 0,
       },
       timestamp: Date.now(),
     });
@@ -248,12 +279,12 @@ export class EvolutionEngine {
     // Pick k random indices without replacement
     const indices = new Set<number>();
     while (indices.size < k) {
-      indices.add(Math.floor(Math.random() * ranked.length));
+      indices.add(Math.floor(this.rng() * ranked.length));
     }
 
     for (const idx of indices) {
       const genome = ranked[idx];
-      const fitness = this.fitnessEval.getFitness(genome.id);
+      const fitness = this.fitnessEval.getFitnessForGenome(genome);
       if (fitness > bestFitness) {
         bestFitness = fitness;
         best = genome;
@@ -277,9 +308,12 @@ export class EvolutionEngine {
       return parent1.clone();
     }
 
-    // Single-point crossover
-    const cut1 = p1.length > 0 ? Math.floor(Math.random() * p1.length) : 0;
-    const cut2 = p2.length > 0 ? Math.floor(Math.random() * p2.length) : 0;
+    // Single-point crossover. Cuts sampled in [0, len] INCLUSIVE (#451 M6) so
+    // every gene position is inheritable — cut=len takes all of p1's head /
+    // none of p2's tail; cut=0 the reverse. Sampling [0, len-1] would make
+    // p1's last gene un-inheritable and p2's last gene always inherited.
+    const cut1 = Math.floor(this.rng() * (p1.length + 1));
+    const cut2 = Math.floor(this.rng() * (p2.length + 1));
 
     const childPrimitives: WeightedPrimitive[] = [
       ...p1.slice(0, cut1).map(p => ({ ...p })),
@@ -314,7 +348,7 @@ export class EvolutionEngine {
    * 3. Reweight a random primitive
    */
   private mutate(genome: ResolutionGenome): void {
-    const roll = Math.random();
+    const roll = this.rng();
     const primitiveIds = this.registry.list().map(p => p.id);
 
     if (roll < 0.33 && genome.primitives.length < primitiveIds.length) {
@@ -322,18 +356,18 @@ export class EvolutionEngine {
       const existing = new Set(genome.primitives.map(p => p.primitiveId));
       const available = primitiveIds.filter(id => !existing.has(id));
       if (available.length > 0) {
-        const newId = available[Math.floor(Math.random() * available.length)];
-        const weight = this.config.minWeight + Math.random() * (this.config.maxWeight - this.config.minWeight);
+        const newId = available[Math.floor(this.rng() * available.length)];
+        const weight = this.config.minWeight + this.rng() * (this.config.maxWeight - this.config.minWeight);
         genome.primitives.push({ primitiveId: newId, weight });
       }
     } else if (roll < 0.66 && genome.primitives.length > 1) {
       // Remove: drop a random primitive
-      const idx = Math.floor(Math.random() * genome.primitives.length);
+      const idx = Math.floor(this.rng() * genome.primitives.length);
       genome.primitives.splice(idx, 1);
     } else if (genome.primitives.length > 0) {
       // Reweight: adjust a random primitive's weight
-      const idx = Math.floor(Math.random() * genome.primitives.length);
-      const delta = (Math.random() - 0.5) * 1.0; // ±0.5
+      const idx = Math.floor(this.rng() * genome.primitives.length);
+      const delta = (this.rng() - 0.5) * 1.0; // ±0.5
       genome.primitives[idx].weight = Math.max(
         this.config.minWeight,
         Math.min(this.config.maxWeight, genome.primitives[idx].weight + delta),
@@ -345,19 +379,19 @@ export class EvolutionEngine {
 
   private rankByFitness(population: ResolutionGenome[]): ResolutionGenome[] {
     return [...population].sort(
-      (a, b) => this.fitnessEval.getFitness(b.id) - this.fitnessEval.getFitness(a.id),
+      (a, b) => this.fitnessEval.getFitnessForGenome(b) - this.fitnessEval.getFitnessForGenome(a),
     );
   }
 
   private createRandomGenome(primitiveIds: string[], processArea: string): ResolutionGenome {
     // Each genome gets 2-5 random primitives with random weights
-    const count = 2 + Math.floor(Math.random() * 4);
-    const shuffled = [...primitiveIds].sort(() => Math.random() - 0.5);
+    const count = 2 + Math.floor(this.rng() * 4);
+    const shuffled = shuffleInPlace([...primitiveIds], this.rng);
     const selected = shuffled.slice(0, Math.min(count, shuffled.length));
 
     const primitives: WeightedPrimitive[] = selected.map(id => ({
       primitiveId: id,
-      weight: this.config.minWeight + Math.random() * (this.config.maxWeight - this.config.minWeight),
+      weight: this.config.minWeight + this.rng() * (this.config.maxWeight - this.config.minWeight),
     }));
 
     return new ResolutionGenome({
@@ -386,7 +420,7 @@ export class EvolutionEngine {
     const pop = this.populations.get(processArea);
     if (!pop) return null;
 
-    const fitnesses = pop.map(g => this.fitnessEval.getFitness(g.id));
+    const fitnesses = pop.map(g => this.fitnessEval.getFitnessForGenome(g));
 
     return {
       processArea,

--- a/server/services/integrity/evolutionary/evolution-engine.ts
+++ b/server/services/integrity/evolutionary/evolution-engine.ts
@@ -320,6 +320,13 @@ export class EvolutionEngine {
       ...p2.slice(cut2).map(p => ({ ...p })),
     ];
 
+    // Empty-child guard: cut1=0 with cut2=p2.length yields no genes at all.
+    // An empty genome evaluates to the constant 0.5 fallback (genome.ts) and
+    // could win selection by doing nothing — inherit a parent instead.
+    if (childPrimitives.length === 0) {
+      return (p1.length >= p2.length ? parent1 : parent2).clone();
+    }
+
     // Deduplicate: if same primitive appears twice, merge weights (average)
     const seen = new Map<string, WeightedPrimitive>();
     for (const wp of childPrimitives) {

--- a/server/services/integrity/evolutionary/evolutionary-resolver.ts
+++ b/server/services/integrity/evolutionary/evolutionary-resolver.ts
@@ -26,8 +26,8 @@ import {
   Resolution,
   ScadaEvent,
 } from '../paradox-resolver';
-import { EvolutionEngine } from './evolution-engine';
-import { SafetyGuard } from './safety-guard';
+import { EvolutionEngine, type EvolutionConfig } from './evolution-engine';
+import { SafetyGuard, type SafetyConfig } from './safety-guard';
 import { FitnessEvaluator } from './fitness';
 import { PrimitiveRegistry } from './registry';
 import { ResolutionGenome } from './genome';
@@ -40,6 +40,10 @@ export interface EvolutionaryResolverConfig {
   enabled: boolean;
   /** Process areas where evolution is allowed (empty = all) */
   allowedProcessAreas: string[];
+  /** Evolution-engine overrides (population size, seed, resolutionsPerCycle, …) */
+  evolution?: Partial<EvolutionConfig>;
+  /** Safety-guard overrides (confidence floor, novelty budget, maturity gen, …) */
+  safety?: Partial<SafetyConfig>;
 }
 
 export interface EvolutionaryResolution {
@@ -104,8 +108,8 @@ export class EvolutionaryResolver extends EventEmitter {
     // Initialize sub-components
     this.registry = new PrimitiveRegistry();
     this.fitness = new FitnessEvaluator();
-    this.engine = new EvolutionEngine(this.registry, this.fitness);
-    this.guard = new SafetyGuard(this.fitness);
+    this.engine = new EvolutionEngine(this.registry, this.fitness, this.config.evolution);
+    this.guard = new SafetyGuard(this.fitness, this.config.safety);
   }
 
   // ─── Resolution ─────────────────────────────────────────────────
@@ -134,8 +138,9 @@ export class EvolutionaryResolver extends EventEmitter {
       };
     }
 
-    // Get best genome for this process area
-    const genome = this.engine.getBestGenome(processArea);
+    // Select a genome for this process area (epsilon-greedy — #451 M3 — so the
+    // whole population accrues fitness, not only the incumbent best).
+    const genome = this.engine.selectResolutionGenome(processArea);
     if (!genome) {
       // No population yet — initialize and fall back
       this.engine.initializePopulation(processArea);
@@ -159,13 +164,31 @@ export class EvolutionaryResolver extends EventEmitter {
     // Safety check
     const safetyDecision = this.guard.checkResolution(genome, evaluation, processArea);
 
+    // Every conflict handled here (allowed OR blocked-after-evaluation) counts
+    // toward the evolution cycle (#451 B1). Counting only allowed resolutions
+    // meant the counter never advanced while the novelty budget was blocking,
+    // so genomes never matured and evolution stalled permanently.
+    const shouldEvolve = this.engine.recordResolution(processArea);
+
     if (!safetyDecision.allowed) {
       // Safety guard blocked — fall back to static resolver
       const resolution = await this.resolver.resolve(conflict);
       this.staticFallbackCount++;
 
-      // Still record fitness (low score for blocked genome)
-      this.fitness.evaluate(genome, resolution, evaluation);
+      // Record fitness from the GENOME'S OWN evaluation (#451 B2), NOT the
+      // static fallback's confidence. Crediting a blocked (low-confidence)
+      // genome with the static strategy's high confidence inverted selection
+      // pressure — failing genomes would out-compete good ones.
+      const genomeResolution: Resolution = {
+        conflictId: conflict.conflictId,
+        method: 'confidence_weighted',
+        confidence: evaluation.score,
+        reasoning: `[Evolved-blocked] ${evaluation.reasoning}`,
+        resolvedAt: new Date(),
+      };
+      this.fitness.evaluate(genome, genomeResolution, evaluation);
+
+      if (shouldEvolve) this.evolveAndEmit(processArea);
 
       this.emit('safety_blocked', {
         processArea,
@@ -199,10 +222,7 @@ export class EvolutionaryResolver extends EventEmitter {
     // Record fitness
     this.fitness.evaluate(genome, resolution, evaluation);
 
-    // Check if evolution cycle should trigger
-    if (this.engine.recordResolution(processArea)) {
-      this.evolveAndEmit(processArea);
-    }
+    if (shouldEvolve) this.evolveAndEmit(processArea);
 
     this.emit('evolutionary_resolution', {
       processArea,

--- a/server/services/integrity/evolutionary/fitness.ts
+++ b/server/services/integrity/evolutionary/fitness.ts
@@ -15,6 +15,12 @@
 import type { Resolution } from '../paradox-resolver';
 import type { ResolutionGenome, GenomeEvaluation } from './genome';
 
+/** Clamp to [0, 1], mapping NaN/Infinity to 0 so bad inputs cannot poison ranking. */
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  return x < 0 ? 0 : x > 1 ? 1 : x;
+}
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface FitnessRecord {
@@ -85,7 +91,7 @@ export class FitnessEvaluator {
         ? this.config.physicsPenaltyWeight
         : 0;
 
-    const rawFitness = Math.max(0, Math.min(1, confidenceScore + efficiencyBonus - physicsPenalty));
+    const rawFitness = clamp01(confidenceScore + efficiencyBonus - physicsPenalty);
 
     const record: FitnessRecord = {
       timestamp: Date.now(),
@@ -114,7 +120,7 @@ export class FitnessEvaluator {
     latest.validationBonus = confirmed
       ? this.config.validationConfirmBonus
       : -this.config.validationRejectPenalty;
-    latest.rawFitness = Math.max(0, Math.min(1, latest.rawFitness + latest.validationBonus));
+    latest.rawFitness = clamp01(latest.rawFitness + latest.validationBonus);
   }
 
   /**
@@ -124,19 +130,38 @@ export class FitnessEvaluator {
   getFitness(genomeId: string): number {
     const records = this.records.get(genomeId);
     if (!records || records.length === 0) return 0;
+    return this.decayWeightedAverage(records.map(r => r.rawFitness));
+  }
 
+  /**
+   * Genome-aware fitness (#451 M2): use this evaluator's records if it has any,
+   * otherwise fall back to the genome's own inherited `fitnessHistory`. Elites
+   * and mutation-clones carry their history across generations, so their
+   * fitness survives even when this evaluator's per-ID records were pruned.
+   */
+  getFitnessForGenome(genome: ResolutionGenome): number {
+    const records = this.records.get(genome.id);
+    if (records && records.length > 0) {
+      return this.decayWeightedAverage(records.map(r => r.rawFitness));
+    }
+    if (genome.fitnessHistory.length > 0) {
+      return this.decayWeightedAverage(genome.fitnessHistory);
+    }
+    return 0;
+  }
+
+  /** Exponential-decay weighted average: most recent value weighted highest. */
+  private decayWeightedAverage(values: number[]): number {
+    if (values.length === 0) return 0;
     let totalWeight = 0;
     let weightedSum = 0;
-    const n = records.length;
-
+    const n = values.length;
     for (let i = 0; i < n; i++) {
-      // Most recent record has highest weight
       const age = n - 1 - i;
       const w = Math.pow(this.config.decayFactor, age);
-      weightedSum += records[i].rawFitness * w;
+      weightedSum += values[i] * w;
       totalWeight += w;
     }
-
     return totalWeight > 0 ? weightedSum / totalWeight : 0;
   }
 

--- a/server/services/integrity/evolutionary/rng.ts
+++ b/server/services/integrity/evolutionary/rng.ts
@@ -1,0 +1,39 @@
+/**
+ * Seedable pseudo-random generator for reproducible / auditable evolution.
+ *
+ * The evolution engine's mutation, crossover, selection, and exploration all
+ * draw from an injectable `() => number` in [0, 1). Default is `Math.random`;
+ * pass a seed for a deterministic, replayable stream (ADR-0023 requires
+ * evolution to be auditable — issue #451).
+ */
+
+export type Rng = () => number;
+
+/**
+ * mulberry32 — a fast, well-distributed 32-bit seedable PRNG.
+ * Same seed → same sequence, across processes and platforms.
+ */
+export function mulberry32(seed: number): Rng {
+  let a = seed >>> 0;
+  return function next(): number {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * In-place Fisher-Yates shuffle using the supplied RNG. Unbiased, unlike
+ * `Array.sort(() => rng() - 0.5)`.
+ */
+export function shuffleInPlace<T>(arr: T[], rng: Rng): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+  }
+  return arr;
+}

--- a/server/services/integrity/evolutionary/safety-guard.ts
+++ b/server/services/integrity/evolutionary/safety-guard.ts
@@ -197,12 +197,6 @@ export class SafetyGuard {
       noveltyRatio: currentNoveltyRatio,
     };
 
-    // Track novelty usage
-    this.noveltyWindow.push(isExperimental);
-    if (this.noveltyWindow.length > this.config.noveltyWindowSize) {
-      this.noveltyWindow.shift();
-    }
-
     this.recordDecision(decision, genome, evaluation.score, processArea);
     return decision;
   }
@@ -232,7 +226,15 @@ export class SafetyGuard {
   // ─── Novelty Budget ─────────────────────────────────────────────
 
   /**
-   * Get current novelty ratio: fraction of recent resolutions using experimental genomes.
+   * Get current novelty ratio: fraction of recent resolution DECISIONS that
+   * actually used an experimental genome (#451 B1).
+   *
+   * The window records every decision — allowed-experimental (true),
+   * allowed-mature (false), and blocked→static-fallback (false) — so the
+   * denominator is all resolutions, matching the ADR-0023 budget semantics
+   * ("max fraction of resolutions using experimental genomes"). Recording only
+   * allowed-experimental outcomes made the ratio collapse to 1.0 after the
+   * first experimental resolution and deadlock every subsequent one.
    */
   getNoveltyRatio(): number {
     if (this.noveltyWindow.length === 0) return 0;
@@ -253,6 +255,17 @@ export class SafetyGuard {
     confidence: number,
     processArea: string,
   ): void {
+    // Novelty tracking (#451 B1): record EVERY decision. An experimental
+    // genome was actually used only when the decision was allowed AND the
+    // genome is below the maturity generation; every other outcome (mature
+    // genome, or blocked→static fallback) counts as a non-experimental
+    // resolution.
+    const usedExperimental = decision.allowed && decision.isExperimental;
+    this.noveltyWindow.push(usedExperimental);
+    if (this.noveltyWindow.length > this.config.noveltyWindowSize) {
+      this.noveltyWindow.shift();
+    }
+
     const entry: AuditEntry = {
       timestamp: Date.now(),
       processArea,

--- a/server/services/integrity/paradox-resolver.ts
+++ b/server/services/integrity/paradox-resolver.ts
@@ -136,8 +136,13 @@ export interface ProcessAreaRules {
   physicsConstraints: PhysicsConstraint[];
   /** Sensor priority order (highest first) */
   sensorPriority: string[];
-  /** Auto-resolve threshold: conflicts below this severity auto-resolve */
-  autoResolveSeverity: ConflictDetection['severity'];
+  /**
+   * Auto-resolve threshold: conflicts at/below this severity auto-resolve.
+   * Optional (#451): when omitted, the area defers to the global
+   * `autoResolveLowSeverity` switch, so an operator can flip that off as a
+   * real kill-switch. When set, the area opts in regardless of the global flag.
+   */
+  autoResolveSeverity?: ConflictDetection['severity'];
   /** Custom confidence weight overrides per device */
   deviceConfidenceOverrides: Record<string, number>;
 }

--- a/server/services/integrity/paradox-resolver.ts
+++ b/server/services/integrity/paradox-resolver.ts
@@ -163,6 +163,16 @@ const DEFAULT_CONFIG: ParadoxResolverConfig = {
   defaultVotingQuorum: 3,
 };
 
+/**
+ * Coerce a sensor-confidence value to a usable weight in [0, 1].
+ * `?? fallback` does NOT catch NaN (NaN is not null/undefined), so a NaN or
+ * out-of-range confidence would otherwise poison weighted merges (#451 minor).
+ */
+function sanitizeConfidence(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return value < 0 ? 0 : value > 1 ? 1 : value;
+}
+
 // ─── Built-in Physics Constraints ───────────────────────────────────────────
 
 /** Common SCADA physics constraints */
@@ -329,11 +339,17 @@ export class ParadoxResolver extends EventEmitter {
   }
 
   private shouldAutoResolve(conflict: ConflictDetection, areaRules: ProcessAreaRules | null): boolean {
-    const threshold = areaRules?.autoResolveSeverity ?? 'low';
     const severityOrder = ['low', 'medium', 'high', 'critical'];
     const conflictLevel = severityOrder.indexOf(conflict.severity);
-    const thresholdLevel = severityOrder.indexOf(threshold);
-    return this.config.autoResolveLowSeverity && conflictLevel <= thresholdLevel;
+
+    // An area that explicitly configured autoResolveSeverity opts in regardless
+    // of the global autoResolveLowSeverity default (#451 minor): the two are
+    // separate controls, and conflating them silently disabled per-area policy.
+    if (areaRules?.autoResolveSeverity !== undefined) {
+      return conflictLevel <= severityOrder.indexOf(areaRules.autoResolveSeverity);
+    }
+
+    return this.config.autoResolveLowSeverity && conflictLevel <= severityOrder.indexOf('low');
   }
 
   // ─── Conflict Detection ─────────────────────────────────────────────────
@@ -538,6 +554,17 @@ export class ParadoxResolver extends EventEmitter {
       }
     }
 
+    // Quorum + empty guard (#451 B3): voting is only valid with enough distinct
+    // devices. Callers other than resolveByBestStrategy (e.g. an area's
+    // preferredStrategy='voting') reach here without a prior quorum check, and
+    // the per-tag window can be empty by the time a deferred conflict resolves.
+    // Fall back to confidence weighting rather than crash or "vote" with one
+    // device at confidence 1.0.
+    const quorum = areaRules?.minVotingQuorum ?? this.config.defaultVotingQuorum;
+    if (byDevice.size < quorum) {
+      return this.resolveByConfidenceWeighting(conflict, areaRules);
+    }
+
     // Count votes per value (for numeric, bucket to nearest integer)
     const votes = new Map<string, { count: number; events: ScadaEvent[] }>();
     for (const event of byDevice.values()) {
@@ -551,7 +578,7 @@ export class ParadoxResolver extends EventEmitter {
     }
 
     // Find majority
-    let bestKey = '';
+    let bestKey: string | undefined;
     let bestCount = 0;
     for (const [key, bucket] of votes) {
       if (bucket.count > bestCount) {
@@ -560,19 +587,24 @@ export class ParadoxResolver extends EventEmitter {
       }
     }
 
-    const winnerBucket = votes.get(bestKey)!;
+    const winnerBucket = bestKey !== undefined ? votes.get(bestKey) : undefined;
+    if (!winnerBucket) {
+      // No countable votes — defer to confidence weighting.
+      return this.resolveByConfidenceWeighting(conflict, areaRules);
+    }
     const totalVotes = byDevice.size;
     const confidence = bestCount / totalVotes;
 
     // For numeric values, use weighted average of the winning group
     let finalValue: unknown;
     if (winnerBucket.events.every(e => typeof e.value === 'number')) {
-      const weights = winnerBucket.events.map(e => e.sensorConfidence ?? this.qualityScore(e));
+      const weights = winnerBucket.events.map(e => sanitizeConfidence(e.sensorConfidence, this.qualityScore(e)));
       const totalWeight = weights.reduce((a, b) => a + b, 0);
-      finalValue = winnerBucket.events.reduce(
-        (sum, e, i) => sum + (e.value as number) * weights[i],
-        0,
-      ) / totalWeight;
+      // Zero-weight guard (#451 minor): if every winning reading has zero
+      // effective weight, a weighted mean is NaN — use the plain mean instead.
+      finalValue = totalWeight > 0
+        ? winnerBucket.events.reduce((sum, e, i) => sum + (e.value as number) * weights[i], 0) / totalWeight
+        : winnerBucket.events.reduce((sum, e) => sum + (e.value as number), 0) / winnerBucket.events.length;
     } else {
       finalValue = winnerBucket.events[0].value;
     }
@@ -595,9 +627,20 @@ export class ParadoxResolver extends EventEmitter {
     areaRules: ProcessAreaRules | null,
   ): Resolution {
     const events = conflict.events;
+    // Empty guard (#451 minor): a voting fallback or external resolve() call
+    // can arrive with no events; `scored[0]` would be undefined.
+    if (events.length === 0) {
+      return {
+        conflictId: conflict.conflictId,
+        method: 'confidence_weighted',
+        confidence: 0,
+        reasoning: 'No events available to resolve',
+        resolvedAt: new Date(),
+      };
+    }
     const scored = events.map(e => {
       const override = areaRules?.deviceConfidenceOverrides[e.deviceId];
-      const sensorConf = override ?? e.sensorConfidence ?? 0.5;
+      const sensorConf = sanitizeConfidence(override ?? e.sensorConfidence, 0.5);
       const qualityMult = { good: 1.0, uncertain: 0.5, bad: 0.1 }[e.quality];
       return { event: e, score: sensorConf * qualityMult };
     });


### PR DESCRIPTION
Fixes #491 · closes the blocker/major findings from #451 (`docs/reviews/adr-0023-wave2-devils-advocate.md`)

The evolutionary ParadoxResolver stack was simultaneously self-disabling and bias-inducing, with **zero test coverage**. Each fix below is **mutation-verified**: I reverted the fix and confirmed the named test fails (details per fix), then confirmed green when restored.

## Blockers

- **B1 — novelty-budget deadlock.** The novelty window recorded only *allowed-experimental* resolutions, so the ratio hit 1.0 after the very first evolved resolution and blocked every one thereafter; blocked resolutions also never advanced the evolution-cycle counter, so genomes never matured. Now the window records **every** decision (allowed-experimental = true, else false) → the ratio is fraction-of-*all*-resolutions per ADR-0023 intent, and blocked resolutions count toward the cycle. Evolution self-regulates to ~30% experimental usage instead of stalling after one. *Mutant (only-on-allowed) → `does NOT deadlock` test fails.*
- **B2 — inverted fitness on the blocked path.** Blocked genomes were scored with the **static fallback's** confidence (0.7–0.85), so failing genomes out-competed good ones. Now scored on the genome's **own** `evaluation.score`. *Mutant (static confidence) → the B2 integration test fails: recorded fitness jumps from ~0.1 to ~0.99.*
- **B3 — voting crash + quorum bypass.** `resolveByVoting` threw `TypeError: Cannot read properties of undefined (reading 'events')` on an empty device window and ignored `minVotingQuorum`. Now enforces quorum (falls back to confidence weighting below it), guards empty/no-winner, and guards zero-total-weight numeric merges (NaN). *Mutant (original unguarded code) reproduces the exact TypeError; mutant (no quorum guard) → the quorum test fails.*

## Majors

- **M2 — fitness wiped every generation.** Elitism cloned genomes (new id) and `pruneInactive` then deleted their records → everyone re-entered at fitness 0. Elites are now preserved **by reference** (id + records survive), and a new `getFitnessForGenome()` falls back to the genome's own `fitnessHistory` so clones/offspring rank sensibly. *Mutant (clone elitism) → elite-identity test fails.*
- **M3 — only the best genome ever evaluated.** Added epsilon-greedy `selectResolutionGenome` (`explorationRate`, default 0.2) so the whole population accrues fitness.
- **M6 — crossover off-by-one.** Cuts were sampled `[0, len-1]`, making parent1's last gene un-inheritable. Now `[0, len]` inclusive. *Mutant → crossover last-gene test fails.*

## Also

Seedable RNG (`rng.ts`: mulberry32 + unbiased Fisher-Yates) for reproducible/auditable evolution — replaces `Math.random` and the biased `sort(() => rng()-0.5)` shuffle; NaN-safe fitness clamping; NaN sensor-confidence sanitizer; confidence-weighting empty-events guard; auto-resolve no longer conflates the global flag with explicit per-area `autoResolveSeverity`.

## Deliberately out of scope (→ #492)

Wiring `EvolutionaryResolver` into the integrity service (M1), `ConflictContext` population (M5), and the governance-gate + explainability audit (M7). Those **must** land after this PR — wiring first would expose the (now-fixed) inverted selection pressure to production. This PR makes the engine correct while it's still dead code.

## Tests

27 new tests across `evolution.test.ts` and `paradox-resolver.test.ts`: RNG determinism, fitness fallback/NaN, elite identity, epsilon-greedy exploration, crossover gene inheritance, mutation invariants, single/identical populations, novelty non-deadlock + budget ceiling, maturity, kill switch, B2 blocked fitness, B3 empty/quorum/zero-weight, NaN confidence, auto-resolve config. `tsc --noEmit` clean; full node suite **1189 pass / 9 skip** (the one failing file is the pre-existing `openssl`-gated e2e, unchanged from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)