### PR TITLE
[13.2] Agent-Driven Alarm Correlation (ADR-0013)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,8 @@ import pidRoutes from "./routes/pid";
 import { fluxRoutes } from "./routes/flux";
 import { gatewayRoutes } from "./routes/gateway";
 import { intelligenceRoutes } from "./routes/intelligence";
+import { alarmCorrelationRoutes } from "./routes/alarm-correlation";
+import { alarmCorrelationService } from "./services/alarm-correlation";
 import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
@@ -52,6 +54,7 @@ export async function registerRoutes(
 
   // P1 Wiring: Intelligence, Governance, and Security modules
   app.use("/api/intelligence", intelligenceRoutes);
+  app.use("/api/alarm-correlation", alarmCorrelationRoutes);  // ADR-0013 [13.2] (#213)
   app.use("/api/governance", governanceRoutes);
   app.use("/api/security", securityRoutes);
   app.use("/api/geometry", geometryRoutes(getFluxPublisher()));
@@ -80,6 +83,10 @@ export async function registerRoutes(
   // WebSocket servers initialize if available
   try { tagStreamServer?.initialize(httpServer, "/ws/tags"); } catch {}
   try { unifiedStreamServer?.initialize(httpServer, "/ws"); } catch {}  // unified endpoint (#255)
+
+  // Start alarm-correlation idle-group sweeps (#213). Registered here rather
+  // than in services/initializeServices(), which no startup path invokes.
+  void alarmCorrelationService.initialize();
 
   // WebSocket metrics endpoint. The legacy event-stream server was removed;
   // only the tag and unified streams report (#446, #479).

--- a/server/routes/alarm-correlation.ts
+++ b/server/routes/alarm-correlation.ts
@@ -1,0 +1,252 @@
+/**
+ * Alarm Correlation API
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * REST surface for the alarm correlation engine: alarm ingestion and
+ * lifecycle, correlated groups and root causes, the correlation rules
+ * engine, equipment topology, and suppression policy.
+ */
+
+import { Router } from "express";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+import { alarmCorrelationService } from "../services/alarm-correlation";
+import { validateRule } from "../services/alarm-correlation/rules";
+import type { CorrelationRule } from "@shared/types/alarm-correlation";
+
+const router = Router();
+const engine = alarmCorrelationService.engine;
+
+// Auth middleware placeholder — same pattern as other protected routes
+function requireAuth(
+  req: import("express").Request,
+  res: import("express").Response,
+  next: import("express").NextFunction
+) {
+  // TODO: implement real auth check (JWT / session validation)
+  next();
+}
+router.use(requireAuth);
+
+// ── Schemas ────────────────────────────────────────────────────────────────
+
+const MAX_FUTURE_SKEW_MS = 60 * 60 * 1000;
+
+const SeveritySchema = z.enum(["critical", "high", "medium", "low", "info"]);
+
+const AlarmInputSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    name: z.string().optional(),
+    tagId: z.string().optional(),
+    equipmentId: z.string().optional(),
+    siteId: z.string().optional(),
+    processArea: z.string().optional(),
+    severity: z.string().optional(),
+    state: z.string().optional(),
+    message: z.string().optional(),
+    timestamp: z.union([z.number().finite(), z.string().min(1)]),
+    value: z.union([z.number(), z.string()]).optional(),
+    limit: z.union([z.number(), z.string()]).optional(),
+    source: z.string().optional(),
+  })
+  .refine((a) => a.id || a.tagId, {
+    message: "alarm requires at least an id or a tagId",
+  });
+
+const IngestSchema = z.object({
+  alarms: z.array(AlarmInputSchema).min(1).max(1000),
+});
+
+const RuleSchema = z.object({
+  id: z.string().min(1).max(128),
+  name: z.string().min(1).max(256),
+  type: z.enum(["causal", "hierarchy", "temporal"]),
+  enabled: z.boolean().default(true),
+  priority: z.number().int().min(0).max(10_000),
+  config: z.record(z.unknown()),
+});
+
+const TopologySchema = z.object({
+  nodes: z
+    .array(
+      z.object({
+        equipmentId: z.string().min(1).max(256),
+        name: z.string().max(256).optional(),
+        parentId: z.string().max(256).optional(),
+        causalDownstream: z.array(z.string().min(1).max(256)).max(64).default([]),
+        siteId: z.string().max(64).optional(),
+        processArea: z.string().max(256).optional(),
+      })
+    )
+    .min(1)
+    .max(1000),
+});
+
+const SuppressionPolicySchema = z
+  .object({
+    enabled: z.boolean(),
+    neverSuppressAtOrAbove: SeveritySchema,
+    unsuppressOnRootClear: z.boolean(),
+  })
+  .partial();
+
+const GroupQuerySchema = z.object({
+  state: z.enum(["open", "closed"]).optional(),
+});
+
+// ── Alarm ingestion & lifecycle ────────────────────────────────────────────
+
+router.post("/alarms", (req, res) => {
+  const parsed = IngestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+
+  const now = Date.now();
+  const results = [];
+  const rejected = [];
+  for (const input of parsed.data.alarms) {
+    const outcome = alarmCorrelationService.ingest(input as Record<string, unknown>);
+    if (!outcome) {
+      rejected.push({ input, reason: "unparseable timestamp" });
+      continue;
+    }
+    if (outcome.alarm.timestamp > now + MAX_FUTURE_SKEW_MS) {
+      rejected.push({ input, reason: "timestamp too far in the future" });
+      continue;
+    }
+    results.push(outcome.result);
+  }
+  res.json({ ingested: results.length, results, rejected });
+});
+
+router.post("/alarms/:alarmId/clear", (req, res) => {
+  const outcome = engine.alarmCleared(req.params.alarmId);
+  res.json(outcome);
+});
+
+router.post("/alarms/:alarmId/acknowledge", (req, res) => {
+  const ok = engine.alarmAcknowledged(req.params.alarmId);
+  if (!ok) {
+    return res.status(404).json({ error: `Alarm ${req.params.alarmId} not tracked` });
+  }
+  res.json({ acknowledged: true });
+});
+
+// ── Groups & root cause ────────────────────────────────────────────────────
+
+router.get("/groups", (req, res) => {
+  const parsed = GroupQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  res.json({ groups: engine.getGroups(parsed.data) });
+});
+
+router.get("/groups/:groupId", (req, res) => {
+  const group = engine.getGroup(req.params.groupId);
+  if (!group) {
+    return res.status(404).json({ error: `Group ${req.params.groupId} not found` });
+  }
+  res.json(group);
+});
+
+router.get("/groups/:groupId/root-cause", (req, res) => {
+  const rootCause = engine.getRootCause(req.params.groupId);
+  if (!rootCause) {
+    return res.status(404).json({ error: `Group ${req.params.groupId} not found` });
+  }
+  res.json(rootCause);
+});
+
+// ── Rules engine ───────────────────────────────────────────────────────────
+
+router.get("/rules", (_req, res) => {
+  res.json({ rules: engine.rules.list() });
+});
+
+router.put("/rules/:ruleId", (req, res) => {
+  const parsed = RuleSchema.safeParse({ ...req.body, id: req.params.ruleId });
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const rule = parsed.data as unknown as CorrelationRule;
+  const error = validateRule(rule);
+  if (error) {
+    return res.status(400).json({ error });
+  }
+  res.json(engine.rules.upsert(rule));
+});
+
+router.delete("/rules/:ruleId", (req, res) => {
+  if (!engine.rules.remove(req.params.ruleId)) {
+    return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
+  }
+  res.json({ removed: true });
+});
+
+router.post("/rules/:ruleId/enable", (req, res) => {
+  const rule = engine.rules.setEnabled(req.params.ruleId, true);
+  if (!rule) return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
+  res.json(rule);
+});
+
+router.post("/rules/:ruleId/disable", (req, res) => {
+  const rule = engine.rules.setEnabled(req.params.ruleId, false);
+  if (!rule) return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
+  res.json(rule);
+});
+
+// ── Equipment topology ─────────────────────────────────────────────────────
+
+router.get("/topology", (_req, res) => {
+  res.json({ nodes: engine.topology.list() });
+});
+
+router.put("/topology", (req, res) => {
+  const parsed = TopologySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  try {
+    const nodes = engine.topology.upsertMany(parsed.data.nodes);
+    res.json({ upserted: nodes.length, nodes });
+  } catch (error) {
+    res.status(400).json({ error: error instanceof Error ? error.message : "invalid topology" });
+  }
+});
+
+router.delete("/topology/:equipmentId", (req, res) => {
+  if (!engine.topology.remove(req.params.equipmentId)) {
+    return res.status(404).json({ error: `Equipment ${req.params.equipmentId} not found` });
+  }
+  res.json({ removed: true });
+});
+
+// ── Suppression policy ─────────────────────────────────────────────────────
+
+router.get("/suppression-policy", (_req, res) => {
+  res.json(engine.getSuppressionPolicy());
+});
+
+router.put("/suppression-policy", (req, res) => {
+  const parsed = SuppressionPolicySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  res.json(engine.setSuppressionPolicy(parsed.data));
+});
+
+// ── Metrics & status ───────────────────────────────────────────────────────
+
+router.get("/metrics", (_req, res) => {
+  res.json(engine.getMetrics());
+});
+
+router.get("/status", async (_req, res) => {
+  const health = await alarmCorrelationService.healthCheck();
+  res.json({ ...engine.getMetrics(), ...health });
+});
+
+export { router as alarmCorrelationRoutes };

--- a/server/services/alarm-correlation/__tests__/alarm-correlation.test.ts
+++ b/server/services/alarm-correlation/__tests__/alarm-correlation.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Alarm Correlation Engine tests
+ * ADR-0013 [13.2] — Issue #213
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { CorrelatedAlarm } from '@shared/types/alarm-correlation';
+import { EquipmentTopology } from '../topology';
+import { CorrelationRulesEngine, validateRule, DEFAULT_RULES } from '../rules';
+import { AlarmCorrelationEngine } from '../engine';
+import {
+  AlarmCorrelationService,
+  normalizeAlarm,
+  normalizeSeverity,
+  resolveEquipmentFromTag,
+} from '../index';
+
+let alarmCounter = 0;
+function alarm(overrides: Partial<CorrelatedAlarm>): CorrelatedAlarm {
+  return {
+    id: overrides.id ?? `A-${++alarmCounter}`,
+    name: 'test alarm',
+    tagId: 'TAG.EVENT',
+    severity: 'medium',
+    state: 'active',
+    message: 'test',
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+/** Feeder → breaker → motor causal chain under one substation */
+function plantTopology(): EquipmentTopology {
+  const topology = new EquipmentTopology();
+  topology.upsertMany([
+    { equipmentId: 'SUB-1', causalDownstream: [] },
+    { equipmentId: 'FDR-1', parentId: 'SUB-1', causalDownstream: ['BK-1'] },
+    { equipmentId: 'BK-1', parentId: 'SUB-1', causalDownstream: ['MTR-1'] },
+    { equipmentId: 'MTR-1', parentId: 'SUB-1', causalDownstream: [] },
+    { equipmentId: 'UNRELATED', causalDownstream: [] },
+  ]);
+  return topology;
+}
+
+// ── Topology ──────────────────────────────────────────────────────────────
+
+describe('EquipmentTopology', () => {
+  it('rejects hierarchy cycles at registration', () => {
+    const t = new EquipmentTopology();
+    t.upsert({ equipmentId: 'a', parentId: 'b', causalDownstream: [] });
+    expect(() =>
+      t.upsert({ equipmentId: 'b', parentId: 'a', causalDownstream: [] })
+    ).toThrow(/cycle/);
+    // failed upsert must not leave the cyclic node behind
+    expect(t.get('b')).toBeUndefined();
+  });
+
+  it('computes hierarchy distance: parent-child 1, siblings 1, unrelated null', () => {
+    const t = plantTopology();
+    expect(t.hierarchyDistance('FDR-1', 'SUB-1')).toBe(1);
+    expect(t.hierarchyDistance('FDR-1', 'BK-1')).toBe(1);
+    expect(t.hierarchyDistance('FDR-1', 'FDR-1')).toBe(0);
+    expect(t.hierarchyDistance('FDR-1', 'UNRELATED')).toBeNull();
+  });
+
+  it('finds transitive causal reachability with hop bound', () => {
+    const t = plantTopology();
+    expect(t.isCausallyReachable('FDR-1', 'MTR-1', 5)).toBe(true); // 2 hops
+    expect(t.isCausallyReachable('FDR-1', 'MTR-1', 1)).toBe(false); // capped
+    expect(t.isCausallyReachable('MTR-1', 'FDR-1', 5)).toBe(false); // directed
+    expect(t.isCausallyRelated('MTR-1', 'FDR-1', 5)).toBe(true); // either direction
+  });
+
+  it('survives causal cycles (recirculation loops)', () => {
+    const t = new EquipmentTopology();
+    t.upsert({ equipmentId: 'p1', causalDownstream: ['p2'] });
+    t.upsert({ equipmentId: 'p2', causalDownstream: ['p1', 'p3'] });
+    t.upsert({ equipmentId: 'p3', causalDownstream: [] });
+    expect(t.isCausallyReachable('p1', 'p3', 10)).toBe(true);
+    expect(t.isCausallyReachable('p3', 'p1', 10)).toBe(false);
+  });
+
+  it('measures causal dominance', () => {
+    const t = plantTopology();
+    expect(t.causalDominance('FDR-1', ['BK-1', 'MTR-1', 'UNRELATED'], 5)).toBe(2);
+    expect(t.causalDominance('MTR-1', ['FDR-1', 'BK-1'], 5)).toBe(0);
+  });
+});
+
+// ── Rules ─────────────────────────────────────────────────────────────────
+
+describe('CorrelationRulesEngine', () => {
+  it('validates rule configs', () => {
+    expect(
+      validateRule({
+        id: 'r',
+        name: 'r',
+        type: 'causal',
+        enabled: true,
+        priority: 1,
+        config: { windowMs: 1000 } as never,
+      })
+    ).toMatch(/maxHops/);
+    expect(
+      validateRule({
+        id: 'r',
+        name: 'r',
+        type: 'temporal',
+        enabled: true,
+        priority: 1,
+        config: { windowMs: 1000, scope: 'everything' } as never,
+      })
+    ).toMatch(/scope/);
+  });
+
+  it('evaluates rules in priority order and skips disabled ones', () => {
+    const rules = new CorrelationRulesEngine();
+    expect(rules.list().map((r) => r.id)).toEqual(DEFAULT_RULES.map((r) => r.id));
+    rules.setEnabled('default-causal', false);
+    const t = plantTopology();
+    const a = alarm({ equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 });
+    const b = alarm({ equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 2000 });
+    // causal disabled → falls through to hierarchy (siblings under SUB-1)
+    const matched = rules.evaluatePair(a, b, t);
+    expect(matched?.id).toBe('default-hierarchy');
+  });
+
+  it('never pairs unrelated equipment on bare temporal proximity', () => {
+    const rules = new CorrelationRulesEngine();
+    const t = plantTopology();
+    const a = alarm({ equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 });
+    const b = alarm({ equipmentId: 'UNRELATED', tagId: 'UNRELATED.TRIP', timestamp: 1001 });
+    expect(rules.evaluatePair(a, b, t)).toBeNull();
+  });
+
+  it('pairs same-process-area alarms under a scoped temporal rule', () => {
+    const rules = new CorrelationRulesEngine();
+    rules.upsert({
+      id: 'area',
+      name: 'area burst',
+      type: 'temporal',
+      enabled: true,
+      priority: 50,
+      config: { windowMs: 5000, scope: 'process-area' },
+    });
+    const t = new EquipmentTopology();
+    const a = alarm({ processArea: 'unit-100', tagId: 'X.1', timestamp: 0 });
+    const b = alarm({ processArea: 'unit-100', tagId: 'Y.1', timestamp: 100 });
+    expect(rules.evaluatePair(a, b, t)?.id).toBe('area');
+  });
+});
+
+// ── Engine ────────────────────────────────────────────────────────────────
+
+describe('AlarmCorrelationEngine', () => {
+  it('groups a causal chain and elects the upstream cause as root', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    const events: string[] = [];
+    engine.on('group-created', () => events.push('created'));
+
+    const r1 = engine.ingest(
+      alarm({ id: 'feeder', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 })
+    );
+    expect(r1.action).toBe('standalone');
+
+    const r2 = engine.ingest(
+      alarm({ id: 'breaker', equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 2000 })
+    );
+    expect(r2.action).toBe('formed-group');
+
+    const r3 = engine.ingest(
+      alarm({ id: 'motor', equipmentId: 'MTR-1', tagId: 'MTR-1.STALL', timestamp: 3000 })
+    );
+    expect(r3.action).toBe('joined-group');
+    expect(r3.groupId).toBe(r2.groupId);
+
+    const group = engine.getGroup(r2.groupId!)!;
+    expect(group.rootCauseAlarmId).toBe('feeder');
+    expect(group.alarmIds).toEqual(['feeder', 'breaker', 'motor']);
+    expect(events).toEqual(['created']);
+
+    const rootCause = engine.getRootCause(group.id)!;
+    expect(rootCause.alarm.id).toBe('feeder');
+    expect(rootCause.causalDominance).toBe(2);
+  });
+
+  it('re-elects the root when an earlier upstream cause arrives late (out-of-order)', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    const rootChanges: unknown[] = [];
+    engine.on('root-cause-changed', (e) => rootChanges.push(e));
+
+    engine.ingest(alarm({ id: 'motor', equipmentId: 'MTR-1', tagId: 'MTR-1.STALL', timestamp: 5000 }));
+    engine.ingest(alarm({ id: 'breaker', equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 5200 }));
+    // Upstream cause with the earliest event time arrives last
+    const r = engine.ingest(
+      alarm({ id: 'feeder', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 4800 })
+    );
+    expect(r.action).toBe('joined-group');
+    expect(r.isRootCause).toBe(true);
+
+    const group = engine.getGroup(r.groupId!)!;
+    expect(group.rootCauseAlarmId).toBe('feeder');
+    expect(rootChanges.length).toBeGreaterThan(0);
+  });
+
+  it('keeps unrelated concurrent alarms in separate groups', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    engine.ingest(alarm({ id: 'a1', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 }));
+    engine.ingest(alarm({ id: 'b1', equipmentId: 'UNRELATED', tagId: 'UNRELATED.X', timestamp: 1001 }));
+    expect(engine.getGroups()).toHaveLength(0); // both standalone — never merged
+  });
+
+  it('suppresses downstream alarms but never critical ones', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    const suppressed: unknown[] = [];
+    engine.on('alarm-suppressed', (e) => suppressed.push(e));
+
+    engine.ingest(alarm({ id: 'feeder', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000, severity: 'high' }));
+    engine.ingest(alarm({ id: 'breaker', equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 1500, severity: 'medium' }));
+    engine.ingest(alarm({ id: 'motor', equipmentId: 'MTR-1', tagId: 'MTR-1.STALL', timestamp: 2000, severity: 'critical' }));
+
+    const group = engine.getGroups()[0];
+    expect(group.rootCauseAlarmId).toBe('feeder');
+    expect(group.suppressedAlarmIds).toEqual(['breaker']); // critical motor spared
+    expect(group.alarms.find((a) => a.id === 'breaker')!.state).toBe('suppressed');
+    expect(group.alarms.find((a) => a.id === 'motor')!.state).toBe('active');
+    expect(suppressed).toHaveLength(1);
+  });
+
+  it('closes the group and un-suppresses members when the root cause clears', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    const unsuppressed: unknown[] = [];
+    engine.on('alarms-unsuppressed', (e) => unsuppressed.push(e));
+
+    engine.ingest(alarm({ id: 'feeder', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 }));
+    engine.ingest(alarm({ id: 'breaker', equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 1500 }));
+
+    const outcome = engine.alarmCleared('feeder');
+    expect(outcome.groupClosed).toBeDefined();
+    expect(outcome.unsuppressed).toEqual(['breaker']);
+
+    const group = engine.getGroups({ state: 'closed' })[0];
+    expect(group.closeReason).toBe('root-cause-cleared');
+    expect(group.alarms.find((a) => a.id === 'breaker')!.state).toBe('active');
+    expect(unsuppressed).toHaveLength(1);
+  });
+
+  it('ignores duplicate alarm ids', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    engine.ingest(alarm({ id: 'dup', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 }));
+    const again = engine.ingest(alarm({ id: 'dup', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 9999 }));
+    expect(again.reason).toMatch(/duplicate/);
+    expect(engine.getMetrics().alarmsIngested).toBe(1);
+  });
+
+  it('closes idle groups on sweep and enforces the group cap', () => {
+    const engine = new AlarmCorrelationEngine({
+      topology: plantTopology(),
+      groupCloseAfterMs: 1000,
+      maxGroups: 1,
+    });
+    engine.ingest(alarm({ id: 'f1', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 }));
+    engine.ingest(alarm({ id: 'b1', equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 1500 }));
+    expect(engine.getGroups({ state: 'open' })).toHaveLength(1);
+
+    const { closedGroups } = engine.sweep(10_000);
+    expect(closedGroups).toHaveLength(1);
+
+    // A later, unrelated-to-window group forms; cap 1 evicts the closed one
+    engine.ingest(alarm({ id: 'f2', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP2', timestamp: 100_000 }));
+    engine.ingest(alarm({ id: 'b2', equipmentId: 'BK-1', tagId: 'BK-1.TRIP2', timestamp: 100_500 }));
+    expect(engine.getGroups()).toHaveLength(1);
+    expect(engine.getGroups()[0].alarmIds).toEqual(['f2', 'b2']);
+  });
+
+  it('does not admit alarms beyond the group span cap', () => {
+    const engine = new AlarmCorrelationEngine({
+      topology: plantTopology(),
+      maxGroupSpanMs: 10_000,
+    });
+    engine.rules.upsert({
+      id: 'wide',
+      name: 'wide causal',
+      type: 'causal',
+      enabled: true,
+      priority: 1,
+      config: { windowMs: 1_000_000, maxHops: 5 },
+    });
+    engine.ingest(alarm({ id: 'f', equipmentId: 'FDR-1', tagId: 'FDR-1.T', timestamp: 0 }));
+    engine.ingest(alarm({ id: 'b', equipmentId: 'BK-1', tagId: 'BK-1.T', timestamp: 100 }));
+    const late = engine.ingest(
+      alarm({ id: 'm', equipmentId: 'MTR-1', tagId: 'MTR-1.T', timestamp: 50_000 })
+    );
+    expect(late.action).not.toBe('joined-group');
+  });
+
+  it('tracks suppression rate as the fatigue KPI', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    engine.ingest(alarm({ id: 'f', equipmentId: 'FDR-1', tagId: 'FDR-1.T', timestamp: 0 }));
+    engine.ingest(alarm({ id: 'b', equipmentId: 'BK-1', tagId: 'BK-1.T', timestamp: 100 }));
+    engine.ingest(alarm({ id: 'm', equipmentId: 'MTR-1', tagId: 'MTR-1.T', timestamp: 200 }));
+    const metrics = engine.getMetrics();
+    expect(metrics.alarmsIngested).toBe(3);
+    expect(metrics.groupsCreated).toBe(1);
+    expect(metrics.alarmsSuppressed).toBe(2);
+    expect(metrics.suppressionRate).toBeCloseTo(2 / 3);
+  });
+});
+
+// ── Normalization & service ───────────────────────────────────────────────
+
+describe('normalizeAlarm', () => {
+  it('normalizes the tag-stream broadcastAlarm shape', () => {
+    const a = normalizeAlarm({
+      id: 'alm-1',
+      name: 'BK-FEEDER-01 BREAKER_TRIP',
+      severity: 'critical',
+      state: 'active',
+      tagValue: 1450,
+      triggeredAt: '2026-07-22T10:00:00.000Z',
+      tagId: 'BK-FEEDER-01.BREAKER_TRIP',
+    })!;
+    expect(a.id).toBe('alm-1');
+    expect(a.equipmentId).toBe('BK-FEEDER-01');
+    expect(a.severity).toBe('critical');
+    expect(a.timestamp).toBe(Date.parse('2026-07-22T10:00:00.000Z'));
+    expect(a.value).toBe(1450);
+  });
+
+  it('normalizes the SingularisPrime/GR::LISTEN AlarmPayload shape', () => {
+    const a = normalizeAlarm({
+      alarmId: 'AL-9',
+      alarmName: 'High pressure',
+      sourceTagId: 'PT-101.PV',
+      priority: 'high',
+      message: 'above limit',
+      triggerValue: 9.2,
+      limitValue: 8.5,
+      timestamp: 1700000000000,
+    })!;
+    expect(a.id).toBe('AL-9');
+    expect(a.tagId).toBe('PT-101.PV');
+    expect(a.equipmentId).toBe('PT-101');
+    expect(a.severity).toBe('high');
+    expect(a.limit).toBe(8.5);
+  });
+
+  it('maps DB-enum severities onto the runtime vocabulary', () => {
+    expect(normalizeSeverity('EMERGENCY')).toBe('critical');
+    expect(normalizeSeverity('CRITICAL')).toBe('critical');
+    expect(normalizeSeverity('WARNING')).toBe('medium');
+    expect(normalizeSeverity('alarm')).toBe('high');
+    expect(normalizeSeverity(undefined)).toBe('info');
+  });
+
+  it('rejects alarms without a usable timestamp', () => {
+    expect(normalizeAlarm({ id: 'x', tagId: 'T.1' })).toBeNull();
+    expect(normalizeAlarm({ id: 'x', tagId: 'T.1', timestamp: 'garbage' })).toBeNull();
+  });
+
+  it('resolves equipment from the ASSET.EVENT tag convention', () => {
+    expect(resolveEquipmentFromTag('BK-FEEDER-01.BREAKER_TRIP')).toBe('BK-FEEDER-01');
+    expect(resolveEquipmentFromTag('PLAINTAG')).toBe('PLAINTAG');
+    expect(resolveEquipmentFromTag('')).toBeUndefined();
+  });
+});
+
+describe('AlarmCorrelationService', () => {
+  it('ingests end-to-end and re-emits engine events', () => {
+    const service = new AlarmCorrelationService();
+    const created = vi.fn();
+    service.on('group-created', created);
+
+    service.engine.topology.upsertMany([
+      { equipmentId: 'BK-1', causalDownstream: ['MTR-1'] },
+      { equipmentId: 'MTR-1', causalDownstream: [] },
+    ]);
+
+    const first = service.ingest({
+      id: 'w1', tagId: 'BK-1.TRIP', severity: 'high', state: 'active',
+      timestamp: 1000, message: 'trip',
+    })!;
+    expect(first.result.action).toBe('standalone');
+
+    const second = service.ingest({
+      id: 'w2', tagId: 'MTR-1.STALL', severity: 'medium', state: 'active',
+      timestamp: 1800, message: 'stall',
+    })!;
+    expect(second.result.action).toBe('formed-group');
+    expect(second.result.suppressed).toBe(true);
+    expect(created).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports health based on initialization', async () => {
+    const service = new AlarmCorrelationService();
+    expect((await service.healthCheck()).healthy).toBe(false);
+    await service.initialize();
+    expect((await service.healthCheck()).healthy).toBe(true);
+    await service.shutdown();
+    expect((await service.healthCheck()).healthy).toBe(false);
+  });
+});

--- a/server/services/alarm-correlation/engine.ts
+++ b/server/services/alarm-correlation/engine.ts
@@ -1,0 +1,512 @@
+/**
+ * Alarm Correlation Engine
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * Groups related alarms via the rules engine (causal chains, equipment
+ * hierarchy, scoped temporal proximity), elects a deterministic root
+ * cause per group, and suppresses downstream/consequential alarms with
+ * severity guards and un-suppression when the root cause clears.
+ *
+ * All correlation logic is event-time driven — wall-clock never enters
+ * grouping decisions, so replayed/backfilled alarm streams correlate
+ * identically. Wall-clock is only supplied externally to sweep() for
+ * idle-group housekeeping.
+ */
+
+import { EventEmitter } from 'events';
+import type {
+  AlarmGroup,
+  AlarmSeverity,
+  CorrelatedAlarm,
+  CorrelationMetrics,
+  CorrelationRule,
+  IngestResult,
+  RootCauseResult,
+  SuppressionPolicy,
+} from '@shared/types/alarm-correlation';
+import { EquipmentTopology } from './topology';
+import { CorrelationRulesEngine } from './rules';
+
+const SEVERITY_RANK: Record<AlarmSeverity, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+  info: 0,
+};
+
+/** Alarms this close in event time tie on "earliest" during root election */
+const ROOT_ELECTION_TIME_BUCKET_MS = 100;
+
+export const DEFAULT_SUPPRESSION_POLICY: SuppressionPolicy = {
+  enabled: true,
+  neverSuppressAtOrAbove: 'critical',
+  unsuppressOnRootClear: true,
+};
+
+export interface CorrelationEngineOptions {
+  topology?: EquipmentTopology;
+  rules?: CorrelationRulesEngine;
+  suppressionPolicy?: Partial<SuppressionPolicy>;
+  /** Open groups with no new alarms for this long (vs sweep clock) close */
+  groupCloseAfterMs?: number;
+  /** A group never admits alarms this far (event time) after its earliest member */
+  maxGroupSpanMs?: number;
+  /** Retained groups (open + closed); oldest closed evicted first */
+  maxGroups?: number;
+  /** Ungrouped alarms retained as candidate peers for future groups */
+  maxPendingAlarms?: number;
+}
+
+export class AlarmCorrelationEngine extends EventEmitter {
+  readonly topology: EquipmentTopology;
+  readonly rules: CorrelationRulesEngine;
+
+  private suppressionPolicy: SuppressionPolicy;
+  private readonly groupCloseAfterMs: number;
+  private readonly maxGroupSpanMs: number;
+  private readonly maxGroups: number;
+  private readonly maxPendingAlarms: number;
+
+  private groups: Map<string, AlarmGroup> = new Map();
+  /** Ungrouped recent alarms — candidate peers for group formation */
+  private pending: CorrelatedAlarm[] = [];
+  /** alarmId → groupId, or null while standalone/pending */
+  private alarmIndex: Map<string, string | null> = new Map();
+  private groupCounter = 0;
+
+  private metrics = {
+    alarmsIngested: 0,
+    groupsCreated: 0,
+    groupsClosed: 0,
+    alarmsSuppressed: 0,
+    alarmsUnsuppressed: 0,
+  };
+
+  constructor(options: CorrelationEngineOptions = {}) {
+    super();
+    this.topology = options.topology ?? new EquipmentTopology();
+    this.rules = options.rules ?? new CorrelationRulesEngine();
+    this.suppressionPolicy = { ...DEFAULT_SUPPRESSION_POLICY, ...options.suppressionPolicy };
+    this.groupCloseAfterMs = options.groupCloseAfterMs ?? 10 * 60 * 1000;
+    this.maxGroupSpanMs = options.maxGroupSpanMs ?? 30 * 60 * 1000;
+    this.maxGroups = options.maxGroups ?? 1000;
+    this.maxPendingAlarms = options.maxPendingAlarms ?? 2000;
+  }
+
+  // ── Ingestion & correlation ──────────────────────────────────────────
+
+  ingest(alarm: CorrelatedAlarm): IngestResult {
+    if (this.alarmIndex.has(alarm.id)) {
+      const groupId = this.alarmIndex.get(alarm.id) ?? undefined;
+      const group = groupId ? this.groups.get(groupId) : undefined;
+      return {
+        alarmId: alarm.id,
+        action: group ? 'joined-group' : 'standalone',
+        groupId,
+        suppressed: group ? group.suppressedAlarmIds.includes(alarm.id) : false,
+        isRootCause: group ? group.rootCauseAlarmId === alarm.id : false,
+        reason: 'duplicate alarm id — already ingested',
+      };
+    }
+
+    this.metrics.alarmsIngested++;
+
+    // 1. Try to join an existing open group (most recently active first)
+    const openGroups = Array.from(this.groups.values())
+      .filter((g) => g.state === 'open')
+      .sort((a, b) => b.lastAlarmAt - a.lastAlarmAt);
+
+    for (const group of openGroups) {
+      const earliest = group.alarms[0]?.timestamp ?? group.createdAt;
+      if (alarm.timestamp - earliest > this.maxGroupSpanMs) continue;
+      const rule = this.rules.evaluateJoin(alarm, group, this.topology);
+      if (rule) {
+        return this.joinGroup(alarm, group, rule);
+      }
+    }
+
+    // 2. Try to form a new group with a pending (ungrouped) alarm
+    for (let i = this.pending.length - 1; i >= 0; i--) {
+      const peer = this.pending[i];
+      const rule = this.rules.evaluatePair(alarm, peer, this.topology);
+      if (rule) {
+        return this.formGroup(alarm, peer, rule);
+      }
+    }
+
+    // 3. Standalone — buffer as a candidate peer for future alarms
+    this.pending.push(alarm);
+    this.alarmIndex.set(alarm.id, null);
+    this.prunePending(alarm.timestamp);
+    return {
+      alarmId: alarm.id,
+      action: 'standalone',
+      suppressed: false,
+      isRootCause: false,
+      reason: 'no enabled rule matched an open group or pending alarm',
+    };
+  }
+
+  // ── Alarm lifecycle updates ──────────────────────────────────────────
+
+  /**
+   * Mark an alarm cleared. Clearing a group's root cause closes the group
+   * and (per policy) un-suppresses its remaining active members.
+   */
+  alarmCleared(alarmId: string): { groupClosed?: string; unsuppressed: string[] } {
+    const groupId = this.alarmIndex.get(alarmId);
+    if (groupId === undefined) return { unsuppressed: [] };
+
+    if (groupId === null) {
+      const pendingAlarm = this.pending.find((a) => a.id === alarmId);
+      if (pendingAlarm) pendingAlarm.state = 'cleared';
+      return { unsuppressed: [] };
+    }
+
+    const group = this.groups.get(groupId);
+    if (!group) return { unsuppressed: [] };
+
+    const member = group.alarms.find((a) => a.id === alarmId);
+    if (member) member.state = 'cleared';
+
+    if (group.state === 'open' && group.rootCauseAlarmId === alarmId) {
+      const unsuppressed = this.suppressionPolicy.unsuppressOnRootClear
+        ? this.unsuppressActiveMembers(group)
+        : [];
+      this.closeGroup(group, 'root-cause-cleared');
+      return { groupClosed: group.id, unsuppressed };
+    }
+
+    this.emit('group-updated', group);
+    return { unsuppressed: [] };
+  }
+
+  alarmAcknowledged(alarmId: string): boolean {
+    const groupId = this.alarmIndex.get(alarmId);
+    if (groupId === undefined) return false;
+    const alarm =
+      groupId === null
+        ? this.pending.find((a) => a.id === alarmId)
+        : this.groups.get(groupId)?.alarms.find((a) => a.id === alarmId);
+    if (!alarm) return false;
+    if (alarm.state === 'active' || alarm.state === 'suppressed') {
+      alarm.state = 'acknowledged';
+    }
+    return true;
+  }
+
+  // ── Housekeeping (wall-clock supplied externally) ────────────────────
+
+  /** Close idle groups, prune stale pending alarms, enforce retention caps */
+  sweep(nowMs: number): { closedGroups: string[] } {
+    const closedGroups: string[] = [];
+    for (const group of this.groups.values()) {
+      if (group.state === 'open' && nowMs - group.lastAlarmAt > this.groupCloseAfterMs) {
+        this.closeGroup(group, 'idle-timeout');
+        closedGroups.push(group.id);
+      }
+    }
+    this.prunePending(nowMs);
+    this.enforceGroupCap();
+    return { closedGroups };
+  }
+
+  // ── Queries ──────────────────────────────────────────────────────────
+
+  getGroups(filter?: { state?: 'open' | 'closed' }): AlarmGroup[] {
+    let groups = Array.from(this.groups.values());
+    if (filter?.state) groups = groups.filter((g) => g.state === filter.state);
+    return groups.sort((a, b) => b.lastAlarmAt - a.lastAlarmAt);
+  }
+
+  getGroup(groupId: string): AlarmGroup | undefined {
+    return this.groups.get(groupId);
+  }
+
+  getRootCause(groupId: string): RootCauseResult | null {
+    const group = this.groups.get(groupId);
+    if (!group) return null;
+    const root = group.alarms.find((a) => a.id === group.rootCauseAlarmId);
+    if (!root) return null;
+
+    const memberEquipment = group.alarms
+      .map((a) => a.equipmentId)
+      .filter((id): id is string => !!id);
+    return {
+      groupId,
+      alarm: root,
+      causalDominance: root.equipmentId
+        ? this.topology.causalDominance(root.equipmentId, memberEquipment, 8)
+        : 0,
+      hierarchyDepth: root.equipmentId ? this.topology.depth(root.equipmentId) : 0,
+      electedBy: 'earliest-bucket, causal-dominance, hierarchy-depth, id',
+    };
+  }
+
+  setSuppressionPolicy(policy: Partial<SuppressionPolicy>): SuppressionPolicy {
+    this.suppressionPolicy = { ...this.suppressionPolicy, ...policy };
+    return this.suppressionPolicy;
+  }
+
+  getSuppressionPolicy(): SuppressionPolicy {
+    return { ...this.suppressionPolicy };
+  }
+
+  getMetrics(): CorrelationMetrics {
+    const openGroups = Array.from(this.groups.values()).filter(
+      (g) => g.state === 'open'
+    ).length;
+    return {
+      ...this.metrics,
+      suppressionRate:
+        this.metrics.alarmsIngested === 0
+          ? 0
+          : this.metrics.alarmsSuppressed / this.metrics.alarmsIngested,
+      openGroups,
+      trackedAlarms: this.alarmIndex.size,
+    };
+  }
+
+  // ── Private: group mechanics ─────────────────────────────────────────
+
+  private joinGroup(
+    alarm: CorrelatedAlarm,
+    group: AlarmGroup,
+    rule: CorrelationRule
+  ): IngestResult {
+    group.alarms.push(alarm);
+    group.alarmIds.push(alarm.id);
+    group.joinedVia[alarm.id] = rule.id;
+    group.lastAlarmAt = Math.max(group.lastAlarmAt, alarm.timestamp);
+    if (SEVERITY_RANK[alarm.severity] > SEVERITY_RANK[group.maxSeverity]) {
+      group.maxSeverity = alarm.severity;
+    }
+    this.alarmIndex.set(alarm.id, group.id);
+    this.removeFromPending(alarm.id);
+
+    const previousRoot = group.rootCauseAlarmId;
+    this.electRootCause(group);
+    if (group.rootCauseAlarmId !== previousRoot) {
+      this.emit('root-cause-changed', {
+        groupId: group.id,
+        previous: previousRoot,
+        current: group.rootCauseAlarmId,
+      });
+    }
+    this.applySuppression(group);
+    this.emit('group-updated', group);
+
+    return {
+      alarmId: alarm.id,
+      action: 'joined-group',
+      groupId: group.id,
+      ruleId: rule.id,
+      suppressed: group.suppressedAlarmIds.includes(alarm.id),
+      isRootCause: group.rootCauseAlarmId === alarm.id,
+      reason: `matched rule "${rule.name}"`,
+    };
+  }
+
+  private formGroup(
+    alarm: CorrelatedAlarm,
+    peer: CorrelatedAlarm,
+    rule: CorrelationRule
+  ): IngestResult {
+    const members = [peer, alarm].sort((a, b) => a.timestamp - b.timestamp);
+    const group: AlarmGroup = {
+      id: `ACG-${++this.groupCounter}`,
+      state: 'open',
+      alarms: members,
+      alarmIds: members.map((a) => a.id),
+      rootCauseAlarmId: members[0].id,
+      formedByRuleId: rule.id,
+      joinedVia: { [peer.id]: rule.id, [alarm.id]: rule.id },
+      suppressedAlarmIds: [],
+      maxSeverity: members.reduce<AlarmSeverity>(
+        (max, a) => (SEVERITY_RANK[a.severity] > SEVERITY_RANK[max] ? a.severity : max),
+        'info'
+      ),
+      createdAt: members[0].timestamp,
+      lastAlarmAt: members[members.length - 1].timestamp,
+    };
+
+    this.groups.set(group.id, group);
+    this.metrics.groupsCreated++;
+    this.alarmIndex.set(alarm.id, group.id);
+    this.alarmIndex.set(peer.id, group.id);
+    this.removeFromPending(peer.id);
+    this.removeFromPending(alarm.id);
+
+    this.electRootCause(group);
+    this.applySuppression(group);
+    this.enforceGroupCap();
+    this.emit('group-created', group);
+
+    return {
+      alarmId: alarm.id,
+      action: 'formed-group',
+      groupId: group.id,
+      ruleId: rule.id,
+      suppressed: group.suppressedAlarmIds.includes(alarm.id),
+      isRootCause: group.rootCauseAlarmId === alarm.id,
+      reason: `formed group with "${peer.id}" via rule "${rule.name}"`,
+    };
+  }
+
+  /**
+   * Deterministic root election (total order):
+   * earliest 100ms time bucket → highest causal dominance → shallowest
+   * hierarchy depth → lexicographically smallest id.
+   */
+  private electRootCause(group: AlarmGroup): void {
+    const memberEquipment = group.alarms
+      .map((a) => a.equipmentId)
+      .filter((id): id is string => !!id);
+
+    const scored = group.alarms.map((alarm) => ({
+      alarm,
+      bucket: Math.floor(alarm.timestamp / ROOT_ELECTION_TIME_BUCKET_MS),
+      dominance: alarm.equipmentId
+        ? this.topology.causalDominance(alarm.equipmentId, memberEquipment, 8)
+        : 0,
+      depth: alarm.equipmentId ? this.topology.depth(alarm.equipmentId) : Number.MAX_SAFE_INTEGER,
+    }));
+
+    scored.sort((a, b) => {
+      if (a.bucket !== b.bucket) return a.bucket - b.bucket;
+      if (a.dominance !== b.dominance) return b.dominance - a.dominance;
+      if (a.depth !== b.depth) return a.depth - b.depth;
+      return a.alarm.id < b.alarm.id ? -1 : 1;
+    });
+
+    group.rootCauseAlarmId = scored[0].alarm.id;
+  }
+
+  /**
+   * Root cause is never suppressed. Other members are suppressed unless
+   * severity meets the never-suppress floor or they are already
+   * cleared/acknowledged.
+   */
+  private applySuppression(group: AlarmGroup): void {
+    if (!this.suppressionPolicy.enabled) return;
+    const floor = SEVERITY_RANK[this.suppressionPolicy.neverSuppressAtOrAbove];
+
+    for (const alarm of group.alarms) {
+      const isRoot = alarm.id === group.rootCauseAlarmId;
+      const alreadySuppressed = group.suppressedAlarmIds.includes(alarm.id);
+
+      if (isRoot && alreadySuppressed) {
+        // A re-election promoted a suppressed member to root — restore it
+        group.suppressedAlarmIds = group.suppressedAlarmIds.filter((id) => id !== alarm.id);
+        if (alarm.state === 'suppressed') alarm.state = 'active';
+        this.metrics.alarmsUnsuppressed++;
+        this.emit('alarms-unsuppressed', { groupId: group.id, alarmIds: [alarm.id] });
+        continue;
+      }
+
+      if (
+        !isRoot &&
+        !alreadySuppressed &&
+        alarm.state === 'active' &&
+        SEVERITY_RANK[alarm.severity] < floor
+      ) {
+        group.suppressedAlarmIds.push(alarm.id);
+        alarm.state = 'suppressed';
+        this.metrics.alarmsSuppressed++;
+        this.emit('alarm-suppressed', {
+          groupId: group.id,
+          alarmId: alarm.id,
+          rootCauseAlarmId: group.rootCauseAlarmId,
+        });
+      }
+    }
+  }
+
+  private unsuppressActiveMembers(group: AlarmGroup): string[] {
+    const restored: string[] = [];
+    for (const alarmId of group.suppressedAlarmIds) {
+      const alarm = group.alarms.find((a) => a.id === alarmId);
+      if (alarm && alarm.state === 'suppressed') {
+        alarm.state = 'active';
+        restored.push(alarmId);
+        this.metrics.alarmsUnsuppressed++;
+      }
+    }
+    group.suppressedAlarmIds = group.suppressedAlarmIds.filter(
+      (id) => !restored.includes(id)
+    );
+    if (restored.length > 0) {
+      this.emit('alarms-unsuppressed', { groupId: group.id, alarmIds: restored });
+    }
+    return restored;
+  }
+
+  private closeGroup(group: AlarmGroup, reason: AlarmGroup['closeReason']): void {
+    if (group.state === 'closed') return;
+    group.state = 'closed';
+    group.closeReason = reason;
+    group.closedAt = group.lastAlarmAt;
+    this.metrics.groupsClosed++;
+    this.emit('group-closed', group);
+  }
+
+  private enforceGroupCap(): void {
+    if (this.groups.size <= this.maxGroups) return;
+    const closedOldestFirst = Array.from(this.groups.values())
+      .filter((g) => g.state === 'closed')
+      .sort((a, b) => a.lastAlarmAt - b.lastAlarmAt);
+    for (const group of closedOldestFirst) {
+      if (this.groups.size <= this.maxGroups) return;
+      this.evictGroup(group);
+    }
+    // Still over cap — evict oldest open groups (pathological load)
+    const openOldestFirst = Array.from(this.groups.values()).sort(
+      (a, b) => a.lastAlarmAt - b.lastAlarmAt
+    );
+    for (const group of openOldestFirst) {
+      if (this.groups.size <= this.maxGroups) return;
+      this.closeGroup(group, 'evicted');
+      this.evictGroup(group);
+    }
+  }
+
+  private evictGroup(group: AlarmGroup): void {
+    for (const alarmId of group.alarmIds) {
+      this.alarmIndex.delete(alarmId);
+    }
+    this.groups.delete(group.id);
+  }
+
+  private removeFromPending(alarmId: string): void {
+    const idx = this.pending.findIndex((a) => a.id === alarmId);
+    if (idx >= 0) this.pending.splice(idx, 1);
+  }
+
+  /** Drop pending alarms too old to pair under the widest enabled rule window */
+  private prunePending(referenceMs: number): void {
+    const maxWindow = Math.max(
+      1000,
+      ...this.rules
+        .list()
+        .filter((r) => r.enabled)
+        .map((r) => (r.config as { windowMs: number }).windowMs)
+    );
+    const cutoff = referenceMs - maxWindow * 2;
+    let removed = 0;
+    this.pending = this.pending.filter((alarm) => {
+      const keep = alarm.timestamp >= cutoff;
+      if (!keep) {
+        this.alarmIndex.delete(alarm.id);
+        removed++;
+      }
+      return keep;
+    });
+    if (this.pending.length > this.maxPendingAlarms) {
+      const excess = this.pending.splice(0, this.pending.length - this.maxPendingAlarms);
+      for (const alarm of excess) this.alarmIndex.delete(alarm.id);
+      removed += excess.length;
+    }
+    if (removed > 0) this.emit('pending-pruned', { removed });
+  }
+}

--- a/server/services/alarm-correlation/index.ts
+++ b/server/services/alarm-correlation/index.ts
@@ -1,0 +1,190 @@
+/**
+ * Alarm Correlation Service
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * Singleton wrapper around the correlation engine: normalizes the repo's
+ * divergent alarm shapes (tag-stream broadcastAlarm, SingularisPrime /
+ * GR::LISTEN AlarmPayload, DB enum vocabulary) into CorrelatedAlarm,
+ * runs periodic idle-group sweeps, and re-emits engine events for
+ * downstream consumers (WebSocket bridge, routes).
+ */
+
+import { EventEmitter } from 'events';
+
+export * from './topology';
+export * from './rules';
+export * from './engine';
+
+import type {
+  AlarmSeverity,
+  AlarmLifecycleState,
+  CorrelatedAlarm,
+  IngestResult,
+} from '@shared/types/alarm-correlation';
+import { AlarmCorrelationEngine } from './engine';
+
+/**
+ * Map any severity vocabulary seen in this repo onto the runtime one.
+ * DB enums (INFO/WARNING/CRITICAL/EMERGENCY), SPC ('warning'|'alarm'),
+ * and client severities all funnel through here.
+ */
+export function normalizeSeverity(raw: unknown): AlarmSeverity {
+  const value = String(raw ?? '').toLowerCase();
+  switch (value) {
+    case 'critical':
+    case 'emergency':
+      return 'critical';
+    case 'high':
+    case 'alarm':
+      return 'high';
+    case 'medium':
+    case 'warning':
+      return 'medium';
+    case 'low':
+      return 'low';
+    default:
+      return 'info';
+  }
+}
+
+function normalizeState(raw: unknown): AlarmLifecycleState {
+  const value = String(raw ?? '').toLowerCase();
+  switch (value) {
+    case 'acknowledged':
+      return 'acknowledged';
+    case 'cleared':
+      return 'cleared';
+    case 'shelved':
+      return 'shelved';
+    case 'suppressed':
+      return 'suppressed';
+    default:
+      return 'active';
+  }
+}
+
+function normalizeTimestamp(raw: unknown): number | null {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    const parsed = new Date(raw).getTime();
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+/**
+ * Resolve an equipment id from a tag following the repo convention
+ * "ASSET.EVENT" (simulator: `${asset.nameOrTag}.${eventType}`). Tags that
+ * do not follow the convention resolve to themselves so same-equipment
+ * grouping still works per tag.
+ */
+export function resolveEquipmentFromTag(tagId: string): string | undefined {
+  if (!tagId) return undefined;
+  const dot = tagId.indexOf('.');
+  return dot > 0 ? tagId.slice(0, dot) : tagId;
+}
+
+/**
+ * Normalize any of the repo's alarm shapes into a CorrelatedAlarm.
+ * Accepts the tag-stream broadcastAlarm shape ({id, name, severity, state,
+ * tagValue, triggeredAt}), the SingularisPrime/GR::LISTEN AlarmPayload
+ * shape ({alarmId, alarmName, sourceTagId, priority, message, ...}), or a
+ * native CorrelatedAlarm. Returns null when no usable timestamp exists.
+ */
+export function normalizeAlarm(raw: Record<string, unknown>): CorrelatedAlarm | null {
+  const timestamp = normalizeTimestamp(
+    raw.timestamp ?? raw.triggeredAt ?? raw.sourceTimestamp
+  );
+  if (timestamp === null) return null;
+
+  const tagId = String(raw.tagId ?? raw.sourceTagId ?? raw.tagName ?? '');
+  const id = String(raw.id ?? raw.alarmId ?? `${tagId || 'alarm'}:${timestamp}`);
+  const equipmentId =
+    typeof raw.equipmentId === 'string' && raw.equipmentId !== ''
+      ? raw.equipmentId
+      : resolveEquipmentFromTag(tagId);
+
+  return {
+    id,
+    name: String(raw.name ?? raw.alarmName ?? id),
+    tagId,
+    equipmentId,
+    siteId: typeof raw.siteId === 'string' ? raw.siteId : undefined,
+    processArea: typeof raw.processArea === 'string' ? raw.processArea : undefined,
+    severity: normalizeSeverity(raw.severity ?? raw.priority),
+    state: normalizeState(raw.state),
+    message: String(raw.message ?? raw.name ?? raw.alarmName ?? ''),
+    timestamp,
+    value: raw.value as number | string | undefined ?? (raw.tagValue as number | undefined) ?? (raw.triggerValue as number | string | undefined),
+    limit: (raw.limit as number | string | undefined) ?? (raw.limitValue as number | string | undefined),
+    source: typeof raw.source === 'string' ? raw.source : undefined,
+  };
+}
+
+export class AlarmCorrelationService extends EventEmitter {
+  readonly engine = new AlarmCorrelationEngine();
+
+  private initialized = false;
+  private sweepTimer: NodeJS.Timeout | null = null;
+  private readonly sweepIntervalMs: number;
+
+  constructor(sweepIntervalMs = 30_000) {
+    super();
+    this.sweepIntervalMs = sweepIntervalMs;
+    for (const event of [
+      'group-created',
+      'group-updated',
+      'group-closed',
+      'root-cause-changed',
+      'alarm-suppressed',
+      'alarms-unsuppressed',
+    ]) {
+      this.engine.on(event, (payload) => this.emit(event, payload));
+    }
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+    this.sweepTimer = setInterval(() => {
+      try {
+        this.engine.sweep(Date.now());
+      } catch {
+        /* sweep failures must never take down the interval */
+      }
+    }, this.sweepIntervalMs);
+    this.sweepTimer.unref?.();
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+    this.initialized = false;
+  }
+
+  /**
+   * Normalize and correlate one alarm in any supported shape.
+   * Returns null when the input has no usable timestamp.
+   */
+  ingest(raw: Record<string, unknown>): { alarm: CorrelatedAlarm; result: IngestResult } | null {
+    const alarm = normalizeAlarm(raw);
+    if (!alarm) return null;
+    const result = this.engine.ingest(alarm);
+    return { alarm, result };
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
+    const metrics = this.engine.getMetrics();
+    return {
+      healthy: this.initialized,
+      message: this.initialized
+        ? `Alarm correlation running: ${metrics.openGroups} open groups, ` +
+          `${(metrics.suppressionRate * 100).toFixed(1)}% suppression rate`
+        : 'Alarm correlation service not initialized',
+    };
+  }
+}
+
+export const alarmCorrelationService = new AlarmCorrelationService();

--- a/server/services/alarm-correlation/rules.ts
+++ b/server/services/alarm-correlation/rules.ts
@@ -1,0 +1,233 @@
+/**
+ * Correlation Rules Engine
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * Rules are evaluated in priority order (lower first) to decide whether an
+ * alarm joins an existing group or pairs with another alarm to form one.
+ * Every stored rule is actually evaluated — a rule that matches nothing is
+ * an authoring problem, not dead machinery.
+ *
+ * Bare temporal proximity across unrelated equipment never correlates:
+ * temporal rules require an explicit scope (same tag, same equipment, or
+ * shared process area); cross-equipment grouping requires causal or
+ * hierarchy evidence from the topology.
+ */
+
+import type {
+  AlarmGroup,
+  CausalRuleConfig,
+  CorrelatedAlarm,
+  CorrelationRule,
+  HierarchyRuleConfig,
+  TemporalRuleConfig,
+} from '@shared/types/alarm-correlation';
+import type { EquipmentTopology } from './topology';
+
+export const DEFAULT_RULES: CorrelationRule[] = [
+  {
+    id: 'default-causal',
+    name: 'Causal chain (topology causalDownstream, transitive)',
+    type: 'causal',
+    enabled: true,
+    priority: 10,
+    config: { windowMs: 30_000, maxHops: 5 } satisfies CausalRuleConfig,
+  },
+  {
+    id: 'default-hierarchy',
+    name: 'Equipment hierarchy (common ancestor)',
+    type: 'hierarchy',
+    enabled: true,
+    priority: 20,
+    config: { windowMs: 10_000, maxDistance: 2 } satisfies HierarchyRuleConfig,
+  },
+  {
+    id: 'default-tag-chatter',
+    name: 'Same-tag chatter',
+    type: 'temporal',
+    enabled: true,
+    priority: 30,
+    config: { windowMs: 5_000, scope: 'same-tag' } satisfies TemporalRuleConfig,
+  },
+  {
+    id: 'default-equipment-burst',
+    name: 'Same-equipment burst',
+    type: 'temporal',
+    enabled: true,
+    priority: 40,
+    config: { windowMs: 5_000, scope: 'same-equipment' } satisfies TemporalRuleConfig,
+  },
+];
+
+export function validateRule(rule: CorrelationRule): string | null {
+  const cfg = rule.config as unknown as Record<string, unknown>;
+  if (typeof cfg.windowMs !== 'number' || cfg.windowMs <= 0) {
+    return 'config.windowMs must be a positive number';
+  }
+  switch (rule.type) {
+    case 'causal':
+      if (typeof cfg.maxHops !== 'number' || cfg.maxHops < 1) {
+        return 'causal rule requires config.maxHops >= 1';
+      }
+      return null;
+    case 'hierarchy':
+      if (typeof cfg.maxDistance !== 'number' || cfg.maxDistance < 1) {
+        return 'hierarchy rule requires config.maxDistance >= 1';
+      }
+      return null;
+    case 'temporal':
+      if (!['same-tag', 'same-equipment', 'process-area'].includes(cfg.scope as string)) {
+        return "temporal rule requires config.scope of 'same-tag' | 'same-equipment' | 'process-area'";
+      }
+      return null;
+    default:
+      return `unknown rule type "${(rule as CorrelationRule).type}"`;
+  }
+}
+
+export class CorrelationRulesEngine {
+  private rules: Map<string, CorrelationRule> = new Map();
+
+  constructor(initial: CorrelationRule[] = DEFAULT_RULES) {
+    for (const rule of initial) this.rules.set(rule.id, { ...rule });
+  }
+
+  list(): CorrelationRule[] {
+    return Array.from(this.rules.values()).sort((a, b) => a.priority - b.priority);
+  }
+
+  get(id: string): CorrelationRule | undefined {
+    return this.rules.get(id);
+  }
+
+  upsert(rule: CorrelationRule): CorrelationRule {
+    const error = validateRule(rule);
+    if (error) throw new Error(`Invalid rule "${rule.id}": ${error}`);
+    this.rules.set(rule.id, { ...rule });
+    return rule;
+  }
+
+  remove(id: string): boolean {
+    return this.rules.delete(id);
+  }
+
+  setEnabled(id: string, enabled: boolean): CorrelationRule | undefined {
+    const rule = this.rules.get(id);
+    if (!rule) return undefined;
+    rule.enabled = enabled;
+    return rule;
+  }
+
+  private enabledRules(): CorrelationRule[] {
+    return this.list().filter((r) => r.enabled);
+  }
+
+  /**
+   * First enabled rule (by priority) under which `alarm` belongs in `group`.
+   * The temporal window anchors to the group's latest alarm; relatedness
+   * anchors to the root cause (hierarchy/temporal scopes) or any member
+   * (causal — chains propagate through intermediate members, and checking
+   * both directions admits an upstream cause that arrives late).
+   */
+  evaluateJoin(
+    alarm: CorrelatedAlarm,
+    group: AlarmGroup,
+    topology: EquipmentTopology
+  ): CorrelationRule | null {
+    const root = group.alarms.find((a) => a.id === group.rootCauseAlarmId);
+    for (const rule of this.enabledRules()) {
+      const windowMs = (rule.config as { windowMs: number }).windowMs;
+      if (Math.abs(alarm.timestamp - group.lastAlarmAt) > windowMs) continue;
+
+      switch (rule.type) {
+        case 'causal': {
+          const { maxHops } = rule.config as CausalRuleConfig;
+          if (!alarm.equipmentId) break;
+          const related = group.alarms.some(
+            (member) =>
+              member.equipmentId &&
+              topology.isCausallyRelated(alarm.equipmentId!, member.equipmentId, maxHops)
+          );
+          if (related) return rule;
+          break;
+        }
+        case 'hierarchy': {
+          const { maxDistance } = rule.config as HierarchyRuleConfig;
+          if (!alarm.equipmentId || !root?.equipmentId) break;
+          if (topology.isHierarchyRelated(alarm.equipmentId, root.equipmentId, maxDistance)) {
+            return rule;
+          }
+          break;
+        }
+        case 'temporal': {
+          if (root && this.temporalScopeMatches(rule.config as TemporalRuleConfig, alarm, root)) {
+            return rule;
+          }
+          break;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * First enabled rule under which two ungrouped alarms belong together —
+   * used to form a new group.
+   */
+  evaluatePair(
+    alarm: CorrelatedAlarm,
+    other: CorrelatedAlarm,
+    topology: EquipmentTopology
+  ): CorrelationRule | null {
+    for (const rule of this.enabledRules()) {
+      const windowMs = (rule.config as { windowMs: number }).windowMs;
+      if (Math.abs(alarm.timestamp - other.timestamp) > windowMs) continue;
+
+      switch (rule.type) {
+        case 'causal': {
+          const { maxHops } = rule.config as CausalRuleConfig;
+          if (
+            alarm.equipmentId &&
+            other.equipmentId &&
+            topology.isCausallyRelated(alarm.equipmentId, other.equipmentId, maxHops)
+          ) {
+            return rule;
+          }
+          break;
+        }
+        case 'hierarchy': {
+          const { maxDistance } = rule.config as HierarchyRuleConfig;
+          if (
+            alarm.equipmentId &&
+            other.equipmentId &&
+            topology.isHierarchyRelated(alarm.equipmentId, other.equipmentId, maxDistance)
+          ) {
+            return rule;
+          }
+          break;
+        }
+        case 'temporal': {
+          if (this.temporalScopeMatches(rule.config as TemporalRuleConfig, alarm, other)) {
+            return rule;
+          }
+          break;
+        }
+      }
+    }
+    return null;
+  }
+
+  private temporalScopeMatches(
+    config: TemporalRuleConfig,
+    a: CorrelatedAlarm,
+    b: CorrelatedAlarm
+  ): boolean {
+    switch (config.scope) {
+      case 'same-tag':
+        return a.tagId !== '' && a.tagId === b.tagId;
+      case 'same-equipment':
+        return !!a.equipmentId && a.equipmentId === b.equipmentId;
+      case 'process-area':
+        return !!a.processArea && a.processArea === b.processArea;
+    }
+  }
+}

--- a/server/services/alarm-correlation/topology.ts
+++ b/server/services/alarm-correlation/topology.ts
@@ -1,0 +1,177 @@
+/**
+ * Equipment Topology Graph
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * Two edge sets per node: an acyclic containment hierarchy (parentId) and
+ * directed causal edges (causalDownstream). Hierarchy cycles are rejected
+ * at registration; causal traversal is cycle-safe because recirculation
+ * loops legitimately exist in real processes.
+ */
+
+import type { EquipmentNode } from '@shared/types/alarm-correlation';
+
+const MAX_TRAVERSAL_DEPTH = 64;
+
+export class EquipmentTopology {
+  private nodes: Map<string, EquipmentNode> = new Map();
+
+  /**
+   * Insert or replace a node. Throws if the parent chain would form a
+   * cycle. Parents and causal targets need not exist yet — topology can
+   * be registered incrementally.
+   */
+  upsert(node: EquipmentNode): EquipmentNode {
+    const previous = this.nodes.get(node.equipmentId);
+    const stored: EquipmentNode = {
+      ...node,
+      causalDownstream: [...new Set(node.causalDownstream)].filter(
+        (id) => id !== node.equipmentId
+      ),
+    };
+    this.nodes.set(node.equipmentId, stored);
+
+    if (this.hasParentCycle(node.equipmentId)) {
+      if (previous) {
+        this.nodes.set(node.equipmentId, previous);
+      } else {
+        this.nodes.delete(node.equipmentId);
+      }
+      throw new Error(
+        `Equipment "${node.equipmentId}": parentId "${node.parentId}" would create a hierarchy cycle`
+      );
+    }
+    return stored;
+  }
+
+  upsertMany(nodes: EquipmentNode[]): EquipmentNode[] {
+    return nodes.map((n) => this.upsert(n));
+  }
+
+  get(equipmentId: string): EquipmentNode | undefined {
+    return this.nodes.get(equipmentId);
+  }
+
+  list(): EquipmentNode[] {
+    return Array.from(this.nodes.values());
+  }
+
+  remove(equipmentId: string): boolean {
+    return this.nodes.delete(equipmentId);
+  }
+
+  size(): number {
+    return this.nodes.size;
+  }
+
+  /** Depth from the hierarchy root (root = 0). Unknown nodes are depth 0. */
+  depth(equipmentId: string): number {
+    let depth = 0;
+    let current = this.nodes.get(equipmentId);
+    const visited = new Set<string>([equipmentId]);
+    while (current?.parentId && depth < MAX_TRAVERSAL_DEPTH) {
+      if (visited.has(current.parentId)) break;
+      visited.add(current.parentId);
+      depth++;
+      current = this.nodes.get(current.parentId);
+    }
+    return depth;
+  }
+
+  /**
+   * Hierarchy relatedness: steps to the nearest common ancestor, counted
+   * from the deeper side (so parent↔child = 1, siblings = 1, cousins = 2).
+   * Returns null when the nodes share no ancestor.
+   */
+  hierarchyDistance(a: string, b: string): number | null {
+    if (a === b) return 0;
+    const ancestorsA = this.ancestorDepths(a);
+    const ancestorsB = this.ancestorDepths(b);
+    let best: number | null = null;
+    for (const [ancestor, da] of ancestorsA) {
+      const db = ancestorsB.get(ancestor);
+      if (db !== undefined) {
+        const distance = Math.max(da, db);
+        if (best === null || distance < best) best = distance;
+      }
+    }
+    return best;
+  }
+
+  isHierarchyRelated(a: string, b: string, maxDistance: number): boolean {
+    const distance = this.hierarchyDistance(a, b);
+    return distance !== null && distance <= maxDistance;
+  }
+
+  /**
+   * Transitive causal reachability over causalDownstream edges (BFS with
+   * visited-set cycle guard, bounded hops).
+   */
+  isCausallyReachable(from: string, to: string, maxHops: number): boolean {
+    if (from === to) return false;
+    if (!this.nodes.has(from)) return false;
+
+    let frontier = [from];
+    const visited = new Set<string>([from]);
+    for (let hop = 0; hop < maxHops && frontier.length > 0; hop++) {
+      const next: string[] = [];
+      for (const id of frontier) {
+        for (const target of this.nodes.get(id)?.causalDownstream ?? []) {
+          if (target === to) return true;
+          if (!visited.has(target)) {
+            visited.add(target);
+            next.push(target);
+          }
+        }
+      }
+      frontier = next;
+    }
+    return false;
+  }
+
+  /** Causal relatedness in either direction — handles out-of-order arrival */
+  isCausallyRelated(a: string, b: string, maxHops: number): boolean {
+    return (
+      this.isCausallyReachable(a, b, maxHops) || this.isCausallyReachable(b, a, maxHops)
+    );
+  }
+
+  /** How many of `others` this node causally reaches — root-cause dominance */
+  causalDominance(candidate: string, others: string[], maxHops: number): number {
+    let count = 0;
+    for (const other of others) {
+      if (other !== candidate && this.isCausallyReachable(candidate, other, maxHops)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────
+
+  /** Map of ancestor id → steps up from the given node (self = 0) */
+  private ancestorDepths(equipmentId: string): Map<string, number> {
+    const result = new Map<string, number>();
+    let current = this.nodes.get(equipmentId);
+    let steps = 0;
+    result.set(equipmentId, 0);
+    while (current?.parentId && steps < MAX_TRAVERSAL_DEPTH) {
+      if (result.has(current.parentId)) break;
+      steps++;
+      result.set(current.parentId, steps);
+      current = this.nodes.get(current.parentId);
+    }
+    return result;
+  }
+
+  private hasParentCycle(startId: string): boolean {
+    const visited = new Set<string>();
+    let current = this.nodes.get(startId);
+    while (current?.parentId) {
+      if (visited.has(current.equipmentId)) return true;
+      visited.add(current.equipmentId);
+      if (current.parentId === startId) return true;
+      current = this.nodes.get(current.parentId);
+    }
+    return false;
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -66,6 +66,10 @@ export { spcService } from './spc';
 export * from './l2-rollup';
 export { l2RollupService } from './l2-rollup';
 
+// ── Alarm Correlation Service (ADR-0013 [13.2], #213) ────────────────────────
+export * from './alarm-correlation';
+export { alarmCorrelationService } from './alarm-correlation';
+
 /**
  * Initialize all services
  * 
@@ -80,7 +84,8 @@ export async function initializeServices(): Promise<void> {
     { name: 'Ubiquity', service: () => import('./ubiquity').then(m => m.ubiquityService.initialize()) },
     { name: 'Layer 2 Rollup', service: () => import('./l2-rollup').then(m => m.l2RollupService.initialize()) },
     { name: 'Optimization', service: () => import('./optimization').then(m => m.optimizationService.initialize()) },
-    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) }
+    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) },
+    { name: 'Alarm Correlation', service: () => import('./alarm-correlation').then(m => m.alarmCorrelationService.initialize()) }
   ];
 
   for (const { name, service } of services) {
@@ -171,6 +176,14 @@ export async function getServicesHealthStatus(): Promise<{
         return await spcService.healthCheck();
       } catch {
         return { healthy: false, message: 'SPC service not available' };
+      }
+    },
+    alarmCorrelation: async () => {
+      try {
+        const { alarmCorrelationService } = await import('./alarm-correlation');
+        return await alarmCorrelationService.healthCheck();
+      } catch {
+        return { healthy: false, message: 'Alarm correlation service not available' };
       }
     }
   };

--- a/server/simulator.ts
+++ b/server/simulator.ts
@@ -1,5 +1,6 @@
 import { log, logError, logWarn } from "./logger";
 import { tagStreamServer } from "./websocket/tag-stream";
+import { cachedEventBridge } from "./websocket/cached-event-bridge";
 import { getFluxPublisher } from "./services/flux";
 import { natsPublisher } from "./services/nats";
 
@@ -114,6 +115,27 @@ class FieldSimulator {
           timestamp: new Date().toISOString(),
         });
       } catch { /* WebSocket not connected — that's fine */ }
+
+      // Raise a real alarm for trip events — feeds the correlation engine
+      // and the alarm WebSocket channel, which had no producer (#213)
+      if (eventType === "BREAKER_TRIP") {
+        try {
+          void cachedEventBridge.publishAlarm({
+            id: `ALM-${asset.nameOrTag}-${Date.now()}`,
+            name: `${asset.nameOrTag} ${eventType}`,
+            tagId: `${asset.nameOrTag}.${eventType}`,
+            equipmentId: asset.nameOrTag,
+            siteId: asset.siteId,
+            severity: asset.critical ? "critical" : "high",
+            state: "active",
+            message: details,
+            timestamp: new Date().toISOString(),
+            triggeredAt: new Date().toISOString(),
+            value: (payload as any).current,
+            source: "simulator",
+          });
+        } catch { /* alarm fan-out failure must not break event generation */ }
+      }
 
       // Publish to NATS for blockchain anchoring (canonical wire schema, #440)
       try {

--- a/server/websocket/cached-event-bridge.ts
+++ b/server/websocket/cached-event-bridge.ts
@@ -11,6 +11,7 @@ import { getRedisClient, isRedisHealthy } from '../services/cache/redis-client.j
 import { eventCache, type CachedEvent } from '../services/cache/event-cache.js';
 import { unifiedStreamServer } from './unified-stream.js';
 import { tagStreamServer, type TagUpdate } from './tag-stream.js';
+import { alarmCorrelationService } from '../services/alarm-correlation';
 import type Redis from 'ioredis';
 
 const CHANNEL_EVENTS = '0xscada:ws:events';
@@ -124,14 +125,37 @@ class CachedEventBridge {
 
   /**
    * Publish an alarm — fans out to all instances.
+   *
+   * Every alarm passes through the correlation engine first (#213); the
+   * broadcast payload is enriched with a `correlation` field carrying
+   * group membership, root-cause, and suppression info so consumers can
+   * de-clutter without any alarm being silently dropped.
    */
   async publishAlarm(alarm: Record<string, unknown>): Promise<void> {
-    tagStreamServer.broadcastAlarm(alarm as any);
-    unifiedStreamServer.broadcastAlarm(alarm);
+    let enriched = alarm;
+    try {
+      const outcome = alarmCorrelationService.ingest(alarm);
+      if (outcome) {
+        enriched = {
+          ...alarm,
+          correlation: {
+            action: outcome.result.action,
+            groupId: outcome.result.groupId ?? null,
+            suppressed: outcome.result.suppressed,
+            isRootCause: outcome.result.isRootCause,
+          },
+        };
+      }
+    } catch {
+      // Correlation must never block alarm fan-out
+    }
+
+    tagStreamServer.broadcastAlarm(enriched as any);
+    unifiedStreamServer.broadcastAlarm(enriched);
 
     if (!this.publisher) return;
     try {
-      await this.publisher.publish(CHANNEL_ALARMS, JSON.stringify(alarm));
+      await this.publisher.publish(CHANNEL_ALARMS, JSON.stringify(enriched));
     } catch {
       // Non-fatal
     }

--- a/shared/types/alarm-correlation.ts
+++ b/shared/types/alarm-correlation.ts
@@ -1,0 +1,165 @@
+/**
+ * Alarm Correlation Types
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * Types for grouping related alarms by temporal proximity, causal chains,
+ * and equipment hierarchy; root-cause identification; and suppression of
+ * downstream/consequential alarms.
+ *
+ * Severity aligns with the live runtime vocabulary (SingularisPrime
+ * Severity / GR::LISTEN priority). Lifecycle state extends the client's
+ * active|acknowledged|cleared vocabulary with 'shelved' (DB enum) and
+ * 'suppressed' (ScadaAlarmBlock), which correlation introduces.
+ */
+
+export type AlarmSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+export type AlarmLifecycleState =
+  | 'active'
+  | 'acknowledged'
+  | 'cleared'
+  | 'shelved'
+  | 'suppressed';
+
+/** Normalized alarm instance flowing through the correlation engine */
+export interface CorrelatedAlarm {
+  id: string;
+  name: string;
+  /** Tag that triggered the alarm (free-string, convention "ASSET.EVENT") */
+  tagId: string;
+  /** Resolved equipment id — enables hierarchy/causal correlation */
+  equipmentId?: string;
+  siteId?: string;
+  processArea?: string;
+  severity: AlarmSeverity;
+  state: AlarmLifecycleState;
+  message: string;
+  /** Event time in epoch ms — all correlation logic is event-time driven */
+  timestamp: number;
+  value?: number | string;
+  limit?: number | string;
+  /** Where the alarm came from (simulator, phi, spc, api, ...) */
+  source?: string;
+}
+
+// ── Equipment topology ────────────────────────────────────────────────────
+
+/**
+ * A node in the equipment graph. Two edge sets:
+ * - parentId: physical/functional containment hierarchy (must be acyclic)
+ * - causalDownstream: directed process-causality edges (cycles tolerated
+ *   by traversal guards — recirculation loops exist in real plants)
+ */
+export interface EquipmentNode {
+  equipmentId: string;
+  name?: string;
+  parentId?: string;
+  causalDownstream: string[];
+  siteId?: string;
+  processArea?: string;
+}
+
+// ── Correlation rules ─────────────────────────────────────────────────────
+
+export type CorrelationRuleType = 'causal' | 'hierarchy' | 'temporal';
+
+export interface CausalRuleConfig {
+  /** Max event-time gap between an alarm and the group's latest alarm */
+  windowMs: number;
+  /** Max causal-edge hops for reachability */
+  maxHops: number;
+}
+
+export interface HierarchyRuleConfig {
+  windowMs: number;
+  /** Max steps to a common ancestor for two nodes to count as related */
+  maxDistance: number;
+}
+
+export interface TemporalRuleConfig {
+  windowMs: number;
+  /**
+   * Bare temporal proximity never merges unrelated equipment. Scope
+   * restricts which alarms a temporal rule may group:
+   * - 'same-tag': repeats/chatter of one tag
+   * - 'same-equipment': alarms of one equipment id
+   * - 'process-area': alarms sharing a processArea value
+   */
+  scope: 'same-tag' | 'same-equipment' | 'process-area';
+}
+
+export interface CorrelationRule {
+  id: string;
+  name: string;
+  type: CorrelationRuleType;
+  enabled: boolean;
+  /** Lower runs first */
+  priority: number;
+  config: CausalRuleConfig | HierarchyRuleConfig | TemporalRuleConfig;
+}
+
+/** Policy governing suppression of consequential alarms within groups */
+export interface SuppressionPolicy {
+  enabled: boolean;
+  /** Alarms at or above this severity are never suppressed */
+  neverSuppressAtOrAbove: AlarmSeverity;
+  /** Re-emit suppressed members when the root cause clears */
+  unsuppressOnRootClear: boolean;
+}
+
+// ── Groups & results ──────────────────────────────────────────────────────
+
+export type AlarmGroupState = 'open' | 'closed';
+
+export interface AlarmGroup {
+  id: string;
+  state: AlarmGroupState;
+  /** Snapshots of member alarms, in ingestion order */
+  alarms: CorrelatedAlarm[];
+  /** Membership is tracked by id, never object identity */
+  alarmIds: string[];
+  rootCauseAlarmId: string;
+  /** Rule that formed the group */
+  formedByRuleId: string;
+  /** Rule that admitted each member, keyed by alarm id */
+  joinedVia: Record<string, string>;
+  suppressedAlarmIds: string[];
+  maxSeverity: AlarmSeverity;
+  createdAt: number;
+  lastAlarmAt: number;
+  closedAt?: number;
+  closeReason?: 'root-cause-cleared' | 'idle-timeout' | 'evicted';
+}
+
+export type IngestAction = 'joined-group' | 'formed-group' | 'standalone';
+
+export interface IngestResult {
+  alarmId: string;
+  action: IngestAction;
+  groupId?: string;
+  ruleId?: string;
+  suppressed: boolean;
+  isRootCause: boolean;
+  reason: string;
+}
+
+export interface RootCauseResult {
+  groupId: string;
+  alarm: CorrelatedAlarm;
+  /** How many other members this alarm causally reaches */
+  causalDominance: number;
+  hierarchyDepth: number;
+  electedBy: string;
+}
+
+export interface CorrelationMetrics {
+  alarmsIngested: number;
+  groupsCreated: number;
+  groupsClosed: number;
+  alarmsSuppressed: number;
+  alarmsUnsuppressed: number;
+  /** suppressed / ingested — the alarm-fatigue KPI */
+  suppressionRate: number;
+  openGroups: number;
+  trackedAlarms: number;
+}


### PR DESCRIPTION
Closes #213

Rebuilds the Alarm Correlation module from ADR-0013 [13.2]. (The Wave 2 implementation from PR #220 was lost in the repo restructure `6f9d9219c`; this reimplements it against the current codebase and fixes its design flaws.)

## What's included

**Correlation engine** (`server/services/alarm-correlation/`)
- **Equipment topology**: acyclic containment hierarchy (cycles rejected at registration) + directed causal edges with cycle-safe, hop-bounded transitive BFS — recirculation loops in the causal graph are tolerated by traversal guards
- **Rules engine that actually evaluates**: `causal` / `hierarchy` / `temporal` rule types with typed configs, priority ordering, and full CRUD. Bare temporal proximity never merges unrelated equipment (the Wave 2 correlator's worst bug) — temporal rules require an explicit scope (same tag / same equipment / shared process area)
- **Deterministic root-cause election**: earliest 100 ms time bucket → causal dominance → hierarchy depth → id (a strict total order), with re-election when an upstream cause arrives out of order
- **Real suppression**: downstream members get `suppressed` state with a severity floor (critical never suppressed), and are un-suppressed when the root cause clears; suppression rate is exposed as the alarm-fatigue KPI
- **Event-time driven**: no wall clock in correlation logic, so replayed/backfilled streams correlate identically; wall clock only drives periodic idle-group sweeps

**Live wiring** (the alarm WS pipeline previously had zero producers)
- `cachedEventBridge.publishAlarm` — the fan-out choke point — now routes every alarm through the correlator and attaches a `correlation` field (group, root cause, suppressed) to broadcasts; nothing is silently dropped
- The simulator raises real alarms on `BREAKER_TRIP` events, so `/ws` + `/ws/tags` `alarm:update` and the correlation engine have live traffic in dev
- Normalization layer accepts the repo's divergent alarm shapes (tag-stream `broadcastAlarm`, SingularisPrime/GR::LISTEN `AlarmPayload`, DB enum severities)

**API** — `/api/alarm-correlation`: alarm ingest + clear/acknowledge, groups + root cause, rules CRUD + enable/disable, topology CRUD, suppression policy, metrics/status. Zod-validated, auth placeholder matching sibling routers.

## Relationship to GR::LISTEN (#350)
`gr-listen` does notification-fatigue filtering (attention budgets, time-of-day, same-tag incidents) and is currently unwired. This module does structural correlation (causal/hierarchy/rules). They compose — the correlator's output could feed gr-listen — but wiring that is left out of scope here to avoid entangling two dormant systems in one PR.

## Notes
- Correlation state is in-memory, consistent with every other service in the repo (the `alarms`/`alarm_history` DB tables exist but no storage layer touches them anywhere; persistence is a separate effort)
- Service init happens in `registerRoutes` because `initializeServices()` has no callers at startup (it's also registered there for convention)

## Testing
- 25 new unit tests: topology (cycles, distance, transitive reachability), rules (validation, priority, scoping), engine (causal chains, out-of-order root re-election, unrelated-never-merged, suppression + severity floor, root-clear un-suppression, dedupe, sweep/eviction, span cap, metrics), normalization shapes
- Full suite: 1205 tests pass; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)