### PR TITLE
[13.3] Digital Twin Runtime (ADR-0013)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,8 @@ import pidRoutes from "./routes/pid";
 import { fluxRoutes } from "./routes/flux";
 import { gatewayRoutes } from "./routes/gateway";
 import { intelligenceRoutes } from "./routes/intelligence";
+import { twinRoutes } from "./routes/twin";
+import { digitalTwinService } from "./services/twin";
 import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
@@ -52,6 +54,7 @@ export async function registerRoutes(
 
   // P1 Wiring: Intelligence, Governance, and Security modules
   app.use("/api/intelligence", intelligenceRoutes);
+  app.use("/api/twin", twinRoutes);  // ADR-0013 [13.3] (#214)
   app.use("/api/governance", governanceRoutes);
   app.use("/api/security", securityRoutes);
   app.use("/api/geometry", geometryRoutes(getFluxPublisher()));
@@ -80,6 +83,11 @@ export async function registerRoutes(
   // WebSocket servers initialize if available
   try { tagStreamServer?.initialize(httpServer, "/ws/tags"); } catch {}
   try { unifiedStreamServer?.initialize(httpServer, "/ws"); } catch {}  // unified endpoint (#255)
+
+  // Feed live tag updates into the digital twin and start its step timer
+  // here — services/initializeServices() has no callers at startup (#214).
+  tagStreamServer.onTagUpdate((update) => digitalTwinService.ingestTagUpdate(update));
+  void digitalTwinService.initialize();
 
   // WebSocket metrics endpoint. The legacy event-stream server was removed;
   // only the tag and unified streams report (#446, #479).

--- a/server/routes/twin.ts
+++ b/server/routes/twin.ts
@@ -1,0 +1,194 @@
+/**
+ * Digital Twin API
+ * ADR-0013 [13.3] — Issue #214
+ *
+ * REST surface for the digital twin runtime: model registry, simulation
+ * control, live-state sync/compare, what-if scenarios, and rollback
+ * simulation. Deliberately mounted at /api/twin — the mock
+ * /api/intelligence/digitaltwin endpoints are a separate legacy surface.
+ */
+
+import { Router } from "express";
+import type { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+import { digitalTwinService, listStepFunctions } from "../services/twin";
+import type { ProcessModel, WhatIfScenario } from "@shared/types/digital-twin";
+
+const router = Router();
+const runtime = digitalTwinService.runtime;
+
+// Auth middleware placeholder — same pattern as other protected routes
+function requireAuth(req: Request, res: Response, next: NextFunction) {
+  // TODO: implement real auth check (JWT / session validation)
+  next();
+}
+router.use(requireAuth);
+
+/** Uniform 400 for engine validation errors thrown from handlers */
+function handle(fn: (req: Request, res: Response) => void) {
+  return (req: Request, res: Response) => {
+    try {
+      fn(req, res);
+    } catch (error) {
+      if (!res.headersSent) {
+        res.status(400).json({ error: error instanceof Error ? error.message : "Invalid request" });
+      }
+    }
+  };
+}
+
+// ── Schemas ────────────────────────────────────────────────────────────────
+
+const ComponentSchema = z.object({
+  id: z.string().min(1).max(128),
+  type: z.enum(["tank", "pipe", "valve", "pump", "controller", "sensor", "heater", "mixer"]),
+  name: z.string().min(1).max(256),
+  config: z.record(z.number().finite()).default({}),
+  initialState: z.record(z.number().finite()).default({}),
+  connections: z.array(z.string().min(1)).max(64).default([]),
+  pvSource: z.string().min(1).optional(),
+});
+
+const ModelSchema = z.object({
+  id: z.string().min(1).max(128),
+  name: z.string().min(1).max(256),
+  description: z.string().max(2000).optional(),
+  components: z.array(ComponentSchema).min(1).max(500),
+  tagBindings: z
+    .array(
+      z.object({
+        tagId: z.string().min(1).max(256),
+        componentId: z.string().min(1),
+        parameter: z.string().min(1).max(64),
+      })
+    )
+    .max(1000)
+    .default([]),
+  stepFunction: z.string().min(1).default("basic-flow"),
+  timeStepMs: z.number().int().min(10).max(3_600_000),
+});
+
+const ModificationSchema = z.object({
+  componentId: z.string().min(1),
+  parameter: z.string().min(1).max(64),
+  value: z.number().finite(),
+  target: z.enum(["config", "state"]).optional(),
+});
+
+const ScenarioSchema = z.object({
+  id: z.string().min(1).max(128),
+  name: z.string().min(1).max(256),
+  baseModelId: z.string().min(1),
+  modifications: z.array(ModificationSchema).max(100),
+  durationTicks: z.number().int().min(1).max(100_000),
+  fromLiveState: z.boolean().optional(),
+});
+
+const RollbackSchema = z.object({
+  applied: z.array(ModificationSchema).min(1).max(100),
+  durationTicks: z.number().int().min(1).max(100_000),
+});
+
+const StepSchema = z.object({
+  ticks: z.number().int().min(1).max(10_000).default(1),
+});
+
+// ── Model registry ─────────────────────────────────────────────────────────
+
+router.post("/models", handle((req, res) => {
+  const parsed = ModelSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const state = runtime.registerModel(parsed.data as ProcessModel);
+  res.status(201).json({ model: parsed.data, state });
+}));
+
+router.get("/models", (_req, res) => {
+  res.json({ models: runtime.listModels() });
+});
+
+router.get("/models/:modelId", (req, res) => {
+  const model = runtime.getModel(req.params.modelId);
+  if (!model) return res.status(404).json({ error: `Model ${req.params.modelId} not found` });
+  res.json({ model, state: runtime.getState(req.params.modelId) });
+});
+
+router.delete("/models/:modelId", (req, res) => {
+  if (!runtime.removeModel(req.params.modelId)) {
+    return res.status(404).json({ error: `Model ${req.params.modelId} not found` });
+  }
+  res.json({ removed: true });
+});
+
+// ── Simulation control ─────────────────────────────────────────────────────
+
+router.post("/models/:modelId/start", handle((req, res) => {
+  res.json(runtime.setRunning(req.params.modelId, true));
+}));
+
+router.post("/models/:modelId/stop", handle((req, res) => {
+  res.json(runtime.setRunning(req.params.modelId, false));
+}));
+
+router.post("/models/:modelId/reset", handle((req, res) => {
+  res.json(runtime.resetModel(req.params.modelId));
+}));
+
+router.post("/models/:modelId/step", handle((req, res) => {
+  const parsed = StepSchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  res.json(runtime.step(req.params.modelId, parsed.data.ticks));
+}));
+
+router.get("/models/:modelId/state", (req, res) => {
+  const state = runtime.getState(req.params.modelId);
+  if (!state) return res.status(404).json({ error: `Model ${req.params.modelId} not found` });
+  res.json(state);
+});
+
+// ── Live sync & comparison ─────────────────────────────────────────────────
+
+router.post("/models/:modelId/sync", handle((req, res) => {
+  res.json(runtime.syncFromLive(req.params.modelId, Date.now()));
+}));
+
+router.get("/models/:modelId/compare", handle((req, res) => {
+  res.json({ comparisons: runtime.compare(req.params.modelId) });
+}));
+
+// ── What-if & rollback simulation ──────────────────────────────────────────
+
+router.post("/scenarios", handle((req, res) => {
+  const parsed = ScenarioSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  res.json(runtime.runScenario(parsed.data as WhatIfScenario));
+}));
+
+router.post("/models/:modelId/rollback-simulation", handle((req, res) => {
+  const parsed = RollbackSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  res.json(
+    runtime.simulateRollback(req.params.modelId, parsed.data.applied, parsed.data.durationTicks)
+  );
+}));
+
+// ── Introspection ──────────────────────────────────────────────────────────
+
+router.get("/step-functions", (_req, res) => {
+  res.json({ stepFunctions: listStepFunctions() });
+});
+
+router.get("/status", async (_req, res) => {
+  const health = await digitalTwinService.healthCheck();
+  res.json({ ...runtime.getStatus(), ...health });
+});
+
+export { router as twinRoutes };

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -66,6 +66,10 @@ export { spcService } from './spc';
 export * from './l2-rollup';
 export { l2RollupService } from './l2-rollup';
 
+// ── Digital Twin Service (ADR-0013 [13.3], #214) ─────────────────────────────
+export * from './twin';
+export { digitalTwinService } from './twin';
+
 /**
  * Initialize all services
  * 
@@ -80,7 +84,8 @@ export async function initializeServices(): Promise<void> {
     { name: 'Ubiquity', service: () => import('./ubiquity').then(m => m.ubiquityService.initialize()) },
     { name: 'Layer 2 Rollup', service: () => import('./l2-rollup').then(m => m.l2RollupService.initialize()) },
     { name: 'Optimization', service: () => import('./optimization').then(m => m.optimizationService.initialize()) },
-    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) }
+    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) },
+    { name: 'Digital Twin', service: () => import('./twin').then(m => m.digitalTwinService.initialize()) }
   ];
 
   for (const { name, service } of services) {
@@ -171,6 +176,14 @@ export async function getServicesHealthStatus(): Promise<{
         return await spcService.healthCheck();
       } catch {
         return { healthy: false, message: 'SPC service not available' };
+      }
+    },
+    twin: async () => {
+      try {
+        const { digitalTwinService } = await import('./twin');
+        return await digitalTwinService.healthCheck();
+      } catch {
+        return { healthy: false, message: 'Digital twin service not available' };
       }
     }
   };

--- a/server/services/twin/__tests__/digital-twin.test.ts
+++ b/server/services/twin/__tests__/digital-twin.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Digital Twin Runtime tests
+ * ADR-0013 [13.3] — Issue #214
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { ProcessModel } from '@shared/types/digital-twin';
+import { TwinRuntime } from '../engine';
+import { DigitalTwinService, registerStepFunction, listStepFunctions } from '../index';
+
+/** Valve (maxFlow 10, position 50 → flow 5) feeding a tank draining at 2 */
+function valveTankModel(overrides: Partial<ProcessModel> = {}): ProcessModel {
+  return {
+    id: 'm1',
+    name: 'valve-tank',
+    components: [
+      {
+        id: 'valve-1',
+        type: 'valve',
+        name: 'Feed valve',
+        config: { maxFlow: 10 },
+        initialState: { position: 50 },
+        connections: ['tank-1'],
+      },
+      {
+        id: 'tank-1',
+        type: 'tank',
+        name: 'Buffer tank',
+        // capacity deliberately declared before level — predictions must
+        // come from tag bindings, never from property order
+        config: { capacity: 100, outflow: 2 },
+        initialState: { level: 20 },
+        connections: [],
+      },
+    ],
+    tagBindings: [{ tagId: 'TK-1.LEVEL', componentId: 'tank-1', parameter: 'level' }],
+    stepFunction: 'basic-flow',
+    timeStepMs: 1000,
+    ...overrides,
+  };
+}
+
+describe('basic-flow solver', () => {
+  it('fills the tank linearly — inflow is recomputed each tick, never accumulated', () => {
+    const runtime = new TwinRuntime();
+    runtime.registerModel(valveTankModel());
+
+    // flow 5 in, 2 out → +3/tick, strictly linear (the Wave-2 twin grew
+    // quadratically because inflow accumulated across ticks)
+    const levels: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const state = runtime.step('m1');
+      levels.push(state.componentStates['tank-1'].level);
+    }
+    expect(levels).toEqual([23, 26, 29, 32, 35]);
+  });
+
+  it('clamps tank level at capacity and warns', () => {
+    const runtime = new TwinRuntime();
+    const warnings = vi.fn();
+    runtime.on('model-warnings', warnings);
+    runtime.registerModel(valveTankModel());
+    runtime.step('m1', 60); // +3/tick from 20 → hits capacity 100 within 27 ticks
+
+    const state = runtime.getState('m1')!;
+    expect(state.componentStates['tank-1'].level).toBe(100);
+    expect(warnings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        warnings: expect.arrayContaining([expect.stringContaining('capacity')]),
+      })
+    );
+  });
+
+  it('a P-controller drives its valve to hold the tank at setpoint', () => {
+    const runtime = new TwinRuntime();
+    runtime.registerModel({
+      id: 'ctl',
+      name: 'level control',
+      components: [
+        {
+          id: 'lc-1',
+          type: 'controller',
+          name: 'Level controller',
+          config: { kp: 5, setpoint: 50 },
+          initialState: {},
+          connections: ['valve-1'],
+          pvSource: 'tank-1',
+        },
+        {
+          id: 'valve-1',
+          type: 'valve',
+          name: 'Feed valve',
+          config: { maxFlow: 10 },
+          initialState: { position: 0 },
+          connections: ['tank-1'],
+        },
+        {
+          id: 'tank-1',
+          type: 'tank',
+          name: 'Tank',
+          config: { capacity: 100, outflow: 3 },
+          initialState: { level: 10 },
+          connections: [],
+        },
+      ],
+      tagBindings: [],
+      stepFunction: 'basic-flow',
+      timeStepMs: 1000,
+    });
+
+    runtime.step('ctl', 200);
+    const level = runtime.getState('ctl')!.componentStates['tank-1'].level;
+    // P-control steady state: flow == outflow → 50 − outflow/(kp·maxFlow/100)
+    // = 50 − 3/0.5 = 44 (the classic proportional-only offset)
+    expect(level).toBeCloseTo(44, 1);
+  });
+
+  it('heater temperature rises with power and settles toward equilibrium', () => {
+    const runtime = new TwinRuntime();
+    runtime.registerModel({
+      id: 'h',
+      name: 'heater',
+      components: [
+        {
+          id: 'htr-1',
+          type: 'heater',
+          name: 'Heater',
+          config: { power: 5, heatRate: 0.5, ambient: 20, lossRate: 0.05 },
+          initialState: { temperature: 20 },
+          connections: [],
+        },
+      ],
+      tagBindings: [],
+      stepFunction: 'basic-flow',
+      timeStepMs: 1000,
+    });
+    runtime.step('h', 200);
+    // Equilibrium: power*heatRate/lossRate + ambient = 2.5/0.05 + 20 = 70
+    const temp = runtime.getState('h')!.componentStates['htr-1'].temperature;
+    expect(temp).toBeGreaterThan(60);
+    expect(temp).toBeLessThanOrEqual(70.5);
+  });
+});
+
+describe('model validation', () => {
+  it('rejects unknown step functions at registration, not silently at step time', () => {
+    const runtime = new TwinRuntime();
+    expect(() =>
+      runtime.registerModel(valveTankModel({ stepFunction: 'no-such-solver' }))
+    ).toThrow(/Unknown step function/);
+  });
+
+  it('rejects duplicate component ids and dangling connections', () => {
+    const runtime = new TwinRuntime();
+    const model = valveTankModel();
+    model.components[0].connections = ['ghost'];
+    expect(() => runtime.registerModel(model)).toThrow(/unknown component "ghost"/);
+
+    const dup = valveTankModel();
+    dup.components[1].id = 'valve-1';
+    expect(() => runtime.registerModel(dup)).toThrow(/Duplicate/);
+  });
+
+  it('marks the model errored when a custom solver throws mid-run', () => {
+    registerStepFunction('exploding', () => {
+      throw new Error('numerical instability');
+    });
+    const runtime = new TwinRuntime();
+    const onError = vi.fn();
+    runtime.on('model-error', onError);
+    runtime.registerModel(valveTankModel({ stepFunction: 'exploding' }));
+
+    const state = runtime.step('m1');
+    expect(state.status).toBe('error');
+    expect(state.error).toMatch(/instability/);
+    expect(onError).toHaveBeenCalled();
+    expect(listStepFunctions()).toContain('basic-flow');
+  });
+});
+
+describe('live assimilation and what-if', () => {
+  it('predictions read the bound parameter, not the first state property', () => {
+    const runtime = new TwinRuntime();
+    runtime.registerModel(valveTankModel());
+    const result = runtime.runScenario({
+      id: 's1',
+      name: 'baseline',
+      baseModelId: 'm1',
+      modifications: [],
+      durationTicks: 3,
+      fromLiveState: false,
+    });
+    // level (bound) rises 23, 26, 29 — capacity (first-declared config key)
+    // would have been 100
+    expect(result.predictions['TK-1.LEVEL']).toEqual([23, 26, 29]);
+  });
+
+  it('what-if forks from the live-synced state by default', () => {
+    const runtime = new TwinRuntime();
+    runtime.registerModel(valveTankModel());
+    // Live plant reports the tank at 80, not the authored initial 20
+    runtime.ingestActual('TK-1.LEVEL', 80, 1000);
+    runtime.syncFromLive('m1', 1000);
+
+    const result = runtime.runScenario({
+      id: 's2',
+      name: 'close the valve',
+      baseModelId: 'm1',
+      modifications: [{ componentId: 'valve-1', parameter: 'position', value: 0, target: 'state' }],
+      durationTicks: 3,
+    });
+    // From live level 80 with valve shut: only outflow 2 → 78, 76, 74
+    expect(result.predictions['TK-1.LEVEL']).toEqual([78, 76, 74]);
+  });
+
+  it('scenario runs never mutate the live model or state', () => {
+    const runtime = new TwinRuntime();
+    runtime.registerModel(valveTankModel());
+    runtime.step('m1', 2); // live level 26
+
+    runtime.runScenario({
+      id: 's3',
+      name: 'wide open',
+      baseModelId: 'm1',
+      modifications: [
+        { componentId: 'valve-1', parameter: 'maxFlow', value: 1000 },
+        { componentId: 'valve-1', parameter: 'position', value: 100, target: 'state' },
+      ],
+      durationTicks: 10,
+    });
+
+    expect(runtime.getState('m1')!.componentStates['tank-1'].level).toBe(26);
+    expect(runtime.getModel('m1')!.components[0].config.maxFlow).toBe(10);
+  });
+
+  it('simulates rollback by restoring registered-model values from live state', () => {
+    const runtime = new TwinRuntime();
+    runtime.registerModel(valveTankModel());
+    // Operator opened the valve wide (applied change); tank is now at 60
+    runtime.ingestActual('TK-1.LEVEL', 60, 1000);
+    runtime.syncFromLive('m1', 1000);
+
+    const rollback = runtime.simulateRollback(
+      'm1',
+      [{ componentId: 'valve-1', parameter: 'position', value: 100, target: 'state' }],
+      3
+    );
+    // Restores position to the authored initialState value (50) → +3/tick
+    expect(rollback.restoredValues).toEqual([
+      { componentId: 'valve-1', parameter: 'position', value: 50, target: 'state' },
+    ]);
+    expect(rollback.result.predictions['TK-1.LEVEL']).toEqual([63, 66, 69]);
+  });
+
+  it('compares predicted vs actual with relative divergence', () => {
+    const runtime = new TwinRuntime({ divergenceTolerance: 0.05 });
+    runtime.registerModel(valveTankModel());
+    runtime.step('m1'); // predicted level 23
+
+    runtime.ingestActual('TK-1.LEVEL', 23.5, 2000);
+    let [comparison] = runtime.compare('m1');
+    expect(comparison.predicted).toBe(23);
+    expect(comparison.actual).toBe(23.5);
+    expect(comparison.withinTolerance).toBe(true);
+
+    runtime.ingestActual('TK-1.LEVEL', 60, 3000);
+    [comparison] = runtime.compare('m1');
+    expect(comparison.withinTolerance).toBe(false);
+  });
+});
+
+describe('DigitalTwinService', () => {
+  it('filters non-numeric and non-good tag updates', () => {
+    const service = new DigitalTwinService();
+    service.runtime.registerModel(valveTankModel());
+
+    service.ingestTagUpdate({ tagName: 'TK-1.LEVEL', value: 42, timestamp: 1000, quality: 'bad' });
+    service.ingestTagUpdate({ tagName: 'TK-1.LEVEL', value: 'running', timestamp: 2000 });
+    service.ingestTagUpdate({ tagName: 'TK-1.LEVEL', value: '', timestamp: 2500 });
+    service.runtime.syncFromLive('m1', 3000);
+    expect(service.runtime.getState('m1')!.componentStates['tank-1'].level).toBe(20);
+
+    service.ingestTagUpdate({ tagName: 'TK-1.LEVEL', value: '55.5', timestamp: 4000, quality: 'good' });
+    service.runtime.syncFromLive('m1', 5000);
+    expect(service.runtime.getState('m1')!.componentStates['tank-1'].level).toBe(55.5);
+  });
+
+  it('reports health based on initialization', async () => {
+    const service = new DigitalTwinService();
+    expect((await service.healthCheck()).healthy).toBe(false);
+    await service.initialize();
+    expect((await service.healthCheck()).healthy).toBe(true);
+    await service.shutdown();
+    expect((await service.healthCheck()).healthy).toBe(false);
+  });
+});

--- a/server/services/twin/engine.ts
+++ b/server/services/twin/engine.ts
@@ -1,0 +1,346 @@
+/**
+ * Digital Twin Runtime
+ * ADR-0013 [13.3] — Issue #214
+ *
+ * Maintains per-model simulation state, assimilates live tag data through
+ * explicit tag bindings, and answers what-if / rollback questions by
+ * forking the current state into isolated scenario runs. The runtime is
+ * strictly read-only toward the plant: it never emits control writes
+ * (ADR-0009 — twins are the sandbox, not the actuator).
+ */
+
+import { EventEmitter } from 'events';
+import type {
+  ProcessModel,
+  RollbackSimulationResult,
+  ScenarioModification,
+  SimulationResult,
+  SimulationState,
+  TwinComparison,
+  WhatIfScenario,
+} from '@shared/types/digital-twin';
+import { getStepFunction, seedStates, type ComponentStates } from './solver';
+
+export interface TwinRuntimeOptions {
+  /** Max models registered at once */
+  maxModels?: number;
+  /** Max ticks a single scenario run may simulate */
+  maxScenarioTicks?: number;
+  /** Relative divergence below which predicted ≈ actual */
+  divergenceTolerance?: number;
+}
+
+interface ModelEntry {
+  model: ProcessModel;
+  state: SimulationState;
+  /** Latest live values per bound tag */
+  actuals: Map<string, { value: number; timestamp: number }>;
+}
+
+export class TwinRuntime extends EventEmitter {
+  private readonly maxModels: number;
+  private readonly maxScenarioTicks: number;
+  private readonly divergenceTolerance: number;
+
+  private entries: Map<string, ModelEntry> = new Map();
+
+  constructor(options: TwinRuntimeOptions = {}) {
+    super();
+    this.maxModels = options.maxModels ?? 100;
+    this.maxScenarioTicks = options.maxScenarioTicks ?? 100_000;
+    this.divergenceTolerance = options.divergenceTolerance ?? 0.05;
+  }
+
+  // ── Model registry ───────────────────────────────────────────────────
+
+  registerModel(model: ProcessModel): SimulationState {
+    this.validateModel(model);
+    if (!this.entries.has(model.id) && this.entries.size >= this.maxModels) {
+      throw new Error(`Model limit (${this.maxModels}) reached`);
+    }
+    const state: SimulationState = {
+      modelId: model.id,
+      tick: 0,
+      timeMs: 0,
+      componentStates: seedStates(model),
+      status: 'idle',
+    };
+    this.entries.set(model.id, { model, state, actuals: new Map() });
+    return state;
+  }
+
+  getModel(modelId: string): ProcessModel | undefined {
+    return this.entries.get(modelId)?.model;
+  }
+
+  listModels(): Array<{ model: ProcessModel; state: SimulationState }> {
+    return Array.from(this.entries.values()).map((e) => ({ model: e.model, state: e.state }));
+  }
+
+  removeModel(modelId: string): boolean {
+    return this.entries.delete(modelId);
+  }
+
+  getState(modelId: string): SimulationState | undefined {
+    return this.entries.get(modelId)?.state;
+  }
+
+  setRunning(modelId: string, running: boolean): SimulationState {
+    const entry = this.require(modelId);
+    if (entry.state.status !== 'error') {
+      entry.state.status = running ? 'running' : 'idle';
+    } else if (running) {
+      // Explicit restart clears a previous solver error
+      entry.state.status = 'running';
+      entry.state.error = undefined;
+    }
+    return entry.state;
+  }
+
+  resetModel(modelId: string): SimulationState {
+    const entry = this.require(modelId);
+    entry.state = {
+      modelId,
+      tick: 0,
+      timeMs: 0,
+      componentStates: seedStates(entry.model),
+      status: 'idle',
+    };
+    return entry.state;
+  }
+
+  // ── Live data assimilation ───────────────────────────────────────────
+
+  /**
+   * Record a live tag value. It is applied to bound component parameters
+   * on the next sync, so the twin tracks the real plant.
+   */
+  ingestActual(tagId: string, value: number, timestamp: number): void {
+    if (!Number.isFinite(value) || !Number.isFinite(timestamp)) return;
+    for (const entry of this.entries.values()) {
+      if (entry.model.tagBindings.some((b) => b.tagId === tagId)) {
+        entry.actuals.set(tagId, { value, timestamp });
+      }
+    }
+  }
+
+  /** Write recorded actuals into the simulation state via tag bindings */
+  syncFromLive(modelId: string, nowMs: number): SimulationState {
+    const entry = this.require(modelId);
+    for (const binding of entry.model.tagBindings) {
+      const actual = entry.actuals.get(binding.tagId);
+      if (!actual) continue;
+      const componentState = entry.state.componentStates[binding.componentId];
+      if (componentState) {
+        componentState[binding.parameter] = actual.value;
+      }
+    }
+    entry.state.lastSyncAt = nowMs;
+    return entry.state;
+  }
+
+  // ── Simulation stepping ──────────────────────────────────────────────
+
+  /** Advance the live simulation state by n ticks */
+  step(modelId: string, ticks = 1): SimulationState {
+    const entry = this.require(modelId);
+    const warnings: string[] = [];
+    try {
+      const stepFn = getStepFunction(entry.model.stepFunction);
+      for (let i = 0; i < ticks; i++) {
+        entry.state.componentStates = stepFn(
+          entry.model,
+          entry.state.componentStates,
+          entry.model.timeStepMs,
+          warnings
+        );
+        entry.state.tick++;
+        entry.state.timeMs += entry.model.timeStepMs;
+      }
+    } catch (error) {
+      entry.state.status = 'error';
+      entry.state.error = error instanceof Error ? error.message : String(error);
+      this.emit('model-error', { modelId, error: entry.state.error });
+      return entry.state;
+    }
+    if (warnings.length > 0) {
+      this.emit('model-warnings', { modelId, warnings });
+    }
+    return entry.state;
+  }
+
+  /** Step every running model — the service's periodic driver */
+  stepRunning(): void {
+    for (const [modelId, entry] of this.entries) {
+      if (entry.state.status === 'running') {
+        this.step(modelId, 1);
+      }
+    }
+  }
+
+  // ── What-if, prediction, rollback ────────────────────────────────────
+
+  /**
+   * Run a scenario in an isolated fork. By default the fork starts from
+   * the CURRENT (live-synced) state — predicting "what happens if we make
+   * this change now", not "what would happen from authored initial
+   * conditions" (the Wave-2 flaw). The live state is never touched.
+   */
+  runScenario(scenario: WhatIfScenario): SimulationResult {
+    const entry = this.require(scenario.baseModelId);
+    if (scenario.durationTicks < 1 || scenario.durationTicks > this.maxScenarioTicks) {
+      throw new Error(`durationTicks must be 1..${this.maxScenarioTicks}`);
+    }
+
+    const warnings: string[] = [];
+    const fromLive = scenario.fromLiveState !== false;
+    let states: ComponentStates = fromLive
+      ? structuredClone(entry.state.componentStates)
+      : seedStates(entry.model);
+
+    // Apply modifications to a scenario-local model clone (config) and the
+    // forked states (state) — the registered model must stay pristine.
+    const model: ProcessModel = structuredClone(entry.model);
+    for (const mod of scenario.modifications) {
+      const component = model.components.find((c) => c.id === mod.componentId);
+      if (!component) {
+        warnings.push(`modification targets unknown component "${mod.componentId}"`);
+        continue;
+      }
+      if (mod.target === 'state') {
+        states[mod.componentId] = { ...states[mod.componentId], [mod.parameter]: mod.value };
+      } else {
+        component.config[mod.parameter] = mod.value;
+      }
+    }
+
+    const stepFn = getStepFunction(model.stepFunction);
+    const predictions: Record<string, number[]> = {};
+    for (const binding of model.tagBindings) {
+      predictions[binding.tagId] = [];
+    }
+
+    for (let tick = 0; tick < scenario.durationTicks; tick++) {
+      states = stepFn(model, states, model.timeStepMs, warnings);
+      for (const binding of model.tagBindings) {
+        predictions[binding.tagId].push(
+          states[binding.componentId]?.[binding.parameter] ?? NaN
+        );
+      }
+    }
+
+    return {
+      scenarioId: scenario.id,
+      baseModelId: scenario.baseModelId,
+      ticks: scenario.durationTicks,
+      predictions,
+      finalState: states,
+      warnings: [...new Set(warnings)],
+    };
+  }
+
+  /**
+   * Simulate reverting already-applied modifications: restores each listed
+   * parameter to the registered model's value and runs forward from the
+   * current live-synced state.
+   */
+  simulateRollback(
+    modelId: string,
+    applied: ScenarioModification[],
+    durationTicks: number
+  ): RollbackSimulationResult {
+    const entry = this.require(modelId);
+    const restoredValues: ScenarioModification[] = [];
+    for (const mod of applied) {
+      const component = entry.model.components.find((c) => c.id === mod.componentId);
+      if (!component) continue;
+      const original =
+        mod.target === 'state'
+          ? component.initialState[mod.parameter]
+          : component.config[mod.parameter];
+      if (original !== undefined) {
+        restoredValues.push({ ...mod, value: original });
+      }
+    }
+
+    const result = this.runScenario({
+      id: `rollback-${modelId}`,
+      name: `Rollback simulation for ${modelId}`,
+      baseModelId: modelId,
+      modifications: restoredValues,
+      durationTicks,
+      fromLiveState: true,
+    });
+
+    return { modelId, restoredValues, result };
+  }
+
+  /** Compare current simulated values against the latest live actuals */
+  compare(modelId: string): TwinComparison[] {
+    const entry = this.require(modelId);
+    return entry.model.tagBindings.map((binding) => {
+      const predicted =
+        entry.state.componentStates[binding.componentId]?.[binding.parameter] ?? null;
+      const actual = entry.actuals.get(binding.tagId)?.value ?? null;
+      let divergence: number | null = null;
+      if (predicted !== null && actual !== null) {
+        const scale = Math.max(Math.abs(actual), Math.abs(predicted), 1e-9);
+        divergence = Math.abs(predicted - actual) / scale;
+      }
+      return {
+        tagId: binding.tagId,
+        predicted,
+        actual,
+        divergence,
+        withinTolerance: divergence !== null && divergence <= this.divergenceTolerance,
+      };
+    });
+  }
+
+  getStatus(): {
+    models: number;
+    running: number;
+    boundTags: number;
+  } {
+    let running = 0;
+    let boundTags = 0;
+    for (const entry of this.entries.values()) {
+      if (entry.state.status === 'running') running++;
+      boundTags += entry.model.tagBindings.length;
+    }
+    return { models: this.entries.size, running, boundTags };
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────
+
+  private require(modelId: string): ModelEntry {
+    const entry = this.entries.get(modelId);
+    if (!entry) throw new Error(`Unknown model "${modelId}"`);
+    return entry;
+  }
+
+  private validateModel(model: ProcessModel): void {
+    getStepFunction(model.stepFunction); // throws on unknown solver
+    if (model.timeStepMs <= 0) throw new Error('timeStepMs must be positive');
+    const ids = new Set<string>();
+    for (const comp of model.components) {
+      if (ids.has(comp.id)) throw new Error(`Duplicate component id "${comp.id}"`);
+      ids.add(comp.id);
+    }
+    for (const comp of model.components) {
+      for (const target of comp.connections) {
+        if (!ids.has(target)) {
+          throw new Error(`Component "${comp.id}" connects to unknown component "${target}"`);
+        }
+      }
+      if (comp.pvSource && !ids.has(comp.pvSource)) {
+        throw new Error(`Controller "${comp.id}" pvSource "${comp.pvSource}" does not exist`);
+      }
+    }
+    for (const binding of model.tagBindings) {
+      if (!ids.has(binding.componentId)) {
+        throw new Error(`Tag binding "${binding.tagId}" references unknown component`);
+      }
+    }
+  }
+}

--- a/server/services/twin/index.ts
+++ b/server/services/twin/index.ts
@@ -1,0 +1,92 @@
+/**
+ * Digital Twin Service
+ * ADR-0013 [13.3] — Issue #214
+ *
+ * Singleton wrapper: drives running models on their time step, feeds live
+ * tag updates into the runtime (numeric, good-quality readings only), and
+ * exposes health. Read-only toward the plant — predictions never become
+ * control writes here.
+ */
+
+import { EventEmitter } from 'events';
+
+export * from './solver';
+export * from './engine';
+
+import { TwinRuntime } from './engine';
+
+export interface TwinTagUpdateInput {
+  tagName: string;
+  value: number | string | boolean;
+  timestamp: string | number;
+  quality?: 'good' | 'bad' | 'uncertain';
+}
+
+export class DigitalTwinService extends EventEmitter {
+  readonly runtime = new TwinRuntime();
+
+  private initialized = false;
+  private stepTimer: NodeJS.Timeout | null = null;
+  private readonly stepIntervalMs: number;
+
+  constructor(stepIntervalMs = 1000) {
+    super();
+    this.stepIntervalMs = stepIntervalMs;
+    this.runtime.on('model-error', (e) => this.emit('model-error', e));
+    this.runtime.on('model-warnings', (e) => this.emit('model-warnings', e));
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+    this.stepTimer = setInterval(() => {
+      try {
+        const now = Date.now();
+        for (const { model, state } of this.runtime.listModels()) {
+          if (state.status === 'running') {
+            this.runtime.syncFromLive(model.id, now);
+          }
+        }
+        this.runtime.stepRunning();
+      } catch {
+        /* per-model errors surface via 'model-error' */
+      }
+    }, this.stepIntervalMs);
+    this.stepTimer.unref?.();
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.stepTimer) {
+      clearInterval(this.stepTimer);
+      this.stepTimer = null;
+    }
+    this.initialized = false;
+  }
+
+  /** Feed a live tag update — non-numeric or non-good readings are ignored */
+  ingestTagUpdate(update: TwinTagUpdateInput): void {
+    if (update.quality !== undefined && update.quality !== 'good') return;
+    if (typeof update.value === 'boolean') return;
+    if (typeof update.value === 'string' && update.value.trim() === '') return;
+    const value = typeof update.value === 'number' ? update.value : Number(update.value);
+    if (!Number.isFinite(value)) return;
+    const timestamp =
+      typeof update.timestamp === 'number'
+        ? update.timestamp
+        : new Date(update.timestamp).getTime();
+    if (!Number.isFinite(timestamp)) return;
+    this.runtime.ingestActual(update.tagName, value, timestamp);
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
+    const status = this.runtime.getStatus();
+    return {
+      healthy: this.initialized,
+      message: this.initialized
+        ? `Digital twin running: ${status.models} models (${status.running} live), ${status.boundTags} bound tags`
+        : 'Digital twin service not initialized',
+    };
+  }
+}
+
+export const digitalTwinService = new DigitalTwinService();

--- a/server/services/twin/solver.ts
+++ b/server/services/twin/solver.ts
@@ -1,0 +1,192 @@
+/**
+ * Twin Solver — component step functions
+ * ADR-0013 [13.3] — Issue #214
+ *
+ * Fixed-timestep explicit-Euler process dynamics. Step functions are
+ * registered by name so ProcessModel stays JSON-serializable; an unknown
+ * name is a hard error, never a silent no-op.
+ *
+ * Flow semantics (fixes the Wave-2 accumulating-inflow bug): flows are
+ * recomputed from sources and connections every tick — tank inflow is
+ * derived state, zeroed and re-aggregated each step, never carried over.
+ */
+
+import type { ProcessComponent, ProcessModel } from '@shared/types/digital-twin';
+
+export type ComponentStates = Record<string, Record<string, number>>;
+
+export type StepFunction = (
+  model: ProcessModel,
+  states: ComponentStates,
+  dtMs: number,
+  warnings: string[]
+) => ComponentStates;
+
+const registry = new Map<string, StepFunction>();
+
+export function registerStepFunction(name: string, fn: StepFunction): void {
+  registry.set(name, fn);
+}
+
+export function getStepFunction(name: string): StepFunction {
+  const fn = registry.get(name);
+  if (!fn) {
+    throw new Error(
+      `Unknown step function "${name}" — registered: ${[...registry.keys()].join(', ') || '(none)'}`
+    );
+  }
+  return fn;
+}
+
+export function listStepFunctions(): string[] {
+  return [...registry.keys()];
+}
+
+/** Seed each component's state from initialState (config stays separate) */
+export function seedStates(model: ProcessModel): ComponentStates {
+  const states: ComponentStates = {};
+  for (const comp of model.components) {
+    states[comp.id] = { ...comp.initialState };
+  }
+  return states;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * 'basic-flow': tanks, valves, pumps, pipes, heaters, P-controllers.
+ *
+ * Pass 1 — sources: valves/pumps compute currentFlow from config + state.
+ * Pass 2 — controllers: P-control output drives connected actuators
+ *          (valve position / pump speed) inside the simulation.
+ * Pass 3 — aggregation: tank inflow = Σ currentFlow of components that
+ *          connect into it (recomputed from zero every tick).
+ * Pass 4 — integration: tank levels and heater temperatures advance by dt.
+ */
+export const basicFlowStep: StepFunction = (model, states, dtMs, warnings) => {
+  const dt = dtMs / 1000;
+  const next: ComponentStates = {};
+  const byId = new Map<string, ProcessComponent>(model.components.map((c) => [c.id, c]));
+
+  for (const comp of model.components) {
+    next[comp.id] = { ...(states[comp.id] ?? comp.initialState) };
+  }
+
+  // Pass 1 — actuator/source flows
+  for (const comp of model.components) {
+    const s = next[comp.id];
+    switch (comp.type) {
+      case 'valve': {
+        const maxFlow = comp.config.maxFlow ?? 0;
+        const position = clamp(s.position ?? 0, 0, 100);
+        s.position = position;
+        s.currentFlow = maxFlow * (position / 100);
+        break;
+      }
+      case 'pump': {
+        const maxFlow = comp.config.maxFlow ?? 0;
+        const running = (s.running ?? 1) > 0 ? 1 : 0;
+        const speed = clamp(s.speed ?? 100, 0, 100);
+        s.speed = speed;
+        s.currentFlow = running * maxFlow * (speed / 100);
+        break;
+      }
+      case 'pipe': {
+        // Pipes relay the flow of whatever feeds them; resolved in pass 3.
+        s.currentFlow = 0;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  // Pass 2 — P-controllers drive connected actuators
+  for (const comp of model.components) {
+    if (comp.type !== 'controller') continue;
+    const s = next[comp.id];
+    const kp = comp.config.kp ?? 1;
+    const setpoint = comp.config.setpoint ?? s.setpoint ?? 0;
+    let pv = s.processVariable ?? 0;
+    if (comp.pvSource) {
+      const source = next[comp.pvSource];
+      if (source) {
+        pv = source.level ?? source.temperature ?? pv;
+      } else {
+        warnings.push(`controller "${comp.id}" pvSource "${comp.pvSource}" not found`);
+      }
+    }
+    const output = clamp(kp * (setpoint - pv), 0, 100);
+    s.processVariable = pv;
+    s.output = output;
+
+    for (const targetId of comp.connections) {
+      const target = byId.get(targetId);
+      if (!target) {
+        warnings.push(`controller "${comp.id}" connects to unknown component "${targetId}"`);
+        continue;
+      }
+      if (target.type === 'valve') next[targetId].position = output;
+      else if (target.type === 'pump') next[targetId].speed = output;
+    }
+  }
+
+  // Pass 3 — aggregate flows into tanks (inflow recomputed from zero)
+  for (const comp of model.components) {
+    if (comp.type === 'tank') next[comp.id].inflow = 0;
+  }
+  for (const comp of model.components) {
+    if (comp.type !== 'valve' && comp.type !== 'pump' && comp.type !== 'pipe') continue;
+    const flow = next[comp.id].currentFlow ?? 0;
+    for (const targetId of comp.connections) {
+      const target = byId.get(targetId);
+      if (!target) {
+        warnings.push(`component "${comp.id}" connects to unknown component "${targetId}"`);
+        continue;
+      }
+      if (target.type === 'tank') {
+        next[targetId].inflow = (next[targetId].inflow ?? 0) + flow;
+      } else if (target.type === 'pipe') {
+        next[targetId].currentFlow = (next[targetId].currentFlow ?? 0) + flow;
+      }
+    }
+  }
+
+  // Pass 4 — integrate tank levels and heater temperatures
+  for (const comp of model.components) {
+    const s = next[comp.id];
+    switch (comp.type) {
+      case 'tank': {
+        const capacity = comp.config.capacity ?? Number.MAX_SAFE_INTEGER;
+        const outflow = s.outflow ?? comp.config.outflow ?? 0;
+        const level = clamp((s.level ?? 0) + ((s.inflow ?? 0) - outflow) * dt, 0, capacity);
+        if (level === 0 && (s.level ?? 0) + ((s.inflow ?? 0) - outflow) * dt < 0) {
+          warnings.push(`tank "${comp.id}" ran empty`);
+        }
+        if (level === capacity) {
+          warnings.push(`tank "${comp.id}" reached capacity`);
+        }
+        s.level = level;
+        s.fillPercent = capacity > 0 ? (level / capacity) * 100 : 0;
+        break;
+      }
+      case 'heater': {
+        const power = s.power ?? comp.config.power ?? 0;
+        const heatRate = comp.config.heatRate ?? 0.1;
+        const ambient = comp.config.ambient ?? 20;
+        const lossRate = comp.config.lossRate ?? 0.01;
+        const temp = s.temperature ?? ambient;
+        s.temperature = temp + (power * heatRate - (temp - ambient) * lossRate) * dt;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return next;
+};
+
+registerStepFunction('basic-flow', basicFlowStep);

--- a/server/websocket/tag-stream.ts
+++ b/server/websocket/tag-stream.ts
@@ -46,6 +46,24 @@ export class TagStreamServer {
   private totalUpdates = 0;
   private startTime = Date.now();
   private pingInterval?: ReturnType<typeof setInterval>;
+  private updateListeners: Array<(update: TagUpdate) => void> = [];
+
+  /**
+   * Register a server-side listener for every tag update flowing through the
+   * stream (e.g. predictive maintenance ingestion). Listener errors are
+   * swallowed so a consumer can never break broadcasting.
+   */
+  onTagUpdate(listener: (update: TagUpdate) => void): void {
+    this.updateListeners.push(listener);
+  }
+
+  private notifyListeners(update: TagUpdate): void {
+    for (const listener of this.updateListeners) {
+      try {
+        listener(update);
+      } catch { /* consumer error — never disrupt broadcasting */ }
+    }
+  }
 
   initialize(httpServer: HttpServer, path = "/ws/tags"): void {
     this.wss = new WebSocketServer({ noServer: true });
@@ -112,6 +130,7 @@ export class TagStreamServer {
   broadcastTagUpdate(update: TagUpdate): void {
     this.latestValues.set(update.tagName, update);
     this.totalUpdates++;
+    this.notifyListeners(update);
 
     const message = JSON.stringify({ event: "tag:update", payload: update });
 
@@ -167,6 +186,7 @@ export class TagStreamServer {
   broadcastBatch(updates: TagUpdate[]): void {
     for (const u of updates) {
       this.latestValues.set(u.tagName, u);
+      this.notifyListeners(u);
     }
     this.totalUpdates += updates.length;
 

--- a/shared/types/digital-twin.ts
+++ b/shared/types/digital-twin.ts
@@ -1,0 +1,125 @@
+/**
+ * Digital Twin Runtime Types
+ * ADR-0013 [13.3] — Issue #214
+ *
+ * Component-model process simulation: tanks, pipes, valves, pumps,
+ * controllers. Models are plain JSON (step functions referenced by name),
+ * so they can be persisted and transported. The twin is strictly
+ * read-only toward the real plant: it consumes live tag data and produces
+ * predictions — it never writes control outputs (ADR-0009).
+ */
+
+export type ComponentType =
+  | 'tank'
+  | 'pipe'
+  | 'valve'
+  | 'pump'
+  | 'controller'
+  | 'sensor'
+  | 'heater'
+  | 'mixer';
+
+/**
+ * A process component. `config` is static configuration (capacity, maxFlow,
+ * kp); `initialState` seeds the mutable simulation state (level, position).
+ * The two are deliberately separate — the Wave-2 twin conflated them.
+ *
+ * `connections` are DIRECTED downstream edges (this component feeds the
+ * listed components): valve/pump/pipe flow pushes into connected tanks,
+ * controller output drives connected valve position / pump speed.
+ */
+export interface ProcessComponent {
+  id: string;
+  type: ComponentType;
+  name: string;
+  config: Record<string, number>;
+  initialState: Record<string, number>;
+  connections: string[];
+  /**
+   * Controllers only: id of the component whose level/temperature is the
+   * process variable this controller regulates.
+   */
+  pvSource?: string;
+}
+
+/**
+ * Explicit tag → (component, parameter) binding. Live values assimilate
+ * into exactly this parameter, and predictions for the tag read exactly
+ * this parameter — never "the first property of the state object".
+ */
+export interface TagBinding {
+  tagId: string;
+  componentId: string;
+  parameter: string;
+}
+
+export interface ProcessModel {
+  id: string;
+  name: string;
+  description?: string;
+  components: ProcessComponent[];
+  tagBindings: TagBinding[];
+  /** Name of a registered step function — keeps models JSON-serializable */
+  stepFunction: string;
+  timeStepMs: number;
+}
+
+export type SimulationStatus = 'idle' | 'running' | 'error';
+
+export interface SimulationState {
+  modelId: string;
+  tick: number;
+  timeMs: number;
+  componentStates: Record<string, Record<string, number>>;
+  status: SimulationStatus;
+  error?: string;
+  /** Wall-clock ms of the last live-data assimilation, if any */
+  lastSyncAt?: number;
+}
+
+export interface ScenarioModification {
+  componentId: string;
+  parameter: string;
+  value: number;
+  /** Whether the parameter lives in config (default) or mutable state */
+  target?: 'config' | 'state';
+}
+
+export interface WhatIfScenario {
+  id: string;
+  name: string;
+  baseModelId: string;
+  modifications: ScenarioModification[];
+  durationTicks: number;
+  /**
+   * Fork from the current (live-synced) simulation state — the default.
+   * false replays from the model's authored initial conditions instead.
+   */
+  fromLiveState?: boolean;
+}
+
+export interface SimulationResult {
+  scenarioId: string;
+  baseModelId: string;
+  ticks: number;
+  /** Predicted series per bound tag, one value per tick */
+  predictions: Record<string, number[]>;
+  finalState: Record<string, Record<string, number>>;
+  warnings: string[];
+}
+
+export interface TwinComparison {
+  tagId: string;
+  predicted: number | null;
+  actual: number | null;
+  divergence: number | null;
+  withinTolerance: boolean;
+}
+
+/** Result of simulating the reversal of already-applied modifications */
+export interface RollbackSimulationResult {
+  modelId: string;
+  /** The parameter values the rollback would restore */
+  restoredValues: ScenarioModification[];
+  result: SimulationResult;
+}


### PR DESCRIPTION
Closes #214

Rebuilds the Digital Twin Runtime from ADR-0013 [13.3]. (The Wave 2 implementation from PR #220 was lost in restructure `6f9d9219c`; recon of that code found three confirmed defects, all fixed here by construction.)

## What's included

**Solver** (`server/services/twin/solver.ts`)
- Fixed-timestep explicit-Euler dynamics for tanks, pipes, valves, pumps, heaters, and P-controllers
- Flows are recomputed from sources and directed connections **every tick** — the Wave 2 twin carried tank inflow across ticks and added to it, so levels grew quadratically until the capacity clamp hid it. A regression test pins exact linear fill.
- Step functions are registered by name so models stay pure JSON; an unknown name is a hard error at model registration, never a silent null
- Controllers regulate a declared `pvSource` component and drive connected valve position / pump speed inside the simulation

**Runtime** (`server/services/twin/engine.ts`)
- Explicit `tagId → (componentId, parameter)` bindings for live-data assimilation *and* predictions — Wave 2 read `Object.values(state)[0]`, making predictions depend on property declaration order
- **What-if scenarios fork from the current live-synced state by default** (Wave 2 always replayed cold authored initial conditions, so "predict before applying" never reflected the actual plant). Scenario runs are isolated: the live model and state are never mutated.
- **Rollback simulation**: restores the registered model's values for a set of applied modifications and projects the recovery trajectory from live state
- Predicted-vs-actual comparison per bound tag with relative divergence and tolerance
- Config vs mutable state separated; model validation rejects duplicate ids, dangling connections, and missing pvSources at registration

**ADR-0009/0013 posture**: the twin is strictly read-only toward the plant. It consumes the existing tag stream (via the same `onTagUpdate` hook PR #493 introduces — identical hunks, merges cleanly) and produces predictions; there is deliberately no control-write path.

**API** — `/api/twin`: model CRUD, start/stop/reset/step, state, sync, compare, what-if scenarios, rollback simulation, step-function introspection, status. Zod-validated with bounded inputs, auth placeholder matching sibling routers, engine validation errors mapped to 400s. The mock `/api/intelligence/digitaltwin/*` endpoints are left untouched (all four ADR-0013 branches would conflict in that file); they can be retired once this merges.

## Testing
- 14 unit tests: linear-fill regression, capacity clamp warnings, P-controller steady state (analytic offset), heater equilibrium, validation errors, solver-error surfacing, binding-driven predictions, live-state forking, scenario isolation, rollback restoration, divergence comparison, ingestion filtering
- Full suite: 1194 tests pass; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)