### PR TITLE
[13.4] Auto-Tuning PID Controllers (ADR-0013)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,8 @@ import pidRoutes from "./routes/pid";
 import { fluxRoutes } from "./routes/flux";
 import { gatewayRoutes } from "./routes/gateway";
 import { intelligenceRoutes } from "./routes/intelligence";
+import { tuningRoutes } from "./routes/tuning";
+import { tuningService } from "./services/tuning";
 import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
@@ -52,6 +54,7 @@ export async function registerRoutes(
 
   // P1 Wiring: Intelligence, Governance, and Security modules
   app.use("/api/intelligence", intelligenceRoutes);
+  app.use("/api/tuning", tuningRoutes);  // ADR-0013 [13.4] (#215)
   app.use("/api/governance", governanceRoutes);
   app.use("/api/security", securityRoutes);
   app.use("/api/geometry", geometryRoutes(getFluxPublisher()));
@@ -80,6 +83,10 @@ export async function registerRoutes(
   // WebSocket servers initialize if available
   try { tagStreamServer?.initialize(httpServer, "/ws/tags"); } catch {}
   try { unifiedStreamServer?.initialize(httpServer, "/ws"); } catch {}  // unified endpoint (#255)
+
+  // Start the tuning service (and its underlying optimization service)
+  // here — services/initializeServices() has no callers at startup (#215).
+  void tuningService.initialize();
 
   // WebSocket metrics endpoint. The legacy event-stream server was removed;
   // only the tag and unified streams report (#446, #479).

--- a/server/routes/tuning.ts
+++ b/server/routes/tuning.ts
@@ -1,0 +1,244 @@
+/**
+ * PID Tuning API
+ * ADR-0013 [13.4] — Issue #215
+ *
+ * REST surface for human-gated PID auto-tuning: loop registry with
+ * safety envelopes, relay/Cohen-Coon/RL tuning (all simulation-based,
+ * all producing approval-gated proposals), and the approve/reject gate.
+ * Mounted at /api/tuning — /api/pid is semantically claimed by P&ID
+ * diagrams. forceGains is deliberately not exposed.
+ */
+
+import { Router } from "express";
+import type { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+import { tuningService } from "../services/tuning";
+
+const router = Router();
+
+// Auth middleware placeholder — same pattern as other protected routes
+function requireAuth(req: Request, res: Response, next: NextFunction) {
+  // TODO: implement real auth check (JWT / session validation)
+  next();
+}
+router.use(requireAuth);
+
+/** Async handler wrapper (Express 4 does not catch async rejections) */
+function asyncHandler(fn: (req: Request, res: Response) => Promise<unknown>) {
+  return (req: Request, res: Response) => {
+    fn(req, res).catch((error) => {
+      if (!res.headersSent) {
+        res.status(400).json({ error: error instanceof Error ? error.message : "Invalid request" });
+      }
+    });
+  };
+}
+
+// ── Schemas ────────────────────────────────────────────────────────────────
+
+const GainsSchema = z.object({
+  kp: z.number().finite().min(0),
+  ki: z.number().finite().min(0),
+  kd: z.number().finite().min(0),
+});
+
+const RangeSchema = z
+  .object({ min: z.number().finite().min(0), max: z.number().finite() })
+  .refine((r) => r.min <= r.max, { message: "min must not exceed max" });
+
+const EnvelopeSchema = z.object({
+  kpRange: RangeSchema,
+  kiRange: RangeSchema,
+  kdRange: RangeSchema,
+});
+
+const LoopSchema = z.object({
+  id: z.string().min(1).max(128),
+  name: z.string().min(1).max(256),
+  gains: GainsSchema,
+  setpoint: z.number().finite(),
+  outputMin: z.number().finite(),
+  outputMax: z.number().finite(),
+  maxGainChangeFraction: z.number().gt(0).lte(1).optional(),
+  sampleTime: z.number().positive().optional(),
+  envelope: EnvelopeSchema.optional(),
+}).refine((l) => l.outputMin < l.outputMax, { message: "outputMin must be below outputMax" });
+
+const ModelSchema = z.object({
+  gain: z.number().finite().refine((g) => g !== 0, { message: "gain must be non-zero" }),
+  timeConstantS: z.number().positive().max(86_400),
+  deadTimeS: z.number().min(0).max(3600),
+  noiseSigma: z.number().min(0).optional(),
+});
+
+const RelaySchema = z.object({
+  model: ModelSchema,
+  relayAmplitude: z.number().positive().optional(),
+  hysteresis: z.number().positive().optional(),
+  minCycles: z.number().int().min(2).max(20).optional(),
+  dtS: z.number().positive().max(60).optional(),
+});
+
+const RLSchema = z.object({
+  model: ModelSchema,
+  config: z
+    .object({
+      episodes: z.number().int().min(1).max(500),
+      episodeTicks: z.number().int().min(10).max(10_000),
+      dtS: z.number().positive().max(60),
+      epsilon: z.number().min(0).max(1),
+      epsilonDecay: z.number().gt(0).lte(1),
+      learningRate: z.number().gt(0).lte(1),
+      discount: z.number().min(0).lte(1),
+      overshootPenalty: z.number().min(0),
+      oscillationPenalty: z.number().min(0),
+      seed: z.number().int().optional(),
+    })
+    .partial()
+    .optional(),
+});
+
+const DecisionSchema = z.object({
+  approver: z.string().min(1).max(128),
+  comment: z.string().max(2000).optional(),
+});
+
+// ── Loop registry ──────────────────────────────────────────────────────────
+
+router.post("/loops", (req, res) => {
+  const parsed = LoopSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  try {
+    const { controller, envelope } = tuningService.registerLoop(parsed.data);
+    res.status(201).json({
+      id: controller.id,
+      name: controller.name,
+      gains: controller.getGains(),
+      setpoint: controller.getSetpoint(),
+      envelope,
+    });
+  } catch (error) {
+    res.status(400).json({ error: error instanceof Error ? error.message : "Invalid loop" });
+  }
+});
+
+router.get("/loops/:loopId", (req, res) => {
+  const controller = tuningService.getController(req.params.loopId);
+  if (!controller) {
+    return res.status(404).json({ error: `Loop ${req.params.loopId} not found` });
+  }
+  res.json({
+    id: controller.id,
+    name: controller.name,
+    gains: controller.getGains(),
+    setpoint: controller.getSetpoint(),
+    metrics: controller.getMetrics(),
+    envelope: tuningService.getEnvelope(req.params.loopId),
+  });
+});
+
+router.put("/loops/:loopId/envelope", (req, res) => {
+  const parsed = EnvelopeSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  if (!tuningService.getController(req.params.loopId)) {
+    return res.status(404).json({ error: `Loop ${req.params.loopId} not found` });
+  }
+  res.json(tuningService.setEnvelope(req.params.loopId, parsed.data));
+});
+
+// ── Tuning (simulation-based; every result is a gated proposal) ────────────
+
+router.post("/loops/:loopId/tune/relay", asyncHandler(async (req, res) => {
+  const parsed = RelaySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const { model, ...options } = parsed.data;
+  const proposal = await tuningService.tuneRelay(req.params.loopId, model, options);
+  res.status(201).json(proposal);
+}));
+
+router.post("/loops/:loopId/tune/cohen-coon", asyncHandler(async (req, res) => {
+  const parsed = z.object({ model: ModelSchema }).safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const proposal = await tuningService.tuneCohenCoon(req.params.loopId, parsed.data.model);
+  res.status(201).json(proposal);
+}));
+
+router.post("/loops/:loopId/tune/rl", asyncHandler(async (req, res) => {
+  const parsed = RLSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const { proposal, outcome } = await tuningService.tuneRL(
+    req.params.loopId,
+    parsed.data.model,
+    parsed.data.config ?? {}
+  );
+  res.status(201).json({ proposal, outcome });
+}));
+
+// ── Approval gate ──────────────────────────────────────────────────────────
+
+router.get("/proposals", (req, res) => {
+  const status = req.query.status as string | undefined;
+  const controllerId = req.query.loopId as string | undefined;
+  res.json({
+    proposals: tuningService.getProposals({
+      status: status as never,
+      controllerId,
+    }),
+  });
+});
+
+router.get("/proposals/:proposalId", (req, res) => {
+  const proposal = tuningService.getProposal(req.params.proposalId);
+  if (!proposal) {
+    return res.status(404).json({ error: `Proposal ${req.params.proposalId} not found` });
+  }
+  res.json(proposal);
+});
+
+router.post("/proposals/:proposalId/approve", asyncHandler(async (req, res) => {
+  const parsed = DecisionSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const proposal = await tuningService.decide(
+    req.params.proposalId,
+    parsed.data.approver,
+    "approve",
+    parsed.data.comment
+  );
+  res.json(proposal);
+}));
+
+router.post("/proposals/:proposalId/reject", asyncHandler(async (req, res) => {
+  const parsed = DecisionSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const proposal = await tuningService.decide(
+    req.params.proposalId,
+    parsed.data.approver,
+    "reject",
+    parsed.data.comment
+  );
+  res.json(proposal);
+}));
+
+// ── Status ─────────────────────────────────────────────────────────────────
+
+router.get("/status", asyncHandler(async (_req, res) => {
+  const health = await tuningService.healthCheck();
+  res.json(health);
+}));
+
+export { router as tuningRoutes };

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -66,6 +66,10 @@ export { spcService } from './spc';
 export * from './l2-rollup';
 export { l2RollupService } from './l2-rollup';
 
+// ── PID Tuning Service (ADR-0013 [13.4], #215) ───────────────────────────────
+export * from './tuning';
+export { tuningService } from './tuning';
+
 /**
  * Initialize all services
  * 
@@ -80,7 +84,8 @@ export async function initializeServices(): Promise<void> {
     { name: 'Ubiquity', service: () => import('./ubiquity').then(m => m.ubiquityService.initialize()) },
     { name: 'Layer 2 Rollup', service: () => import('./l2-rollup').then(m => m.l2RollupService.initialize()) },
     { name: 'Optimization', service: () => import('./optimization').then(m => m.optimizationService.initialize()) },
-    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) }
+    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) },
+    { name: 'PID Tuning', service: () => import('./tuning').then(m => m.tuningService.initialize()) }
   ];
 
   for (const { name, service } of services) {
@@ -171,6 +176,14 @@ export async function getServicesHealthStatus(): Promise<{
         return await spcService.healthCheck();
       } catch {
         return { healthy: false, message: 'SPC service not available' };
+      }
+    },
+    tuning: async () => {
+      try {
+        const { tuningService } = await import('./tuning');
+        return await tuningService.healthCheck();
+      } catch {
+        return { healthy: false, message: 'Tuning service not available' };
       }
     }
   };

--- a/server/services/optimization/pid-autotuner.ts
+++ b/server/services/optimization/pid-autotuner.ts
@@ -171,16 +171,10 @@ export class PIDAutoTuner extends EventEmitter {
     if (this.recommendations.length > 50) this.recommendations.shift();
 
     this.emit('recommendation', rec);
-
-    if (this.mode === 'automatic') {
-      const applied = this.controller.applyGains(rec.gains);
-      if (applied) {
-        this.emit('gains-applied', rec);
-        this.controller.resetMetrics();
-      } else {
-        this.emit('gains-rejected', rec);
-      }
-    }
+    // Note: gains are never self-applied here, regardless of mode. Every
+    // application goes through the human-approval gate in the tuning
+    // service (ADR-0013 [13.4], issue #215). 'automatic' mode now only
+    // controls how aggressively recommendations are generated.
 
     return rec;
   }
@@ -309,11 +303,7 @@ export class PIDAutoTuner extends EventEmitter {
       };
       this.recommendations.push(rec);
       this.emit('relay-complete', rec);
-
-      if (this.mode === 'automatic') {
-        const applied = this.controller.applyGains(gains);
-        this.emit(applied ? 'gains-applied' : 'gains-rejected', rec);
-      }
+      // No self-apply — see evaluatePerformance (ADR-0013 [13.4], #215)
     } else {
       this.emit('relay-failed', 'Insufficient oscillation data');
     }

--- a/server/services/tuning/__tests__/tuning.test.ts
+++ b/server/services/tuning/__tests__/tuning.test.ts
@@ -1,0 +1,261 @@
+/**
+ * PID Auto-Tuning tests
+ * ADR-0013 [13.4] — Issue #215
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { FOPDTModel } from '@shared/types/tuning';
+import {
+  DEFAULT_ENVELOPE,
+  clampToEnvelope,
+  isWithinEnvelope,
+  limitStepTowards,
+  validateEnvelope,
+} from '../envelope';
+import {
+  FOPDTPlant,
+  relayIdentify,
+  runClosedLoopEpisode,
+  zieglerNicholsFromUltimate,
+} from '../process-sim';
+import { runRLTuning } from '../rl-tuner';
+import { TuningService } from '../index';
+import { PIDAutoTuner } from '../../optimization/pid-autotuner';
+import { PIDController } from '../../optimization/pid-controller';
+
+const MODEL: FOPDTModel = { gain: 2, timeConstantS: 10, deadTimeS: 1 };
+
+// ── Envelope ──────────────────────────────────────────────────────────────
+
+describe('gain envelope (ADR-0009)', () => {
+  it('validates ranges', () => {
+    expect(validateEnvelope(DEFAULT_ENVELOPE)).toBeNull();
+    expect(
+      validateEnvelope({ ...DEFAULT_ENVELOPE, kpRange: { min: 5, max: 1 } })
+    ).toMatch(/exceeds/);
+    expect(
+      validateEnvelope({ ...DEFAULT_ENVELOPE, kiRange: { min: -1, max: 1 } })
+    ).toMatch(/negative/);
+  });
+
+  it('clamps gains to the envelope and reports it', () => {
+    const envelope = {
+      kpRange: { min: 0.1, max: 5 },
+      kiRange: { min: 0, max: 2 },
+      kdRange: { min: 0, max: 1 },
+    };
+    const { gains, clamped } = clampToEnvelope({ kp: 50, ki: 1, kd: 3 }, envelope);
+    expect(gains).toEqual({ kp: 5, ki: 1, kd: 1 });
+    expect(clamped).toBe(true);
+    expect(isWithinEnvelope(gains, envelope)).toBe(true);
+    expect(clampToEnvelope({ kp: 1, ki: 1, kd: 0.5 }, envelope).clamped).toBe(false);
+  });
+
+  it('limits a step to the rate-limit fraction so applyGains always accepts', () => {
+    const current = { kp: 1, ki: 0.5, kd: 0.1 };
+    const target = { kp: 10, ki: 0.55, kd: 0.1 };
+    const { gains, complete } = limitStepTowards(current, target, 0.25);
+    expect(gains.kp).toBeCloseTo(1.25); // truncated to +25%
+    expect(gains.ki).toBeCloseTo(0.55); // within limit — reaches target
+    expect(complete).toBe(false);
+
+    const controller = new PIDController({
+      id: 'c', name: 'c', gains: current, setpoint: 50, outputMin: 0, outputMax: 100,
+    });
+    expect(controller.applyGains(gains)).toBe(true);
+  });
+});
+
+// ── FOPDT simulation ──────────────────────────────────────────────────────
+
+describe('FOPDT plant and closed-loop episodes', () => {
+  it('settles to gain × input in open loop', () => {
+    const plant = new FOPDTPlant(MODEL, 0.5);
+    for (let i = 0; i < 400; i++) plant.step(10, 0.5);
+    expect(plant.output).toBeCloseTo(20, 1); // K=2 × u=10
+  });
+
+  it('reasonable gains regulate to setpoint; zero gains do not', () => {
+    const good = runClosedLoopEpisode({ kp: 2, ki: 0.4, kd: 0.5 }, MODEL, {
+      setpoint: 50, ticks: 1200, dtS: 0.5,
+    });
+    expect(good.settlingTimeS).not.toBeNull();
+    expect(good.iae).toBeGreaterThan(0);
+
+    const dead = runClosedLoopEpisode({ kp: 0, ki: 0, kd: 0 }, MODEL, {
+      setpoint: 50, ticks: 1200, dtS: 0.5,
+    });
+    expect(dead.settlingTimeS).toBeNull();
+    expect(dead.iae).toBeGreaterThan(good.iae * 5);
+  });
+
+  it('relay identification recovers a usable ultimate gain and period', () => {
+    const identification = relayIdentify(MODEL, {
+      setpoint: 50,
+      relayAmplitude: 5,
+      hysteresis: 0.2,
+      minCycles: 4,
+      dtS: 0.1,
+    })!;
+    expect(identification).not.toBeNull();
+    expect(identification.ku).toBeGreaterThan(0);
+    expect(identification.tu).toBeGreaterThan(0);
+
+    // The derived Ziegler-Nichols gains must actually stabilize the loop
+    const gains = zieglerNicholsFromUltimate(identification.ku, identification.tu);
+    const metrics = runClosedLoopEpisode(gains, MODEL, { setpoint: 50, ticks: 2000, dtS: 0.5 });
+    expect(metrics.settlingTimeS).not.toBeNull();
+  });
+});
+
+// ── RL tuner ──────────────────────────────────────────────────────────────
+
+describe('RL tuner', () => {
+  it('improves reward over deliberately detuned initial gains', () => {
+    const outcome = runRLTuning(
+      { kp: 0.05, ki: 0.005, kd: 0 }, // sluggish start
+      MODEL,
+      DEFAULT_ENVELOPE,
+      50,
+      { episodes: 40, episodeTicks: 400, dtS: 0.5, seed: 7 }
+    );
+    expect(outcome.improvedOverInitial).toBe(true);
+    expect(outcome.bestReward).toBeGreaterThan(outcome.initialReward);
+    expect(outcome.episodes).toHaveLength(40);
+    expect(isWithinEnvelope(outcome.bestGains, DEFAULT_ENVELOPE)).toBe(true);
+  });
+
+  it('is deterministic for a fixed seed', () => {
+    const run = () =>
+      runRLTuning({ kp: 0.5, ki: 0.05, kd: 0 }, MODEL, DEFAULT_ENVELOPE, 50, {
+        episodes: 15, episodeTicks: 200, dtS: 0.5, seed: 11,
+      });
+    expect(run().bestGains).toEqual(run().bestGains);
+  });
+
+  it('never proposes gains outside the envelope', () => {
+    const tight = {
+      kpRange: { min: 0, max: 0.8 },
+      kiRange: { min: 0, max: 0.1 },
+      kdRange: { min: 0, max: 0.1 },
+    };
+    const outcome = runRLTuning({ kp: 0.5, ki: 0.05, kd: 0 }, MODEL, tight, 50, {
+      episodes: 30, episodeTicks: 200, dtS: 0.5, seed: 3,
+    });
+    for (const episode of outcome.episodes) {
+      expect(isWithinEnvelope(episode.gains, tight)).toBe(true);
+    }
+  });
+});
+
+// ── Approval gate ─────────────────────────────────────────────────────────
+
+describe('TuningService approval gate (ADR-0013 human-in-the-loop)', () => {
+  it('proposals stay pending until a human decides; approval applies gains', async () => {
+    const service = new TuningService();
+    const { controller } = service.registerLoop({
+      id: 'flow-1', name: 'Flow', gains: { kp: 1, ki: 0.1, kd: 0.05 },
+      setpoint: 50, outputMin: 0, outputMax: 100,
+    });
+    const applied = vi.fn();
+    service.on('proposal-applied', applied);
+
+    const proposal = await service.propose('flow-1', 'ziegler-nichols',
+      { kp: 1.2, ki: 0.12, kd: 0.06 }, { reason: 'test', confidence: 0.8 });
+    expect(proposal.status).toBe('pending');
+    expect(controller.getGains()).toEqual({ kp: 1, ki: 0.1, kd: 0.05 }); // unchanged
+
+    const decided = await service.decide(proposal.id, 'operator-1', 'approve');
+    expect(decided.status).toBe('applied');
+    expect(decided.fullyApplied).toBe(true);
+    expect(controller.getGains()).toEqual({ kp: 1.2, ki: 0.12, kd: 0.06 });
+    expect(applied).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejection leaves gains untouched', async () => {
+    const service = new TuningService();
+    const { controller } = service.registerLoop({
+      id: 'flow-2', name: 'Flow', gains: { kp: 1, ki: 0.1, kd: 0.05 },
+      setpoint: 50, outputMin: 0, outputMax: 100,
+    });
+    const proposal = await service.propose('flow-2', 'rl',
+      { kp: 2, ki: 0.2, kd: 0.1 }, { reason: 'test', confidence: 0.5 });
+    const decided = await service.decide(proposal.id, 'operator-1', 'reject', 'too aggressive');
+    expect(decided.status).toBe('rejected');
+    expect(controller.getGains()).toEqual({ kp: 1, ki: 0.1, kd: 0.05 });
+    await expect(service.decide(proposal.id, 'operator-2', 'approve')).rejects.toThrow(/already/);
+  });
+
+  it('clamps proposals to the envelope and flags it', async () => {
+    const service = new TuningService();
+    service.registerLoop({
+      id: 'flow-3', name: 'Flow', gains: { kp: 1, ki: 0.1, kd: 0.05 },
+      setpoint: 50, outputMin: 0, outputMax: 100,
+      envelope: {
+        kpRange: { min: 0, max: 1.2 },
+        kiRange: { min: 0, max: 1 },
+        kdRange: { min: 0, max: 1 },
+      },
+    });
+    const proposal = await service.propose('flow-3', 'cohen-coon',
+      { kp: 99, ki: 0.11, kd: 0.05 }, { reason: 'test', confidence: 0.7 });
+    expect(proposal.clampedByEnvelope).toBe(true);
+    expect(proposal.proposedGains.kp).toBe(1.2);
+  });
+
+  it('truncates large approved moves to the rate limit and reports partial application', async () => {
+    const service = new TuningService();
+    const { controller } = service.registerLoop({
+      id: 'flow-4', name: 'Flow', gains: { kp: 1, ki: 0.1, kd: 0.05 },
+      setpoint: 50, outputMin: 0, outputMax: 100,
+    });
+    const proposal = await service.propose('flow-4', 'rl',
+      { kp: 10, ki: 0.1, kd: 0.05 }, { reason: 'big jump', confidence: 0.6 });
+    const decided = await service.decide(proposal.id, 'operator-1', 'approve');
+    expect(decided.status).toBe('applied');
+    expect(decided.fullyApplied).toBe(false);
+    expect(controller.getGains().kp).toBeCloseTo(1.25); // one 25% step, not 10
+  });
+
+  it('end-to-end: relay and RL tuning produce pending proposals, never direct changes', async () => {
+    const service = new TuningService();
+    const { controller } = service.registerLoop({
+      id: 'e2e', name: 'E2E', gains: { kp: 0.5, ki: 0.05, kd: 0 },
+      setpoint: 50, outputMin: 0, outputMax: 100,
+    });
+    const before = controller.getGains();
+
+    const relayProposal = await service.tuneRelay('e2e', MODEL, { dtS: 0.1 });
+    const { proposal: rlProposal } = await service.tuneRL('e2e', MODEL, {
+      episodes: 10, episodeTicks: 200, dtS: 0.5, seed: 5,
+    });
+
+    expect(relayProposal.status).toBe('pending');
+    expect(rlProposal.status).toBe('pending');
+    expect(controller.getGains()).toEqual(before);
+    expect(service.getProposals({ controllerId: 'e2e' })).toHaveLength(2);
+  });
+});
+
+// ── Regression: autotuner no longer self-applies (ADR-0013) ───────────────
+
+describe('PIDAutoTuner automatic mode', () => {
+  it('emits recommendations but never applies gains itself', () => {
+    const controller = new PIDController({
+      id: 'auto', name: 'auto', gains: { kp: 1, ki: 0.1, kd: 0.05 },
+      setpoint: 50, outputMin: 0, outputMax: 100,
+    });
+    const before = controller.getGains();
+    const tuner = new PIDAutoTuner(controller, 'automatic');
+    const applied = vi.fn();
+    tuner.on('gains-applied', applied);
+
+    // Degrade performance: large persistent error accumulates IAE
+    for (let i = 0; i < 200; i++) controller.update(0, 1);
+    const rec = tuner.evaluatePerformance();
+
+    expect(rec).not.toBeNull();
+    expect(controller.getGains()).toEqual(before);
+    expect(applied).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/tuning/envelope.ts
+++ b/server/services/tuning/envelope.ts
@@ -1,0 +1,93 @@
+/**
+ * Gain Safety Envelope (ADR-0009)
+ * ADR-0013 [13.4] — Issue #215
+ *
+ * Absolute bounds on controller gains. The pre-existing per-step rate
+ * limit (PIDController.maxGainChangeFraction) constrains each change;
+ * the envelope constrains the reachable set, so repeated rate-limited
+ * steps can never walk gains outside safe territory.
+ */
+
+import type { GainEnvelope, GainRange } from '@shared/types/tuning';
+import type { PIDGains } from '../optimization/pid-controller';
+
+export const DEFAULT_ENVELOPE: GainEnvelope = {
+  kpRange: { min: 0, max: 100 },
+  kiRange: { min: 0, max: 50 },
+  kdRange: { min: 0, max: 50 },
+};
+
+export function validateEnvelope(envelope: GainEnvelope): string | null {
+  for (const [name, range] of Object.entries(envelope) as Array<[string, GainRange]>) {
+    if (!Number.isFinite(range.min) || !Number.isFinite(range.max)) {
+      return `${name} bounds must be finite`;
+    }
+    if (range.min > range.max) {
+      return `${name}: min (${range.min}) exceeds max (${range.max})`;
+    }
+    if (range.min < 0) {
+      return `${name}: negative gains are outside the supported envelope`;
+    }
+  }
+  return null;
+}
+
+export function isWithinEnvelope(gains: PIDGains, envelope: GainEnvelope): boolean {
+  return (
+    gains.kp >= envelope.kpRange.min &&
+    gains.kp <= envelope.kpRange.max &&
+    gains.ki >= envelope.kiRange.min &&
+    gains.ki <= envelope.kiRange.max &&
+    gains.kd >= envelope.kdRange.min &&
+    gains.kd <= envelope.kdRange.max
+  );
+}
+
+export function clampToEnvelope(
+  gains: PIDGains,
+  envelope: GainEnvelope
+): { gains: PIDGains; clamped: boolean } {
+  const clampValue = (value: number, range: GainRange) =>
+    Math.min(range.max, Math.max(range.min, value));
+  const clamped: PIDGains = {
+    kp: clampValue(gains.kp, envelope.kpRange),
+    ki: clampValue(gains.ki, envelope.kiRange),
+    kd: clampValue(gains.kd, envelope.kdRange),
+  };
+  return {
+    gains: clamped,
+    clamped: clamped.kp !== gains.kp || clamped.ki !== gains.ki || clamped.kd !== gains.kd,
+  };
+}
+
+/**
+ * Largest move from `current` toward `target` that stays within the
+ * per-step rate-limit fraction on every gain. Guarantees the result
+ * passes PIDController.applyGains.
+ */
+export function limitStepTowards(
+  current: PIDGains,
+  target: PIDGains,
+  maxFraction: number
+): { gains: PIDGains; complete: boolean } {
+  const step = (from: number, to: number): number => {
+    if (from === 0) {
+      // applyGains admits |next| < 1 when the current gain is zero
+      return Math.abs(to) < 1 ? to : Math.sign(to) * 0.999;
+    }
+    const maxDelta = Math.abs(from) * maxFraction;
+    const delta = to - from;
+    if (Math.abs(delta) <= maxDelta) return to;
+    return from + Math.sign(delta) * maxDelta;
+  };
+
+  const gains: PIDGains = {
+    kp: step(current.kp, target.kp),
+    ki: step(current.ki, target.ki),
+    kd: step(current.kd, target.kd),
+  };
+  return {
+    gains,
+    complete: gains.kp === target.kp && gains.ki === target.ki && gains.kd === target.kd,
+  };
+}

--- a/server/services/tuning/index.ts
+++ b/server/services/tuning/index.ts
@@ -1,0 +1,320 @@
+/**
+ * PID Tuning Service — human-gated auto-tuning with safety envelopes
+ * ADR-0013 [13.4] — Issue #215
+ *
+ * Composes the existing PID stack (issue #351: PIDController, relay
+ * feedback, Ziegler-Nichols, Cohen-Coon) with:
+ * - absolute gain envelopes (ADR-0009) via ./envelope
+ * - RL-based tuning over a FOPDT simulation via ./rl-tuner
+ * - a mandatory human approval gate (GateManager, issue #345): every
+ *   gain change becomes a TuningProposal; nothing applies automatically
+ *
+ * Application on approval is envelope-clamped AND rate-limited: the move
+ * is truncated to the controller's maxGainChangeFraction when needed and
+ * reported as partially applied.
+ */
+
+import { EventEmitter } from 'events';
+
+export * from './envelope';
+export * from './process-sim';
+export * from './rl-tuner';
+
+import type {
+  FOPDTModel,
+  GainEnvelope,
+  ProposalMethod,
+  RLTunerConfig,
+  RLTuningOutcome,
+  TuningProposal,
+} from '@shared/types/tuning';
+import { optimizationService } from '../optimization';
+import type { PIDController, PIDControllerConfig, PIDGains } from '../optimization/pid-controller';
+import { GateManager } from '../governance/gate-manager';
+import { DEFAULT_ENVELOPE, clampToEnvelope, limitStepTowards, validateEnvelope } from './envelope';
+import { relayIdentify, zieglerNicholsFromUltimate } from './process-sim';
+import { runRLTuning } from './rl-tuner';
+
+const GATE_DEFINITION_ID = 'pid-tuning-approval';
+const MAX_PROPOSALS = 500;
+
+export interface RegisterLoopInput extends PIDControllerConfig {
+  envelope?: GainEnvelope;
+}
+
+export class TuningService extends EventEmitter {
+  readonly gates = new GateManager();
+
+  private envelopes: Map<string, GainEnvelope> = new Map();
+  private proposals: Map<string, TuningProposal> = new Map();
+  private proposalCounter = 0;
+  private readonly bootId = Date.now().toString(36);
+  private initialized = false;
+
+  constructor() {
+    super();
+    this.gates.registerGate({
+      id: GATE_DEFINITION_ID,
+      name: 'PID tuning approval',
+      description:
+        'Human approval required before controller gains change (ADR-0013 [13.4])',
+      type: 'manual',
+      conditions: [],
+      timeoutMs: 24 * 60 * 60 * 1000,
+      approvers: [], // any authenticated approver; RBAC integration is follow-up
+      requiredApprovals: 1,
+      allowOverride: false,
+    });
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+    await optimizationService.initialize();
+  }
+
+  async shutdown(): Promise<void> {
+    this.initialized = false;
+  }
+
+  // ── Loop registry ────────────────────────────────────────────────────
+
+  registerLoop(input: RegisterLoopInput): { controller: PIDController; envelope: GainEnvelope } {
+    const envelope = input.envelope ?? DEFAULT_ENVELOPE;
+    const envelopeError = validateEnvelope(envelope);
+    if (envelopeError) throw new Error(`Invalid envelope: ${envelopeError}`);
+    const { gains } = clampToEnvelope(input.gains, envelope);
+    const controller = optimizationService.createController({ ...input, gains });
+    this.envelopes.set(input.id, envelope);
+    return { controller, envelope };
+  }
+
+  getController(id: string): PIDController | undefined {
+    return optimizationService.getController(id);
+  }
+
+  getEnvelope(id: string): GainEnvelope {
+    return this.envelopes.get(id) ?? DEFAULT_ENVELOPE;
+  }
+
+  setEnvelope(id: string, envelope: GainEnvelope): GainEnvelope {
+    const error = validateEnvelope(envelope);
+    if (error) throw new Error(`Invalid envelope: ${error}`);
+    this.envelopes.set(id, envelope);
+    return envelope;
+  }
+
+  // ── Tuning methods (all produce proposals, never direct application) ─
+
+  /** Relay identification against a FOPDT model → Ziegler-Nichols gains */
+  async tuneRelay(
+    controllerId: string,
+    model: FOPDTModel,
+    options: { relayAmplitude?: number; hysteresis?: number; minCycles?: number; dtS?: number } = {}
+  ): Promise<TuningProposal> {
+    const controller = this.requireController(controllerId);
+    const identification = relayIdentify(model, {
+      setpoint: controller.getSetpoint(),
+      relayAmplitude: options.relayAmplitude ?? 5,
+      hysteresis: options.hysteresis ?? 0.5,
+      minCycles: options.minCycles ?? 4,
+      dtS: options.dtS ?? 0.1,
+    });
+    if (!identification) {
+      throw new Error('Relay identification failed: no sustained oscillation observed');
+    }
+    const gains = zieglerNicholsFromUltimate(identification.ku, identification.tu);
+    return this.propose(controllerId, 'relay-feedback', gains, {
+      reason: `Relay identification: Ku=${identification.ku.toFixed(3)}, Tu=${identification.tu.toFixed(2)}s (${identification.cycles} cycles) → Ziegler-Nichols`,
+      confidence: 0.85,
+    });
+  }
+
+  /** Cohen-Coon from FOPDT model parameters via the existing autotuner math */
+  async tuneCohenCoon(controllerId: string, model: FOPDTModel): Promise<TuningProposal> {
+    this.requireController(controllerId);
+    const tuner = optimizationService.createAutoTuner(controllerId, 'suggest');
+    if (!tuner) throw new Error(`Controller "${controllerId}" not found`);
+    const rec = tuner.cohenCoonTune(model.gain, model.timeConstantS, model.deadTimeS);
+    return this.propose(controllerId, 'cohen-coon', rec.gains, {
+      reason: rec.reason,
+      confidence: rec.confidence,
+    });
+  }
+
+  /** RL tuning: Q-learning episodes in simulation, best gains proposed */
+  async tuneRL(
+    controllerId: string,
+    model: FOPDTModel,
+    config: Partial<RLTunerConfig> = {}
+  ): Promise<{ proposal: TuningProposal; outcome: RLTuningOutcome }> {
+    const controller = this.requireController(controllerId);
+    const envelope = this.getEnvelope(controllerId);
+    const outcome = runRLTuning(
+      controller.getGains(),
+      model,
+      envelope,
+      controller.getSetpoint(),
+      config
+    );
+    const proposal = await this.propose(controllerId, 'rl', outcome.bestGains, {
+      reason:
+        `RL tuning (${outcome.episodes.length} episodes in simulation): reward ` +
+        `${outcome.initialReward.toFixed(2)} → ${outcome.bestReward.toFixed(2)}` +
+        (outcome.improvedOverInitial ? '' : ' (no improvement — review before approving)'),
+      confidence: outcome.improvedOverInitial ? 0.7 : 0.3,
+    });
+    return { proposal, outcome };
+  }
+
+  /** Wrap any externally computed recommendation as a gated proposal */
+  async propose(
+    controllerId: string,
+    method: ProposalMethod,
+    rawGains: PIDGains,
+    meta: { reason: string; confidence: number }
+  ): Promise<TuningProposal> {
+    const controller = this.requireController(controllerId);
+    const envelope = this.getEnvelope(controllerId);
+    const { gains, clamped } = clampToEnvelope(rawGains, envelope);
+
+    const proposalId = `TUNE-${this.bootId}-${++this.proposalCounter}`;
+    const gate = await this.gates.createInstance(
+      GATE_DEFINITION_ID,
+      {
+        id: proposalId,
+        type: 'pid-tuning-proposal',
+        data: { controllerId, method, proposedGains: gains, ...meta },
+      },
+      'tuning-service'
+    );
+
+    const proposal: TuningProposal = {
+      id: proposalId,
+      controllerId,
+      method,
+      currentGains: controller.getGains(),
+      proposedGains: gains,
+      clampedByEnvelope: clamped,
+      reason: meta.reason,
+      confidence: meta.confidence,
+      status: 'pending',
+      gateInstanceId: gate.id,
+      createdAt: Date.now(),
+    };
+    this.proposals.set(proposalId, proposal);
+    this.evictOldProposals();
+    this.emit('proposal', proposal);
+    return proposal;
+  }
+
+  // ── Approval gate ────────────────────────────────────────────────────
+
+  async decide(
+    proposalId: string,
+    approver: string,
+    action: 'approve' | 'reject',
+    comment?: string
+  ): Promise<TuningProposal> {
+    const proposal = this.proposals.get(proposalId);
+    if (!proposal) throw new Error(`Proposal "${proposalId}" not found`);
+    if (proposal.status !== 'pending') {
+      throw new Error(`Proposal "${proposalId}" already ${proposal.status}`);
+    }
+
+    const gate = await this.gates.submitDecision(
+      proposal.gateInstanceId,
+      approver,
+      action,
+      comment
+    );
+
+    if (gate.state === 'rejected') {
+      proposal.status = 'rejected';
+      proposal.resolvedAt = Date.now();
+      proposal.decidedBy = approver;
+      this.emit('proposal-rejected', proposal);
+      return proposal;
+    }
+
+    if (gate.state === 'approved') {
+      proposal.decidedBy = approver;
+      this.applyApproved(proposal);
+    }
+    return proposal;
+  }
+
+  getProposals(filter?: { controllerId?: string; status?: TuningProposal['status'] }): TuningProposal[] {
+    let list = Array.from(this.proposals.values());
+    if (filter?.controllerId) list = list.filter((p) => p.controllerId === filter.controllerId);
+    if (filter?.status) list = list.filter((p) => p.status === filter.status);
+    return list.sort((a, b) => b.createdAt - a.createdAt);
+  }
+
+  getProposal(id: string): TuningProposal | undefined {
+    return this.proposals.get(id);
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
+    const pending = this.getProposals({ status: 'pending' }).length;
+    return {
+      healthy: this.initialized,
+      message: this.initialized
+        ? `Tuning service running: ${this.envelopes.size} loops, ${pending} pending proposals`
+        : 'Tuning service not initialized',
+    };
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────
+
+  private applyApproved(proposal: TuningProposal): void {
+    const controller = optimizationService.getController(proposal.controllerId);
+    if (!controller) {
+      proposal.status = 'failed';
+      proposal.resolvedAt = Date.now();
+      this.emit('proposal-failed', proposal);
+      return;
+    }
+
+    // Envelope re-check against the live envelope at approval time
+    const envelope = this.getEnvelope(proposal.controllerId);
+    const { gains: target } = clampToEnvelope(proposal.proposedGains, envelope);
+
+    // Truncate to the per-step rate limit so applyGains always accepts
+    const current = controller.getGains();
+    const { gains: stepGains, complete } = limitStepTowards(current, target, 0.25);
+    const applied = controller.applyGains(stepGains);
+
+    if (!applied) {
+      proposal.status = 'failed';
+      proposal.resolvedAt = Date.now();
+      this.emit('proposal-failed', proposal);
+      return;
+    }
+
+    proposal.status = 'applied';
+    proposal.resolvedAt = Date.now();
+    proposal.appliedGains = controller.getGains();
+    proposal.fullyApplied = complete;
+    this.emit('proposal-applied', proposal);
+  }
+
+  private requireController(id: string): PIDController {
+    const controller = optimizationService.getController(id);
+    if (!controller) throw new Error(`Controller "${id}" not found`);
+    return controller;
+  }
+
+  private evictOldProposals(): void {
+    if (this.proposals.size <= MAX_PROPOSALS) return;
+    const resolvedOldest = Array.from(this.proposals.values())
+      .filter((p) => p.status !== 'pending')
+      .sort((a, b) => a.createdAt - b.createdAt);
+    for (const proposal of resolvedOldest) {
+      if (this.proposals.size <= MAX_PROPOSALS) return;
+      this.proposals.delete(proposal.id);
+    }
+  }
+}
+
+export const tuningService = new TuningService();

--- a/server/services/tuning/process-sim.ts
+++ b/server/services/tuning/process-sim.ts
@@ -1,0 +1,217 @@
+/**
+ * FOPDT Process Simulation
+ * ADR-0013 [13.4] — Issue #215
+ *
+ * First-order-plus-dead-time plant used for tuning episodes: relay
+ * identification and RL exploration run against this model, never the
+ * real plant (ADR-0009 — exploration happens in simulation only).
+ *
+ * Everything here runs on SIM time. The existing PIDAutoTuner.relayStep
+ * path stamps peaks with wall-clock time, which is correct against a live
+ * plant but meaningless in a fast loop — hence the separate sim-time
+ * identification below.
+ */
+
+import type { EpisodeMetrics, FOPDTModel } from '@shared/types/tuning';
+import { PIDController, type PIDGains } from '../optimization/pid-controller';
+
+/** Deterministic RNG (mulberry32) so simulated noise is reproducible */
+export function makeRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export class FOPDTPlant {
+  private y = 0;
+  private readonly delayBuffer: number[];
+  private readonly model: FOPDTModel;
+  private readonly rng: (() => number) | null;
+
+  constructor(model: FOPDTModel, dtS: number, seed = 1) {
+    this.model = model;
+    const delaySteps = Math.max(0, Math.round(model.deadTimeS / dtS));
+    this.delayBuffer = new Array(delaySteps).fill(0);
+    this.rng = model.noiseSigma ? makeRng(seed) : null;
+  }
+
+  get output(): number {
+    return this.y;
+  }
+
+  /** Advance one step with control input u */
+  step(u: number, dtS: number): number {
+    let delayed = u;
+    if (this.delayBuffer.length > 0) {
+      this.delayBuffer.push(u);
+      delayed = this.delayBuffer.shift()!;
+    }
+    const { gain, timeConstantS } = this.model;
+    this.y += (dtS / timeConstantS) * (gain * delayed - this.y);
+    if (this.rng) {
+      // Box-Muller from two uniforms
+      const u1 = Math.max(this.rng(), 1e-12);
+      const u2 = this.rng();
+      this.y += this.model.noiseSigma! * Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+    }
+    return this.y;
+  }
+}
+
+export interface EpisodeOptions {
+  setpoint: number;
+  ticks: number;
+  dtS: number;
+  outputMin?: number;
+  outputMax?: number;
+  seed?: number;
+}
+
+/**
+ * Run one closed-loop episode of the given gains against a FOPDT model.
+ * Metrics are computed from the sim-time trajectory (the controller's
+ * internal metrics are wall-clock based and unusable in a fast loop).
+ */
+export function runClosedLoopEpisode(
+  gains: PIDGains,
+  model: FOPDTModel,
+  options: EpisodeOptions
+): EpisodeMetrics {
+  const { setpoint, ticks, dtS } = options;
+  const plant = new FOPDTPlant(model, dtS, options.seed ?? 1);
+  const controller = new PIDController({
+    id: 'episode',
+    name: 'episode',
+    gains,
+    setpoint,
+    outputMin: options.outputMin ?? 0,
+    outputMax: options.outputMax ?? 100,
+    sampleTime: dtS,
+  });
+
+  let ise = 0;
+  let iae = 0;
+  let itae = 0;
+  let peak = -Infinity;
+  let settledSince: number | null = null;
+  let zeroCrossings = 0;
+  let prevError = setpoint - plant.output;
+  const band = Math.abs(setpoint) * 0.02 || 0.02;
+
+  for (let i = 0; i < ticks; i++) {
+    const t = i * dtS;
+    const pv = plant.output;
+    const { output } = controller.update(pv, dtS);
+    plant.step(output, dtS);
+
+    const error = setpoint - plant.output;
+    ise += error * error * dtS;
+    iae += Math.abs(error) * dtS;
+    itae += t * Math.abs(error) * dtS;
+    if (plant.output > peak) peak = plant.output;
+    if ((error > 0 && prevError < 0) || (error < 0 && prevError > 0)) zeroCrossings++;
+    if (Math.abs(error) <= band) {
+      if (settledSince === null) settledSince = t;
+    } else {
+      settledSince = null;
+    }
+    prevError = error;
+  }
+
+  return {
+    ise,
+    iae,
+    itae,
+    overshoot: setpoint !== 0 ? Math.max(0, (peak - setpoint) / Math.abs(setpoint)) : 0,
+    settlingTimeS: settledSince,
+    oscillating: zeroCrossings > 6,
+  };
+}
+
+/** Ziegler-Nichols classic PID from ultimate gain and period */
+export function zieglerNicholsFromUltimate(ku: number, tu: number): PIDGains {
+  return { kp: 0.6 * ku, ki: (1.2 * ku) / tu, kd: 0.075 * ku * tu };
+}
+
+export interface RelayIdentification {
+  ku: number;
+  tu: number;
+  cycles: number;
+}
+
+/**
+ * Åström-Hägglund relay identification against the FOPDT model in sim
+ * time: toggle a relay output around the setpoint, measure the induced
+ * limit-cycle amplitude and period, and derive Ku = 4d/(π·a), Tu.
+ */
+export function relayIdentify(
+  model: FOPDTModel,
+  options: {
+    setpoint: number;
+    relayAmplitude: number;
+    hysteresis: number;
+    minCycles: number;
+    dtS: number;
+    maxTicks?: number;
+    /** Output bias the relay toggles around */
+    outputBias?: number;
+  }
+): RelayIdentification | null {
+  const { setpoint, relayAmplitude, hysteresis, minCycles, dtS } = options;
+  const maxTicks = options.maxTicks ?? 200_000;
+  // Toggle around the steady-state input that holds the setpoint, so the
+  // limit cycle oscillates about the setpoint for any process gain.
+  const bias = options.outputBias ?? (model.gain !== 0 ? setpoint / model.gain : 0);
+
+  const plant = new FOPDTPlant(model, dtS, 1);
+  let relay = relayAmplitude;
+  const peakTimes: number[] = [];
+  const peakValues: number[] = [];
+  const valleyValues: number[] = [];
+  let rising = true;
+
+  for (let i = 0; i < maxTicks; i++) {
+    const t = i * dtS;
+    const pv = plant.output;
+    const error = setpoint - pv;
+
+    if (error > hysteresis && relay < 0) relay = relayAmplitude;
+    else if (error < -hysteresis && relay > 0) relay = -relayAmplitude;
+
+    plant.step(bias + relay, dtS);
+
+    const nextPv = plant.output;
+    if (rising && nextPv < pv && pv > setpoint) {
+      peakTimes.push(t);
+      peakValues.push(pv);
+      rising = false;
+      if (peakTimes.length > minCycles) break;
+    } else if (!rising && nextPv > pv && pv < setpoint) {
+      valleyValues.push(pv);
+      rising = true;
+    }
+  }
+
+  if (peakTimes.length < 2 || valleyValues.length < 1) return null;
+
+  const peakAvg = peakValues.reduce((a, b) => a + b, 0) / peakValues.length;
+  const valleyAvg = valleyValues.reduce((a, b) => a + b, 0) / valleyValues.length;
+  const amplitude = (peakAvg - valleyAvg) / 2;
+  if (amplitude <= 0) return null;
+
+  let totalPeriod = 0;
+  for (let i = 1; i < peakTimes.length; i++) totalPeriod += peakTimes[i] - peakTimes[i - 1];
+  const tu = totalPeriod / (peakTimes.length - 1);
+  if (tu <= 0) return null;
+
+  return {
+    ku: (4 * relayAmplitude) / (Math.PI * amplitude),
+    tu,
+    cycles: peakTimes.length,
+  };
+}

--- a/server/services/tuning/rl-tuner.ts
+++ b/server/services/tuning/rl-tuner.ts
@@ -1,0 +1,176 @@
+/**
+ * RL-Based PID Tuner
+ * ADR-0013 [13.4] — Issue #215
+ *
+ * Tabular Q-learning over multiplicative gain adjustments, evaluated in
+ * closed-loop episodes against a FOPDT process model. Exploration happens
+ * strictly in simulation (ADR-0009); the outcome is a recommendation that
+ * still requires human approval before touching a controller.
+ *
+ * State  — discretized episode performance (overshoot bucket × settling
+ *          bucket × oscillation flag) of the current gains.
+ * Action — one of nine gain nudges (±20% per term, ±10% all, no-op),
+ *          always clamped to the safety envelope.
+ * Reward — −normalized ITAE − overshoot penalty − oscillation penalty.
+ */
+
+import type {
+  EpisodeMetrics,
+  FOPDTModel,
+  GainEnvelope,
+  RLEpisode,
+  RLTunerConfig,
+  RLTuningOutcome,
+} from '@shared/types/tuning';
+import type { PIDGains } from '../optimization/pid-controller';
+import { clampToEnvelope } from './envelope';
+import { makeRng, runClosedLoopEpisode } from './process-sim';
+
+export const DEFAULT_RL_CONFIG: RLTunerConfig = {
+  episodes: 60,
+  episodeTicks: 600,
+  dtS: 0.5,
+  epsilon: 0.4,
+  epsilonDecay: 0.95,
+  learningRate: 0.3,
+  discount: 0.8,
+  overshootPenalty: 50,
+  oscillationPenalty: 20,
+  seed: 42,
+};
+
+interface Action {
+  name: string;
+  apply: (g: PIDGains) => PIDGains;
+}
+
+const ACTIONS: Action[] = [
+  { name: 'kp+20%', apply: (g) => ({ ...g, kp: g.kp * 1.2 }) },
+  { name: 'kp-20%', apply: (g) => ({ ...g, kp: g.kp * 0.8 }) },
+  { name: 'ki+20%', apply: (g) => ({ ...g, ki: g.ki * 1.2 }) },
+  { name: 'ki-20%', apply: (g) => ({ ...g, ki: g.ki * 0.8 }) },
+  { name: 'kd+20%', apply: (g) => ({ ...g, kd: g.kd * 1.2 }) },
+  { name: 'kd-20%', apply: (g) => ({ ...g, kd: g.kd * 0.8 }) },
+  { name: 'all+10%', apply: (g) => ({ kp: g.kp * 1.1, ki: g.ki * 1.1, kd: g.kd * 1.1 }) },
+  { name: 'all-10%', apply: (g) => ({ kp: g.kp * 0.9, ki: g.ki * 0.9, kd: g.kd * 0.9 }) },
+  { name: 'hold', apply: (g) => ({ ...g }) },
+];
+
+function discretizeState(metrics: EpisodeMetrics, episodeSeconds: number): string {
+  const overshootBucket =
+    metrics.overshoot < 0.05 ? 0 : metrics.overshoot < 0.15 ? 1 : metrics.overshoot < 0.3 ? 2 : 3;
+  const settle = metrics.settlingTimeS;
+  const settleBucket =
+    settle === null
+      ? 3
+      : settle < episodeSeconds * 0.25
+        ? 0
+        : settle < episodeSeconds * 0.5
+          ? 1
+          : 2;
+  return `${overshootBucket}:${settleBucket}:${metrics.oscillating ? 1 : 0}`;
+}
+
+function computeReward(metrics: EpisodeMetrics, config: RLTunerConfig, setpoint: number): number {
+  const episodeSeconds = config.episodeTicks * config.dtS;
+  // Normalize ITAE by the worst case of holding max error the whole episode
+  const worstItae = (Math.abs(setpoint) || 1) * episodeSeconds * episodeSeconds * 0.5;
+  const itaeNorm = worstItae > 0 ? metrics.itae / worstItae : metrics.itae;
+  return (
+    -itaeNorm * 100 -
+    config.overshootPenalty * metrics.overshoot -
+    (metrics.oscillating ? config.oscillationPenalty : 0)
+  );
+}
+
+export function runRLTuning(
+  initialGains: PIDGains,
+  model: FOPDTModel,
+  envelope: GainEnvelope,
+  setpoint: number,
+  configOverrides: Partial<RLTunerConfig> = {}
+): RLTuningOutcome {
+  const config: RLTunerConfig = { ...DEFAULT_RL_CONFIG, ...configOverrides };
+  const rng = makeRng(config.seed ?? 42);
+  const episodeSeconds = config.episodeTicks * config.dtS;
+  const q = new Map<string, number[]>();
+  const qFor = (state: string): number[] => {
+    let row = q.get(state);
+    if (!row) {
+      row = new Array(ACTIONS.length).fill(0);
+      q.set(state, row);
+    }
+    return row;
+  };
+
+  const evaluate = (gains: PIDGains): { metrics: EpisodeMetrics; reward: number } => {
+    const metrics = runClosedLoopEpisode(gains, model, {
+      setpoint,
+      ticks: config.episodeTicks,
+      dtS: config.dtS,
+      seed: config.seed,
+    });
+    return { metrics, reward: computeReward(metrics, config, setpoint) };
+  };
+
+  let currentGains = clampToEnvelope(initialGains, envelope).gains;
+  let { metrics: currentMetrics, reward: currentReward } = evaluate(currentGains);
+  const initialReward = currentReward;
+  let bestGains = currentGains;
+  let bestReward = currentReward;
+  let epsilon = config.epsilon;
+
+  const episodes: RLEpisode[] = [];
+
+  for (let episode = 0; episode < config.episodes; episode++) {
+    const state = discretizeState(currentMetrics, episodeSeconds);
+    const row = qFor(state);
+
+    const explored = rng() < epsilon;
+    const actionIndex = explored
+      ? Math.floor(rng() * ACTIONS.length)
+      : row.indexOf(Math.max(...row));
+    const action = ACTIONS[actionIndex];
+
+    const candidate = clampToEnvelope(action.apply(currentGains), envelope).gains;
+    const { metrics: candidateMetrics, reward: candidateReward } = evaluate(candidate);
+    const nextState = discretizeState(candidateMetrics, episodeSeconds);
+    const nextRow = qFor(nextState);
+
+    // Q-learning update: reward for taking `action` in `state`
+    row[actionIndex] +=
+      config.learningRate *
+      (candidateReward + config.discount * Math.max(...nextRow) - row[actionIndex]);
+
+    // Greedy hill-climb over the accepted point: only move when better —
+    // the Q-table still learns from every attempt.
+    if (candidateReward >= currentReward) {
+      currentGains = candidate;
+      currentMetrics = candidateMetrics;
+      currentReward = candidateReward;
+    }
+    if (candidateReward > bestReward) {
+      bestGains = candidate;
+      bestReward = candidateReward;
+    }
+
+    episodes.push({
+      episode,
+      gains: candidate,
+      reward: candidateReward,
+      metrics: candidateMetrics,
+      action: action.name,
+      explored,
+    });
+
+    epsilon *= config.epsilonDecay;
+  }
+
+  return {
+    bestGains,
+    bestReward,
+    initialReward,
+    improvedOverInitial: bestReward > initialReward,
+    episodes,
+  };
+}

--- a/shared/types/tuning.ts
+++ b/shared/types/tuning.ts
@@ -1,0 +1,122 @@
+/**
+ * PID Auto-Tuning Types
+ * ADR-0013 [13.4] — Issue #215
+ *
+ * Safety envelopes (ADR-0009), human-approval tuning proposals, and
+ * RL-based tuning over a FOPDT process model. Builds on the existing
+ * PIDController/PIDAutoTuner stack from issue #351.
+ */
+
+export interface GainRange {
+  min: number;
+  max: number;
+}
+
+/**
+ * Absolute safety envelope for controller gains (ADR-0009). The existing
+ * per-step rate limit (maxGainChangeFraction) bounds each change; the
+ * envelope bounds where gains can ever end up — repeated rate-limited
+ * steps can no longer walk gains arbitrarily far.
+ */
+export interface GainEnvelope {
+  kpRange: GainRange;
+  kiRange: GainRange;
+  kdRange: GainRange;
+}
+
+/** First-order-plus-dead-time process model for simulation-based tuning */
+export interface FOPDTModel {
+  /** Process gain K */
+  gain: number;
+  /** Time constant τ in seconds */
+  timeConstantS: number;
+  /** Dead time θ in seconds */
+  deadTimeS: number;
+  /** Optional measurement noise sigma */
+  noiseSigma?: number;
+}
+
+export interface EpisodeMetrics {
+  ise: number;
+  iae: number;
+  itae: number;
+  /** Peak overshoot as a fraction of the setpoint change */
+  overshoot: number;
+  /** Sim-time seconds to stay within the 2% band, null if never settled */
+  settlingTimeS: number | null;
+  oscillating: boolean;
+}
+
+export interface RLTunerConfig {
+  episodes: number;
+  episodeTicks: number;
+  dtS: number;
+  /** Exploration rate (0..1), decayed per episode */
+  epsilon: number;
+  epsilonDecay: number;
+  learningRate: number;
+  discount: number;
+  /** Reward penalty multiplier for overshoot */
+  overshootPenalty: number;
+  /** Reward penalty applied when the loop oscillates */
+  oscillationPenalty: number;
+  /** RNG seed for reproducible runs */
+  seed?: number;
+}
+
+export interface RLEpisode {
+  episode: number;
+  gains: { kp: number; ki: number; kd: number };
+  reward: number;
+  metrics: EpisodeMetrics;
+  action: string;
+  explored: boolean;
+}
+
+export interface RLTuningOutcome {
+  bestGains: { kp: number; ki: number; kd: number };
+  bestReward: number;
+  initialReward: number;
+  improvedOverInitial: boolean;
+  episodes: RLEpisode[];
+}
+
+export type TuningProposalStatus =
+  | 'pending'
+  | 'approved'
+  | 'applied'
+  | 'rejected'
+  | 'expired'
+  | 'failed';
+
+export type ProposalMethod = 'relay-feedback' | 'ziegler-nichols' | 'cohen-coon' | 'rl' | 'monitor';
+
+/**
+ * A human-approval tuning proposal. Every gain change flows through one of
+ * these — there is no auto-apply path (ADR-0013: human-in-the-loop).
+ */
+export interface TuningProposal {
+  id: string;
+  controllerId: string;
+  method: ProposalMethod;
+  currentGains: { kp: number; ki: number; kd: number };
+  /** Target gains after envelope clamping */
+  proposedGains: { kp: number; ki: number; kd: number };
+  /** True when the raw recommendation exceeded the envelope and was clamped */
+  clampedByEnvelope: boolean;
+  reason: string;
+  confidence: number;
+  status: TuningProposalStatus;
+  /** Governance gate instance backing the approval */
+  gateInstanceId: string;
+  createdAt: number;
+  resolvedAt?: number;
+  decidedBy?: string;
+  /**
+   * Gains actually written on approval. May differ from proposedGains when
+   * the per-step rate limit truncated the move; `fullyApplied` is false in
+   * that case and a follow-up proposal is required to finish the move.
+   */
+  appliedGains?: { kp: number; ki: number; kd: number };
+  fullyApplied?: boolean;
+}


### PR DESCRIPTION
Closes #215

Unlike the sibling ADR-0013 modules, most of the classical tuning math for this issue **already existed** (issue #351: `PIDController` with anti-windup + metrics, relay feedback, Ziegler–Nichols, Cohen–Coon) — but it was unreachable (no route, never initialized), untested, had no absolute safety bounds, no approval gate (its `automatic` mode applied gains directly, contradicting ADR-0013's human-in-the-loop mandate), and no RL. This PR composes that stack with the missing pieces rather than duplicating it.

## What's included

**Safety envelopes (ADR-0009)** — absolute per-loop `kp/ki/kd` ranges. The existing 25%-per-step rate limit bounds each change; the envelope bounds the *reachable set*, closing the "repeated small steps walk gains arbitrarily far" hole. Every proposal is envelope-clamped (and flagged when clamping occurred).

**Mandatory human approval gate** — every gain change, from every method, becomes a `TuningProposal` backed by a `GateManager` (issue #345) gate instance with approver validation, duplicate-decision rejection, and an audit trail. On approval, application is envelope-clamped **and** rate-limited: an approved 10× jump truncates to one 25% step and reports `fullyApplied: false`. The autotuner's two `automatic`-mode self-apply paths are **removed** (they had zero consumers and violated ADR-0013). `forceGains` is not exposed over HTTP.

**RL-based tuning** — tabular Q-learning over nine multiplicative gain actions, with state = discretized episode performance (overshoot × settling × oscillation) and reward = −normalized ITAE − overshoot/oscillation penalties. Episodes run closed-loop against a **FOPDT process model** with a seeded RNG (fully deterministic), so exploration happens strictly in simulation per ADR-0009. The best gains become a pending proposal like everything else.

**Sim-time relay identification** — Åström–Hägglund limit-cycle identification against the FOPDT model, relaying around the setpoint-holding bias input. Needed because the existing `relayStep` stamps peaks with wall-clock time (fine against a live plant, division-by-zero territory in a fast sim loop); that path is left intact for future live-plant use.

**API** — `/api/tuning`: loop registry + envelope management, `tune/relay`, `tune/cohen-coon`, `tune/rl`, proposals list/detail + `approve`/`reject`, status. Mounted at `/api/tuning` since `/api/pid` is semantically claimed by P&ID diagrams (client expects `/api/pid/diagrams/:id`). Zod-validated with cross-field checks; auth placeholder matching sibling routers.

## Testing
- 15 unit tests: envelope validation/clamping, rate-limit stepping guaranteed to pass `applyGains`, FOPDT open-loop gain, closed-loop regulation vs dead gains, relay identification producing gains that demonstrably stabilize the loop, RL improvement over detuned gains + seed determinism + envelope containment across all episodes, full approval-gate lifecycle, and a regression pinning that `automatic` mode never self-applies
- The previously untested #351 controller/autotuner code is now exercised through these paths
- Full suite: 1195 tests pass; `tsc --noEmit` clean

## Notes
- Proposals/gates are in-memory like every service in this repo (no storage layer exists); surfacing proposals through the documented `/api/agents` AgentProposal contract (currently placeholder routes) is a natural follow-up
- Merge order with the sibling ADR-0013 PRs (#493, #497, #498): each adds adjacent lines in `server/routes.ts` and `server/services/index.ts`; conflicts, if any, are trivial adjacent-line resolutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)