### PR TITLE
feat(integrity): wire EvolutionaryResolver into runtime + governance gate + explainability audit (#492)

### DIFF
--- a/server/services/integrity/__tests__/integrity-service.test.ts
+++ b/server/services/integrity/__tests__/integrity-service.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Integration tests for the #492 wiring: EvolutionaryResolver composed into
+ * the IntegrityService with governance gates + explainability audit, feeding
+ * evolved resolutions back through the base resolver's event stream.
+ */
+import { describe, it, expect } from 'vitest';
+import { IntegrityService } from '../integrity-service';
+import { EvolutionaryResolver } from '../evolutionary/evolutionary-resolver';
+import { ParadoxResolver, type ScadaEvent, type ConflictDetection } from '../paradox-resolver';
+import { ExplainabilityMonitor, type GovernanceGate } from '../explainability-monitor';
+import { ResolutionGenome } from '../evolutionary/genome';
+
+function evt(overrides: Partial<ScadaEvent> = {}): ScadaEvent {
+  return {
+    id: `e_${Math.random().toString(36).slice(2)}`,
+    deviceId: 'dev-1',
+    tag: 'TT-101',
+    value: 100,
+    timestamp: new Date('2026-03-15T00:00:00Z'),
+    quality: 'good',
+    source: 'sensor',
+    logicalClock: 1,
+    vectorClock: {},
+    processArea: 'area-1',
+    ...overrides,
+  };
+}
+
+function conflict(events: ScadaEvent[], area = 'area-1'): ConflictDetection {
+  return {
+    conflictId: `c_${Math.random().toString(36).slice(2)}`,
+    type: 'simultaneous_reading',
+    events,
+    severity: 'medium',
+    detectedAt: new Date(),
+    description: 'test',
+    processArea: area,
+  };
+}
+
+/** Pin the sole population genome to a controllable primitive. */
+function forceGenome(resolver: EvolutionaryResolver, primitiveId: string, score: number, area = 'area-1') {
+  resolver.getRegistry().add({
+    id: primitiveId,
+    name: primitiveId,
+    description: 'test',
+    evaluate: () => ({ score, weight: 1, reasoning: `fixed ${score}` }),
+  });
+  const g = new ResolutionGenome({
+    id: `genome_${primitiveId}`,
+    primitives: [{ primitiveId, weight: 1 }],
+    generation: 10, // mature → not novelty-gated
+    processAreaAffinity: area,
+  });
+  const engine = resolver.getEngine();
+  (engine as any).populations.set(area, [g]);
+  (engine as any).generations.set(area, 0);
+  (engine as any).resolutionCounters.set(area, 0);
+  return g;
+}
+
+describe('IntegrityService wiring (#492)', () => {
+  it('an evolved resolution commits to the base resolver AND lands in the explainability audit', async () => {
+    const svc = new IntegrityService({
+      evolutionary: { evolution: { seed: 1, populationSize: 1 }, safety: { confidenceFloor: 0.3, maturityGeneration: 5 } },
+    });
+    // High-scoring genome → passes safety floor + the 0.6 governance gate.
+    forceGenome(svc.evolutionary, 'strong', 0.95);
+
+    const resolvedEvents: unknown[] = [];
+    svc.on('resolved_event', e => resolvedEvents.push(e));
+
+    const conf = conflict([
+      evt({ deviceId: 'd1', value: 100 }),
+      evt({ id: 'e2', deviceId: 'd2', value: 101 }),
+    ]);
+    const outcome = await svc.evolutionary.resolveConflict(conf);
+
+    // Evolved path taken…
+    expect(outcome.usedEvolved).toBe(true);
+    expect(outcome.resolution.confidence).toBeCloseTo(0.95, 2);
+
+    // …committed to the base resolver (downstream resolved_event fired, and the
+    // resolution is queryable) — this is the M1 fix.
+    expect(resolvedEvents.length).toBe(1);
+    expect(svc.resolver.getResolution(conf.conflictId)).toBeDefined();
+
+    // …and recorded in the tamper-evident explainability audit (M7).
+    const decisions = svc.monitor.getRecentDecisions(10);
+    const evolved = decisions.find(d => d.source === 'EvolutionaryResolver' && d.action === 'evolved_resolution');
+    expect(evolved).toBeDefined();
+    expect(evolved!.output).toMatchObject({ applied: true });
+    const audit = svc.monitor.getAuditTrail({ resource: 'evolved_resolution' });
+    expect(audit.some(a => a.action === 'approve')).toBe(true);
+    expect(svc.monitor.verifyDecisionChain().valid).toBe(true);
+    expect(svc.monitor.verifyAuditChain().valid).toBe(true);
+  });
+
+  it('the governance gate demotes a low-confidence evolved strategy to static + records a reject audit (#492 M7)', async () => {
+    const svc = new IntegrityService({
+      evolutionary: { evolution: { seed: 2, populationSize: 1 }, safety: { confidenceFloor: 0.1, maturityGeneration: 5 } },
+      // gate blocks below 0.6; the genome scores 0.4 — above the safety floor,
+      // below the governance gate.
+    });
+    forceGenome(svc.evolutionary, 'midling', 0.4);
+
+    let govBlocked = 0;
+    svc.on('governance_blocked', () => govBlocked++);
+
+    const conf = conflict([
+      evt({ deviceId: 'd1', value: 100 }),
+      evt({ id: 'e2', deviceId: 'd2', value: 200 }),
+    ]);
+    const outcome = await svc.evolutionary.resolveConflict(conf);
+
+    expect(outcome.usedEvolved).toBe(false);
+    expect(outcome.safetyDecision.reason).toMatch(/Governance gate/);
+    expect(govBlocked).toBe(1);
+
+    const audit = svc.monitor.getAuditTrail({ resource: 'evolved_resolution' });
+    expect(audit.some(a => a.action === 'reject')).toBe(true);
+    // Static fallback still produced a real resolution.
+    expect(outcome.resolution).toBeDefined();
+    expect(svc.evolutionary.getStatus().totalGovernanceBlocked).toBe(1);
+  });
+
+  it('ingestEvent detects a conflict and routes it through the evolutionary resolver end-to-end', async () => {
+    const svc = new IntegrityService({
+      resolver: { simultaneousWindowMs: 100000 },
+      evolutionary: { evolution: { seed: 3, populationSize: 1 }, safety: { confidenceFloor: 0.3, maturityGeneration: 5 } },
+    });
+    forceGenome(svc.evolutionary, 'strong2', 0.9);
+
+    const now = Date.now();
+    // First reading establishes state; the second (different device, different
+    // value, within the window) triggers a simultaneous-reading conflict.
+    const r1 = await svc.ingestEvent(evt({ deviceId: 'd1', value: 100, timestamp: new Date(now) }));
+    expect(r1.conflict).toBeNull();
+
+    const r2 = await svc.ingestEvent(evt({ id: 'e2', deviceId: 'd2', value: 150, timestamp: new Date(now + 5) }));
+    expect(r2.conflict).not.toBeNull();
+    expect(r2.resolution).not.toBeNull();
+    // The base resolver did NOT auto-resolve (auto-resolve is off); resolution
+    // came from the evolutionary path and was committed.
+    expect(svc.resolver.getResolution(r2.conflict!.conflictId)).toBeDefined();
+  });
+
+  it('ConflictContext is populated so history/rate primitives run on real data (#492 M5)', async () => {
+    // A resolver seeded with recent readings; a genome using the history_bias
+    // primitive should now receive non-empty recentReadings and favor the
+    // reading closest to the historical mean, instead of returning neutral 0.5.
+    const base = new ParadoxResolver({ simultaneousWindowMs: 100000 });
+    const monitor = new ExplainabilityMonitor();
+    const resolver = new EvolutionaryResolver(base, {
+      evolution: { seed: 4, populationSize: 1 },
+      safety: { confidenceFloor: 0.05, maturityGeneration: 5 },
+    }, monitor);
+
+    // Historical trend centered on 100 with real spread (σ≈7), so a reading at
+    // 101 sits well within a stddev (score clears the safety floor) while 500 is
+    // far out — history_bias should favor 101.
+    const now = Date.now();
+    for (const [i, v] of [90, 95, 100, 105, 110].entries()) {
+      await base.ingestEvent(evt({ deviceId: 'hist', value: v, timestamp: new Date(now + i), tag: 'FT-9' }));
+    }
+
+    const g = new ResolutionGenome({
+      id: 'hist-genome',
+      primitives: [{ primitiveId: 'history_bias', weight: 1 }],
+      generation: 10,
+      processAreaAffinity: 'area-1',
+    });
+    (resolver.getEngine() as any).populations.set('area-1', [g]);
+    (resolver.getEngine() as any).generations.set('area-1', 0);
+    (resolver.getEngine() as any).resolutionCounters.set('area-1', 0);
+
+    // Conflict: 500 (wild) FIRST, then 101 (near history). history_bias must
+    // favor 101. The wild reading is events[0], so if recentReadings were NOT
+    // populated (history_bias returns no favoredEventId) the winner would
+    // default to the wild reading — the test discriminates on that.
+    const conf = conflict([
+      evt({ id: 'wild', deviceId: 'd2', value: 500, tag: 'FT-9' }),
+      evt({ id: 'near', deviceId: 'd1', value: 101, tag: 'FT-9' }),
+    ]);
+    const outcome = await resolver.resolveConflict(conf);
+
+    expect(outcome.usedEvolved).toBe(true);
+    // Winner is the near-history reading → history_bias actually ran on real
+    // recentReadings (M5). With empty context it would default to events[0]=wild.
+    expect(outcome.resolution.winner?.id).toBe('near');
+  });
+
+  it('without a monitor, resolveConflict still works (governance/audit are no-ops)', async () => {
+    const base = new ParadoxResolver();
+    const resolver = new EvolutionaryResolver(base, {
+      evolution: { seed: 5, populationSize: 1 },
+      safety: { confidenceFloor: 0.3, maturityGeneration: 5 },
+    }); // no monitor
+    forceGenome(resolver, 'strong3', 0.9);
+    const outcome = await resolver.resolveConflict(conflict([
+      evt({ deviceId: 'd1', value: 100 }),
+      evt({ id: 'e2', deviceId: 'd2', value: 101 }),
+    ]));
+    expect(outcome.usedEvolved).toBe(true);
+    expect(resolver.getStatus().complianceMonitorActive).toBe(false);
+  });
+});

--- a/server/services/integrity/__tests__/integrity-service.test.ts
+++ b/server/services/integrity/__tests__/integrity-service.test.ts
@@ -190,6 +190,37 @@ describe('IntegrityService wiring (#492)', () => {
     expect(outcome.resolution.winner?.id).toBe('near');
   });
 
+  it('does NOT double-commit when a process area has an explicit autoResolveSeverity', async () => {
+    // Regression: base ingestEvent must not auto-resolve (which would commit
+    // once) and then have the evolutionary resolver commit again. The
+    // externalResolution master switch suppresses base auto-resolution even
+    // for an area that opted in via autoResolveSeverity.
+    const svc = new IntegrityService({
+      resolver: { simultaneousWindowMs: 100000 },
+      evolutionary: { evolution: { seed: 6, populationSize: 1 }, safety: { confidenceFloor: 0.3, maturityGeneration: 5 } },
+    });
+    svc.registerProcessAreaRules({
+      processArea: 'area-1',
+      preferredStrategy: 'confidence_weighted',
+      minVotingQuorum: 3,
+      physicsConstraints: [],
+      sensorPriority: [],
+      autoResolveSeverity: 'critical', // would auto-resolve everything if honored
+      deviceConfidenceOverrides: {},
+    });
+    forceGenome(svc.evolutionary, 'strong4', 0.9);
+
+    const resolvedEvents: unknown[] = [];
+    svc.on('resolved_event', e => resolvedEvents.push(e));
+
+    const now = Date.now();
+    await svc.ingestEvent(evt({ deviceId: 'd1', value: 100, timestamp: new Date(now) }));
+    await svc.ingestEvent(evt({ id: 'e2', deviceId: 'd2', value: 150, timestamp: new Date(now + 5) }));
+
+    // Exactly ONE resolved_event for the one conflict — no double commit.
+    expect(resolvedEvents.length).toBe(1);
+  });
+
   it('without a monitor, resolveConflict still works (governance/audit are no-ops)', async () => {
     const base = new ParadoxResolver();
     const resolver = new EvolutionaryResolver(base, {

--- a/server/services/integrity/evolutionary/evolutionary-resolver.ts
+++ b/server/services/integrity/evolutionary/evolutionary-resolver.ts
@@ -15,6 +15,15 @@
  * 7. Fitness evaluator scores the result
  * 8. After N resolutions, evolution cycle runs
  *
+ * COMMIT-ONCE INVARIANT: an approved evolved resolution calls
+ * `resolver.commitResolution(...)`. If you ALSO let the same base resolver
+ * auto-resolve the same conflict inside its own `ingestEvent` (the default
+ * ParadoxResolver behavior), that conflict is committed twice. When driving
+ * events through `ingestEvent` and then routing the conflict here, construct
+ * the base resolver with `externalResolution: true` (the IntegrityService does
+ * this). Calling `resolveConflict(conflict)` directly on a conflict object —
+ * as the unit tests do — never double-commits.
+ *
  * @see ADR-0023
  * @closes #384
  */

--- a/server/services/integrity/evolutionary/evolutionary-resolver.ts
+++ b/server/services/integrity/evolutionary/evolutionary-resolver.ts
@@ -30,8 +30,9 @@ import { EvolutionEngine, type EvolutionConfig } from './evolution-engine';
 import { SafetyGuard, type SafetyConfig } from './safety-guard';
 import { FitnessEvaluator } from './fitness';
 import { PrimitiveRegistry } from './registry';
-import { ResolutionGenome } from './genome';
+import { ResolutionGenome, type GenomeEvaluation } from './genome';
 import { ConflictContext } from './primitives';
+import type { ExplainabilityMonitor } from '../explainability-monitor';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -44,6 +45,11 @@ export interface EvolutionaryResolverConfig {
   evolution?: Partial<EvolutionConfig>;
   /** Safety-guard overrides (confidence floor, novelty budget, maturity gen, …) */
   safety?: Partial<SafetyConfig>;
+  /**
+   * Action string used for governance gates + explainability decisions
+   * (ADR-0023 / CFR 21 Part 11). Default 'evolved_resolution'.
+   */
+  governanceAction?: string;
 }
 
 export interface EvolutionaryResolution {
@@ -76,11 +82,15 @@ export interface EvolutionaryResolverStatus {
   safetyStats: ReturnType<SafetyGuard['getStats']>;
   totalEvolutionaryResolutions: number;
   totalStaticFallbacks: number;
+  totalGovernanceBlocked: number;
+  /** Whether a CFR-21-Part-11 compliance monitor is wired */
+  complianceMonitorActive: boolean;
 }
 
 const DEFAULT_CONFIG: EvolutionaryResolverConfig = {
   enabled: true,
   allowedProcessAreas: [],
+  governanceAction: 'evolved_resolution',
 };
 
 // ─── Evolutionary Resolver ──────────────────────────────────────────────────
@@ -92,18 +102,23 @@ export class EvolutionaryResolver extends EventEmitter {
   private guard: SafetyGuard;
   private fitness: FitnessEvaluator;
   private registry: PrimitiveRegistry;
+  /** Optional CFR-21-Part-11 compliance layer (governance gates + audit). */
+  private monitor?: ExplainabilityMonitor;
 
   /** Counters for status tracking */
   private evolutionaryCount = 0;
   private staticFallbackCount = 0;
+  private governanceBlockedCount = 0;
 
   constructor(
     resolver: ParadoxResolver,
     config: Partial<EvolutionaryResolverConfig> = {},
+    monitor?: ExplainabilityMonitor,
   ) {
     super();
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.resolver = resolver;
+    this.monitor = monitor;
 
     // Initialize sub-components
     this.registry = new PrimitiveRegistry();
@@ -205,7 +220,7 @@ export class EvolutionaryResolver extends EventEmitter {
       };
     }
 
-    // Evolved strategy approved — build resolution from genome evaluation
+    // SafetyGuard approved — build the evolved resolution from the evaluation.
     const resolution: Resolution = {
       conflictId: conflict.conflictId,
       method: 'confidence_weighted', // closest static equivalent
@@ -217,10 +232,37 @@ export class EvolutionaryResolver extends EventEmitter {
       resolvedAt: new Date(),
     };
 
+    // Governance gate (#492 M7): ADR-0023 requires evolved strategies to pass a
+    // gate before production use. A blocking gate failure demotes to static.
+    const govBlockReason = this.checkGovernance(resolution);
+    if (govBlockReason) {
+      const staticResolution = await this.resolver.resolve(conflict);
+      this.staticFallbackCount++;
+      this.governanceBlockedCount++;
+      this.fitness.evaluate(genome, this.genomeSelfResolution(conflict, evaluation), evaluation);
+      this.recordExplainability(resolution, genome, evaluation, processArea, false, govBlockReason);
+      if (shouldEvolve) this.evolveAndEmit(processArea);
+      this.emit('governance_blocked', { processArea, genomeId: genome.id, reason: govBlockReason });
+      return {
+        resolution: staticResolution,
+        usedEvolved: false,
+        genomeId: genome.id,
+        generation: genome.generation,
+        safetyDecision: { allowed: false, reason: `Governance gate: ${govBlockReason}` },
+      };
+    }
+
     this.evolutionaryCount++;
 
     // Record fitness
     this.fitness.evaluate(genome, resolution, evaluation);
+
+    // Commit through the base resolver (#492 M1) so its maps update and
+    // downstream `resolved` / `resolved_event` listeners (ADR-0024/0025) fire.
+    this.resolver.commitResolution(conflict, resolution);
+
+    // Explainability audit for the approved evolved decision (#492 M7).
+    this.recordExplainability(resolution, genome, evaluation, processArea, true);
 
     if (shouldEvolve) this.evolveAndEmit(processArea);
 
@@ -283,12 +325,109 @@ export class EvolutionaryResolver extends EventEmitter {
   }
 
   private buildConflictContext(conflict: ConflictDetection): ConflictContext {
+    // #492 M5: populate the context from the base resolver's state so the
+    // history_bias / rate_filter (recentReadings) and neighbor_correlation
+    // (neighborValues) primitives actually run instead of returning neutral.
+    const tag = conflict.events[0]?.tag;
+    let recentReadings: ScadaEvent[] | undefined;
+    let neighborValues: Map<string, unknown> | undefined;
+
+    if (tag) {
+      const conflictIds = new Set(conflict.events.map(e => e.id));
+      const readings = this.resolver.getRecentReadings(tag, conflictIds);
+      if (readings.length > 0) recentReadings = readings;
+
+      const neighborTags = this.resolver.getNeighborTags(tag, conflict.processArea);
+      if (neighborTags.length > 0) {
+        const values = new Map<string, unknown>();
+        for (const nt of neighborTags) {
+          const v = this.resolver.getLatestValue(nt);
+          if (v !== undefined) values.set(nt, v);
+        }
+        if (values.size > 0) neighborValues = values;
+      }
+    }
+
     return {
       conflict,
-      recentReadings: undefined, // Could be populated from resolver's event history
-      neighborValues: undefined, // Could be populated from tag correlations
+      recentReadings,
+      neighborValues,
       physicsValid: conflict.type !== 'physics_violation' ? undefined : false,
     };
+  }
+
+  /** A resolution carrying the genome's OWN score, for fitness on demoted paths. */
+  private genomeSelfResolution(conflict: ConflictDetection, evaluation: GenomeEvaluation): Resolution {
+    return {
+      conflictId: conflict.conflictId,
+      method: 'confidence_weighted',
+      confidence: evaluation.score,
+      reasoning: `[Evolved-demoted] ${evaluation.reasoning}`,
+      resolvedAt: new Date(),
+    };
+  }
+
+  /**
+   * Run the evolved resolution through the compliance governance gates.
+   * Returns a block reason if any applicable gate with `block` enforcement
+   * fails, otherwise null (including when no monitor is wired).
+   */
+  private checkGovernance(resolution: Resolution): string | null {
+    if (!this.monitor) return null;
+    const results = this.monitor.checkGovernanceGates(
+      this.config.governanceAction ?? 'evolved_resolution',
+      resolution.confidence,
+      false, // evolved resolutions are automated — no electronic signature
+    );
+    const blocking = results.find(r => !r.passed && r.enforcement === 'block');
+    return blocking ? blocking.reason : null;
+  }
+
+  /**
+   * Record a CFR-21-Part-11 explainability decision + tamper-evident audit
+   * entry for an evolved-resolution decision (#492 M7). No-op without a monitor.
+   */
+  private recordExplainability(
+    resolution: Resolution,
+    genome: ResolutionGenome,
+    evaluation: GenomeEvaluation,
+    processArea: string,
+    approved: boolean,
+    blockReason?: string,
+  ): void {
+    if (!this.monitor) return;
+    const decision = this.monitor.recordDecision({
+      source: 'EvolutionaryResolver',
+      action: this.config.governanceAction ?? 'evolved_resolution',
+      ruleApplied: `evolved-genome:${genome.id} gen=${genome.generation}`,
+      reasoning: approved ? resolution.reasoning : `Gated: ${blockReason}. ${resolution.reasoning}`,
+      inputs: {
+        conflictId: resolution.conflictId,
+        processArea,
+        primitivesEvaluated: evaluation.primitivesEvaluated,
+        genomeId: genome.id,
+        generation: genome.generation,
+      },
+      output: {
+        method: resolution.method,
+        winner: resolution.winner?.id,
+        mergedValue: resolution.mergedValue,
+        applied: approved,
+      },
+      confidence: resolution.confidence,
+      verificationLayers: [
+        { layer: 'safety_guard', passed: true, score: resolution.confidence, timestamp: new Date() },
+        { layer: 'governance_gate', passed: approved, score: resolution.confidence, details: blockReason, timestamp: new Date() },
+      ],
+    });
+
+    this.monitor.addAuditEntry({
+      userId: 'system:evolutionary-resolver',
+      action: approved ? 'approve' : 'reject',
+      resource: 'evolved_resolution',
+      resourceId: decision.id,
+      reason: approved ? 'Evolved strategy applied' : `Evolved strategy gated: ${blockReason}`,
+    });
   }
 
   private evolveAndEmit(processArea: string): void {
@@ -326,6 +465,8 @@ export class EvolutionaryResolver extends EventEmitter {
       safetyStats: this.guard.getStats(),
       totalEvolutionaryResolutions: this.evolutionaryCount,
       totalStaticFallbacks: this.staticFallbackCount,
+      totalGovernanceBlocked: this.governanceBlockedCount,
+      complianceMonitorActive: this.monitor !== undefined,
     };
   }
 

--- a/server/services/integrity/index.ts
+++ b/server/services/integrity/index.ts
@@ -39,3 +39,13 @@ export type {
   VerificationHook,
   ExplainabilityConfig,
 } from './explainability-monitor';
+
+// Evolutionary resolution + composition root (#492)
+export { EvolutionaryResolver } from './evolutionary/evolutionary-resolver';
+export type {
+  EvolutionaryResolverConfig,
+  EvolutionaryResolution,
+  EvolutionaryResolverStatus,
+} from './evolutionary/evolutionary-resolver';
+export { IntegrityService, integrityService } from './integrity-service';
+export type { IntegrityServiceConfig, IngestOutcome } from './integrity-service';

--- a/server/services/integrity/integrity-service.ts
+++ b/server/services/integrity/integrity-service.ts
@@ -1,0 +1,124 @@
+/**
+ * Integrity Service — composition root for paradox resolution (#492)
+ *
+ * Wires the three previously-disconnected integrity components into one flow:
+ *
+ *   ScadaEvent → ParadoxResolver (detect)
+ *              → EvolutionaryResolver (evolved strategy, SafetyGuard-gated)
+ *              → governance gate + explainability audit (CFR 21 Part 11)
+ *              → commit to ParadoxResolver → `resolved` / `resolved_event`
+ *
+ * Before this, ParadoxResolver.ingestEvent was never called from production,
+ * and the entire evolutionary/ subsystem had no importer. This module is the
+ * mountable entry point a live event pipeline (#489) hooks into.
+ *
+ * The base resolver is created with auto-resolve OFF: the EvolutionaryResolver
+ * owns the resolve step (it internally falls back to the base resolver's static
+ * strategies when SafetyGuard or the governance gate blocks an evolved one).
+ *
+ * @see ADR-0023, ADR-0024, ADR-0025
+ * @closes #492
+ */
+
+import { EventEmitter } from 'events';
+import {
+  ParadoxResolver,
+  type ScadaEvent,
+  type ConflictDetection,
+  type Resolution,
+  type ParadoxResolverConfig,
+} from './paradox-resolver';
+import { EvolutionaryResolver, type EvolutionaryResolverConfig } from './evolutionary/evolutionary-resolver';
+import { ExplainabilityMonitor, type GovernanceGate } from './explainability-monitor';
+
+export interface IntegrityServiceConfig {
+  /** ParadoxResolver overrides. `autoResolveLowSeverity` is forced false. */
+  resolver?: Partial<Omit<ParadoxResolverConfig, 'autoResolveLowSeverity'>>;
+  /** EvolutionaryResolver overrides (evolution/safety/governanceAction, …) */
+  evolutionary?: Partial<EvolutionaryResolverConfig>;
+  /**
+   * Governance gate applied to every evolved resolution. Omit to use the
+   * default (block evolved resolutions below 0.6 confidence). Pass `null` to
+   * register no gate.
+   */
+  governanceGate?: GovernanceGate | null;
+}
+
+const DEFAULT_GOVERNANCE_GATE: GovernanceGate = {
+  id: 'evolved_resolution_gate',
+  name: 'Evolved Resolution Approval',
+  description: 'Blocks evolved resolution strategies whose confidence is below the production threshold.',
+  actionPatterns: ['evolved_resolution'],
+  requiredApproval: 'none', // automated; no electronic signature required
+  minConfidence: 0.6,
+  enforcement: 'block',
+};
+
+export interface IngestOutcome {
+  conflict: ConflictDetection | null;
+  resolution: Resolution | null;
+  usedEvolved: boolean;
+}
+
+export class IntegrityService extends EventEmitter {
+  readonly resolver: ParadoxResolver;
+  readonly evolutionary: EvolutionaryResolver;
+  readonly monitor: ExplainabilityMonitor;
+
+  constructor(config: IntegrityServiceConfig = {}) {
+    super();
+
+    // Auto-resolve OFF: the evolutionary resolver owns resolution.
+    this.resolver = new ParadoxResolver({
+      ...config.resolver,
+      autoResolveLowSeverity: false,
+    });
+
+    this.monitor = new ExplainabilityMonitor();
+    const gate = config.governanceGate === undefined ? DEFAULT_GOVERNANCE_GATE : config.governanceGate;
+    if (gate) this.monitor.registerGovernanceGate(gate);
+
+    this.evolutionary = new EvolutionaryResolver(this.resolver, config.evolutionary, this.monitor);
+
+    // Re-emit downstream signals for ADR-0024/0025 consumers.
+    this.resolver.on('resolved', r => this.emit('resolved', r));
+    this.resolver.on('resolved_event', e => this.emit('resolved_event', e));
+    this.resolver.on('conflict', c => this.emit('conflict', c));
+    this.evolutionary.on('evolutionary_resolution', e => this.emit('evolutionary_resolution', e));
+    this.evolutionary.on('governance_blocked', e => this.emit('governance_blocked', e));
+    this.evolutionary.on('safety_blocked', e => this.emit('safety_blocked', e));
+  }
+
+  /**
+   * Ingest a SCADA event: detect a conflict and, if one is found, resolve it
+   * through the evolutionary resolver (evolved-or-static, gated + audited).
+   */
+  async ingestEvent(event: ScadaEvent): Promise<IngestOutcome> {
+    const conflict = await this.resolver.ingestEvent(event);
+    if (!conflict) {
+      return { conflict: null, resolution: null, usedEvolved: false };
+    }
+    const outcome = await this.evolutionary.resolveConflict(conflict);
+    return {
+      conflict,
+      resolution: outcome.resolution,
+      usedEvolved: outcome.usedEvolved,
+    };
+  }
+
+  /** Register per-process-area resolution rules on the base resolver. */
+  registerProcessAreaRules(...args: Parameters<ParadoxResolver['registerProcessAreaRules']>): void {
+    this.resolver.registerProcessAreaRules(...args);
+  }
+
+  getStatus() {
+    return {
+      resolver: this.resolver.getStatus(),
+      evolutionary: this.evolutionary.getStatus(),
+      explainability: this.monitor.getStatus(),
+    };
+  }
+}
+
+/** Shared singleton for the default integrity pipeline. */
+export const integrityService = new IntegrityService();

--- a/server/services/integrity/integrity-service.ts
+++ b/server/services/integrity/integrity-service.ts
@@ -32,8 +32,11 @@ import { EvolutionaryResolver, type EvolutionaryResolverConfig } from './evoluti
 import { ExplainabilityMonitor, type GovernanceGate } from './explainability-monitor';
 
 export interface IntegrityServiceConfig {
-  /** ParadoxResolver overrides. `autoResolveLowSeverity` is forced false. */
-  resolver?: Partial<Omit<ParadoxResolverConfig, 'autoResolveLowSeverity'>>;
+  /**
+   * ParadoxResolver overrides. `autoResolveLowSeverity` and
+   * `externalResolution` are forced (the evolutionary resolver owns resolution).
+   */
+  resolver?: Partial<Omit<ParadoxResolverConfig, 'autoResolveLowSeverity' | 'externalResolution'>>;
   /** EvolutionaryResolver overrides (evolution/safety/governanceAction, …) */
   evolutionary?: Partial<EvolutionaryResolverConfig>;
   /**
@@ -68,10 +71,14 @@ export class IntegrityService extends EventEmitter {
   constructor(config: IntegrityServiceConfig = {}) {
     super();
 
-    // Auto-resolve OFF: the evolutionary resolver owns resolution.
+    // Resolution is owned by the evolutionary resolver. `externalResolution`
+    // is the hard switch that suppresses base auto-resolution even for process
+    // areas registered with an explicit autoResolveSeverity, so each conflict
+    // is committed exactly once (by the evolved-or-static path below).
     this.resolver = new ParadoxResolver({
       ...config.resolver,
       autoResolveLowSeverity: false,
+      externalResolution: true,
     });
 
     this.monitor = new ExplainabilityMonitor();

--- a/server/services/integrity/paradox-resolver.ts
+++ b/server/services/integrity/paradox-resolver.ts
@@ -158,6 +158,14 @@ export interface ParadoxResolverConfig {
   qualityWeight: number;
   /** Default minimum quorum for voting strategy */
   defaultVotingQuorum: number;
+  /**
+   * When true, `ingestEvent` detects conflicts but NEVER resolves them —
+   * resolution is driven externally (e.g. by the EvolutionaryResolver via the
+   * IntegrityService, #492). This is a hard master switch that overrides even a
+   * process area's explicit `autoResolveSeverity`, so a conflict is committed
+   * exactly once by the external owner rather than double-committed.
+   */
+  externalResolution: boolean;
 }
 
 const DEFAULT_CONFIG: ParadoxResolverConfig = {
@@ -166,6 +174,7 @@ const DEFAULT_CONFIG: ParadoxResolverConfig = {
   autoResolveLowSeverity: true,
   qualityWeight: 0.7,
   defaultVotingQuorum: 3,
+  externalResolution: false,
 };
 
 /**
@@ -344,6 +353,11 @@ export class ParadoxResolver extends EventEmitter {
   }
 
   private shouldAutoResolve(conflict: ConflictDetection, areaRules: ProcessAreaRules | null): boolean {
+    // Hard master switch (#492): when resolution is owned externally, never
+    // auto-resolve internally — otherwise the conflict is committed twice
+    // (once here, once by the external resolver).
+    if (this.config.externalResolution) return false;
+
     const severityOrder = ['low', 'medium', 'high', 'critical'];
     const conflictLevel = severityOrder.indexOf(conflict.severity);
 

--- a/server/services/integrity/paradox-resolver.ts
+++ b/server/services/integrity/paradox-resolver.ts
@@ -491,6 +491,18 @@ export class ParadoxResolver extends EventEmitter {
       }
     }
 
+    this.commitResolution(conflict, resolution);
+    return resolution;
+  }
+
+  /**
+   * Record a resolution into the resolver's maps and emit the `resolved` /
+   * `resolved_event` events. Factored out of `resolve()` so an external
+   * strategy (e.g. the EvolutionaryResolver, #492) can commit its own
+   * resolution through the same path — otherwise downstream ADR-0024/0025
+   * listeners never see evolved resolutions.
+   */
+  commitResolution(conflict: ConflictDetection, resolution: Resolution): ResolvedEvent {
     this.resolutions.set(conflict.conflictId, resolution);
     this.enforceMapLimit(this.conflicts, ParadoxResolver.MAX_MAP_SIZE);
     this.enforceMapLimit(this.resolutions, ParadoxResolver.MAX_MAP_SIZE);
@@ -502,7 +514,43 @@ export class ParadoxResolver extends EventEmitter {
 
     this.emit('resolved', resolution);
     this.emit('resolved_event', resolved);
-    return resolution;
+    return resolved;
+  }
+
+  // ─── Read accessors for external resolvers (#492 ConflictContext) ─────────
+
+  /**
+   * Recent readings for a tag (oldest→newest) from the voting window,
+   * optionally excluding a set of event ids (e.g. the conflict's own events).
+   */
+  getRecentReadings(tag: string, excludeIds?: Set<string>): ScadaEvent[] {
+    const window = this.tagEventWindow.get(tag) ?? [];
+    const filtered = excludeIds ? window.filter(e => !excludeIds.has(e.id)) : window;
+    return [...filtered].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  }
+
+  /** Latest known value for a tag, or undefined if never seen. */
+  getLatestValue(tag: string): unknown | undefined {
+    return this.tagLatest.get(tag)?.value;
+  }
+
+  /**
+   * Tags linked to `tag` via a shared physics constraint (global + area) —
+   * a reasonable "neighbor" set for correlation checks.
+   */
+  getNeighborTags(tag: string, area?: string): string[] {
+    const areaRules = this.getRulesForArea(area);
+    const constraints = [
+      ...this.globalPhysicsConstraints,
+      ...(areaRules?.physicsConstraints ?? []),
+    ];
+    const neighbors = new Set<string>();
+    for (const c of constraints) {
+      if (c.tags.includes(tag)) {
+        for (const t of c.tags) if (t !== tag) neighbors.add(t);
+      }
+    }
+    return Array.from(neighbors);
   }
 
   /** Pick the best strategy for simultaneous readings */


### PR DESCRIPTION
Fixes #492 · builds on #491 (engine correctness, merged)

Closes the M1/M5/M7 wiring gaps from the #451 review. The evolutionary subsystem was dead code with no importer and, even if called, fed nothing downstream, ran its context-dependent primitives blind, and had no compliance layer. This lands the composition and the governance/audit path **now that #491 made the engine correct** — so what gets wired is the fixed selection pressure, not the inverted one.

## What's new

**`server/services/integrity/integrity-service.ts`** — composition root:
```
ScadaEvent → ParadoxResolver (detect, auto-resolve OFF)
           → EvolutionaryResolver (evolved, SafetyGuard-gated)
           → governance gate + explainability audit (CFR 21 Part 11)
           → commit to ParadoxResolver → resolved / resolved_event
```
Exposes `ingestEvent()` and a singleton — the mountable entry point #489's live pipeline hooks into. The base resolver runs with `autoResolveLowSeverity: false` so the evolutionary resolver owns the resolve step.

**M1 — evolved resolutions now commit downstream.** Factored `ParadoxResolver.commitResolution` out of `resolve()`; the evolved path calls it so the resolver's maps update and `resolved`/`resolved_event` (ADR-0024/0025) fire. Previously the evolved path updated nothing.

**M5 — `ConflictContext` is populated.** New read accessors (`getRecentReadings` excluding the conflict's own events, `getLatestValue`, `getNeighborTags` via physics constraints) feed `recentReadings`/`neighborValues`, so `history_bias` / `rate_filter` / `neighbor_correlation` (and their Wave-1 fixes) run on real data instead of returning neutral 0.5.

**M7 — governance gate + explainability audit.** `EvolutionaryResolver` takes an optional `ExplainabilityMonitor`. Each evolved decision passes through `checkGovernanceGates` (a blocking gate demotes it to static, scoring the genome on its own eval) and is recorded as a tamper-evident decision + audit entry (approve/reject). `IntegrityService` registers a default gate blocking evolved resolutions below 0.6 confidence. The monitor is **optional** — no monitor = no-op, existing callers unaffected.

## Tests

5 integration tests (`integrity-service.test.ts`), each **mutation-verified** (revert the behavior → the named test fails):
- evolved resolution **commits to the base resolver** (downstream `resolved_event` fires) **and** lands in the explainability audit with a valid hash chain — *M1 mutant fails*
- governance gate **demotes** a low-confidence evolved strategy to static and records a `reject` audit — *M7 mutant fails*
- `ingestEvent` detects a conflict and routes it end-to-end through the evolutionary path
- `ConflictContext` drives `history_bias` to the near-history winner (wild reading is `events[0]`, so unpopulated context would default to it) — *M5 mutant fails*
- monitor-less operation still works

`tsc --noEmit` clean; full node suite **1199 pass / 9 skip** (the one failing file is the pre-existing `openssl`-gated e2e, unchanged).

An independent adversarial review is running (focused on double-commit risk between the base auto-resolve and the evolved commit); I'll fold in any findings before requesting merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)