### PR TITLE
[13.5] Natural Language Process Query (ADR-0013)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,7 @@ import pidRoutes from "./routes/pid";
 import { fluxRoutes } from "./routes/flux";
 import { gatewayRoutes } from "./routes/gateway";
 import { intelligenceRoutes } from "./routes/intelligence";
+import { nlQueryService } from "./services/nlquery";
 import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
@@ -80,6 +81,11 @@ export async function registerRoutes(
   // WebSocket servers initialize if available
   try { tagStreamServer?.initialize(httpServer, "/ws/tags"); } catch {}
   try { unifiedStreamServer?.initialize(httpServer, "/ws"); } catch {}  // unified endpoint (#255)
+
+  // Feed live tag updates into the NL query store and start the service
+  // here — services/initializeServices() has no callers at startup (#216).
+  tagStreamServer.onTagUpdate((update) => nlQueryService.ingestTagUpdate(update));
+  void nlQueryService.initialize();
 
   // WebSocket metrics endpoint. The legacy event-stream server was removed;
   // only the tag and unified streams report (#446, #479).

--- a/server/routes/intelligence.ts
+++ b/server/routes/intelligence.ts
@@ -1,11 +1,12 @@
 import { Router } from "express";
 import { z } from "zod";
+import { nlQueryService } from "../services/nlquery";
 
 const router = Router();
 
 // Schema definitions for intelligence modules
 const NLQuerySchema = z.object({
-  query: z.string().min(1),
+  query: z.string().min(1).max(1000),
   context: z.string().optional(),
   filters: z.record(z.any()).optional(),
 });
@@ -31,44 +32,39 @@ const MLPipelineSchema = z.object({
   data: z.array(z.record(z.any())),
 });
 
-// NL Query Engine endpoints
+// NL Query Engine endpoints (ADR-0013 [13.5], #216 — real implementation)
 router.post("/nlquery", async (req, res) => {
+  const parsed = NLQuerySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: "Invalid NL query request" });
+  }
   try {
-    const { query, context, filters } = NLQuerySchema.parse(req.body);
-    
-    // Basic NL query processing (placeholder implementation)
-    const results = {
-      query,
-      interpretation: `Processed query: ${query}`,
-      results: [],
-      suggestions: [
-        "Try refining your query with more specific terms",
-        "Consider adding time filters",
-      ],
-    };
-    
-    res.json(results);
+    const result = await nlQueryService.engine.execute(parsed.data.query);
+    res.json({
+      query: result.query,
+      interpretation: result.interpretation,
+      intent: result.intent.type,
+      success: result.success,
+      answer: result.answer,
+      results: [result.data],
+      suggestions: result.suggestions,
+      parsedBy: result.parsedBy,
+    });
   } catch (error) {
-    res.status(400).json({ error: "Invalid NL query request" });
+    console.error("[nlquery] execution error:", error);
+    if (!res.headersSent) res.status(500).json({ error: "Query execution failed" });
   }
 });
 
-router.get("/nlquery/history", async (req, res) => {
-  try {
-    // Mock query history
-    const history = [
-      {
-        id: "1",
-        query: "Show me pump efficiency trends",
-        timestamp: new Date().toISOString(),
-        results: 15,
-      },
-    ];
-    
-    res.json({ history });
-  } catch (error) {
-    res.status(500).json({ error: "Failed to fetch query history" });
-  }
+router.get("/nlquery/history", async (_req, res) => {
+  const history = nlQueryService.engine.getHistory().map((r) => ({
+    id: r.id,
+    query: r.query,
+    timestamp: new Date(r.timestamp).toISOString(),
+    results: r.success ? 1 : 0,
+    answer: r.answer,
+  }));
+  res.json({ history });
 });
 
 // Predictive Maintenance endpoints

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -66,6 +66,10 @@ export { spcService } from './spc';
 export * from './l2-rollup';
 export { l2RollupService } from './l2-rollup';
 
+// ── NL Query Service (ADR-0013 [13.5], #216) ─────────────────────────────────
+export * from './nlquery';
+export { nlQueryService } from './nlquery';
+
 /**
  * Initialize all services
  * 
@@ -80,7 +84,8 @@ export async function initializeServices(): Promise<void> {
     { name: 'Ubiquity', service: () => import('./ubiquity').then(m => m.ubiquityService.initialize()) },
     { name: 'Layer 2 Rollup', service: () => import('./l2-rollup').then(m => m.l2RollupService.initialize()) },
     { name: 'Optimization', service: () => import('./optimization').then(m => m.optimizationService.initialize()) },
-    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) }
+    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) },
+    { name: 'NL Query', service: () => import('./nlquery').then(m => m.nlQueryService.initialize()) }
   ];
 
   for (const { name, service } of services) {
@@ -171,6 +176,14 @@ export async function getServicesHealthStatus(): Promise<{
         return await spcService.healthCheck();
       } catch {
         return { healthy: false, message: 'SPC service not available' };
+      }
+    },
+    nlquery: async () => {
+      try {
+        const { nlQueryService } = await import('./nlquery');
+        return await nlQueryService.healthCheck();
+      } catch {
+        return { healthy: false, message: 'NL query service not available' };
       }
     }
   };

--- a/server/services/nlquery/__tests__/nl-query.test.ts
+++ b/server/services/nlquery/__tests__/nl-query.test.ts
@@ -1,0 +1,255 @@
+/**
+ * NL Query Engine tests
+ * ADR-0013 [13.5] — Issue #216
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { LLMBackend, QueryIntent } from '@shared/types/nl-query';
+import { parseIntent, parseDurationMs } from '../parser';
+import { TagResolver, tokenize } from '../resolver';
+import { NLQueryEngine } from '../engine';
+import { InMemoryTagStore, NLQueryService } from '../index';
+
+const NOW = 1_800_000_000_000;
+
+function storeWithData(): InMemoryTagStore {
+  const store = new InMemoryTagStore();
+  for (let i = 0; i < 10; i++) {
+    store.ingest({ tagId: 'TANK-3.PRESSURE', value: 40 + i, timestamp: NOW - (10 - i) * 60_000 });
+    store.ingest({ tagId: 'FEEDER-01.CURRENT', value: 800 + i, timestamp: NOW - (10 - i) * 60_000 });
+    store.ingest({ tagId: 'FEEDER-02.CURRENT', value: 700 + i, timestamp: NOW - (10 - i) * 60_000 });
+  }
+  store.ingest({ tagId: 'TR-MAIN-01.STATUS', value: 'OK', quality: 'good', timestamp: NOW - 5_000 });
+  return store;
+}
+
+// ── Parser ────────────────────────────────────────────────────────────────
+
+describe('parseIntent (ordering regressions)', () => {
+  it('routes status questions to status, not the read_tag catch-all', () => {
+    // Wave-2 put read_tag first, making this unreachable
+    const intent = parseIntent('What is the status of pump 1?', NOW);
+    expect(intent.type).toBe('status');
+    expect(intent.subjects).toEqual(['pump 1']);
+  });
+
+  it('parses the canonical read_tag question with measurement and location', () => {
+    const intent = parseIntent('What is the pressure in tank 3?', NOW);
+    expect(intent.type).toBe('read_tag');
+    expect(intent.subjects).toEqual(['pressure tank 3']);
+  });
+
+  it('parses alarms with and without a subject', () => {
+    expect(parseIntent('Any active alarms?', NOW).type).toBe('alarms');
+    const scoped = parseIntent('alarms on tank 3', NOW);
+    expect(scoped.type).toBe('alarms');
+    expect(scoped.subjects).toEqual(['tank 3']);
+  });
+
+  it('parses trend with an explicit duration', () => {
+    const intent = parseIntent('Trend of pressure in tank 3 over the last 2 hours', NOW);
+    expect(intent.type).toBe('trend');
+    expect(intent.timeRange).toEqual({ start: NOW - 2 * 3_600_000, end: NOW });
+  });
+
+  it('defaults trend to the last hour when no duration is given', () => {
+    const intent = parseIntent('history of FEEDER-01.CURRENT', NOW);
+    expect(intent.type).toBe('trend');
+    expect(intent.timeRange).toEqual({ start: NOW - 3_600_000, end: NOW });
+  });
+
+  it('parses compare with two subjects', () => {
+    const intent = parseIntent('Compare FEEDER-01 current and FEEDER-02 current', NOW);
+    expect(intent.type).toBe('compare');
+    expect(intent.subjects).toHaveLength(2);
+  });
+
+  it('parses list_tags and falls through to unknown', () => {
+    expect(parseIntent('What tags are available?', NOW).type).toBe('list_tags');
+    expect(parseIntent('make me a sandwich', NOW).type).toBe('unknown');
+  });
+
+  it('parses durations', () => {
+    expect(parseDurationMs(30, 'minutes')).toBe(30 * 60_000);
+    expect(parseDurationMs(3, 'd')).toBe(3 * 86_400_000);
+    expect(parseDurationMs(1, 'fortnight')).toBeNull();
+  });
+});
+
+// ── Resolver ──────────────────────────────────────────────────────────────
+
+describe('TagResolver', () => {
+  const tags = ['TANK-3.PRESSURE', 'TANK-3.LEVEL', 'TANK-12.PRESSURE', 'FEEDER-01.CURRENT'];
+
+  it('tokenizes tags and phrases comparably', () => {
+    expect(tokenize('TANK-3.PRESSURE')).toEqual(['tank', '3', 'pressure']);
+    expect(tokenize('the pressure in tank 03')).toEqual(['pressure', 'tank', '3']);
+  });
+
+  it('resolves a natural phrase to the right tag', () => {
+    const resolver = new TagResolver();
+    const result = resolver.resolve('pressure tank 3', tags);
+    expect(result.tagId).toBe('TANK-3.PRESSURE');
+  });
+
+  it('returns null with candidates when ambiguous — never guesses', () => {
+    const resolver = new TagResolver();
+    // "tank 3" matches PRESSURE and LEVEL equally
+    const result = resolver.resolve('tank 3', tags);
+    expect(result.tagId).toBeNull();
+    expect(result.candidates).toEqual(
+      expect.arrayContaining(['TANK-3.PRESSURE', 'TANK-3.LEVEL'])
+    );
+  });
+
+  it('returns null with no candidates for nonsense — no fabricated tag ids', () => {
+    const resolver = new TagResolver();
+    const result = resolver.resolve('warp core temperature', tags);
+    expect(result.tagId).toBeNull();
+    expect(result.candidates).toEqual([]);
+  });
+
+  it('honors explicit aliases and exact ids', () => {
+    const resolver = new TagResolver();
+    resolver.registerAlias('main feeder amps', 'FEEDER-01.CURRENT');
+    expect(resolver.resolve('main feeder amps', tags).tagId).toBe('FEEDER-01.CURRENT');
+    expect(resolver.resolve('tank-3.pressure', tags).tagId).toBe('TANK-3.PRESSURE');
+  });
+});
+
+// ── Engine ────────────────────────────────────────────────────────────────
+
+describe('NLQueryEngine', () => {
+  it('answers the canonical question end-to-end', async () => {
+    const engine = new NLQueryEngine({ dataSource: storeWithData() });
+    const result = await engine.execute('What is the pressure in tank 3?', NOW);
+    expect(result.success).toBe(true);
+    expect(result.intent.type).toBe('read_tag');
+    expect(result.answer).toContain('TANK-3.PRESSURE');
+    expect(result.answer).toContain('49'); // latest value
+    expect(result.parsedBy).toBe('regex');
+  });
+
+  it('reports missing data explicitly in comparisons — never coerces to 0', async () => {
+    const store = storeWithData();
+    const engine = new NLQueryEngine({ dataSource: store });
+    const ok = await engine.execute('Compare FEEDER-01 current and FEEDER-02 current', NOW);
+    expect(ok.success).toBe(true);
+    expect(ok.data.difference).toBe(100);
+
+    const missing = await engine.execute('Compare FEEDER-01 current and TANK-12 pressure', NOW);
+    expect(missing.success).toBe(false);
+    expect(missing.answer).toMatch(/couldn't|No data/i);
+    expect(missing.data.difference).toBeUndefined();
+  });
+
+  it('computes trend statistics from history', async () => {
+    const engine = new NLQueryEngine({ dataSource: storeWithData() });
+    const result = await engine.execute('Trend of tank 3 pressure over the last 30 minutes', NOW);
+    expect(result.success).toBe(true);
+    expect(result.data.direction).toBe('rising');
+    expect(result.data.min).toBeGreaterThanOrEqual(40);
+  });
+
+  it('answers unresolved subjects with suggestions, not fabricated data', async () => {
+    const engine = new NLQueryEngine({ dataSource: storeWithData() });
+    const result = await engine.execute('What is the flux capacitor charge?', NOW);
+    expect(result.success).toBe(false);
+    expect(result.answer).toMatch(/couldn't find/i);
+  });
+
+  it('executes the alarms intent against an alarm source', async () => {
+    const engine = new NLQueryEngine({
+      dataSource: storeWithData(),
+      alarmSource: {
+        getActiveAlarms: () => [
+          { id: 'a1', name: 'BK-FEEDER-01 TRIP', severity: 'critical', message: 'trip', timestamp: NOW },
+        ],
+      },
+    });
+    const result = await engine.execute('Any active alarms?', NOW);
+    expect(result.success).toBe(true);
+    expect(result.answer).toContain('1 active alarm');
+  });
+
+  it('uses a registered LLM backend and validates its output', async () => {
+    const backend: LLMBackend = {
+      name: 'mock-llm',
+      parseQuery: async (query): Promise<QueryIntent> => ({
+        type: 'read_tag',
+        subjects: ['TANK-3.PRESSURE'],
+        raw: query,
+      }),
+      formatAnswer: async () => 'Tank 3 is sitting at 49 PSI.',
+    };
+    const engine = new NLQueryEngine({ dataSource: storeWithData() });
+    engine.setLLMBackend(backend);
+
+    const result = await engine.execute('how full is my favorite tank', NOW);
+    expect(result.parsedBy).toBe('mock-llm');
+    expect(result.success).toBe(true);
+    expect(result.answer).toBe('Tank 3 is sitting at 49 PSI.');
+  });
+
+  it('falls back to regex when the backend errors, and surfaces the error', async () => {
+    const errors: unknown[] = [];
+    const backend: LLMBackend = {
+      name: 'flaky-llm',
+      parseQuery: async () => {
+        throw new Error('model unavailable');
+      },
+      formatAnswer: async () => null,
+    };
+    const engine = new NLQueryEngine({ dataSource: storeWithData() });
+    engine.on('backend-error', (e) => errors.push(e));
+    engine.setLLMBackend(backend);
+
+    const result = await engine.execute('What is the pressure in tank 3?', NOW);
+    expect(result.success).toBe(true); // regex fallback answered
+    expect(result.parsedBy).toContain('regex');
+    expect(errors).toHaveLength(1);
+  });
+
+  it('keeps bounded query history', async () => {
+    const engine = new NLQueryEngine({ dataSource: storeWithData(), maxHistory: 3 });
+    for (let i = 0; i < 5; i++) {
+      await engine.execute(`What tags are available? (${i})`, NOW + i);
+    }
+    const history = engine.getHistory();
+    expect(history).toHaveLength(3);
+    expect(history[2].query).toContain('(4)');
+  });
+});
+
+// ── Store & service ───────────────────────────────────────────────────────
+
+describe('InMemoryTagStore / NLQueryService', () => {
+  it('bounds history per tag and tag count', () => {
+    const store = new InMemoryTagStore({ maxTags: 2, maxPointsPerTag: 3 });
+    for (let i = 0; i < 5; i++) store.ingest({ tagId: 'a', value: i, timestamp: i });
+    expect(store.readHistory('a', 0, 10).map((p) => p.value)).toEqual([2, 3, 4]);
+
+    store.ingest({ tagId: 'b', value: 1, timestamp: 10 });
+    store.ingest({ tagId: 'a', value: 9, timestamp: 11 }); // refresh a
+    store.ingest({ tagId: 'c', value: 1, timestamp: 12 }); // evicts b
+    expect(store.listTags()).toEqual(expect.arrayContaining(['a', 'c']));
+    expect(store.readLatest('b')).toBeNull();
+  });
+
+  it('ingests numeric strings as numbers and keeps text values as text', () => {
+    const service = new NLQueryService();
+    service.ingestTagUpdate({ tagName: 't', value: '42.5', timestamp: 1000 });
+    service.ingestTagUpdate({ tagName: 't', value: 'RUNNING', timestamp: 2000 });
+    const history = service.store.readHistory('t', 0, 3000);
+    expect(history[0].value).toBe(42.5);
+    expect(history[1].value).toBe('RUNNING');
+  });
+
+  it('reports health with backend info', async () => {
+    const service = new NLQueryService();
+    await service.initialize();
+    const health = await service.healthCheck();
+    expect(health.healthy).toBe(true);
+    expect(health.message).toContain('backend: regex');
+  });
+});

--- a/server/services/nlquery/engine.ts
+++ b/server/services/nlquery/engine.ts
@@ -1,0 +1,364 @@
+/**
+ * NL Query Engine
+ * ADR-0013 [13.5] — Issue #216
+ *
+ * Parse intent (LLM backend if configured, regex otherwise), resolve tag
+ * names, execute the query read-only, answer in natural language. Every
+ * intent has a real execution path; unknown intents and unresolved tags
+ * report success: false with suggestions — never a fabricated answer.
+ */
+
+import { EventEmitter } from 'events';
+import type {
+  AlarmSource,
+  LLMBackend,
+  QueryIntent,
+  QueryIntentType,
+  QueryResult,
+  ResolvedSubject,
+  TagDataSource,
+  TagReading,
+} from '@shared/types/nl-query';
+import { parseIntent } from './parser';
+import { TagResolver } from './resolver';
+
+const VALID_INTENTS: QueryIntentType[] = [
+  'read_tag', 'compare', 'trend', 'status', 'alarms', 'list_tags', 'unknown',
+];
+
+const EXAMPLE_QUERIES = [
+  'What is the pressure in tank 3?',
+  'Compare FEEDER-01 current and FEEDER-02 current',
+  'Trend of transformer temperature over the last 2 hours',
+  'What is the status of BK-FEEDER-01?',
+  'Any active alarms?',
+  'What tags are available?',
+];
+
+export interface NLQueryEngineOptions {
+  dataSource: TagDataSource;
+  alarmSource?: AlarmSource;
+  resolver?: TagResolver;
+  maxHistory?: number;
+}
+
+export class NLQueryEngine extends EventEmitter {
+  readonly resolver: TagResolver;
+
+  private readonly dataSource: TagDataSource;
+  private readonly alarmSource: AlarmSource | null;
+  private readonly maxHistory: number;
+  private llmBackend: LLMBackend | null = null;
+  private history: QueryResult[] = [];
+  private queryCounter = 0;
+  private readonly bootId = Date.now().toString(36);
+
+  constructor(options: NLQueryEngineOptions) {
+    super();
+    this.dataSource = options.dataSource;
+    this.alarmSource = options.alarmSource ?? null;
+    this.resolver = options.resolver ?? new TagResolver();
+    this.maxHistory = options.maxHistory ?? 100;
+  }
+
+  setLLMBackend(backend: LLMBackend | null): void {
+    this.llmBackend = backend;
+  }
+
+  getBackendInfo(): { name: string } | null {
+    return this.llmBackend ? { name: this.llmBackend.name } : null;
+  }
+
+  getHistory(): QueryResult[] {
+    return [...this.history];
+  }
+
+  async execute(query: string, nowMs = Date.now()): Promise<QueryResult> {
+    const availableTags = this.dataSource.listTags();
+    let intent: QueryIntent | null = null;
+    let parsedBy = 'regex';
+
+    if (this.llmBackend) {
+      try {
+        const parsed = await this.llmBackend.parseQuery(query, { availableTags });
+        if (parsed && VALID_INTENTS.includes(parsed.type) && Array.isArray(parsed.subjects)) {
+          intent = { ...parsed, raw: query };
+          parsedBy = this.llmBackend.name;
+        }
+      } catch (error) {
+        this.emit('backend-error', {
+          backend: this.llmBackend.name,
+          stage: 'parseQuery',
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    if (!intent) {
+      intent = parseIntent(query, nowMs);
+      parsedBy = parsedBy === 'regex' ? 'regex' : `${parsedBy} (fallback: regex)`;
+    }
+
+    const resolved = intent.subjects.map((s) => this.resolver.resolve(s, availableTags));
+    const outcome = this.executeIntent(intent, resolved, nowMs);
+
+    // Let the LLM backend phrase the answer; template answer is the fallback
+    let answer = outcome.answer;
+    if (this.llmBackend && outcome.success) {
+      try {
+        const formatted = await this.llmBackend.formatAnswer(intent, outcome.data);
+        if (formatted && formatted.trim() !== '') answer = formatted;
+      } catch (error) {
+        this.emit('backend-error', {
+          backend: this.llmBackend.name,
+          stage: 'formatAnswer',
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const result: QueryResult = {
+      id: `NLQ-${this.bootId}-${++this.queryCounter}`,
+      query,
+      intent,
+      resolved,
+      success: outcome.success,
+      answer,
+      interpretation: this.describe(intent, resolved),
+      data: outcome.data,
+      suggestions: outcome.suggestions,
+      timestamp: nowMs,
+      parsedBy,
+    };
+
+    this.history.push(result);
+    if (this.history.length > this.maxHistory) {
+      this.history.splice(0, this.history.length - this.maxHistory);
+    }
+    return result;
+  }
+
+  // ── Private: intent execution ────────────────────────────────────────
+
+  private executeIntent(
+    intent: QueryIntent,
+    resolved: ResolvedSubject[],
+    nowMs: number
+  ): { success: boolean; answer: string; data: Record<string, unknown>; suggestions: string[] } {
+    switch (intent.type) {
+      case 'read_tag':
+        return this.executeRead(resolved);
+      case 'compare':
+        return this.executeCompare(resolved);
+      case 'trend':
+        return this.executeTrend(resolved, intent, nowMs);
+      case 'status':
+        return this.executeStatus(resolved, nowMs);
+      case 'alarms':
+        return this.executeAlarms(intent);
+      case 'list_tags':
+        return this.executeListTags();
+      default:
+        return {
+          success: false,
+          answer: "I couldn't understand that question.",
+          data: {},
+          suggestions: EXAMPLE_QUERIES,
+        };
+    }
+  }
+
+  private unresolvedResult(subject: ResolvedSubject) {
+    return {
+      success: false,
+      answer:
+        subject.candidates.length > 0
+          ? `I couldn't uniquely identify a tag for "${subject.phrase}". Did you mean: ${subject.candidates.join(', ')}?`
+          : `I couldn't find any tag matching "${subject.phrase}".`,
+      data: { unresolved: subject.phrase, candidates: subject.candidates },
+      suggestions: subject.candidates,
+    };
+  }
+
+  private executeRead(resolved: ResolvedSubject[]) {
+    const subject = resolved[0];
+    if (!subject) {
+      return { success: false, answer: 'What would you like to read?', data: {}, suggestions: EXAMPLE_QUERIES };
+    }
+    if (!subject.tagId) return this.unresolvedResult(subject);
+
+    const reading = this.dataSource.readLatest(subject.tagId);
+    if (!reading) {
+      return {
+        success: false,
+        answer: `No data is available for ${subject.tagId}.`,
+        data: { tagId: subject.tagId },
+        suggestions: [],
+      };
+    }
+    return {
+      success: true,
+      answer: `${subject.tagId} is ${reading.value}${reading.quality && reading.quality !== 'good' ? ` (quality: ${reading.quality})` : ''} as of ${new Date(reading.timestamp).toISOString()}.`,
+      data: { reading },
+      suggestions: [],
+    };
+  }
+
+  private executeCompare(resolved: ResolvedSubject[]) {
+    if (resolved.length < 2) {
+      return { success: false, answer: 'A comparison needs two tags.', data: {}, suggestions: EXAMPLE_QUERIES };
+    }
+    for (const subject of resolved) {
+      if (!subject.tagId) return this.unresolvedResult(subject);
+    }
+    const readings = resolved.map((s) => ({
+      subject: s,
+      reading: this.dataSource.readLatest(s.tagId!),
+    }));
+    // Missing data is reported explicitly — never coerced to 0 (Wave-2 bug)
+    const missing = readings.find((r) => r.reading === null);
+    if (missing) {
+      return {
+        success: false,
+        answer: `No data is available for ${missing.subject.tagId} — cannot compare.`,
+        data: { missing: missing.subject.tagId },
+        suggestions: [],
+      };
+    }
+    const [a, b] = readings.map((r) => r.reading as TagReading);
+    const numericA = typeof a.value === 'number' ? a.value : Number(a.value);
+    const numericB = typeof b.value === 'number' ? b.value : Number(b.value);
+    if (!Number.isFinite(numericA) || !Number.isFinite(numericB)) {
+      return {
+        success: false,
+        answer: `${a.tagId} (${a.value}) and ${b.tagId} (${b.value}) are not both numeric — cannot compute a difference.`,
+        data: { a, b },
+        suggestions: [],
+      };
+    }
+    const difference = numericA - numericB;
+    return {
+      success: true,
+      answer: `${a.tagId} is ${numericA} and ${b.tagId} is ${numericB} — a difference of ${Number(difference.toFixed(6))}.`,
+      data: { a, b, difference },
+      suggestions: [],
+    };
+  }
+
+  private executeTrend(resolved: ResolvedSubject[], intent: QueryIntent, nowMs: number) {
+    const subject = resolved[0];
+    if (!subject) {
+      return { success: false, answer: 'Which tag should I trend?', data: {}, suggestions: EXAMPLE_QUERIES };
+    }
+    if (!subject.tagId) return this.unresolvedResult(subject);
+
+    const range = intent.timeRange ?? { start: nowMs - 3_600_000, end: nowMs };
+    const points = this.dataSource
+      .readHistory(subject.tagId, range.start, range.end)
+      .filter((p) => typeof p.value === 'number') as Array<TagReading & { value: number }>;
+
+    if (points.length === 0) {
+      return {
+        success: false,
+        answer: `No history is available for ${subject.tagId} in that window (the in-memory buffer only covers recent values).`,
+        data: { tagId: subject.tagId, range },
+        suggestions: [],
+      };
+    }
+    const values = points.map((p) => p.value);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const avg = values.reduce((s, v) => s + v, 0) / values.length;
+    const delta = values[values.length - 1] - values[0];
+    const direction = delta > 0 ? 'rising' : delta < 0 ? 'falling' : 'flat';
+    const minutes = Math.round((range.end - range.start) / 60_000);
+    return {
+      success: true,
+      answer:
+        `${subject.tagId} over the last ${minutes} minutes: ${points.length} samples, ` +
+        `min ${min}, max ${max}, average ${Number(avg.toFixed(3))} — ${direction} ` +
+        `(${delta >= 0 ? '+' : ''}${Number(delta.toFixed(3))}).`,
+      data: { tagId: subject.tagId, range, samples: points.length, min, max, avg, delta, direction },
+      suggestions: [],
+    };
+  }
+
+  private executeStatus(resolved: ResolvedSubject[], nowMs: number) {
+    const subject = resolved[0];
+    if (!subject) {
+      return { success: false, answer: 'Which tag or equipment?', data: {}, suggestions: EXAMPLE_QUERIES };
+    }
+    if (!subject.tagId) return this.unresolvedResult(subject);
+
+    const reading = this.dataSource.readLatest(subject.tagId);
+    if (!reading) {
+      return {
+        success: false,
+        answer: `No data is available for ${subject.tagId}.`,
+        data: { tagId: subject.tagId },
+        suggestions: [],
+      };
+    }
+    const ageSeconds = Math.max(0, Math.round((nowMs - reading.timestamp) / 1000));
+    return {
+      success: true,
+      answer:
+        `${subject.tagId}: last value ${reading.value}` +
+        `${reading.quality ? `, quality ${reading.quality}` : ''}, updated ${ageSeconds}s ago.`,
+      data: { reading, ageSeconds },
+      suggestions: [],
+    };
+  }
+
+  private executeAlarms(intent: QueryIntent) {
+    if (!this.alarmSource) {
+      return {
+        success: false,
+        answer: 'Alarm data is not connected to the query engine yet.',
+        data: { alarms: [] },
+        suggestions: [],
+      };
+    }
+    const alarms = this.alarmSource.getActiveAlarms(intent.subjects[0]);
+    if (alarms.length === 0) {
+      return {
+        success: true,
+        answer: intent.subjects[0]
+          ? `No active alarms matching "${intent.subjects[0]}".`
+          : 'No active alarms.',
+        data: { alarms: [] },
+        suggestions: [],
+      };
+    }
+    const summary = alarms
+      .slice(0, 10)
+      .map((a) => `${a.name} (${a.severity})`)
+      .join('; ');
+    return {
+      success: true,
+      answer: `${alarms.length} active alarm${alarms.length === 1 ? '' : 's'}: ${summary}.`,
+      data: { alarms },
+      suggestions: [],
+    };
+  }
+
+  private executeListTags() {
+    const tags = this.dataSource.listTags();
+    const shown = tags.slice(0, 50);
+    return {
+      success: true,
+      answer:
+        tags.length === 0
+          ? 'No tags are currently reporting data.'
+          : `${tags.length} tags available${tags.length > 50 ? ' (showing 50)' : ''}: ${shown.join(', ')}.`,
+      data: { count: tags.length, tags: shown },
+      suggestions: [],
+    };
+  }
+
+  private describe(intent: QueryIntent, resolved: ResolvedSubject[]): string {
+    const subjects = resolved
+      .map((r) => (r.tagId ? `"${r.phrase}" → ${r.tagId}` : `"${r.phrase}" (unresolved)`))
+      .join(', ');
+    return `intent: ${intent.type}${subjects ? `; subjects: ${subjects}` : ''}`;
+  }
+}

--- a/server/services/nlquery/index.ts
+++ b/server/services/nlquery/index.ts
@@ -1,0 +1,125 @@
+/**
+ * NL Query Service
+ * ADR-0013 [13.5] — Issue #216
+ *
+ * Wires the query engine to live data: an in-memory tag store fed by the
+ * tag-stream hook provides current values and a rolling history buffer
+ * (there is no historian read path in this codebase yet). Read-only over
+ * process data.
+ */
+
+import { EventEmitter } from 'events';
+
+export * from './parser';
+export * from './resolver';
+export * from './engine';
+
+import type { TagDataSource, TagReading } from '@shared/types/nl-query';
+import { NLQueryEngine } from './engine';
+
+export interface NLTagUpdateInput {
+  tagName: string;
+  value: number | string | boolean;
+  timestamp: string | number;
+  quality?: string;
+}
+
+/** Rolling in-memory tag store — current values plus bounded history */
+export class InMemoryTagStore implements TagDataSource {
+  private readonly maxTags: number;
+  private readonly maxPointsPerTag: number;
+  /** Insertion order doubles as recency order — refreshed on ingest */
+  private series: Map<string, TagReading[]> = new Map();
+
+  constructor(options: { maxTags?: number; maxPointsPerTag?: number } = {}) {
+    this.maxTags = options.maxTags ?? 500;
+    this.maxPointsPerTag = options.maxPointsPerTag ?? 500;
+  }
+
+  ingest(reading: TagReading): void {
+    let points = this.series.get(reading.tagId);
+    if (points) {
+      this.series.delete(reading.tagId); // refresh recency
+    } else {
+      points = [];
+    }
+    this.series.set(reading.tagId, points);
+    points.push(reading);
+    if (points.length > this.maxPointsPerTag) {
+      points.splice(0, points.length - this.maxPointsPerTag);
+    }
+    while (this.series.size > this.maxTags) {
+      const oldest = this.series.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.series.delete(oldest);
+    }
+  }
+
+  listTags(): string[] {
+    return Array.from(this.series.keys());
+  }
+
+  readLatest(tagId: string): TagReading | null {
+    const points = this.series.get(tagId);
+    return points && points.length > 0 ? points[points.length - 1] : null;
+  }
+
+  readHistory(tagId: string, startMs: number, endMs: number): TagReading[] {
+    const points = this.series.get(tagId) ?? [];
+    return points.filter((p) => p.timestamp >= startMs && p.timestamp <= endMs);
+  }
+}
+
+export class NLQueryService extends EventEmitter {
+  readonly store = new InMemoryTagStore();
+  readonly engine: NLQueryEngine;
+
+  private initialized = false;
+
+  constructor() {
+    super();
+    this.engine = new NLQueryEngine({ dataSource: this.store });
+    this.engine.on('backend-error', (e) => this.emit('backend-error', e));
+  }
+
+  async initialize(): Promise<void> {
+    this.initialized = true;
+  }
+
+  async shutdown(): Promise<void> {
+    this.initialized = false;
+  }
+
+  /** Feed a live tag update into the store (numeric or string values) */
+  ingestTagUpdate(update: NLTagUpdateInput): void {
+    if (typeof update.value === 'boolean') return;
+    const timestamp =
+      typeof update.timestamp === 'number'
+        ? update.timestamp
+        : new Date(update.timestamp).getTime();
+    if (!Number.isFinite(timestamp)) return;
+    const numeric =
+      typeof update.value === 'string' && update.value.trim() !== ''
+        ? Number(update.value)
+        : update.value;
+    this.store.ingest({
+      tagId: update.tagName,
+      value: typeof numeric === 'number' && Number.isFinite(numeric) ? numeric : update.value,
+      quality: update.quality,
+      timestamp,
+    });
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
+    const backend = this.engine.getBackendInfo();
+    return {
+      healthy: this.initialized,
+      message: this.initialized
+        ? `NL query running: ${this.store.listTags().length} tags, ` +
+          `backend: ${backend ? backend.name : 'regex'}`
+        : 'NL query service not initialized',
+    };
+  }
+}
+
+export const nlQueryService = new NLQueryService();

--- a/server/services/nlquery/parser.ts
+++ b/server/services/nlquery/parser.ts
@@ -1,0 +1,116 @@
+/**
+ * Intent Parser (regex MVP)
+ * ADR-0013 [13.5] — Issue #216
+ *
+ * Ordered grammar with SPECIFIC intents first and the generic read_tag
+ * catch-all last — the recovered Wave-2 engine put read_tag first, which
+ * made "what is the status of X" unreachable as a status query.
+ */
+
+import type { QueryIntent } from '@shared/types/nl-query';
+
+const DURATION_UNITS: Record<string, number> = {
+  m: 60_000,
+  min: 60_000,
+  mins: 60_000,
+  minute: 60_000,
+  minutes: 60_000,
+  h: 3_600_000,
+  hr: 3_600_000,
+  hrs: 3_600_000,
+  hour: 3_600_000,
+  hours: 3_600_000,
+  d: 86_400_000,
+  day: 86_400_000,
+  days: 86_400_000,
+};
+
+export function parseDurationMs(amount: number, unit: string): number | null {
+  const ms = DURATION_UNITS[unit.toLowerCase()];
+  return ms ? amount * ms : null;
+}
+
+function clean(phrase: string): string {
+  return phrase.replace(/[?.!]+$/, '').replace(/^the\s+/i, '').trim();
+}
+
+interface Pattern {
+  regex: RegExp;
+  build: (match: RegExpMatchArray, raw: string, nowMs: number) => QueryIntent;
+}
+
+const PATTERNS: Pattern[] = [
+  // list_tags — "what tags are available", "list tags", "show all tags"
+  {
+    regex: /\b(?:list|show|what|which)\b.*\btags?\b(?:\s+(?:are|do)\b.*)?$/i,
+    build: (_m, raw) => ({ type: 'list_tags', subjects: [], raw }),
+  },
+  // alarms — "any active alarms?", "alarms on tank 3"
+  {
+    regex: /\balarms?\b(?:\s+(?:on|for|in)\s+(.+?))?[?.!]*$/i,
+    build: (m, raw) => ({
+      type: 'alarms',
+      subjects: m[1] ? [clean(m[1])] : [],
+      raw,
+    }),
+  },
+  // trend — "trend of pressure in tank 3 over the last 2 hours"
+  {
+    regex:
+      /\b(?:trend|history|graph|chart)\b(?:\s+(?:of|for))?\s+(.+?)(?:\s+(?:over\s+the\s+|for\s+the\s+)?(?:last|past)\s+(\d+)\s*([a-z]+))?[?.!]*$/i,
+    build: (m, raw, nowMs) => {
+      const duration =
+        m[2] && m[3] ? parseDurationMs(parseInt(m[2], 10), m[3]) : null;
+      const windowMs = duration ?? 3_600_000; // default: last hour
+      return {
+        type: 'trend',
+        subjects: [clean(m[1])],
+        timeRange: { start: nowMs - windowMs, end: nowMs },
+        raw,
+      };
+    },
+  },
+  // status — "what is the status of pump 1", "health of feeder 2"
+  {
+    regex: /\b(?:status|state|health)\b\s+(?:of|for)?\s*(.+?)[?.!]*$/i,
+    build: (m, raw) => ({ type: 'status', subjects: [clean(m[1])], raw }),
+  },
+  // compare — "compare X and Y", "difference between X and Y"
+  {
+    regex:
+      /\b(?:compare|difference(?:\s+between)?|diff)\s+(.+?)\s+(?:and|vs\.?|versus|with)\s+(.+?)[?.!]*$/i,
+    build: (m, raw) => ({
+      type: 'compare',
+      subjects: [clean(m[1]), clean(m[2])],
+      raw,
+    }),
+  },
+  // read_tag with measurement + location — "what is the pressure in tank 3"
+  {
+    regex:
+      /\b(?:what(?:'s|\s+is)?|show(?:\s+me)?|get|read|give\s+me)\s+(?:the\s+)?(?:current\s+)?(.+?)\s+(?:in|on|at|of|for)\s+(.+?)[?.!]*$/i,
+    build: (m, raw) => ({
+      type: 'read_tag',
+      // Keep the full phrase — resolution scores measurement AND location
+      subjects: [`${clean(m[1])} ${clean(m[2])}`],
+      raw,
+    }),
+  },
+  // read_tag generic catch-all — "show FEEDER-01.CURRENT"
+  {
+    regex:
+      /\b(?:what(?:'s|\s+is)?|show(?:\s+me)?|get|read|value\s+of)\s+(?:the\s+)?(?:current\s+)?(?:value\s+(?:of|for)\s+)?(.+?)[?.!]*$/i,
+    build: (m, raw) => ({ type: 'read_tag', subjects: [clean(m[1])], raw }),
+  },
+];
+
+export function parseIntent(query: string, nowMs: number): QueryIntent {
+  const trimmed = query.trim();
+  for (const pattern of PATTERNS) {
+    const match = trimmed.match(pattern.regex);
+    if (match) {
+      return pattern.build(match, trimmed, nowMs);
+    }
+  }
+  return { type: 'unknown', subjects: [], raw: trimmed };
+}

--- a/server/services/nlquery/resolver.ts
+++ b/server/services/nlquery/resolver.ts
@@ -1,0 +1,96 @@
+/**
+ * Tag Resolver
+ * ADR-0013 [13.5] — Issue #216
+ *
+ * Resolves natural-language phrases ("pressure in tank 3") against the
+ * actual tag universe by token scoring, with explicit aliases taking
+ * precedence. An unresolvable or ambiguous phrase resolves to null with
+ * candidate suggestions — the Wave-2 engine fabricated snake_case tag ids
+ * from the phrase and silently queried them.
+ */
+
+import type { ResolvedSubject } from '@shared/types/nl-query';
+
+const STOP_WORDS = new Set([
+  'the', 'a', 'an', 'in', 'on', 'at', 'of', 'for', 'is', 'me', 'current',
+  'value', 'level', 'and', 'to', 'from', 'what', 'show',
+]);
+
+/** Split a phrase or tag id into normalized comparable tokens */
+export function tokenize(text: string): string[] {
+  return text
+    .split(/[\s._\-/:]+/)
+    .map((t) => t.toLowerCase().replace(/^0+(?=\d)/, ''))
+    .filter((t) => t.length > 0 && !STOP_WORDS.has(t));
+}
+
+export class TagResolver {
+  private aliases: Map<string, string> = new Map();
+
+  registerAlias(alias: string, tagId: string): void {
+    this.aliases.set(alias.trim().toLowerCase(), tagId);
+  }
+
+  listAliases(): Array<{ alias: string; tagId: string }> {
+    return Array.from(this.aliases.entries()).map(([alias, tagId]) => ({ alias, tagId }));
+  }
+
+  /**
+   * Resolve a phrase against the available tags. Result is a unique best
+   * match, or null with candidates when nothing matches well enough or
+   * several tags tie.
+   */
+  resolve(phrase: string, availableTags: string[]): ResolvedSubject {
+    const trimmed = phrase.trim();
+
+    // Exact tag id (case-insensitive) always wins
+    const exact = availableTags.find((t) => t.toLowerCase() === trimmed.toLowerCase());
+    if (exact) return { phrase, tagId: exact, candidates: [exact] };
+
+    // Explicit alias
+    const alias = this.aliases.get(trimmed.toLowerCase());
+    if (alias) return { phrase, tagId: alias, candidates: [alias] };
+
+    // Token scoring: fraction of phrase tokens found among the tag's tokens
+    const phraseTokens = tokenize(trimmed);
+    if (phraseTokens.length === 0) return { phrase, tagId: null, candidates: [] };
+
+    const scored = availableTags
+      .map((tagId) => {
+        const tagTokens = new Set(tokenize(tagId));
+        let matched = 0;
+        for (const token of phraseTokens) {
+          // Numeric tokens are equipment identity — they must match exactly.
+          // "tank 12" must never resolve to TANK-3.PRESSURE.
+          if (/^\d+$/.test(token) && !tagTokens.has(token)) {
+            return { tagId, score: 0 };
+          }
+          if (tagTokens.has(token)) {
+            matched++;
+          } else if (
+            // Loose singular/plural and prefix matching ("temp" ~ "temperature")
+            [...tagTokens].some(
+              (t) =>
+                (token.length >= 3 && t.startsWith(token)) ||
+                (t.length >= 3 && token.startsWith(t))
+            )
+          ) {
+            matched += 0.75;
+          }
+        }
+        return { tagId, score: matched / phraseTokens.length };
+      })
+      .filter((s) => s.score >= 0.5)
+      .sort((a, b) => b.score - a.score);
+
+    if (scored.length === 0) return { phrase, tagId: null, candidates: [] };
+
+    const best = scored[0];
+    const ties = scored.filter((s) => s.score === best.score);
+    if (ties.length > 1) {
+      // Ambiguous — never guess between equally good matches
+      return { phrase, tagId: null, candidates: ties.slice(0, 5).map((s) => s.tagId) };
+    }
+    return { phrase, tagId: best.tagId, candidates: scored.slice(0, 5).map((s) => s.tagId) };
+  }
+}

--- a/server/websocket/tag-stream.ts
+++ b/server/websocket/tag-stream.ts
@@ -46,6 +46,24 @@ export class TagStreamServer {
   private totalUpdates = 0;
   private startTime = Date.now();
   private pingInterval?: ReturnType<typeof setInterval>;
+  private updateListeners: Array<(update: TagUpdate) => void> = [];
+
+  /**
+   * Register a server-side listener for every tag update flowing through the
+   * stream (e.g. predictive maintenance ingestion). Listener errors are
+   * swallowed so a consumer can never break broadcasting.
+   */
+  onTagUpdate(listener: (update: TagUpdate) => void): void {
+    this.updateListeners.push(listener);
+  }
+
+  private notifyListeners(update: TagUpdate): void {
+    for (const listener of this.updateListeners) {
+      try {
+        listener(update);
+      } catch { /* consumer error — never disrupt broadcasting */ }
+    }
+  }
 
   initialize(httpServer: HttpServer, path = "/ws/tags"): void {
     this.wss = new WebSocketServer({ noServer: true });
@@ -112,6 +130,7 @@ export class TagStreamServer {
   broadcastTagUpdate(update: TagUpdate): void {
     this.latestValues.set(update.tagName, update);
     this.totalUpdates++;
+    this.notifyListeners(update);
 
     const message = JSON.stringify({ event: "tag:update", payload: update });
 
@@ -167,6 +186,7 @@ export class TagStreamServer {
   broadcastBatch(updates: TagUpdate[]): void {
     for (const u of updates) {
       this.latestValues.set(u.tagName, u);
+      this.notifyListeners(u);
     }
     this.totalUpdates += updates.length;
 

--- a/shared/types/nl-query.ts
+++ b/shared/types/nl-query.ts
@@ -1,0 +1,108 @@
+/**
+ * Natural Language Process Query Types
+ * ADR-0013 [13.5] — Issue #216
+ *
+ * Regex-based intent parsing MVP with a pluggable LLM backend interface.
+ * The engine is read-only over process data (ADR-0008 capability scoping):
+ * it answers questions, it never writes.
+ */
+
+export type QueryIntentType =
+  | 'read_tag'
+  | 'compare'
+  | 'trend'
+  | 'status'
+  | 'alarms'
+  | 'list_tags'
+  | 'unknown';
+
+export interface QueryTimeRange {
+  /** Epoch ms */
+  start: number;
+  end: number;
+}
+
+export interface QueryIntent {
+  type: QueryIntentType;
+  /** Natural-language phrases naming tags/equipment ("pressure in tank 3") */
+  subjects: string[];
+  timeRange?: QueryTimeRange;
+  raw: string;
+}
+
+/**
+ * Resolution of one subject phrase against the known tag universe.
+ * An unresolvable phrase yields tagId null plus candidates — it is never
+ * silently passed through as if it were a tag id.
+ */
+export interface ResolvedSubject {
+  phrase: string;
+  tagId: string | null;
+  candidates: string[];
+}
+
+export interface TagReading {
+  tagId: string;
+  value: number | string;
+  quality?: string;
+  /** Epoch ms */
+  timestamp: number;
+}
+
+/** Read-only data access the engine answers from */
+export interface TagDataSource {
+  listTags(): string[];
+  readLatest(tagId: string): TagReading | null;
+  readHistory(tagId: string, startMs: number, endMs: number): TagReading[];
+}
+
+export interface ActiveAlarmSummary {
+  id: string;
+  name: string;
+  severity: string;
+  message: string;
+  timestamp: number;
+}
+
+/** Read-only alarm access; implementations may scope by subject phrase */
+export interface AlarmSource {
+  getActiveAlarms(subject?: string): ActiveAlarmSummary[];
+}
+
+export interface QueryResult {
+  id: string;
+  query: string;
+  intent: QueryIntent;
+  resolved: ResolvedSubject[];
+  success: boolean;
+  /** Natural-language answer */
+  answer: string;
+  /** Human-readable description of how the query was interpreted */
+  interpretation: string;
+  /** Structured data backing the answer */
+  data: Record<string, unknown>;
+  suggestions: string[];
+  timestamp: number;
+  /** 'regex' or the LLM backend's name */
+  parsedBy: string;
+}
+
+/**
+ * Pluggable LLM backend contract. Both methods are optional-decline: return
+ * null to fall back to the regex parser / template formatter. Methods are
+ * async so a real implementation can call a hosted model (e.g. the
+ * Anthropic SDK with structured outputs constraining parseQuery's result
+ * to the QueryIntent schema). Backend errors are surfaced by the engine as
+ * 'backend-error' events and then fall back — never silently swallowed.
+ */
+export interface LLMBackend {
+  readonly name: string;
+  parseQuery(
+    query: string,
+    context: { availableTags: string[] }
+  ): Promise<QueryIntent | null>;
+  formatAnswer(
+    intent: QueryIntent,
+    data: Record<string, unknown>
+  ): Promise<string | null>;
+}


### PR DESCRIPTION
Closes #216

Rebuilds the NL Query Engine from ADR-0013 [13.5] (Wave 2 implementation lost in restructure `6f9d9219c`; recon found its regex ordering made several intents unreachable and its tag resolution fabricated ids).

## What's included

**Intent parser** — ordered regex grammar with specific intents first (`list_tags`, `alarms`, `trend` with duration parsing, `status`, `compare`) and the generic `read_tag` catch-all **last**. "What is the status of pump 1?" now parses as a status query (unreachable in Wave 2). Duration phrases ("over the last 2 hours") produce real time ranges.

**Tag resolver** — token-scoring against the live tag universe with explicit alias registration. Two precision rules the review of Wave 2 motivated: numeric tokens are equipment identity and must match exactly (`tank 12` will never resolve to `TANK-3.PRESSURE`), and ambiguity resolves to `null` + candidate suggestions rather than guessing. Nothing is ever fabricated from the phrase.

**Engine** — every intent has a real execution path: current values, comparisons (missing/non-numeric data reported explicitly — never coerced to 0), trend statistics over an in-memory rolling buffer fed by the tag stream, status with data age, alarms via an injectable `AlarmSource`, and tag listing. Failures return `success: false` with suggestions.

**Pluggable LLM backend** — provider-agnostic `LLMBackend` contract (async `parseQuery`/`formatAnswer`; return `null` to decline). Backend output is schema-validated before use; errors emit `backend-error` events and fall back to regex/template — never silently swallowed. No LLM SDK dependency ships with the MVP; a future backend would slot in via `engine.setLLMBackend()`.

**API** — the mock `POST /api/intelligence/nlquery` and `GET /nlquery/history` endpoints are replaced with real handlers, keeping the promised response shape and extending it with `answer`/`intent`/`success`/`parsedBy`. History is real and bounded.

**Wiring** — tag-stream `onTagUpdate` hook (identical hunks to the sibling ADR-0013 PRs; merges cleanly) feeds the store; service initialized from `registerRoutes`.

## Testing
- 24 unit tests: parser ordering regressions, durations, resolver precision/ambiguity/aliases, end-to-end canonical question ("What is the pressure in tank 3?"), comparison null-safety, trend stats, LLM backend usage/validation/error fallback, bounded history and stores
- Full suite: 1203 pass (the 1 failure is the pre-existing `event-pipeline.test.ts` `uptime_ms` timing flake on `main`, unrelated); `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)