### PR TITLE
[13.6] Agent Marketplace & Plugin System (ADR-0013)

### DIFF
--- a/server/agents/runtime.ts
+++ b/server/agents/runtime.ts
@@ -9,16 +9,27 @@ export interface AgentHealth {
 }
 
 export const getAgentHealth = async (): Promise<AgentHealth> => {
-  // TODO: Implement actual agent health check
-  return {
-    totalAgents: 0,
-    activeAgents: 0,
-    errors: []
-  };
+  // Report marketplace plugins as the agent population (#217). Lazy import
+  // keeps this module dependency-free for callers that only need the shape.
+  try {
+    const { marketplaceService } = await import('../services/marketplace');
+    const status = marketplaceService.marketplace.getStatus();
+    const errors = marketplaceService.marketplace
+      .getAllHealth()
+      .filter((h) => h.status === 'error' && h.lastError)
+      .map((h) => `${h.pluginId}: ${h.lastError}`);
+    return {
+      totalAgents: status.installed,
+      activeAgents: status.running,
+      errors,
+    };
+  } catch {
+    return { totalAgents: 0, activeAgents: 0, errors: [] };
+  }
 };
 
-// Export runtime as expected by health/index.ts  
+// Export runtime as expected by health/index.ts
 export const agentRuntime = {
   getHealth: getAgentHealth,
-  isRunning: () => false
+  isRunning: () => true
 };

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,8 @@ import pidRoutes from "./routes/pid";
 import { fluxRoutes } from "./routes/flux";
 import { gatewayRoutes } from "./routes/gateway";
 import { intelligenceRoutes } from "./routes/intelligence";
+import { marketplaceRoutes } from "./routes/marketplace";
+import { marketplaceService } from "./services/marketplace";
 import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
@@ -52,6 +54,7 @@ export async function registerRoutes(
 
   // P1 Wiring: Intelligence, Governance, and Security modules
   app.use("/api/intelligence", intelligenceRoutes);
+  app.use("/api/marketplace", marketplaceRoutes);  // ADR-0013 [13.6] (#217)
   app.use("/api/governance", governanceRoutes);
   app.use("/api/security", securityRoutes);
   app.use("/api/geometry", geometryRoutes(getFluxPublisher()));
@@ -80,6 +83,10 @@ export async function registerRoutes(
   // WebSocket servers initialize if available
   try { tagStreamServer?.initialize(httpServer, "/ws/tags"); } catch {}
   try { unifiedStreamServer?.initialize(httpServer, "/ws"); } catch {}  // unified endpoint (#255)
+
+  // Start the marketplace service here — services/initializeServices()
+  // has no callers at startup (#217).
+  void marketplaceService.initialize();
 
   // WebSocket metrics endpoint. The legacy event-stream server was removed;
   // only the tag and unified streams report (#446, #479).

--- a/server/routes/marketplace.ts
+++ b/server/routes/marketplace.ts
@@ -1,0 +1,178 @@
+/**
+ * Agent Marketplace API
+ * ADR-0013 [13.6] — Issue #217
+ *
+ * REST surface for the plugin registry and lifecycle. Mounted at
+ * /api/marketplace — /api/agents (and its /agent-outputs, /agent-proposals
+ * redirects) remain untouched.
+ */
+
+import { Router } from "express";
+import type { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+import { marketplaceService } from "../services/marketplace";
+import type { PluginCategory, PluginManifest } from "@shared/types/marketplace";
+
+const router = Router();
+const marketplace = marketplaceService.marketplace;
+
+// Auth middleware placeholder — same pattern as other protected routes
+function requireAuth(req: Request, res: Response, next: NextFunction) {
+  // TODO: implement real auth check (JWT / session validation)
+  next();
+}
+router.use(requireAuth);
+
+/** Engine lifecycle errors map to 400s with the engine's message */
+function handle(fn: (req: Request, res: Response) => void | Promise<void>) {
+  return async (req: Request, res: Response) => {
+    try {
+      await fn(req, res);
+    } catch (error) {
+      if (!res.headersSent) {
+        res.status(400).json({ error: error instanceof Error ? error.message : "Invalid request" });
+      }
+    }
+  };
+}
+
+// ── Schemas ────────────────────────────────────────────────────────────────
+
+const CapabilitySchema = z.enum(["tags:read", "alarms:read", "events:emit", "log"]);
+
+const ManifestSchema = z.object({
+  id: z.string().regex(/^[a-z0-9][a-z0-9-]{1,63}$/),
+  name: z.string().min(1).max(256),
+  version: z.string().regex(/^v?\d+\.\d+\.\d+$/),
+  description: z.string().max(2000).default(""),
+  author: z.string().max(256).default("unknown"),
+  category: z.enum(["intelligence", "integration", "reporting", "safety", "optimization", "custom"]),
+  requiredCapabilities: z.array(CapabilitySchema).max(10).default([]),
+  configSchema: z
+    .record(
+      z.object({
+        type: z.enum(["string", "number", "boolean", "select"]),
+        description: z.string().max(500),
+        default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+        required: z.boolean(),
+        options: z.array(z.string()).max(50).optional(),
+      })
+    )
+    .default({}),
+  dependencies: z.record(z.string().max(64)).default({}),
+  tags: z.array(z.string().max(64)).max(20).default([]),
+});
+
+const InstallSchema = z.object({
+  config: z.record(z.union([z.string(), z.number(), z.boolean()])).default({}),
+  grants: z.array(CapabilitySchema).optional(),
+});
+
+const ConfigSchema = z.object({
+  config: z.record(z.union([z.string(), z.number(), z.boolean()])),
+});
+
+const InvokeSchema = z.object({
+  input: z.unknown().optional(),
+});
+
+// ── Registry ───────────────────────────────────────────────────────────────
+
+router.get("/plugins", (req, res) => {
+  const query = typeof req.query.q === "string" ? req.query.q : "";
+  const category =
+    typeof req.query.category === "string" ? (req.query.category as PluginCategory) : undefined;
+  res.json({ plugins: marketplace.search(query, category) });
+});
+
+router.post("/plugins", handle((req, res) => {
+  const parsed = ManifestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return void res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const entry = marketplace.publish(parsed.data as PluginManifest);
+  res.status(201).json(entry);
+}));
+
+router.get("/plugins/:pluginId", (req, res) => {
+  const entry = marketplace.getEntry(req.params.pluginId);
+  if (!entry) return res.status(404).json({ error: `Plugin ${req.params.pluginId} not found` });
+  res.json(entry);
+});
+
+// ── Lifecycle ──────────────────────────────────────────────────────────────
+
+router.get("/installed", (_req, res) => {
+  res.json({ plugins: marketplace.listInstalled() });
+});
+
+router.post("/plugins/:pluginId/install", handle((req, res) => {
+  const parsed = InstallSchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return void res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  res.status(201).json(
+    marketplace.install(req.params.pluginId, parsed.data.config, parsed.data.grants)
+  );
+}));
+
+router.post("/plugins/:pluginId/update", handle((req, res) => {
+  res.json(marketplace.update(req.params.pluginId));
+}));
+
+router.put("/plugins/:pluginId/config", handle((req, res) => {
+  const parsed = ConfigSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return void res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  res.json(marketplace.configure(req.params.pluginId, parsed.data.config));
+}));
+
+router.post("/plugins/:pluginId/start", handle((req, res) => {
+  res.json(marketplace.start(req.params.pluginId));
+}));
+
+router.post("/plugins/:pluginId/stop", handle((req, res) => {
+  res.json(marketplace.stop(req.params.pluginId));
+}));
+
+router.post("/plugins/:pluginId/enable", handle((req, res) => {
+  res.json(marketplace.enable(req.params.pluginId));
+}));
+
+router.post("/plugins/:pluginId/disable", handle((req, res) => {
+  res.json(marketplace.disable(req.params.pluginId));
+}));
+
+router.delete("/plugins/:pluginId", handle((req, res) => {
+  marketplace.uninstall(req.params.pluginId);
+  res.json({ uninstalled: true });
+}));
+
+// ── Execution & health ─────────────────────────────────────────────────────
+
+router.post("/plugins/:pluginId/invoke", handle(async (req, res) => {
+  const parsed = InvokeSchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return void res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  res.json(await marketplace.invoke(req.params.pluginId, parsed.data.input));
+}));
+
+router.get("/plugins/:pluginId/health", (req, res) => {
+  const health = marketplace.getHealth(req.params.pluginId);
+  if (!health) return res.status(404).json({ error: `Plugin ${req.params.pluginId} not installed` });
+  res.json(health);
+});
+
+router.get("/health", (_req, res) => {
+  res.json({ plugins: marketplace.getAllHealth() });
+});
+
+router.get("/status", async (_req, res) => {
+  const health = await marketplaceService.healthCheck();
+  res.json({ ...marketplace.getStatus(), ...health });
+});
+
+export { router as marketplaceRoutes };

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -66,6 +66,10 @@ export { spcService } from './spc';
 export * from './l2-rollup';
 export { l2RollupService } from './l2-rollup';
 
+// ── Agent Marketplace Service (ADR-0013 [13.6], #217) ────────────────────────
+export * from './marketplace';
+export { marketplaceService } from './marketplace';
+
 /**
  * Initialize all services
  * 
@@ -80,7 +84,8 @@ export async function initializeServices(): Promise<void> {
     { name: 'Ubiquity', service: () => import('./ubiquity').then(m => m.ubiquityService.initialize()) },
     { name: 'Layer 2 Rollup', service: () => import('./l2-rollup').then(m => m.l2RollupService.initialize()) },
     { name: 'Optimization', service: () => import('./optimization').then(m => m.optimizationService.initialize()) },
-    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) }
+    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) },
+    { name: 'Agent Marketplace', service: () => import('./marketplace').then(m => m.marketplaceService.initialize()) }
   ];
 
   for (const { name, service } of services) {
@@ -171,6 +176,14 @@ export async function getServicesHealthStatus(): Promise<{
         return await spcService.healthCheck();
       } catch {
         return { healthy: false, message: 'SPC service not available' };
+      }
+    },
+    marketplace: async () => {
+      try {
+        const { marketplaceService } = await import('./marketplace');
+        return await marketplaceService.healthCheck();
+      } catch {
+        return { healthy: false, message: 'Marketplace service not available' };
       }
     }
   };

--- a/server/services/marketplace/__tests__/marketplace.test.ts
+++ b/server/services/marketplace/__tests__/marketplace.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Agent Marketplace tests
+ * ADR-0013 [13.6] — Issue #217
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { PluginManifest } from '@shared/types/marketplace';
+import { compareSemver, parseSemver, satisfiesRange } from '../semver';
+import { AgentMarketplace } from '../engine';
+
+function manifest(overrides: Partial<PluginManifest> = {}): PluginManifest {
+  return {
+    id: 'demo-plugin',
+    name: 'Demo Plugin',
+    version: '1.0.0',
+    description: 'test plugin',
+    author: 'tests',
+    category: 'custom',
+    requiredCapabilities: ['tags:read', 'log'],
+    configSchema: {
+      threshold: { type: 'number', description: 'limit', default: 50, required: false },
+      mode: {
+        type: 'select',
+        description: 'mode',
+        options: ['fast', 'slow'],
+        default: 'fast',
+        required: true,
+      },
+    },
+    dependencies: {},
+    tags: ['demo'],
+    ...overrides,
+  };
+}
+
+function marketWithTags(): AgentMarketplace {
+  return new AgentMarketplace({
+    tagProvider: {
+      list: () => ['TANK-3.PRESSURE'],
+      readLatest: () => ({ value: 42, timestamp: 1000 }),
+    },
+    invokeTimeoutMs: 200,
+    autoDisableAfter: 3,
+  });
+}
+
+// ── Semver ────────────────────────────────────────────────────────────────
+
+describe('semver', () => {
+  it('parses and compares', () => {
+    expect(parseSemver('1.2.3')).toEqual({ major: 1, minor: 2, patch: 3 });
+    expect(parseSemver('1.2')).toBeNull();
+    expect(compareSemver('1.10.0', '1.9.9')).toBeGreaterThan(0);
+    expect(compareSemver('2.0.0', '2.0.0')).toBe(0);
+  });
+
+  it('evaluates ranges', () => {
+    expect(satisfiesRange('1.4.2', '^1.2.0')).toBe(true);
+    expect(satisfiesRange('2.0.0', '^1.2.0')).toBe(false);
+    expect(satisfiesRange('0.3.5', '^0.3.1')).toBe(true);
+    expect(satisfiesRange('0.4.0', '^0.3.1')).toBe(false);
+    expect(satisfiesRange('1.2.9', '~1.2.3')).toBe(true);
+    expect(satisfiesRange('1.3.0', '~1.2.3')).toBe(false);
+    expect(satisfiesRange('9.9.9', '*')).toBe(true);
+    expect(satisfiesRange('1.0.0', '1.0.0')).toBe(true);
+  });
+});
+
+// ── Registry & versioning ─────────────────────────────────────────────────
+
+describe('registry & versioning', () => {
+  it('republishing requires a strictly newer version and preserves installs', () => {
+    const market = marketWithTags();
+    market.publish(manifest());
+    market.install('demo-plugin');
+    expect(market.getEntry('demo-plugin')!.installs).toBe(1);
+
+    expect(() => market.publish(manifest({ version: '1.0.0' }))).toThrow(/not newer/);
+    expect(() => market.publish(manifest({ version: '0.9.0' }))).toThrow(/not newer/);
+
+    market.publish(manifest({ version: '1.1.0' }));
+    expect(market.getEntry('demo-plugin')!.installs).toBe(1); // not reset
+    expect(market.getEntry('demo-plugin')!.manifest.version).toBe('1.1.0');
+  });
+
+  it('updates an installed plugin to the newer registry version', () => {
+    const market = marketWithTags();
+    market.publish(manifest());
+    market.install('demo-plugin');
+    market.start('demo-plugin');
+
+    market.publish(manifest({ version: '1.2.0' }));
+    const updated = market.update('demo-plugin');
+    expect(updated.manifest.version).toBe('1.2.0');
+    expect(updated.status).toBe('running'); // running state restored
+    expect(() => market.update('demo-plugin')).toThrow(/already at/);
+  });
+
+  it('enforces dependency semver ranges at install', () => {
+    const market = marketWithTags();
+    market.publish(manifest({ id: 'dep-plugin', requiredCapabilities: [], configSchema: {} }));
+    market.publish(
+      manifest({ id: 'consumer', dependencies: { 'dep-plugin': '^2.0.0' }, configSchema: {} })
+    );
+
+    expect(() => market.install('consumer')).toThrow(/Missing dependency/);
+    market.install('dep-plugin'); // v1.0.0
+    expect(() => market.install('consumer')).toThrow(/does not satisfy/);
+  });
+
+  it('refuses to uninstall a plugin others depend on', () => {
+    const market = marketWithTags();
+    market.publish(manifest({ id: 'dep-plugin', requiredCapabilities: [], configSchema: {} }));
+    market.publish(
+      manifest({ id: 'consumer', dependencies: { 'dep-plugin': '^1.0.0' }, configSchema: {} })
+    );
+    market.install('dep-plugin');
+    market.install('consumer');
+    expect(() => market.uninstall('dep-plugin')).toThrow(/depends on it/);
+    market.uninstall('consumer');
+    market.uninstall('dep-plugin'); // now fine
+  });
+});
+
+// ── Config validation ─────────────────────────────────────────────────────
+
+describe('config validation', () => {
+  it('applies defaults to optional fields too (Wave-2 regression)', () => {
+    const market = marketWithTags();
+    market.publish(manifest());
+    const plugin = market.install('demo-plugin');
+    expect(plugin.config.threshold).toBe(50); // optional-with-default applied
+    expect(plugin.config.mode).toBe('fast');
+  });
+
+  it('rejects unknown keys, wrong types, and invalid select values', () => {
+    const market = marketWithTags();
+    market.publish(manifest());
+    expect(() => market.install('demo-plugin', { bogus: 1 })).toThrow(/Unknown config/);
+    expect(() => market.install('demo-plugin', { threshold: 'high' })).toThrow(/must be a number/);
+    expect(() => market.install('demo-plugin', { mode: 'turbo' })).toThrow(/one of/);
+  });
+
+  it('does not mutate the caller-supplied config object', () => {
+    const market = marketWithTags();
+    market.publish(manifest());
+    const supplied: Record<string, number> = {};
+    market.install('demo-plugin', supplied);
+    expect(Object.keys(supplied)).toHaveLength(0);
+  });
+});
+
+// ── Capability scoping & execution ────────────────────────────────────────
+
+describe('capability-scoped execution', () => {
+  it('exposes only granted capability APIs to the handler', async () => {
+    const market = marketWithTags();
+    market.publish(manifest());
+    market.registerImplementation('demo-plugin', (_input, host) => ({
+      hasTags: host.tags !== undefined,
+      hasAlarms: host.alarms !== undefined,
+      hasEmit: host.emitEvent !== undefined,
+      hasLog: host.log !== undefined,
+      tagValue: host.tags?.readLatest('TANK-3.PRESSURE')?.value ?? null,
+    }));
+    // Grant only log — tags:read declared but NOT granted
+    market.install('demo-plugin', {}, ['log']);
+    market.start('demo-plugin');
+
+    const result = await market.invoke('demo-plugin', {});
+    expect(result.success).toBe(true);
+    expect(result.output).toEqual({
+      hasTags: false,
+      hasAlarms: false,
+      hasEmit: false,
+      hasLog: true,
+      tagValue: null,
+    });
+  });
+
+  it('rejects grants beyond the manifest declaration', () => {
+    const market = marketWithTags();
+    market.publish(manifest()); // declares tags:read, log
+    expect(() => market.install('demo-plugin', {}, ['events:emit'])).toThrow(/not declared/);
+  });
+
+  it('granted tag access reads live values', async () => {
+    const market = marketWithTags();
+    market.publish(manifest());
+    market.registerImplementation('demo-plugin', (_i, host) =>
+      host.tags!.readLatest('TANK-3.PRESSURE')
+    );
+    market.install('demo-plugin'); // default grants = declared
+    market.start('demo-plugin');
+    const result = await market.invoke('demo-plugin', {});
+    expect(result.output).toEqual({ value: 42, timestamp: 1000 });
+  });
+
+  it('times out runaway invocations', async () => {
+    const market = marketWithTags(); // 200ms timeout
+    market.publish(manifest());
+    market.registerImplementation(
+      'demo-plugin',
+      () => new Promise((resolve) => setTimeout(resolve, 5_000))
+    );
+    market.install('demo-plugin');
+    market.start('demo-plugin');
+    const result = await market.invoke('demo-plugin', {});
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/timed out/);
+  });
+
+  it('auto-disables after consecutive failures and recovers via enable', async () => {
+    const market = marketWithTags(); // autoDisableAfter 3
+    const disabled = vi.fn();
+    market.on('plugin-auto-disabled', disabled);
+    market.publish(manifest());
+    market.registerImplementation('demo-plugin', () => {
+      throw new Error('boom');
+    });
+    market.install('demo-plugin');
+    market.start('demo-plugin');
+
+    for (let i = 0; i < 3; i++) await market.invoke('demo-plugin', {});
+    expect(disabled).toHaveBeenCalledTimes(1);
+    expect(market.getInstalled('demo-plugin')!.status).toBe('error');
+
+    const blocked = await market.invoke('demo-plugin', {});
+    expect(blocked.success).toBe(false);
+    expect(blocked.error).toMatch(/not running/);
+
+    market.enable('demo-plugin');
+    market.start('demo-plugin');
+    expect(market.getHealth('demo-plugin')!.consecutiveFailures).toBe(0);
+  });
+
+  it('invoking without an implementation fails clearly', async () => {
+    const market = marketWithTags();
+    market.publish(manifest());
+    market.install('demo-plugin');
+    market.start('demo-plugin');
+    const result = await market.invoke('demo-plugin', {});
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/no registered implementation/);
+    expect(market.getHealth('demo-plugin')!.hasImplementation).toBe(false);
+  });
+});
+
+// ── Lifecycle & health ────────────────────────────────────────────────────
+
+describe('lifecycle & health', () => {
+  it('reinstalling throws instead of silently replacing (Wave-2 regression)', () => {
+    const market = marketWithTags();
+    market.publish(manifest());
+    market.install('demo-plugin');
+    expect(() => market.install('demo-plugin')).toThrow(/already installed/);
+  });
+
+  it('disable blocks start until enable', () => {
+    const market = marketWithTags();
+    market.publish(manifest());
+    market.install('demo-plugin');
+    market.disable('demo-plugin');
+    expect(() => market.start('demo-plugin')).toThrow(/disabled/);
+    market.enable('demo-plugin');
+    expect(market.start('demo-plugin').status).toBe('running');
+  });
+
+  it('tracks uptime from start (not install) and windowed error rate', async () => {
+    vi.useFakeTimers();
+    try {
+      const market = marketWithTags();
+      market.publish(manifest());
+      let fail = false;
+      market.registerImplementation('demo-plugin', () => {
+        if (fail) throw new Error('flaky');
+        return 'ok';
+      });
+      market.install('demo-plugin');
+      vi.advanceTimersByTime(60_000); // time passes between install and start
+      market.start('demo-plugin');
+      vi.advanceTimersByTime(10_000);
+
+      await market.invoke('demo-plugin', {});
+      fail = true;
+      await market.invoke('demo-plugin', {});
+
+      const health = market.getHealth('demo-plugin')!;
+      expect(health.uptimeSeconds).toBe(10); // from start, not install
+      expect(health.invocations).toBe(2);
+      expect(health.windowedErrorRate).toBe(0.5);
+      expect(health.lastError).toBe('flaky');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/server/services/marketplace/engine.ts
+++ b/server/services/marketplace/engine.ts
@@ -1,0 +1,523 @@
+/**
+ * Agent Marketplace Engine
+ * ADR-0013 [13.6] — Issue #217
+ *
+ * Plugin registry, install/configure/enable-disable lifecycle with real
+ * semver dependency checking, capability-scoped execution, and health
+ * monitoring with auto-disable.
+ *
+ * Execution model: handlers run in-process through a host context built
+ * from the plugin's GRANTED capabilities only — an ungranted capability's
+ * API is simply absent. Invocations carry a wall-clock timeout and feed a
+ * windowed failure tracker; repeated failures auto-disable the plugin.
+ * This is capability scoping + fault containment, not memory isolation
+ * (see shared/types/marketplace.ts for the full statement).
+ */
+
+import { EventEmitter } from 'events';
+import type {
+  InstalledPlugin,
+  MarketplaceEntry,
+  PluginCapability,
+  PluginCategory,
+  PluginHealth,
+  PluginInvocationResult,
+  PluginManifest,
+} from '@shared/types/marketplace';
+import { compareSemver, parseSemver, satisfiesRange } from './semver';
+
+// ── Host API surface (capability-gated) ───────────────────────────────────
+
+export interface TagProvider {
+  list(): string[];
+  readLatest(tagId: string): { value: number | string; timestamp: number } | null;
+}
+
+export interface AlarmProvider {
+  getActive(): Array<{ id: string; name: string; severity: string; message: string }>;
+}
+
+/** What a handler receives — only granted capability APIs are present */
+export interface PluginHostContext {
+  pluginId: string;
+  config: Record<string, string | number | boolean>;
+  tags?: TagProvider;
+  alarms?: AlarmProvider;
+  emitEvent?: (type: string, payload: Record<string, unknown>) => void;
+  log?: (message: string) => void;
+}
+
+export type PluginHandler = (
+  input: unknown,
+  host: PluginHostContext
+) => Promise<unknown> | unknown;
+
+export interface MarketplaceOptions {
+  tagProvider?: TagProvider;
+  alarmProvider?: AlarmProvider;
+  /** Wall-clock cap per invocation */
+  invokeTimeoutMs?: number;
+  /** Recent invocations tracked for the windowed error rate */
+  errorWindow?: number;
+  /** Consecutive failures before a plugin is auto-disabled */
+  autoDisableAfter?: number;
+}
+
+interface PluginStats {
+  invocations: number;
+  failures: number;
+  consecutiveFailures: number;
+  recent: boolean[]; // true = success
+}
+
+const ID_PATTERN = /^[a-z0-9][a-z0-9-]{1,63}$/;
+
+export class AgentMarketplace extends EventEmitter {
+  private readonly tagProvider: TagProvider | null;
+  private readonly alarmProvider: AlarmProvider | null;
+  private readonly invokeTimeoutMs: number;
+  private readonly errorWindow: number;
+  private readonly autoDisableAfter: number;
+
+  private registry: Map<string, MarketplaceEntry> = new Map();
+  private installed: Map<string, InstalledPlugin> = new Map();
+  private implementations: Map<string, PluginHandler> = new Map();
+  private stats: Map<string, PluginStats> = new Map();
+
+  constructor(options: MarketplaceOptions = {}) {
+    super();
+    this.tagProvider = options.tagProvider ?? null;
+    this.alarmProvider = options.alarmProvider ?? null;
+    this.invokeTimeoutMs = options.invokeTimeoutMs ?? 5000;
+    this.errorWindow = options.errorWindow ?? 20;
+    this.autoDisableAfter = options.autoDisableAfter ?? 5;
+  }
+
+  // ── Registry ─────────────────────────────────────────────────────────
+
+  /**
+   * Publish a manifest. Republishing an existing id requires a strictly
+   * newer semver and preserves the install counter (Wave-2 reset it).
+   */
+  publish(manifest: PluginManifest): MarketplaceEntry {
+    if (!ID_PATTERN.test(manifest.id)) {
+      throw new Error(`Plugin id "${manifest.id}" must match ${ID_PATTERN}`);
+    }
+    if (!parseSemver(manifest.version)) {
+      throw new Error(`Plugin "${manifest.id}" version "${manifest.version}" is not valid semver`);
+    }
+    for (const range of Object.values(manifest.dependencies)) {
+      if (range !== '*' && !parseSemver(range.replace(/^[\^~]/, ''))) {
+        throw new Error(`Plugin "${manifest.id}" has invalid dependency range "${range}"`);
+      }
+    }
+
+    const existing = this.registry.get(manifest.id);
+    if (existing && compareSemver(manifest.version, existing.manifest.version) <= 0) {
+      throw new Error(
+        `Plugin "${manifest.id}" version ${manifest.version} is not newer than published ${existing.manifest.version}`
+      );
+    }
+    const entry: MarketplaceEntry = {
+      manifest: { ...manifest },
+      publishedAt: existing?.publishedAt ?? Date.now(),
+      updatedAt: Date.now(),
+      installs: existing?.installs ?? 0,
+    };
+    this.registry.set(manifest.id, entry);
+    this.emit(existing ? 'plugin-republished' : 'plugin-published', entry);
+    return entry;
+  }
+
+  search(query = '', category?: PluginCategory): MarketplaceEntry[] {
+    const q = query.trim().toLowerCase();
+    return Array.from(this.registry.values()).filter((entry) => {
+      const m = entry.manifest;
+      if (category && m.category !== category) return false;
+      if (!q) return true;
+      return (
+        m.id.includes(q) ||
+        m.name.toLowerCase().includes(q) ||
+        m.description.toLowerCase().includes(q) ||
+        m.tags.some((t) => t.toLowerCase().includes(q))
+      );
+    });
+  }
+
+  getEntry(pluginId: string): MarketplaceEntry | undefined {
+    return this.registry.get(pluginId);
+  }
+
+  /** Handlers are registered in code — a manifest alone is not executable */
+  registerImplementation(pluginId: string, handler: PluginHandler): void {
+    this.implementations.set(pluginId, handler);
+  }
+
+  unregisterImplementation(pluginId: string): boolean {
+    return this.implementations.delete(pluginId);
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────
+
+  install(
+    pluginId: string,
+    config: Record<string, string | number | boolean> = {},
+    grants?: PluginCapability[]
+  ): InstalledPlugin {
+    const entry = this.registry.get(pluginId);
+    if (!entry) throw new Error(`Plugin "${pluginId}" is not in the registry`);
+    if (this.installed.has(pluginId)) {
+      throw new Error(`Plugin "${pluginId}" is already installed — use update()`);
+    }
+
+    // Dependencies must be installed AND satisfy the declared semver range
+    for (const [depId, range] of Object.entries(entry.manifest.dependencies)) {
+      const dep = this.installed.get(depId);
+      if (!dep) throw new Error(`Missing dependency: ${depId}@${range}`);
+      if (!satisfiesRange(dep.manifest.version, range)) {
+        throw new Error(
+          `Dependency ${depId}@${dep.manifest.version} does not satisfy required range "${range}"`
+        );
+      }
+    }
+
+    // Grants must be a subset of what the manifest declares
+    const granted = grants ?? [...entry.manifest.requiredCapabilities];
+    for (const capability of granted) {
+      if (!entry.manifest.requiredCapabilities.includes(capability)) {
+        throw new Error(
+          `Capability "${capability}" is not declared by plugin "${pluginId}"`
+        );
+      }
+    }
+
+    const validatedConfig = this.validateConfig(entry.manifest, config);
+    const plugin: InstalledPlugin = {
+      manifest: { ...entry.manifest },
+      status: 'installed',
+      config: validatedConfig,
+      grantedCapabilities: granted,
+      installedAt: Date.now(),
+      startedAt: null,
+      lastError: null,
+    };
+    this.installed.set(pluginId, plugin);
+    this.stats.set(pluginId, { invocations: 0, failures: 0, consecutiveFailures: 0, recent: [] });
+    entry.installs++;
+    this.emit('plugin-installed', plugin);
+    return plugin;
+  }
+
+  /** Upgrade an installed plugin to the (strictly newer) registry version */
+  update(pluginId: string): InstalledPlugin {
+    const plugin = this.requireInstalled(pluginId);
+    const entry = this.registry.get(pluginId);
+    if (!entry) throw new Error(`Plugin "${pluginId}" is not in the registry`);
+    if (compareSemver(entry.manifest.version, plugin.manifest.version) <= 0) {
+      throw new Error(
+        `Plugin "${pluginId}" is already at ${plugin.manifest.version}; registry has ${entry.manifest.version}`
+      );
+    }
+    const wasRunning = plugin.status === 'running';
+    if (wasRunning) this.stop(pluginId);
+
+    // Revalidate carried-over config against the NEW schema
+    plugin.config = this.validateConfig(entry.manifest, plugin.config);
+    plugin.manifest = { ...entry.manifest };
+    plugin.status = 'installed';
+    plugin.lastError = null;
+    this.emit('plugin-updated', plugin);
+    if (wasRunning) this.start(pluginId);
+    return plugin;
+  }
+
+  configure(
+    pluginId: string,
+    config: Record<string, string | number | boolean>
+  ): InstalledPlugin {
+    const plugin = this.requireInstalled(pluginId);
+    plugin.config = this.validateConfig(plugin.manifest, config);
+    this.emit('plugin-configured', plugin);
+    return plugin;
+  }
+
+  start(pluginId: string): InstalledPlugin {
+    const plugin = this.requireInstalled(pluginId);
+    if (plugin.status === 'disabled') {
+      throw new Error(`Plugin "${pluginId}" is disabled — enable it first`);
+    }
+    if (plugin.status === 'running') return plugin;
+    plugin.status = 'running';
+    plugin.startedAt = Date.now();
+    plugin.lastError = null;
+    const stats = this.stats.get(pluginId);
+    if (stats) stats.consecutiveFailures = 0;
+    this.emit('plugin-started', plugin);
+    return plugin;
+  }
+
+  stop(pluginId: string): InstalledPlugin {
+    const plugin = this.requireInstalled(pluginId);
+    if (plugin.status === 'running' || plugin.status === 'error') {
+      plugin.status = 'stopped';
+      plugin.startedAt = null;
+      this.emit('plugin-stopped', plugin);
+    }
+    return plugin;
+  }
+
+  /** Administratively block a plugin from starting or being invoked */
+  disable(pluginId: string): InstalledPlugin {
+    const plugin = this.requireInstalled(pluginId);
+    plugin.status = 'disabled';
+    plugin.startedAt = null;
+    this.emit('plugin-disabled', plugin);
+    return plugin;
+  }
+
+  enable(pluginId: string): InstalledPlugin {
+    const plugin = this.requireInstalled(pluginId);
+    if (plugin.status === 'disabled' || plugin.status === 'error') {
+      plugin.status = 'stopped';
+      const stats = this.stats.get(pluginId);
+      if (stats) stats.consecutiveFailures = 0;
+      this.emit('plugin-enabled', plugin);
+    }
+    return plugin;
+  }
+
+  uninstall(pluginId: string): void {
+    this.requireInstalled(pluginId);
+    // Refuse while other installed plugins depend on this one
+    for (const other of this.installed.values()) {
+      if (other.manifest.id !== pluginId && pluginId in other.manifest.dependencies) {
+        throw new Error(
+          `Cannot uninstall "${pluginId}": "${other.manifest.id}" depends on it`
+        );
+      }
+    }
+    this.installed.delete(pluginId);
+    this.stats.delete(pluginId);
+    this.emit('plugin-uninstalled', { pluginId });
+  }
+
+  listInstalled(): InstalledPlugin[] {
+    return Array.from(this.installed.values());
+  }
+
+  getInstalled(pluginId: string): InstalledPlugin | undefined {
+    return this.installed.get(pluginId);
+  }
+
+  // ── Execution ────────────────────────────────────────────────────────
+
+  async invoke(pluginId: string, input: unknown): Promise<PluginInvocationResult> {
+    const started = Date.now();
+    const plugin = this.installed.get(pluginId);
+    if (!plugin) {
+      return this.failResult(pluginId, `Plugin "${pluginId}" is not installed`, started);
+    }
+    if (plugin.status !== 'running') {
+      return this.failResult(
+        pluginId,
+        `Plugin "${pluginId}" is ${plugin.status}, not running`,
+        started
+      );
+    }
+    const handler = this.implementations.get(pluginId);
+    if (!handler) {
+      return this.failResult(
+        pluginId,
+        `Plugin "${pluginId}" has no registered implementation`,
+        started
+      );
+    }
+
+    const host = this.buildHostContext(plugin);
+    try {
+      const output = await this.withTimeout(
+        Promise.resolve().then(() => handler(input, host)),
+        this.invokeTimeoutMs,
+        pluginId
+      );
+      this.recordOutcome(pluginId, true, null);
+      return { pluginId, success: true, output, durationMs: Date.now() - started };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.recordOutcome(pluginId, false, message);
+      return { pluginId, success: false, error: message, durationMs: Date.now() - started };
+    }
+  }
+
+  // ── Health ───────────────────────────────────────────────────────────
+
+  getHealth(pluginId: string): PluginHealth | null {
+    const plugin = this.installed.get(pluginId);
+    if (!plugin) return null;
+    const stats = this.stats.get(pluginId) ?? {
+      invocations: 0,
+      failures: 0,
+      consecutiveFailures: 0,
+      recent: [],
+    };
+    const windowFailures = stats.recent.filter((ok) => !ok).length;
+    return {
+      pluginId,
+      status: plugin.status,
+      // Uptime counts from the last start, not install time (Wave-2 bug)
+      uptimeSeconds:
+        plugin.status === 'running' && plugin.startedAt
+          ? Math.round((Date.now() - plugin.startedAt) / 1000)
+          : 0,
+      invocations: stats.invocations,
+      failures: stats.failures,
+      windowedErrorRate:
+        stats.recent.length === 0 ? 0 : windowFailures / stats.recent.length,
+      consecutiveFailures: stats.consecutiveFailures,
+      lastError: plugin.lastError,
+      hasImplementation: this.implementations.has(pluginId),
+    };
+  }
+
+  getAllHealth(): PluginHealth[] {
+    return Array.from(this.installed.keys())
+      .map((id) => this.getHealth(id))
+      .filter((h): h is PluginHealth => h !== null);
+  }
+
+  getStatus(): { published: number; installed: number; running: number } {
+    return {
+      published: this.registry.size,
+      installed: this.installed.size,
+      running: this.listInstalled().filter((p) => p.status === 'running').length,
+    };
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────
+
+  private requireInstalled(pluginId: string): InstalledPlugin {
+    const plugin = this.installed.get(pluginId);
+    if (!plugin) throw new Error(`Plugin "${pluginId}" is not installed`);
+    return plugin;
+  }
+
+  /**
+   * Validate config against the schema. Defaults apply to EVERY field
+   * that declares one (Wave-2 only applied them to required fields);
+   * required fields without a value or default fail; values are
+   * type-checked; select values must be in options; unknown keys fail.
+   * The caller's object is never mutated.
+   */
+  private validateConfig(
+    manifest: PluginManifest,
+    config: Record<string, string | number | boolean>
+  ): Record<string, string | number | boolean> {
+    const result: Record<string, string | number | boolean> = {};
+    for (const key of Object.keys(config)) {
+      if (!(key in manifest.configSchema)) {
+        throw new Error(`Unknown config key "${key}" for plugin "${manifest.id}"`);
+      }
+    }
+    for (const [key, field] of Object.entries(manifest.configSchema)) {
+      let value = config[key];
+      if (value === undefined) {
+        if (field.default !== undefined) {
+          value = field.default;
+        } else if (field.required) {
+          throw new Error(`Missing required config "${key}" for plugin "${manifest.id}"`);
+        } else {
+          continue;
+        }
+      }
+      const expected = field.type === 'select' ? 'string' : field.type;
+      if (typeof value !== expected) {
+        throw new Error(
+          `Config "${key}" for plugin "${manifest.id}" must be a ${expected}`
+        );
+      }
+      if (field.type === 'select' && field.options && !field.options.includes(value as string)) {
+        throw new Error(
+          `Config "${key}" must be one of: ${field.options.join(', ')}`
+        );
+      }
+      result[key] = value;
+    }
+    return result;
+  }
+
+  private buildHostContext(plugin: InstalledPlugin): PluginHostContext {
+    const host: PluginHostContext = {
+      pluginId: plugin.manifest.id,
+      config: { ...plugin.config },
+    };
+    const granted = plugin.grantedCapabilities;
+    if (granted.includes('tags:read') && this.tagProvider) {
+      host.tags = this.tagProvider;
+    }
+    if (granted.includes('alarms:read') && this.alarmProvider) {
+      host.alarms = this.alarmProvider;
+    }
+    if (granted.includes('events:emit')) {
+      host.emitEvent = (type, payload) =>
+        this.emit('plugin-event', { pluginId: plugin.manifest.id, type, payload });
+    }
+    if (granted.includes('log')) {
+      host.log = (message) =>
+        this.emit('plugin-log', { pluginId: plugin.manifest.id, message });
+    }
+    return host;
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, ms: number, pluginId: string): Promise<T> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`Plugin "${pluginId}" invocation timed out after ${ms}ms`)),
+            ms
+          );
+          timer.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  private recordOutcome(pluginId: string, success: boolean, error: string | null): void {
+    const plugin = this.installed.get(pluginId);
+    const stats = this.stats.get(pluginId);
+    if (!plugin || !stats) return;
+
+    stats.invocations++;
+    stats.recent.push(success);
+    if (stats.recent.length > this.errorWindow) stats.recent.shift();
+
+    if (success) {
+      stats.consecutiveFailures = 0;
+    } else {
+      stats.failures++;
+      stats.consecutiveFailures++;
+      plugin.lastError = error;
+      if (stats.consecutiveFailures >= this.autoDisableAfter && plugin.status === 'running') {
+        plugin.status = 'error';
+        plugin.startedAt = null;
+        this.emit('plugin-auto-disabled', {
+          pluginId,
+          consecutiveFailures: stats.consecutiveFailures,
+          lastError: error,
+        });
+      }
+    }
+  }
+
+  private failResult(
+    pluginId: string,
+    error: string,
+    startedMs: number
+  ): PluginInvocationResult {
+    return { pluginId, success: false, error, durationMs: Date.now() - startedMs };
+  }
+}

--- a/server/services/marketplace/index.ts
+++ b/server/services/marketplace/index.ts
@@ -1,0 +1,83 @@
+/**
+ * Agent Marketplace Service
+ * ADR-0013 [13.6] — Issue #217
+ *
+ * Singleton wrapper wiring the marketplace to live read-only providers:
+ * tags from the tag-stream cache, alarms from the phi alerting service.
+ * Handlers registered here run under the capability-scoped host context.
+ */
+
+import { EventEmitter } from 'events';
+
+export * from './semver';
+export * from './engine';
+
+import { AgentMarketplace, type TagProvider, type AlarmProvider } from './engine';
+import { tagStreamServer } from '../../websocket/tag-stream';
+
+const liveTagProvider: TagProvider = {
+  list: () => Array.from(tagStreamServer.getLatestValues().keys()),
+  readLatest: (tagId) => {
+    const update = tagStreamServer.getLatestValues().get(tagId);
+    if (!update) return null;
+    return {
+      value: typeof update.value === 'boolean' ? String(update.value) : update.value,
+      timestamp: new Date(update.timestamp).getTime(),
+    };
+  },
+};
+
+/**
+ * No live process-alarm source exists on this branch (the alarm pipeline
+ * gains a producer with the alarm-correlation work); plugins granted
+ * 'alarms:read' get an empty list rather than fabricated data. Swap this
+ * provider for the correlation service's active groups once merged.
+ */
+const liveAlarmProvider: AlarmProvider = {
+  getActive: () => [],
+};
+
+export class MarketplaceService extends EventEmitter {
+  readonly marketplace: AgentMarketplace;
+
+  private initialized = false;
+
+  constructor() {
+    super();
+    this.marketplace = new AgentMarketplace({
+      tagProvider: liveTagProvider,
+      alarmProvider: liveAlarmProvider,
+    });
+    for (const event of [
+      'plugin-published',
+      'plugin-installed',
+      'plugin-started',
+      'plugin-stopped',
+      'plugin-auto-disabled',
+      'plugin-event',
+      'plugin-log',
+    ]) {
+      this.marketplace.on(event, (payload) => this.emit(event, payload));
+    }
+  }
+
+  async initialize(): Promise<void> {
+    this.initialized = true;
+  }
+
+  async shutdown(): Promise<void> {
+    this.initialized = false;
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
+    const status = this.marketplace.getStatus();
+    return {
+      healthy: this.initialized,
+      message: this.initialized
+        ? `Marketplace running: ${status.published} published, ${status.installed} installed, ${status.running} running`
+        : 'Marketplace service not initialized',
+    };
+  }
+}
+
+export const marketplaceService = new MarketplaceService();

--- a/server/services/marketplace/semver.ts
+++ b/server/services/marketplace/semver.ts
@@ -1,0 +1,64 @@
+/**
+ * Minimal semver — parse, compare, and range satisfaction
+ * ADR-0013 [13.6] — Issue #217
+ *
+ * The Wave-2 marketplace stored semver strings and never compared them;
+ * dependency ranges and update checks here are actually enforced.
+ * Supports exact versions, ^ (compatible), ~ (patch-level), and *.
+ */
+
+export interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+export function parseSemver(version: string): SemVer | null {
+  const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return null;
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: parseInt(match[3], 10),
+  };
+}
+
+/** negative: a < b, 0: equal, positive: a > b. Throws on invalid input. */
+export function compareSemver(a: string, b: string): number {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) throw new Error(`Invalid semver: "${!pa ? a : b}"`);
+  return pa.major - pb.major || pa.minor - pb.minor || pa.patch - pb.patch;
+}
+
+/** Does `version` satisfy `range` ("1.2.3", "^1.2.0", "~1.2.0", "*")? */
+export function satisfiesRange(version: string, range: string): boolean {
+  const trimmed = range.trim();
+  if (trimmed === '*' || trimmed === '') return parseSemver(version) !== null;
+
+  const v = parseSemver(version);
+  if (!v) return false;
+
+  if (trimmed.startsWith('^')) {
+    const base = parseSemver(trimmed.slice(1));
+    if (!base) return false;
+    if (base.major > 0) {
+      return v.major === base.major && compareSemver(version, trimmed.slice(1)) >= 0;
+    }
+    // ^0.x.y — minor acts as the compatibility boundary
+    return (
+      v.major === 0 && v.minor === base.minor && compareSemver(version, trimmed.slice(1)) >= 0
+    );
+  }
+  if (trimmed.startsWith('~')) {
+    const base = parseSemver(trimmed.slice(1));
+    if (!base) return false;
+    return (
+      v.major === base.major &&
+      v.minor === base.minor &&
+      compareSemver(version, trimmed.slice(1)) >= 0
+    );
+  }
+  const exact = parseSemver(trimmed);
+  return exact !== null && compareSemver(version, trimmed) === 0;
+}

--- a/shared/types/marketplace.ts
+++ b/shared/types/marketplace.ts
@@ -1,0 +1,98 @@
+/**
+ * Agent Marketplace & Plugin System Types
+ * ADR-0013 [13.6] — Issue #217
+ *
+ * Registry for agent plugins with install/configure/enable-disable
+ * lifecycle, real semver versioning, health monitoring, and
+ * capability-scoped execution.
+ *
+ * Isolation model (stated honestly per the repo integrity rule): plugin
+ * handlers run in-process through a PluginExecutionContext that exposes
+ * ONLY the host APIs matching the plugin's granted capabilities, with a
+ * wall-clock timeout and windowed error tracking that auto-disables
+ * failing plugins. This is capability scoping and fault containment —
+ * not memory isolation. Arbitrary untrusted code would additionally need
+ * worker/child-process isolation, which this codebase's build pipeline
+ * does not currently support (noEmit + tsx dev runtime). ADR-0008
+ * capability tokens are being built separately; the grant model here is
+ * designed to plug into them.
+ */
+
+export type PluginCategory =
+  | 'intelligence'
+  | 'integration'
+  | 'reporting'
+  | 'safety'
+  | 'optimization'
+  | 'custom';
+
+/** Capabilities a plugin may be granted — enforced by the host API surface */
+export type PluginCapability =
+  | 'tags:read'
+  | 'alarms:read'
+  | 'events:emit'
+  | 'log';
+
+export interface PluginConfigField {
+  type: 'string' | 'number' | 'boolean' | 'select';
+  description: string;
+  default?: string | number | boolean;
+  required: boolean;
+  options?: string[];
+}
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  category: PluginCategory;
+  /** Capabilities the plugin needs; installation grants ⊆ these */
+  requiredCapabilities: PluginCapability[];
+  configSchema: Record<string, PluginConfigField>;
+  /** pluginId → semver range (^, ~, exact, or *) — actually enforced */
+  dependencies: Record<string, string>;
+  tags: string[];
+}
+
+export interface MarketplaceEntry {
+  manifest: PluginManifest;
+  publishedAt: number;
+  updatedAt: number;
+  installs: number;
+}
+
+export type PluginStatus = 'installed' | 'running' | 'stopped' | 'disabled' | 'error';
+
+export interface InstalledPlugin {
+  manifest: PluginManifest;
+  status: PluginStatus;
+  config: Record<string, string | number | boolean>;
+  grantedCapabilities: PluginCapability[];
+  installedAt: number;
+  startedAt: number | null;
+  lastError: string | null;
+}
+
+export interface PluginHealth {
+  pluginId: string;
+  status: PluginStatus;
+  /** Seconds since last start; 0 when not running */
+  uptimeSeconds: number;
+  invocations: number;
+  failures: number;
+  /** Failure fraction over the recent invocation window */
+  windowedErrorRate: number;
+  consecutiveFailures: number;
+  lastError: string | null;
+  hasImplementation: boolean;
+}
+
+export interface PluginInvocationResult {
+  pluginId: string;
+  success: boolean;
+  output?: unknown;
+  error?: string;
+  durationMs: number;
+}


### PR DESCRIPTION
Closes #217

Rebuilds the Agent Marketplace from ADR-0013 [13.6]. Recon of the deleted Wave 2 implementation found its sandbox and capability model were purely declarative data structures (nothing ever enforced or executed), semver was never compared, and the lifecycle had several concrete bugs — all addressed here.

## What's included

**Registry with real versioning** — minimal semver implementation (no new dependency): republish requires a strictly newer version and preserves install counts; dependency ranges (`^`, `~`, exact, `*`) are enforced at install; `update()` upgrades an installed plugin, revalidates carried-over config against the new schema, and restores running state.

**Lifecycle** — install/configure/start/stop/enable/disable/uninstall with every confirmed Wave 2 bug fixed: reinstall throws instead of silently replacing (no leaked timers), config defaults apply to optional fields too, values are type- and select-validated without mutating the caller's object, uninstall is refused while dependents exist, and uptime counts from start rather than install.

**Capability-scoped execution (honest ADR-0008 posture)** — plugin handlers are registered in code and run through a `PluginHostContext` that exposes **only** the APIs matching granted capabilities (`tags:read` from the live tag stream, `alarms:read`, `events:emit`, `log`); grants must be ⊆ the manifest's declared capabilities. Invocations carry a wall-clock timeout and feed a windowed failure tracker; consecutive failures auto-disable the plugin until re-enabled.

Per the repo integrity rule, the isolation model is stated exactly: this is **capability scoping + fault containment, not memory isolation**. `node:vm` is explicitly not a security boundary, and worker-thread entrypoints currently have no emitted-JS path (`noEmit` + tsx dev runtime), so arbitrary-untrusted-code isolation is documented as future work alongside the in-progress ADR-0008 capability-token system (beads `0xSCADA-otp`) — the grant model here is shaped to plug into it.

**Health monitoring** — per-plugin uptime, invocation/failure counts, windowed error rate, consecutive-failure tracking, and implementation presence. `agentRuntime.getHealth()` (consumed by `server/health`) now reports real marketplace stats instead of hardcoded zeros, with its export shape preserved.

**API** — `/api/marketplace`: registry search/publish/detail, install (with config + grants), update, configure, start/stop/enable/disable, uninstall, invoke, per-plugin and aggregate health, status. Zod-validated; `/api/agents` and its `/agent-outputs`/`/agent-proposals` redirects are deliberately untouched.

## Testing
- 18 unit tests: semver parse/compare/ranges, versioned republish + update flow, dependency-range enforcement, config-validation regressions, capability gating (granted vs declared), live tag reads, invocation timeout, auto-disable + recovery, lifecycle transitions, health semantics
- Full suite: 1197 pass (1 failure is the pre-existing `event-pipeline.test.ts` `uptime_ms` timing flake on `main`, unrelated); `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)