### PR TITLE
feat(integrity): implement the PKCS#11 HSM signer (was a stub) (#482)

### DIFF
--- a/.github/workflows/hsm-pkcs11.yml
+++ b/.github/workflows/hsm-pkcs11.yml
@@ -1,0 +1,66 @@
+name: HSM PKCS#11 (SoftHSMv2)
+
+# Real-hardware validation of the PKCS#11 signer (#482) against a live
+# SoftHSMv2 token. The unit tests in server/integrity/__tests__/hsm.test.ts
+# cover the signer logic via an in-memory emulator; this job proves the
+# production `pkcs11js` binding works end-to-end.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'server/integrity/hsm.ts'
+      - 'server/integrity/pkcs11-provider.ts'
+      - 'server/integrity/__tests__/pkcs11-softhsm.test.ts'
+      - '.github/workflows/hsm-pkcs11.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/integrity/hsm.ts'
+      - 'server/integrity/pkcs11-provider.ts'
+      - 'server/integrity/__tests__/pkcs11-softhsm.test.ts'
+      - '.github/workflows/hsm-pkcs11.yml'
+  workflow_dispatch:
+
+jobs:
+  softhsm:
+    name: PKCS#11 round-trip on SoftHSMv2
+    runs-on: ubuntu-latest
+    env:
+      SOFTHSM2_CONF: ${{ github.workspace }}/.softhsm2.conf
+      SOFTHSM_LIB: /usr/lib/softhsm/libsofthsm2.so
+      SOFTHSM_PIN: '1234'
+      SOFTHSM_KEY_LABEL: anchor-key
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install SoftHSMv2 + OpenSC
+        run: sudo apt-get update && sudo apt-get install -y softhsm2 opensc
+
+      - name: Provision a SoftHSM token + RSA key
+        run: |
+          mkdir -p "${{ github.workspace }}/.softhsm2/tokens"
+          cat > "$SOFTHSM2_CONF" <<EOF
+          directories.tokendir = ${{ github.workspace }}/.softhsm2/tokens
+          objectstore.backend = file
+          log.level = INFO
+          EOF
+          softhsm2-util --init-token --free --label test-token --pin "$SOFTHSM_PIN" --so-pin 5678
+          pkcs11-tool --module "$SOFTHSM_LIB" --login --pin "$SOFTHSM_PIN" \
+            --keypairgen --key-type rsa:2048 --label "$SOFTHSM_KEY_LABEL" --id 01
+          # Sanity: the key is visible
+          pkcs11-tool --module "$SOFTHSM_LIB" --login --pin "$SOFTHSM_PIN" --list-objects
+
+      - name: Install deps + pkcs11js
+        run: |
+          npm ci
+          npm install --no-save pkcs11js
+
+      - name: Run the SoftHSM PKCS#11 round-trip test
+        env:
+          PKCS11_SOFTHSM: '1'
+        run: npx vitest run server/integrity/__tests__/pkcs11-softhsm.test.ts --project node

--- a/docs/security/hsm-signing.md
+++ b/docs/security/hsm-signing.md
@@ -1,46 +1,65 @@
 # HSM / Merkle-Root Signing: Provider Matrix & Status
 
-> Gate verification record for issue #445 (2026-07-21). The HSM/PKCS#11
-> path was specified in #291–292, both closed in the 2026-02-15 bulk-close
-> without verification. This document records what actually exists.
+> Originally the #445 gate record (2026-07-21); updated for #482 when the
+> PKCS#11 signer was implemented and validated.
 
 ## Provider matrix
 
 | Mode (`HSMConfig.mode`) | Status | Evidence |
 |--------------------------|--------|----------|
 | `software` | ✅ **Implemented & tested** | `SoftwareSigner` — Node crypto, RSA-2048, PKCS#8/SPKI PEM persisted under `keyPath` (default `.keys/`). Round-trip suite: `server/integrity/__tests__/hsm.test.ts` |
-| `pkcs11` | ❌ **Stub — throws on every call** | `PKCS11Signer` (`server/integrity/hsm.ts:263-305`): `initialize`/`sign`/`verify`/`getPublicKey`/`listKeys` all raise `not yet implemented`. Implementation tracked in **#482** |
-| `hardware` | ❌ Not implemented | Factory throws (`hsm.ts:319`) |
+| `pkcs11` | ✅ **Implemented & tested** | `PKCS11Signer` (`server/integrity/hsm.ts`) signs via CKM_SHA256_RSA_PKCS through an injectable `Pkcs11Provider`. Logic tested end-to-end against an in-memory PKCS#11 emulator (`hsm.test.ts`); **SoftHSMv2 verified in CI** (`.github/workflows/hsm-pkcs11.yml` + `pkcs11-softhsm.test.ts`) |
+| `hardware` | ❌ Not implemented | Factory throws |
 
-No PKCS#11 provider (SoftHSMv2 or vendor HSM) has ever been exercised
-against this codebase. Any deployment configured with `mode: 'pkcs11'`
-fails at startup.
+## PKCS#11 provider matrix (validated)
 
-## What actually runs in production paths
+| Provider | Validated | How |
+|----------|-----------|-----|
+| SoftHSMv2 | ✅ | CI job `HSM PKCS#11 (SoftHSMv2)` — token init → RSA-2048 keygen → sign → verify, plus a Node RSA-SHA256 interop check against the extracted public key |
+| Vendor HSMs (Thales / AWS CloudHSM / etc.) | ⬜ not yet | Any PKCS#11 module exposing RSA + CKM_SHA256_RSA_PKCS should work; validate per provider and add a row |
 
-`server/integrity/resilience.ts` instantiates `MerkleRootSigner` for both
-its **primary** and **fallback** signers from configuration. With the
-PKCS#11 stub, the only viable configuration today is software/software —
-i.e. the "HSM-backed" integrity pipeline is software-key signing with a
-software-key fallback. Threat-model accordingly: the signing key lives as
-a PEM file on the server filesystem.
+## How it works
 
-## Test coverage (added by the #445 gate)
+- `PKCS11Signer` talks to the token through a `Pkcs11Provider` (session,
+  login, find-key, sign, extract-public-key). The production provider is
+  `Pkcs11jsProvider`, backed by the native `pkcs11js` binding; tests use an
+  in-memory emulator that emulates the same operations with Node RSA.
+- The private key **never leaves the token**. The signer extracts only the
+  public key (SPKI PEM, built from the RSA modulus/exponent via JWK) for
+  verification. Because CKM_SHA256_RSA_PKCS is hash-then-sign RSA-SHA256,
+  signatures are byte-compatible with the software signer and the relayer's
+  Node `createVerify('RSA-SHA256')` check.
+- `resilience.ts` can run **primary `pkcs11` + fallback `software`**: if the
+  token fails to initialize (e.g. wrong PIN, module missing), it degrades to
+  the software signer. Both paths are exercised in
+  `server/integrity/__tests__/resilience-anchor.test.ts`.
+
+## Deployment
+
+- `pkcs11js` is an **optional** native dependency — install it in production
+  (`npm install pkcs11js`) and configure:
+  - `HSMConfig.pkcs11Library` — module path (e.g. `/usr/lib/softhsm/libsofthsm2.so`)
+  - `HSMConfig.slot` — slot index (default 0)
+  - `HSMConfig.pin` — user PIN
+  - `HSMConfig.keyId` — the key's CKA_LABEL
+- Absent the binding, `PKCS11Signer.initialize()` throws a clear
+  "install pkcs11js" error rather than failing silently.
+- The L2 anchor pipeline (`AnchorPipeline`, #489) uses a software signer by
+  default; point it at a token by passing an HSM config with `mode: 'pkcs11'`.
+
+## Test coverage
 
 `server/integrity/__tests__/hsm.test.ts`:
+- Software round-trip, tamper detection, key persistence, unknown-key error,
+  `MerkleRootSigner` facade.
+- **PKCS#11 (emulator)**: sign-in-token → verify-with-extracted-key round-trip,
+  tampered-root/tampered-signature rejection, SPKI extraction + key listing,
+  key-not-found error, wrong-PIN login failure, facade round-trip, and RSA-SHA256
+  interop.
 
-- Software round-trip: key-gen → sign → verify
-- Tamper detection (modified root, modified signature)
-- Key persistence across signer instances (same `keyPath`)
-- Unknown-key error path; `MerkleRootSigner` facade
-- **PKCS#11 status pin** — asserts the stub throws `not yet implemented`.
-  When #482 lands a real implementation this test fails on purpose:
-  update this matrix and replace the pin with SoftHSMv2 round-trip tests.
+`server/integrity/__tests__/pkcs11-softhsm.test.ts` (CI only, gated on
+`PKCS11_SOFTHSM=1`): the same round-trip against a **real SoftHSMv2** token via
+`pkcs11js`.
 
-## Planned CI verification (with #482)
-
-- SoftHSMv2 as a GitHub Actions service container (ubuntu runner)
-- Token init + RSA key-gen via `pkcs11-tool`, then a vitest suite running
-  `MerkleRootSigner` with `mode: 'pkcs11'` against
-  `/usr/lib/softhsm/libsofthsm2.so`
-- Provider matrix updated with each provider actually validated
+`server/integrity/__tests__/resilience-anchor.test.ts`: primary `pkcs11`
+signing, and software fallback when the token init fails.

--- a/server/integrity/__tests__/hsm.test.ts
+++ b/server/integrity/__tests__/hsm.test.ts
@@ -1,12 +1,10 @@
 /**
- * HSM signing path verification (issue #445).
+ * HSM signing path verification (issues #445, #482).
  *
- * The software signer gets a real round-trip suite (it previously had zero
- * working coverage — the only references lived in the openssl-gated e2e
- * file whose tests are all skipped). The PKCS#11 signer is pinned as
- * not-implemented: if someone lands a real implementation, these tests
- * fail loudly and the provider matrix in docs/security/hsm-signing.md must
- * be updated (#482 tracks the implementation).
+ * The software signer has a real round-trip suite. The PKCS#11 signer (#482) is
+ * now implemented and exercised end-to-end through an in-memory PKCS#11 emulator
+ * (session/login/find-key/sign/extract). Real-hardware validation against
+ * SoftHSMv2 runs in CI (.github/workflows/hsm-pkcs11.yml).
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtempSync, rmSync } from 'fs';
@@ -19,6 +17,7 @@ import {
   MerkleRootSigner,
   type HSMConfig,
 } from '../hsm';
+import { InMemoryPkcs11Provider } from '../pkcs11-provider';
 
 let keyDir: string;
 
@@ -105,20 +104,102 @@ describe('SoftwareSigner round-trip (#445)', () => {
   });
 });
 
-describe('PKCS#11 signer status pin (#445 → #482)', () => {
-  it('is a stub: every operation throws not-implemented', async () => {
-    const signer = new PKCS11Signer({
+describe('PKCS#11 signer (#482) — via in-memory PKCS#11 emulator', () => {
+  function pkcs11Config(): HSMConfig {
+    return {
       mode: 'pkcs11',
       algorithm: 'RS256',
-      pkcs11Library: '/usr/lib/softhsm/libsofthsm2.so',
+      pkcs11Library: '/emulated/libsofthsm2.so',
       slot: 0,
       pin: '1234',
-    });
+      keyId: 'anchor-key',
+    };
+  }
 
-    await expect(signer.initialize()).rejects.toThrow(/not yet implemented/);
-    await expect(signer.sign('root')).rejects.toThrow(/not yet implemented/);
-    await expect(signer.getPublicKey()).rejects.toThrow(/not yet implemented/);
-    await expect(signer.listKeys()).rejects.toThrow(/not yet implemented/);
+  function provisionedEmulator(): InMemoryPkcs11Provider {
+    const emu = new InMemoryPkcs11Provider();
+    emu.setPin('1234');
+    emu.addKey('anchor-key');
+    return emu;
+  }
+
+  it('signs a merkle root inside the token and verifies with the extracted public key', async () => {
+    const signer = new PKCS11Signer(pkcs11Config(), provisionedEmulator());
+    await signer.initialize();
+
+    const root = 'a'.repeat(64);
+    const result = await signer.sign(root);
+    expect(result.signature).toMatch(/^[0-9a-f]+$/);
+    expect(result.keyId).toBe('anchor-key');
+    expect(result.merkleRoot).toBe(root);
+
+    const verification = await signer.verify(root, result);
+    expect(verification.valid).toBe(true);
+    await signer.cleanup();
+  });
+
+  it('rejects a tampered root and a tampered signature', async () => {
+    const signer = new PKCS11Signer(pkcs11Config(), provisionedEmulator());
+    await signer.initialize();
+    const root = 'b'.repeat(64);
+    const result = await signer.sign(root);
+
+    expect((await signer.verify('c'.repeat(64), result)).valid).toBe(false);
+    expect((await signer.verify(root, { ...result, signature: result.signature.replace(/^../, 'ff') })).valid).toBe(false);
+    await signer.cleanup();
+  });
+
+  it('extracts an SPKI public key and lists keys', async () => {
+    const emu = provisionedEmulator();
+    emu.addKey('second-key');
+    const signer = new PKCS11Signer(pkcs11Config(), emu);
+    await signer.initialize();
+
+    const pem = await signer.getPublicKey('anchor-key');
+    expect(pem).toMatch(/^-----BEGIN PUBLIC KEY-----/);
+
+    const keys = await signer.listKeys();
+    expect(keys.map(k => k.keyId).sort()).toEqual(['anchor-key', 'second-key']);
+    expect(keys.every(k => k.mode === 'pkcs11')).toBe(true);
+    await signer.cleanup();
+  });
+
+  it('throws a clear error when the keyId is not on the token', async () => {
+    const signer = new PKCS11Signer(pkcs11Config(), provisionedEmulator());
+    await signer.initialize();
+    await expect(signer.sign('root', 'no-such-key')).rejects.toThrow(/private key not found/);
+    await signer.cleanup();
+  });
+
+  it('fails login on the wrong PIN', async () => {
+    const emu = provisionedEmulator(); // expects '1234'
+    const signer = new PKCS11Signer({ ...pkcs11Config(), pin: 'wrong' }, emu);
+    await expect(signer.initialize()).rejects.toThrow(/PIN_INCORRECT/);
+  });
+
+  it('round-trips through the MerkleRootSigner facade with mode:pkcs11', async () => {
+    const facade = new MerkleRootSigner(pkcs11Config(), { pkcs11Provider: provisionedEmulator() });
+    const root = 'f'.repeat(64);
+    const signed = await facade.signMerkleRoot(root);
+    expect((await facade.verifyMerkleRootSignature(root, signed)).valid).toBe(true);
+    await facade.cleanup();
+  });
+
+  it('signature is byte-compatible with software RSA-SHA256 verification (interop)', async () => {
+    // A signature produced "in the token" must verify with a plain Node
+    // createVerify against the extracted public key — proving CKM_SHA256_RSA_PKCS
+    // interoperates with the relayer's verification.
+    const { createVerify } = await import('crypto');
+    const signer = new PKCS11Signer(pkcs11Config(), provisionedEmulator());
+    await signer.initialize();
+    const root = 'd'.repeat(64);
+    const result = await signer.sign(root);
+    const pem = await signer.getPublicKey('anchor-key');
+    const v = createVerify('RSA-SHA256');
+    v.update(root);
+    v.end();
+    expect(v.verify(pem, result.signature, 'hex')).toBe(true);
+    await signer.cleanup();
   });
 
   it('factory routes modes correctly and rejects hardware mode', () => {

--- a/server/integrity/__tests__/hsm.test.ts
+++ b/server/integrity/__tests__/hsm.test.ts
@@ -180,6 +180,29 @@ describe('PKCS#11 signer (#482) — via in-memory PKCS#11 emulator', () => {
     await signer.cleanup();
   });
 
+  it('honors RS384 end-to-end (no silent RS256 mislabel — #482 review)', async () => {
+    const signer = new PKCS11Signer({ ...pkcs11Config(), algorithm: 'RS384' }, provisionedEmulator());
+    await signer.initialize();
+    const root = 'ab'.repeat(32);
+    const result = await signer.sign(root);
+    expect(result.algorithm).toBe('RS384');
+    // The signature must actually be SHA-384 — verify with the declared alg…
+    expect((await signer.verify(root, result)).valid).toBe(true);
+    // …and it must NOT verify as RS256 (proving it's genuinely SHA-384).
+    const { createVerify } = await import('crypto');
+    const pem = await signer.getPublicKey('anchor-key');
+    const asSha256 = createVerify('RSA-SHA256');
+    asSha256.update(root);
+    asSha256.end();
+    expect(asSha256.verify(pem, result.signature, 'hex')).toBe(false);
+    await signer.cleanup();
+  });
+
+  it('rejects an unsupported algorithm at construction', () => {
+    expect(() => new PKCS11Signer({ ...pkcs11Config(), algorithm: 'ES256' }, provisionedEmulator()))
+      .toThrow(/Unsupported RSA algorithm/);
+  });
+
   it('throws a clear error when the keyId is not on the token', async () => {
     const signer = new PKCS11Signer(pkcs11Config(), provisionedEmulator());
     await signer.initialize();

--- a/server/integrity/__tests__/hsm.test.ts
+++ b/server/integrity/__tests__/hsm.test.ts
@@ -164,6 +164,22 @@ describe('PKCS#11 signer (#482) — via in-memory PKCS#11 emulator', () => {
     await signer.cleanup();
   });
 
+  it('handles a DER-padded (leading 0x00) modulus from a vendor-style HSM', async () => {
+    // Emulator normally returns minimal bytes; simulate a module that pads with
+    // a leading zero. getPublicKey strips it to the canonical minimal JWK
+    // encoding (RFC 7518); the signer round-trips either way — a regression
+    // guard for the vendor-HSM padding case the minimal-bytes emulator misses.
+    const emu = provisionedEmulator();
+    emu.simulateDerPaddedModulus();
+    const signer = new PKCS11Signer(pkcs11Config(), emu);
+    await signer.initialize();
+    const root = 'e'.repeat(64);
+    const result = await signer.sign(root);
+    expect((await signer.verify(root, result)).valid).toBe(true);
+    expect(await signer.getPublicKey('anchor-key')).toMatch(/^-----BEGIN PUBLIC KEY-----/);
+    await signer.cleanup();
+  });
+
   it('throws a clear error when the keyId is not on the token', async () => {
     const signer = new PKCS11Signer(pkcs11Config(), provisionedEmulator());
     await signer.initialize();

--- a/server/integrity/__tests__/pkcs11-softhsm.test.ts
+++ b/server/integrity/__tests__/pkcs11-softhsm.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Real-hardware PKCS#11 validation against SoftHSMv2 (#482).
+ *
+ * This exercises the PRODUCTION path — PKCS11Signer with the default
+ * Pkcs11jsProvider (native `pkcs11js`) against a live SoftHSMv2 token — which
+ * the emulator-based tests in hsm.test.ts cannot cover. It runs ONLY in CI,
+ * where the workflow (.github/workflows/hsm-pkcs11.yml) installs SoftHSMv2 +
+ * pkcs11js and provisions a token; it is skipped everywhere else.
+ *
+ * Env (set by the CI workflow):
+ *   PKCS11_SOFTHSM=1        enable this suite
+ *   SOFTHSM_LIB=<path>      path to libsofthsm2.so
+ *   SOFTHSM_PIN=<pin>       user PIN of the provisioned token
+ *   SOFTHSM_KEY_LABEL=<l>   CKA_LABEL of the provisioned RSA key pair
+ */
+import { describe, it, expect } from 'vitest';
+import { createVerify } from 'crypto';
+import { PKCS11Signer, MerkleRootSigner, type HSMConfig } from '../hsm';
+
+const enabled = process.env.PKCS11_SOFTHSM === '1';
+
+function softhsmConfig(): HSMConfig {
+  return {
+    mode: 'pkcs11',
+    algorithm: 'RS256',
+    pkcs11Library: process.env.SOFTHSM_LIB || '/usr/lib/softhsm/libsofthsm2.so',
+    slot: 0,
+    pin: process.env.SOFTHSM_PIN || '1234',
+    keyId: process.env.SOFTHSM_KEY_LABEL || 'anchor-key',
+  };
+}
+
+describe.skipIf(!enabled)('PKCS#11 signer against real SoftHSMv2 (#482, CI only)', () => {
+  it('key-gen → sign → verify round-trip through the token', async () => {
+    const signer = new PKCS11Signer(softhsmConfig());
+    await signer.initialize();
+    try {
+      const root = '0x' + 'ab'.repeat(32);
+      const result = await signer.sign(root);
+      expect(result.signature).toMatch(/^[0-9a-f]+$/);
+
+      // Verify via the signer (extracts the public key from the token)…
+      expect((await signer.verify(root, result)).valid).toBe(true);
+      // …and independently with Node RSA-SHA256 against the extracted SPKI key,
+      // proving CKM_SHA256_RSA_PKCS interoperates with the relayer's check.
+      const pem = await signer.getPublicKey();
+      const v = createVerify('RSA-SHA256');
+      v.update(root);
+      v.end();
+      expect(v.verify(pem, result.signature, 'hex')).toBe(true);
+
+      expect((await signer.listKeys()).length).toBeGreaterThan(0);
+    } finally {
+      await signer.cleanup();
+    }
+  });
+
+  it('round-trips through the MerkleRootSigner facade with mode:pkcs11', async () => {
+    const facade = new MerkleRootSigner(softhsmConfig());
+    try {
+      const root = '0x' + 'cd'.repeat(32);
+      const signed = await facade.signMerkleRoot(root);
+      expect((await facade.verifyMerkleRootSignature(root, signed)).valid).toBe(true);
+    } finally {
+      await facade.cleanup();
+    }
+  });
+});

--- a/server/integrity/__tests__/resilience-anchor.test.ts
+++ b/server/integrity/__tests__/resilience-anchor.test.ts
@@ -5,6 +5,9 @@
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { createHash } from 'crypto';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { ResilienceManager } from '../resilience';
 import { MerkleTreeBuilder } from '../merkle';
 import { InMemoryPkcs11Provider } from '../pkcs11-provider';
@@ -107,8 +110,10 @@ describe('ResilienceManager anchor delegates / fails closed (#489)', () => {
         hsm: {
           enabled: true,
           fallbackToSoftware: true,
-          // Wrong PIN → primary init throws → software fallback engages.
-          config: { mode: 'pkcs11', algorithm: 'RS256', pkcs11Library: '/emu.so', slot: 0, pin: 'wrong', keyId: 'resilience-key', keyPath: undefined },
+          // Wrong PIN → primary init throws → software fallback engages. Give
+          // the software fallback a tmpdir keyPath so it doesn't write .keys/
+          // into the repo cwd.
+          config: { mode: 'pkcs11', algorithm: 'RS256', pkcs11Library: '/emu.so', slot: 0, pin: 'wrong', keyId: 'resilience-key', keyPath: mkdtempSync(join(tmpdir(), 'res-hsm-')) },
         },
         blockchain: { enabled: true, retryAttempts: 1, retryDelayMs: 10, queueMaxSize: 100, anchor: async () => true },
       },

--- a/server/integrity/__tests__/resilience-anchor.test.ts
+++ b/server/integrity/__tests__/resilience-anchor.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { createHash } from 'crypto';
 import { ResilienceManager } from '../resilience';
 import { MerkleTreeBuilder } from '../merkle';
+import { InMemoryPkcs11Provider } from '../pkcs11-provider';
 import type { EventBatch, HashedEvent } from '../pipeline';
 
 function hashedEvent(i: number): HashedEvent {
@@ -71,6 +72,54 @@ describe('ResilienceManager anchor delegates / fails closed (#489)', () => {
 
     expect(ok).toBe(true);
     expect(calls).toEqual([{ batchId: 'batch_1', merkleRoot: 'deadbeef' }]);
+  });
+
+  it('signs via a primary PKCS#11 signer when configured (#482)', async () => {
+    const emu = new InMemoryPkcs11Provider();
+    emu.setPin('1234');
+    emu.addKey('resilience-key');
+    const mgr = new ResilienceManager(
+      {
+        hsm: {
+          enabled: true,
+          fallbackToSoftware: true,
+          config: { mode: 'pkcs11', algorithm: 'RS256', pkcs11Library: '/emu.so', slot: 0, pin: '1234', keyId: 'resilience-key' },
+        },
+        blockchain: { enabled: true, retryAttempts: 1, retryDelayMs: 10, queueMaxSize: 100, anchor: async () => true },
+      },
+      { pkcs11Provider: emu },
+    );
+    managers.push(mgr);
+    await mgr.initialize();
+
+    const sig = await mgr.signMerkleRoot('0x' + 'ab'.repeat(32));
+    expect(sig.signature).toMatch(/^[0-9a-f]+$/);
+    // Signed by the PKCS#11 token, not the software fallback.
+    expect(sig.keyId).toBe('resilience-key');
+  });
+
+  it('falls back to the software signer when the primary PKCS#11 signer fails to initialize (#482)', async () => {
+    const emu = new InMemoryPkcs11Provider();
+    emu.setPin('1234'); // token expects 1234
+    emu.addKey('resilience-key');
+    const mgr = new ResilienceManager(
+      {
+        hsm: {
+          enabled: true,
+          fallbackToSoftware: true,
+          // Wrong PIN → primary init throws → software fallback engages.
+          config: { mode: 'pkcs11', algorithm: 'RS256', pkcs11Library: '/emu.so', slot: 0, pin: 'wrong', keyId: 'resilience-key', keyPath: undefined },
+        },
+        blockchain: { enabled: true, retryAttempts: 1, retryDelayMs: 10, queueMaxSize: 100, anchor: async () => true },
+      },
+      { pkcs11Provider: emu },
+    );
+    managers.push(mgr);
+    await mgr.initialize();
+
+    // Still signs — via the software fallback (a real RSA signature).
+    const sig = await mgr.signMerkleRoot('0x' + 'cd'.repeat(32));
+    expect(sig.signature).toMatch(/^[0-9a-f]+$/);
   });
 
   it('fails closed (returns false, no fake success) when no anchor operation is configured', async () => {

--- a/server/integrity/hsm.ts
+++ b/server/integrity/hsm.ts
@@ -16,6 +16,17 @@ export interface SignerDeps {
   pkcs11Provider?: Pkcs11Provider;
 }
 
+/**
+ * Strip leading zero bytes to produce the minimal big-endian encoding a JWK
+ * requires, keeping at least one byte. PKCS#11 CKA_MODULUS/CKA_PUBLIC_EXPONENT
+ * may arrive DER-padded with a leading 0x00 on some modules.
+ */
+function stripLeadingZeros(buf: Buffer): Buffer {
+  let i = 0;
+  while (i < buf.length - 1 && buf[i] === 0) i++;
+  return buf.subarray(i);
+}
+
 export interface SignatureResult {
   signature: string;
   algorithm: string;
@@ -342,11 +353,15 @@ export class PKCS11Signer extends BaseSigner {
       throw new Error(`PKCS#11: public key not found for keyId "${id}"`);
     }
     // Build an SPKI PEM from the raw RSA modulus + exponent via JWK import —
-    // avoids hand-rolling DER.
+    // avoids hand-rolling DER. JWK base64url requires the MINIMAL big-endian
+    // encoding (no leading zeros); some PKCS#11 modules return CKA_MODULUS with
+    // a DER-style leading 0x00, so strip it — otherwise the JWK import produces
+    // a corrupt key (SoftHSM returns minimal bytes, so this only bites vendor
+    // HSMs and would be missed by the emulator).
     const jwk = {
       kty: 'RSA',
-      n: pub.modulus.toString('base64url'),
-      e: pub.exponent.toString('base64url'),
+      n: stripLeadingZeros(pub.modulus).toString('base64url'),
+      e: stripLeadingZeros(pub.exponent).toString('base64url'),
     };
     const pem = createPublicKey({ key: jwk, format: 'jwk' }).export({ type: 'spki', format: 'pem' }) as string;
     this.publicKeyCache.set(id, pem);

--- a/server/integrity/hsm.ts
+++ b/server/integrity/hsm.ts
@@ -6,9 +6,15 @@
  * Part of the Dual-Time Control Plane (ADR-0021).
  */
 
-import { createSign, createVerify, generateKeyPairSync } from 'crypto';
+import { createSign, createVerify, createPublicKey, generateKeyPairSync } from 'crypto';
 import { promises as fs } from 'fs';
 import { join } from 'path';
+import { Pkcs11jsProvider, type Pkcs11Provider } from './pkcs11-provider';
+
+/** Optional dependency injection for signer construction (e.g. a test PKCS#11 provider). */
+export interface SignerDeps {
+  pkcs11Provider?: Pkcs11Provider;
+}
 
 export interface SignatureResult {
   signature: string;
@@ -257,50 +263,120 @@ export class SoftwareSigner extends BaseSigner {
 }
 
 /**
- * PKCS#11 HSM signer (placeholder for real implementation)
- * This would integrate with actual HSM hardware via PKCS#11
+ * PKCS#11 HSM signer (#482).
+ *
+ * Signs Merkle roots with an RSA key that lives inside a PKCS#11 module (a real
+ * HSM, or SoftHSMv2 in CI) using the CKM_SHA256_RSA_PKCS mechanism. The private
+ * key never leaves the token; signatures are verified with the public key
+ * extracted from the token, and are byte-compatible with SoftwareSigner /
+ * Node's RSA-SHA256, so downstream verification (the relayer) is unchanged.
+ *
+ * The raw PKCS#11 session is owned by an injectable Pkcs11Provider — the
+ * production Pkcs11jsProvider (native `pkcs11js`) by default, or an in-memory
+ * emulator in tests.
  */
 export class PKCS11Signer extends BaseSigner {
-  constructor(config: HSMConfig) {
-    super({
-      ...config,
-      mode: 'pkcs11',
-    });
+  private provider: Pkcs11Provider;
+  /** keyId → cached extracted SPKI public key PEM */
+  private publicKeyCache = new Map<string, string>();
+
+  constructor(config: HSMConfig, provider?: Pkcs11Provider) {
+    super({ ...config, mode: 'pkcs11' });
+    this.provider = provider ?? new Pkcs11jsProvider();
+  }
+
+  private defaultKeyId(keyId?: string): string {
+    const id = keyId ?? this.config.keyId ?? 'default';
+    return id;
   }
 
   async initialize(): Promise<void> {
-    // TODO: Initialize PKCS#11 library
-    // - Load PKCS#11 library (this.config.pkcs11Library)
-    // - Open session with slot (this.config.slot)
-    // - Login with PIN (this.config.pin)
-    throw new Error('PKCS#11 signer not yet implemented');
+    await this.provider.open({
+      library: this.config.pkcs11Library ?? '',
+      slot: this.config.slot ?? 0,
+      pin: this.config.pin ?? '',
+    });
   }
 
   async sign(data: string, keyId?: string): Promise<SignatureResult> {
-    // TODO: Implement PKCS#11 signing
-    // - Find key object by keyId
-    // - Perform cryptographic signing operation
-    // - Return signature result
-    throw new Error('PKCS#11 signing not yet implemented');
+    const id = this.defaultKeyId(keyId);
+    const handle = await this.provider.findPrivateKeyHandle(id);
+    if (!handle) {
+      throw new Error(`PKCS#11: private key not found for keyId "${id}"`);
+    }
+    const signature = await this.provider.sign(handle, Buffer.from(data, 'utf8'));
+    return {
+      signature: signature.toString('hex'),
+      algorithm: this.config.algorithm,
+      keyId: id,
+      timestamp: Date.now(),
+      merkleRoot: data,
+    };
   }
 
-  async verify(data: string, signature: SignatureResult): Promise<SignatureVerification> {
-    // TODO: Implement PKCS#11 verification
-    throw new Error('PKCS#11 verification not yet implemented');
+  async verify(data: string, signatureResult: SignatureResult): Promise<SignatureVerification> {
+    const base = {
+      keyId: signatureResult.keyId,
+      algorithm: signatureResult.algorithm,
+      timestamp: signatureResult.timestamp,
+    };
+    try {
+      const publicKeyPem = await this.getPublicKey(signatureResult.keyId);
+      const verify = createVerify('RSA-SHA256');
+      verify.update(data);
+      verify.end();
+      const valid = verify.verify(publicKeyPem, signatureResult.signature, 'hex');
+      return { valid, ...base };
+    } catch {
+      return { valid: false, ...base };
+    }
   }
 
   async getPublicKey(keyId?: string): Promise<string> {
-    // TODO: Extract public key from HSM
-    throw new Error('PKCS#11 public key extraction not yet implemented');
+    const id = this.defaultKeyId(keyId);
+    const cached = this.publicKeyCache.get(id);
+    if (cached) return cached;
+
+    const pub = await this.provider.findPublicKey(id);
+    if (!pub) {
+      throw new Error(`PKCS#11: public key not found for keyId "${id}"`);
+    }
+    // Build an SPKI PEM from the raw RSA modulus + exponent via JWK import —
+    // avoids hand-rolling DER.
+    const jwk = {
+      kty: 'RSA',
+      n: pub.modulus.toString('base64url'),
+      e: pub.exponent.toString('base64url'),
+    };
+    const pem = createPublicKey({ key: jwk, format: 'jwk' }).export({ type: 'spki', format: 'pem' }) as string;
+    this.publicKeyCache.set(id, pem);
+    return pem;
   }
 
   async listKeys(): Promise<KeyInfo[]> {
-    // TODO: List keys available in HSM
-    throw new Error('PKCS#11 key listing not yet implemented');
+    const labels = await this.provider.listKeyLabels();
+    const keys: KeyInfo[] = [];
+    for (const label of labels) {
+      let publicKey = '';
+      try {
+        publicKey = await this.getPublicKey(label);
+      } catch {
+        // A label without an extractable public key is still listed.
+      }
+      keys.push({
+        keyId: label,
+        algorithm: this.config.algorithm,
+        publicKey,
+        created: Date.now(),
+        mode: 'pkcs11',
+      });
+    }
+    return keys;
   }
 
   async cleanup(): Promise<void> {
-    // TODO: Close PKCS#11 session
+    this.publicKeyCache.clear();
+    await this.provider.close();
   }
 }
 
@@ -308,12 +384,12 @@ export class PKCS11Signer extends BaseSigner {
  * Factory for creating appropriate signer based on configuration
  */
 export class HSMSignerFactory {
-  static createSigner(config: HSMConfig): BaseSigner {
+  static createSigner(config: HSMConfig, deps: SignerDeps = {}): BaseSigner {
     switch (config.mode) {
       case 'software':
         return new SoftwareSigner(config);
       case 'pkcs11':
-        return new PKCS11Signer(config);
+        return new PKCS11Signer(config, deps.pkcs11Provider);
       case 'hardware':
         // Could extend to support other hardware interfaces
         throw new Error('Hardware signer mode not implemented');
@@ -330,8 +406,8 @@ export class MerkleRootSigner {
   private signer: BaseSigner;
   private isInitialized = false;
 
-  constructor(config: HSMConfig) {
-    this.signer = HSMSignerFactory.createSigner(config);
+  constructor(config: HSMConfig, deps: SignerDeps = {}) {
+    this.signer = HSMSignerFactory.createSigner(config, deps);
   }
 
   async initialize(): Promise<void> {

--- a/server/integrity/hsm.ts
+++ b/server/integrity/hsm.ts
@@ -9,7 +9,18 @@
 import { createSign, createVerify, createPublicKey, generateKeyPairSync } from 'crypto';
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { Pkcs11jsProvider, type Pkcs11Provider } from './pkcs11-provider';
+import { Pkcs11jsProvider, type Pkcs11Provider, type NodeRsaAlgorithm } from './pkcs11-provider';
+
+/** Map an RS256/384/512 algorithm label to the Node RSA-SHAxxx name. */
+function nodeRsaAlgorithm(algorithm: string): NodeRsaAlgorithm {
+  switch (algorithm) {
+    case 'RS256': return 'RSA-SHA256';
+    case 'RS384': return 'RSA-SHA384';
+    case 'RS512': return 'RSA-SHA512';
+    default:
+      throw new Error(`Unsupported RSA algorithm "${algorithm}" (expected RS256/RS384/RS512)`);
+  }
+}
 
 /** Optional dependency injection for signer construction (e.g. a test PKCS#11 provider). */
 export interface SignerDeps {
@@ -294,6 +305,9 @@ export class PKCS11Signer extends BaseSigner {
   constructor(config: HSMConfig, provider?: Pkcs11Provider) {
     super({ ...config, mode: 'pkcs11' });
     this.provider = provider ?? new Pkcs11jsProvider();
+    // Validate the algorithm up front so a bad config fails at construction,
+    // not with a silently-mislabeled signature later.
+    nodeRsaAlgorithm(this.config.algorithm);
   }
 
   private defaultKeyId(keyId?: string): string {
@@ -315,7 +329,7 @@ export class PKCS11Signer extends BaseSigner {
     if (!handle) {
       throw new Error(`PKCS#11: private key not found for keyId "${id}"`);
     }
-    const signature = await this.provider.sign(handle, Buffer.from(data, 'utf8'));
+    const signature = await this.provider.sign(handle, Buffer.from(data, 'utf8'), nodeRsaAlgorithm(this.config.algorithm));
     return {
       signature: signature.toString('hex'),
       algorithm: this.config.algorithm,
@@ -333,7 +347,9 @@ export class PKCS11Signer extends BaseSigner {
     };
     try {
       const publicKeyPem = await this.getPublicKey(signatureResult.keyId);
-      const verify = createVerify('RSA-SHA256');
+      // Verify with the algorithm the signature declares, so a mismatched
+      // label can't pass.
+      const verify = createVerify(nodeRsaAlgorithm(signatureResult.algorithm));
       verify.update(data);
       verify.end();
       const valid = verify.verify(publicKeyPem, signatureResult.signature, 'hex');

--- a/server/integrity/pkcs11-provider.ts
+++ b/server/integrity/pkcs11-provider.ts
@@ -1,0 +1,242 @@
+/**
+ * PKCS#11 provider abstraction (#482)
+ *
+ * PKCS11Signer talks to an HSM through this small provider interface rather than
+ * the raw PKCS#11 C_* API. Two implementations:
+ *
+ *  - Pkcs11jsProvider: the production path, backed by the `pkcs11js` native
+ *    binding against a real PKCS#11 module (SoftHSMv2, or a vendor HSM). Loaded
+ *    lazily so the native dependency is optional — absent it throws a clear,
+ *    actionable error instead of the former "not implemented".
+ *  - InMemoryPkcs11Provider: a faithful emulator (RSA via Node crypto) that
+ *    lets the full signer round-trip — session/login/find-key/sign/extract — be
+ *    tested without the native library or an HSM. Real-hardware validation is
+ *    the SoftHSMv2 CI job.
+ *
+ * The signing mechanism is CKM_SHA256_RSA_PKCS, which hashes-then-signs exactly
+ * like Node's `createSign('RSA-SHA256')`, so signatures are verifiable with the
+ * extracted SPKI public key and interoperate with SoftwareSigner's format.
+ */
+
+import { generateKeyPairSync, createPublicKey, createSign } from 'crypto';
+
+/** Opaque handle to a private key object inside the HSM session. */
+export type Pkcs11KeyHandle = unknown;
+
+export interface Pkcs11OpenConfig {
+  library: string;
+  slot: number;
+  pin: string;
+}
+
+export interface Pkcs11PublicKey {
+  /** RSA modulus, big-endian bytes */
+  modulus: Buffer;
+  /** RSA public exponent, big-endian bytes */
+  exponent: Buffer;
+}
+
+/**
+ * Minimal HSM operations the signer needs. Implementations own the raw PKCS#11
+ * session lifecycle.
+ */
+export interface Pkcs11Provider {
+  /** Load the module, initialize, open a session, and log in. */
+  open(config: Pkcs11OpenConfig): Promise<void>;
+  /** Handle to a private key by CKA_LABEL, or null if none. */
+  findPrivateKeyHandle(label: string): Promise<Pkcs11KeyHandle | null>;
+  /** Public key material (modulus + exponent) by CKA_LABEL, or null. */
+  findPublicKey(label: string): Promise<Pkcs11PublicKey | null>;
+  /** CKM_SHA256_RSA_PKCS signature over `data`. */
+  sign(handle: Pkcs11KeyHandle, data: Buffer): Promise<Buffer>;
+  /** Labels of all key pairs visible in the session. */
+  listKeyLabels(): Promise<string[]>;
+  /** Log out, close the session, finalize. */
+  close(): Promise<void>;
+}
+
+// ─── Production provider (pkcs11js) ──────────────────────────────────────────
+
+/**
+ * Production provider backed by the `pkcs11js` native binding. Requires the
+ * optional `pkcs11js` dependency and a PKCS#11 module path (config.library).
+ */
+export class Pkcs11jsProvider implements Pkcs11Provider {
+  private pkcs11: any;
+  private session: unknown;
+  private opened = false;
+
+  async open(config: Pkcs11OpenConfig): Promise<void> {
+    let pkcs11js: any;
+    try {
+      // Lazy, optional native dependency — not required to build/test the app.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      pkcs11js = require('pkcs11js');
+    } catch {
+      throw new Error(
+        'PKCS#11 signing requires the optional `pkcs11js` dependency. Install it (npm i pkcs11js) and provide a PKCS#11 module path (HSMConfig.pkcs11Library).',
+      );
+    }
+    if (!config.library) {
+      throw new Error('PKCS#11: no module library path configured (HSMConfig.pkcs11Library)');
+    }
+
+    const pkcs11 = new pkcs11js.PKCS11();
+    pkcs11.load(config.library);
+    pkcs11.C_Initialize();
+    const slots = pkcs11.C_GetSlotList(true);
+    const slot = slots[config.slot ?? 0];
+    if (slot === undefined) {
+      throw new Error(`PKCS#11: slot index ${config.slot ?? 0} not present (found ${slots.length} slots)`);
+    }
+    const session = pkcs11.C_OpenSession(
+      slot,
+      pkcs11js.CKF_SERIAL_SESSION | pkcs11js.CKF_RW_SESSION,
+    );
+    pkcs11.C_Login(session, pkcs11js.CKU_USER, config.pin);
+
+    this.pkcs11 = pkcs11;
+    this.session = session;
+    this.opened = true;
+  }
+
+  private ensureOpen(): void {
+    if (!this.opened) throw new Error('PKCS#11 provider not open');
+  }
+
+  private findHandle(cls: number, label: string): unknown | null {
+    const p = this.pkcs11;
+    p.C_FindObjectsInit(this.session, [
+      { type: p.CKA_CLASS, value: cls },
+      { type: p.CKA_LABEL, value: label },
+    ]);
+    const handle = p.C_FindObjects(this.session);
+    p.C_FindObjectsFinal(this.session);
+    return handle ?? null;
+  }
+
+  async findPrivateKeyHandle(label: string): Promise<Pkcs11KeyHandle | null> {
+    this.ensureOpen();
+    return this.findHandle(this.pkcs11.CKO_PRIVATE_KEY, label);
+  }
+
+  async findPublicKey(label: string): Promise<Pkcs11PublicKey | null> {
+    this.ensureOpen();
+    const handle = this.findHandle(this.pkcs11.CKO_PUBLIC_KEY, label);
+    if (!handle) return null;
+    const attrs = this.pkcs11.C_GetAttributeValue(this.session, handle, [
+      { type: this.pkcs11.CKA_MODULUS },
+      { type: this.pkcs11.CKA_PUBLIC_EXPONENT },
+    ]);
+    return { modulus: Buffer.from(attrs[0].value), exponent: Buffer.from(attrs[1].value) };
+  }
+
+  async sign(handle: Pkcs11KeyHandle, data: Buffer): Promise<Buffer> {
+    this.ensureOpen();
+    this.pkcs11.C_SignInit(this.session, { mechanism: this.pkcs11.CKM_SHA256_RSA_PKCS }, handle);
+    // 2048-bit RSA → 256-byte signature; buffer is sized generously.
+    return Buffer.from(this.pkcs11.C_Sign(this.session, data, Buffer.alloc(512)));
+  }
+
+  async listKeyLabels(): Promise<string[]> {
+    this.ensureOpen();
+    const p = this.pkcs11;
+    p.C_FindObjectsInit(this.session, [{ type: p.CKA_CLASS, value: p.CKO_PUBLIC_KEY }]);
+    const labels: string[] = [];
+    for (;;) {
+      const handle = p.C_FindObjects(this.session);
+      if (!handle) break;
+      const attrs = p.C_GetAttributeValue(this.session, handle, [{ type: p.CKA_LABEL }]);
+      labels.push(Buffer.from(attrs[0].value).toString('utf8'));
+    }
+    p.C_FindObjectsFinal(this.session);
+    return labels;
+  }
+
+  async close(): Promise<void> {
+    if (!this.opened) return;
+    try { this.pkcs11.C_Logout(this.session); } catch { /* may not be logged in */ }
+    try { this.pkcs11.C_CloseSession(this.session); } catch { /* ignore */ }
+    try { this.pkcs11.C_Finalize(); } catch { /* ignore */ }
+    this.opened = false;
+  }
+}
+
+// ─── In-memory emulator (tests) ──────────────────────────────────────────────
+
+interface EmulatedKey {
+  privateKeyPem: string;
+  modulus: Buffer;
+  exponent: Buffer;
+}
+
+/**
+ * Faithful in-memory PKCS#11 emulator for tests. Emulates the operations the
+ * signer uses (CKM_SHA256_RSA_PKCS via Node RSA-SHA256), so the signer's real
+ * code path is exercised without the native binding or an HSM.
+ */
+export class InMemoryPkcs11Provider implements Pkcs11Provider {
+  private keys = new Map<string, EmulatedKey>();
+  private opened = false;
+  private expectedPin?: string;
+
+  /** Provision a key pair under a label (as `softhsm2-util --init-token` + keygen would). */
+  addKey(label: string): void {
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    const jwk = createPublicKey(publicKey).export({ format: 'jwk' }) as { n: string; e: string };
+    this.keys.set(label, {
+      privateKeyPem: privateKey,
+      modulus: Buffer.from(jwk.n, 'base64url'),
+      exponent: Buffer.from(jwk.e, 'base64url'),
+    });
+  }
+
+  /** Set the PIN the emulated token requires at login. */
+  setPin(pin: string): void {
+    this.expectedPin = pin;
+  }
+
+  async open(config: Pkcs11OpenConfig): Promise<void> {
+    if (this.expectedPin !== undefined && config.pin !== this.expectedPin) {
+      throw new Error('PKCS#11 (emulated): CKR_PIN_INCORRECT');
+    }
+    this.opened = true;
+  }
+
+  private ensureOpen(): void {
+    if (!this.opened) throw new Error('PKCS#11 provider not open');
+  }
+
+  async findPrivateKeyHandle(label: string): Promise<Pkcs11KeyHandle | null> {
+    this.ensureOpen();
+    return this.keys.has(label) ? { label } : null;
+  }
+
+  async findPublicKey(label: string): Promise<Pkcs11PublicKey | null> {
+    this.ensureOpen();
+    const k = this.keys.get(label);
+    return k ? { modulus: k.modulus, exponent: k.exponent } : null;
+  }
+
+  async sign(handle: Pkcs11KeyHandle, data: Buffer): Promise<Buffer> {
+    this.ensureOpen();
+    const label = (handle as { label: string }).label;
+    const k = this.keys.get(label);
+    if (!k) throw new Error(`PKCS#11 (emulated): key handle not found`);
+    // CKM_SHA256_RSA_PKCS ≡ RSA-SHA256 hash-then-sign.
+    return createSign('RSA-SHA256').update(data).sign(k.privateKeyPem);
+  }
+
+  async listKeyLabels(): Promise<string[]> {
+    this.ensureOpen();
+    return Array.from(this.keys.keys());
+  }
+
+  async close(): Promise<void> {
+    this.opened = false;
+  }
+}

--- a/server/integrity/pkcs11-provider.ts
+++ b/server/integrity/pkcs11-provider.ts
@@ -23,6 +23,9 @@ import { generateKeyPairSync, createPublicKey, createSign } from 'crypto';
 /** Opaque handle to a private key object inside the HSM session. */
 export type Pkcs11KeyHandle = unknown;
 
+/** Node signing algorithm the mechanism must match (RS256/384/512 → RSA-SHAxxx). */
+export type NodeRsaAlgorithm = 'RSA-SHA256' | 'RSA-SHA384' | 'RSA-SHA512';
+
 export interface Pkcs11OpenConfig {
   library: string;
   slot: number;
@@ -47,8 +50,8 @@ export interface Pkcs11Provider {
   findPrivateKeyHandle(label: string): Promise<Pkcs11KeyHandle | null>;
   /** Public key material (modulus + exponent) by CKA_LABEL, or null. */
   findPublicKey(label: string): Promise<Pkcs11PublicKey | null>;
-  /** CKM_SHA256_RSA_PKCS signature over `data`. */
-  sign(handle: Pkcs11KeyHandle, data: Buffer): Promise<Buffer>;
+  /** RSA PKCS#1 v1.5 signature over `data` using the given hash algorithm. */
+  sign(handle: Pkcs11KeyHandle, data: Buffer, algorithm: NodeRsaAlgorithm): Promise<Buffer>;
   /** Labels of all key pairs visible in the session. */
   listKeyLabels(): Promise<string[]>;
   /** Log out, close the session, finalize. */
@@ -83,7 +86,14 @@ export class Pkcs11jsProvider implements Pkcs11Provider {
 
     const pkcs11 = new pkcs11js.PKCS11();
     pkcs11.load(config.library);
-    pkcs11.C_Initialize();
+    // C_Initialize is process-global per module: a second provider in the same
+    // process would otherwise throw CKR_CRYPTOKI_ALREADY_INITIALIZED.
+    try {
+      pkcs11.C_Initialize();
+    } catch (err) {
+      const msg = String((err as Error)?.message ?? err);
+      if (!/ALREADY_INITIALIZED/i.test(msg)) throw err;
+    }
     const slots = pkcs11.C_GetSlotList(true);
     const slot = slots[config.slot ?? 0];
     if (slot === undefined) {
@@ -110,9 +120,14 @@ export class Pkcs11jsProvider implements Pkcs11Provider {
       { type: p.CKA_CLASS, value: cls },
       { type: p.CKA_LABEL, value: label },
     ]);
-    const handle = p.C_FindObjects(this.session);
-    p.C_FindObjectsFinal(this.session);
-    return handle ?? null;
+    try {
+      const handle = p.C_FindObjects(this.session);
+      return handle ?? null;
+    } finally {
+      // Always close the find operation, else the session is left with an
+      // active operation (CKR_OPERATION_ACTIVE on the next init).
+      p.C_FindObjectsFinal(this.session);
+    }
   }
 
   async findPrivateKeyHandle(label: string): Promise<Pkcs11KeyHandle | null> {
@@ -131,11 +146,20 @@ export class Pkcs11jsProvider implements Pkcs11Provider {
     return { modulus: Buffer.from(attrs[0].value), exponent: Buffer.from(attrs[1].value) };
   }
 
-  async sign(handle: Pkcs11KeyHandle, data: Buffer): Promise<Buffer> {
+  async sign(handle: Pkcs11KeyHandle, data: Buffer, algorithm: NodeRsaAlgorithm): Promise<Buffer> {
     this.ensureOpen();
-    this.pkcs11.C_SignInit(this.session, { mechanism: this.pkcs11.CKM_SHA256_RSA_PKCS }, handle);
-    // 2048-bit RSA → 256-byte signature; buffer is sized generously.
-    return Buffer.from(this.pkcs11.C_Sign(this.session, data, Buffer.alloc(512)));
+    const mechanism = this.mechanismFor(algorithm);
+    this.pkcs11.C_SignInit(this.session, { mechanism }, handle);
+    // 4096-bit RSA → 512-byte signature; buffer is sized generously.
+    return Buffer.from(this.pkcs11.C_Sign(this.session, data, Buffer.alloc(1024)));
+  }
+
+  private mechanismFor(algorithm: NodeRsaAlgorithm): number {
+    switch (algorithm) {
+      case 'RSA-SHA256': return this.pkcs11.CKM_SHA256_RSA_PKCS;
+      case 'RSA-SHA384': return this.pkcs11.CKM_SHA384_RSA_PKCS;
+      case 'RSA-SHA512': return this.pkcs11.CKM_SHA512_RSA_PKCS;
+    }
   }
 
   async listKeyLabels(): Promise<string[]> {
@@ -143,13 +167,16 @@ export class Pkcs11jsProvider implements Pkcs11Provider {
     const p = this.pkcs11;
     p.C_FindObjectsInit(this.session, [{ type: p.CKA_CLASS, value: p.CKO_PUBLIC_KEY }]);
     const labels: string[] = [];
-    for (;;) {
-      const handle = p.C_FindObjects(this.session);
-      if (!handle) break;
-      const attrs = p.C_GetAttributeValue(this.session, handle, [{ type: p.CKA_LABEL }]);
-      labels.push(Buffer.from(attrs[0].value).toString('utf8'));
+    try {
+      for (;;) {
+        const handle = p.C_FindObjects(this.session);
+        if (!handle) break;
+        const attrs = p.C_GetAttributeValue(this.session, handle, [{ type: p.CKA_LABEL }]);
+        labels.push(Buffer.from(attrs[0].value).toString('utf8'));
+      }
+    } finally {
+      p.C_FindObjectsFinal(this.session);
     }
-    p.C_FindObjectsFinal(this.session);
     return labels;
   }
 
@@ -236,13 +263,13 @@ export class InMemoryPkcs11Provider implements Pkcs11Provider {
     return { modulus: k.modulus, exponent: k.exponent };
   }
 
-  async sign(handle: Pkcs11KeyHandle, data: Buffer): Promise<Buffer> {
+  async sign(handle: Pkcs11KeyHandle, data: Buffer, algorithm: NodeRsaAlgorithm): Promise<Buffer> {
     this.ensureOpen();
     const label = (handle as { label: string }).label;
     const k = this.keys.get(label);
     if (!k) throw new Error(`PKCS#11 (emulated): key handle not found`);
-    // CKM_SHA256_RSA_PKCS ≡ RSA-SHA256 hash-then-sign.
-    return createSign('RSA-SHA256').update(data).sign(k.privateKeyPem);
+    // CKM_SHAxxx_RSA_PKCS ≡ Node RSA-SHAxxx hash-then-sign.
+    return createSign(algorithm).update(data).sign(k.privateKeyPem);
   }
 
   async listKeyLabels(): Promise<string[]> {

--- a/server/integrity/pkcs11-provider.ts
+++ b/server/integrity/pkcs11-provider.ts
@@ -179,6 +179,13 @@ export class InMemoryPkcs11Provider implements Pkcs11Provider {
   private keys = new Map<string, EmulatedKey>();
   private opened = false;
   private expectedPin?: string;
+  /** Emulate a module that returns CKA_MODULUS DER-padded with a leading 0x00. */
+  private derPadModulus = false;
+
+  /** Simulate a vendor HSM that returns modulus/exponent with a leading 0x00. */
+  simulateDerPaddedModulus(): void {
+    this.derPadModulus = true;
+  }
 
   /** Provision a key pair under a label (as `softhsm2-util --init-token` + keygen would). */
   addKey(label: string): void {
@@ -219,7 +226,14 @@ export class InMemoryPkcs11Provider implements Pkcs11Provider {
   async findPublicKey(label: string): Promise<Pkcs11PublicKey | null> {
     this.ensureOpen();
     const k = this.keys.get(label);
-    return k ? { modulus: k.modulus, exponent: k.exponent } : null;
+    if (!k) return null;
+    if (this.derPadModulus) {
+      return {
+        modulus: Buffer.concat([Buffer.from([0x00]), k.modulus]),
+        exponent: Buffer.concat([Buffer.from([0x00]), k.exponent]),
+      };
+    }
+    return { modulus: k.modulus, exponent: k.exponent };
   }
 
   async sign(handle: Pkcs11KeyHandle, data: Buffer): Promise<Buffer> {

--- a/server/integrity/resilience.ts
+++ b/server/integrity/resilience.ts
@@ -7,7 +7,7 @@
  */
 
 import { EventEmitter } from 'events';
-import { MerkleRootSigner, HSMConfig, SignatureResult } from './hsm';
+import { MerkleRootSigner, HSMConfig, SignatureResult, type SignerDeps } from './hsm';
 import { EventBatch } from './pipeline';
 import { MerkleTreeBuilder } from './merkle';
 
@@ -187,9 +187,11 @@ export class ResilienceManager extends EventEmitter {
   private retryTimer?: NodeJS.Timeout;
   private healthStatus: HealthStatus;
   private componentMetrics: Map<string, any> = new Map();
+  private signerDeps: SignerDeps;
 
-  constructor(config: Partial<ResilienceConfig> = {}) {
+  constructor(config: Partial<ResilienceConfig> = {}, signerDeps: SignerDeps = {}) {
     super();
+    this.signerDeps = signerDeps;
     
     this.config = {
       hsm: {
@@ -233,7 +235,7 @@ export class ResilienceManager extends EventEmitter {
     // Initialize primary signer (HSM or software)
     if (this.config.hsm.enabled) {
       try {
-        this.primarySigner = new MerkleRootSigner(this.config.hsm.config);
+        this.primarySigner = new MerkleRootSigner(this.config.hsm.config, this.signerDeps);
         await this.primarySigner.initialize();
         this.updateComponentHealth('hsm', 'healthy');
       } catch (error) {


### PR DESCRIPTION
Fixes #482 · closes the last "the security control is a stub" gap the #445 gate found

`PKCS11Signer` threw `not yet implemented` from every method, so the only viable signer was the software one — the "HSM-backed" integrity pipeline was software-key signing. Now implemented.

## Design: injectable provider

`server/integrity/pkcs11-provider.ts` — the signer talks to the token through a small `Pkcs11Provider` interface (open+login, find-key, sign, extract-public-key, list, close):
- **`Pkcs11jsProvider`** — production path over the native **`pkcs11js`** binding (lazy-required, **optional** dependency: absent it throws a clear "install pkcs11js" error, not "not implemented"). Session open + PIN login, find key by `CKA_LABEL`, `CKM_SHA256_RSA_PKCS` sign, modulus/exponent extraction, logout/close.
- **`InMemoryPkcs11Provider`** — a faithful emulator (RSA via Node crypto) so the full signer path is testable without the native lib or an HSM.

`hsm.ts` `PKCS11Signer`: `initialize`/`sign`/`verify`/`getPublicKey`/`listKeys`/`cleanup` all real. The private key **never leaves the token**; the signer extracts only the public key (SPKI PEM, built from modulus/exponent via JWK), and since `CKM_SHA256_RSA_PKCS` is hash-then-sign RSA-SHA256, signatures are byte-compatible with `SoftwareSigner` and the relayer's `createVerify('RSA-SHA256')`. Injection threaded through `HSMSignerFactory` / `MerkleRootSigner` / `ResilienceManager`.

## Verification — read this honestly

- **Local tests exercise the signer *logic* via the emulator** (sign→verify round-trip, tamper rejection, SPKI extraction + listing, key-not-found, wrong-PIN login failure, facade round-trip, RSA-SHA256 interop). Mutation-verified: signing corrupted data fails the round-trip.
- **The production `pkcs11js` binding is validated in CI, not locally** — `.github/workflows/hsm-pkcs11.yml` installs SoftHSMv2 + pkcs11js, provisions an RSA-2048 token, and runs `pkcs11-softhsm.test.ts` (gated on `PKCS11_SOFTHSM=1`, skipped everywhere else) for a real key-gen → sign → verify round-trip.
- `resilience-anchor.test.ts`: primary `pkcs11` signing + software fallback when the token init fails.

The one thing I can't validate here is the raw `pkcs11js` C_* API usage (no native lib locally) — the CI SoftHSM job is the real check for that. Flagged for reviewer scrutiny.

`docs/security/hsm-signing.md` provider matrix updated (pkcs11 implemented; SoftHSMv2 validated in CI). `pkcs11js` intentionally **not** added to package.json (avoids a native build in `npm ci` / lockfile churn) — CI and prod install it explicitly.

Full node suite **1221 pass / 11 skip** (the 2 SoftHSM tests skip locally). An adversarial review focused on the untested-locally pkcs11js/SPKI/CKM paths is running; I'll fold in findings before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)