### PR TITLE
fix(deps): sync package-lock so npm ci passes on CI (#510)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4058,6 +4058,21 @@
         }
       }
     },
+    "node_modules/data-urls/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/data-urls/node_modules/tr46": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
@@ -6107,6 +6122,21 @@
         }
       }
     },
+    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -6893,6 +6923,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/lru-cache": {


### PR DESCRIPTION
## Summary

Closes #510. Fixes the lockfile drift that made **every** PR against `main` fail its required CI checks at the `npm ci` step, before Lint / Type Check / OpenAPI / Security Audit could run — forcing admin merges.

## Root cause

`jsdom@29.1.1 → @exodus/bytes@1.15.1` requires `@noble/hashes@"^1.8.0 || ^2.0.0"`, but the lockfile had a stale `@noble/hashes@1.4.0` deduped into those slots. Local npm 11 tolerates the mismatch; the CI runners' **npm 10.8.2 on Node 20** correctly reject it:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
npm error Missing: @noble/hashes@2.2.0 from lock file
```

## Fix

Regenerated with `npm@10.8.2 install --package-lock-only` (matching CI's npm, per the precedent in commit `457bdd0ee`) so the result is deterministic to the runner. **Purely additive** — adds the three nested `@noble/hashes@2.2.0` entries for the `@exodus/bytes` consumers (`data-urls`, `html-encoding-sniffer`, `jsdom`). No other package versions change; `lockfileVersion` stays 3.

## Verification

- `npm ci --dry-run` under **npm 10.8.2**: ✅ exit 0 (previously EUSAGE) — `add @noble/hashes 2.2.0`
- `npm ci --dry-run` under **npm 11** (local): ✅ exit 0
- `@noble/hashes@2.2.0` engine is `node >= 20.19.0`, compatible with CI's Node 20.20.2.

This PR is itself the proof: its CI should now get past `npm ci` and run the real checks.

## Out of scope

The `EBADENGINE` warnings (`@nomicfoundation/edr@0.14.2` wants Node ≥22 while CI pins Node 20) remain warnings-only; aligning the CI Node version is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)