### PR TITLE
test: allow zero-millisecond event-pipeline uptime (#503)

### DIFF
--- a/server/__tests__/event-pipeline.test.ts
+++ b/server/__tests__/event-pipeline.test.ts
@@ -441,7 +441,7 @@ describe("EventPipeline", () => {
       expect(metrics.events_received).toBe(5);
       expect(metrics.events_batched).toBe(5);
       expect(metrics.batches_processed).toBeGreaterThan(0);
-      expect(metrics.uptime_ms).toBeGreaterThan(0);
+      expect(metrics.uptime_ms).toBeGreaterThanOrEqual(0);
       expect(metrics.last_event_timestamp).toBeDefined();
     });
 


### PR DESCRIPTION
## Summary

Allow the event-pipeline health test to accept a valid zero-millisecond uptime immediately after startup.

This PR is intentionally limited to the flaky assertion identified in #503.

## Validation

- `server/__tests__/event-pipeline.test.ts`: 32/32 tests pass
- `git diff --check`: clean

Closes #503