### PR TITLE
fix(security): activate and harden the API-key gateway

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@ npm-debug.log
 .npm
 .env
 .env.local
+.secrets
 .git
 .gitignore
 README.md

--- a/.env.example
+++ b/.env.example
@@ -11,13 +11,16 @@ DATABASE_URL=postgresql://user:password@localhost:5432/0xscada
 SIMULATOR_ENABLED=true
 SIMULATOR_INTERVAL_MS=10000
 
-# API Gateway
+# API Gateway (development is explicitly unauthenticated by default).
+# Production deployment templates enable this and require a bootstrap secret.
 ENABLE_API_KEYS=false
 # Comma-separated key:name:scope+scope records. Missing scopes grant nothing.
 # Anchor switching requires operator+anchor.admin.
 # Generate real secrets outside source control; this placeholder is not valid.
 # Use an explicit `*` only for a deliberately unrestricted gateway key.
 API_KEYS=
+# Alternative to API_KEYS for Docker/Kubernetes secret mounts.
+API_KEYS_FILE=
 CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX=100

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ SIMULATOR_INTERVAL_MS=10000
 ENABLE_API_KEYS=false
 # Comma-separated key:name:scope+scope records. Missing scopes grant nothing.
 # Anchor switching requires operator+anchor.admin.
+# Generate real secrets outside source control; this placeholder is not valid.
+# Use an explicit `*` only for a deliberately unrestricted gateway key.
 API_KEYS=
 CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 RATE_LIMIT_WINDOW_MS=60000

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ coverage/
 
 # HSM software-signer key material (never commit)
 .keys/
+.secrets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN npm run build
 FROM node:18-alpine AS production
 
 WORKDIR /app
+ENV NODE_ENV=production \
+    ENABLE_API_KEYS=true
 
 # Install dumb-init for proper signal handling
 RUN apk add --no-cache dumb-init

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ import Integrity from './pages/integrity';
 
 // Admin: Anchor-Backend Switch UX (issue #455)
 import AnchorBackend from './pages/admin/AnchorBackend';
+import ApiCredentialControl from './components/ApiCredentialControl';
 
 const App: React.FC = () => {
   return (
@@ -73,6 +74,7 @@ const App: React.FC = () => {
             </a>
           </Link>
         </nav>
+        <ApiCredentialControl />
       </header>
 
       {/* Main Content */}

--- a/client/src/components/ApiCredentialControl.tsx
+++ b/client/src/components/ApiCredentialControl.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from "react";
+import { useApiCredential } from "../lib/api-credential";
+
+/**
+ * Tab-scoped API credential control. The key is masked, never placed in a URL,
+ * and cleared automatically when the browser tab/session ends.
+ */
+export const ApiCredentialControl: React.FC = () => {
+  const { apiKey, setApiKey, clearApiKey } = useApiCredential();
+  const [draft, setDraft] = useState(apiKey);
+
+  useEffect(() => setDraft(apiKey), [apiKey]);
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        setApiKey(draft);
+      }}
+      style={{ display: "flex", gap: 8, alignItems: "center", marginLeft: "auto" }}
+    >
+      <label style={{ fontSize: 12, color: "#9ca3af" }}>
+        <span style={{ marginRight: 6 }}>Session API key</span>
+        <input
+          aria-label="Session API key"
+          type="password"
+          autoComplete="off"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder="Paste X-API-Key"
+          style={{
+            width: 180,
+            padding: "6px 8px",
+            color: "#e5e7eb",
+            background: "#030712",
+            border: "1px solid #4b5563",
+            borderRadius: 4,
+          }}
+        />
+      </label>
+      <button type="submit" disabled={!draft.trim()} style={buttonStyle}>
+        Use for tab
+      </button>
+      {apiKey && (
+        <button
+          type="button"
+          onClick={() => {
+            clearApiKey();
+            setDraft("");
+          }}
+          style={buttonStyle}
+        >
+          Clear
+        </button>
+      )}
+    </form>
+  );
+};
+
+const buttonStyle: React.CSSProperties = {
+  padding: "6px 9px",
+  borderRadius: 4,
+  border: "1px solid #4b5563",
+  color: "#e5e7eb",
+  background: "#1f2937",
+  cursor: "pointer",
+  fontSize: 12,
+};
+
+export default ApiCredentialControl;

--- a/client/src/components/phi/FanoDataBridge.ts
+++ b/client/src/components/phi/FanoDataBridge.ts
@@ -8,6 +8,7 @@
 import { BloomParams, BloomStyle, DEFAULT_BLOOM } from './BloomRenderer';
 import { FlowParams, DEFAULT_FLOW } from './FlowRenderer';
 import { FANO_LINES } from './FanoGeometry';
+import { apiFetch } from '../../lib/api-credential';
 
 export interface PhiApiResponse {
   phi: number;
@@ -82,8 +83,8 @@ export class FanoDataBridge {
   private async fetchAndUpdate(): Promise<void> {
     try {
       const [phiRes, classRes] = await Promise.allSettled([
-        fetch('/api/geometry/phi').then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json() as Promise<PhiApiResponse>; }),
-        fetch('/api/geometry/classes').then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json() as Promise<ClassApiResponse>; }),
+        apiFetch('/api/geometry/phi').then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json() as Promise<PhiApiResponse>; }),
+        apiFetch('/api/geometry/classes').then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json() as Promise<ClassApiResponse>; }),
       ]);
       const phiData = phiRes.status === 'fulfilled' ? phiRes.value : null;
       const classData = classRes.status === 'fulfilled' ? classRes.value : null;

--- a/client/src/components/phi/PhiGauge.tsx
+++ b/client/src/components/phi/PhiGauge.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useEffect, useState } from "react";
+import { apiFetch } from "../../lib/api-credential";
 
 interface PhiData {
   phi: number;
@@ -158,7 +159,7 @@ export function PhiGauge({ refreshMs = 10000 }: { refreshMs?: number }) {
     let active = true;
     const fetchPhi = async () => {
       try {
-        const res = await fetch("/api/geometry/phi");
+        const res = await apiFetch("/api/geometry/phi");
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const json = await res.json();
         if (active) { setData(json); setError(null); }

--- a/client/src/components/pid/PIDDataBinding.tsx
+++ b/client/src/components/pid/PIDDataBinding.tsx
@@ -6,6 +6,10 @@
 
 import React, { createContext, useContext, useEffect, useRef, useState, useCallback } from 'react';
 import type { PIDTagValue, PIDDataSnapshot, AlarmState } from '@shared/types/pid';
+import {
+  buildWebSocketProtocols,
+  useApiCredential,
+} from '../../lib/api-credential';
 
 // =============================================================================
 // TYPES
@@ -71,6 +75,7 @@ export const PIDDataProvider: React.FC<PIDDataProviderProps> = ({
   diagramId,
   children,
 }) => {
+  const { apiKey } = useApiCredential();
   const [values, setValues] = useState<Record<string, PIDTagValue>>({});
   const [connected, setConnected] = useState(false);
   const [lastUpdate, setLastUpdate] = useState<string | null>(null);
@@ -84,7 +89,11 @@ export const PIDDataProvider: React.FC<PIDDataProviderProps> = ({
   }, [wsUrl]);
 
   useEffect(() => {
-    const ws = new WebSocket(getWsUrl());
+    const protocols = buildWebSocketProtocols(apiKey);
+    const ws = new WebSocket(
+      getWsUrl(),
+      protocols.length > 0 ? protocols : undefined,
+    );
     wsRef.current = ws;
 
     ws.onopen = () => {
@@ -119,7 +128,7 @@ export const PIDDataProvider: React.FC<PIDDataProviderProps> = ({
       ws.close();
       wsRef.current = null;
     };
-  }, [getWsUrl, diagramId]);
+  }, [getWsUrl, diagramId, apiKey]);
 
   const subscribe = useCallback((tagIds: string[]) => {
     tagIds.forEach(t => subscribedTags.current.add(t));

--- a/client/src/hooks/use-tag-stream.ts
+++ b/client/src/hooks/use-tag-stream.ts
@@ -8,6 +8,10 @@
  */
 
 import { useEffect, useRef, useState, useCallback } from "react";
+import {
+  buildWebSocketProtocols,
+  useApiCredential,
+} from "../lib/api-credential";
 
 export interface TagValue {
   tagName: string;
@@ -53,6 +57,7 @@ export interface UseTagStreamReturn {
 
 export function useTagStream(options: UseTagStreamOptions = {}): UseTagStreamReturn {
   const { tags: initialTags, autoConnect = true } = options;
+  const { apiKey } = useApiCredential();
   const wsRef = useRef<WebSocket | null>(null);
   const [connected, setConnected] = useState(false);
   const [tagValues, setTagValues] = useState<Map<string, TagValue>>(new Map());
@@ -88,7 +93,11 @@ export function useTagStream(options: UseTagStreamOptions = {}): UseTagStreamRet
   const connect = useCallback(() => {
     if (wsRef.current?.readyState === WebSocket.OPEN) return;
 
-    const ws = new WebSocket(getWsUrl());
+    const protocols = buildWebSocketProtocols(apiKey);
+    const ws = new WebSocket(
+      getWsUrl(),
+      protocols.length > 0 ? protocols : undefined,
+    );
     wsRef.current = ws;
 
     ws.onopen = () => {
@@ -155,7 +164,7 @@ export function useTagStream(options: UseTagStreamOptions = {}): UseTagStreamRet
         }
       } catch { /* ignore parse errors */ }
     };
-  }, [getWsUrl, initialTags, send]);
+  }, [getWsUrl, initialTags, send, apiKey]);
 
   useEffect(() => {
     mountedRef.current = true;

--- a/client/src/hooks/use-websocket.ts
+++ b/client/src/hooks/use-websocket.ts
@@ -10,7 +10,11 @@
  * - Heartbeat/ping support
  */
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo } from "react";
+import {
+  buildWebSocketProtocols,
+  useApiCredential,
+} from "../lib/api-credential";
 
 export type ConnectionStatus = "connecting" | "connected" | "disconnected" | "error";
 
@@ -30,6 +34,8 @@ export interface UseWebSocketOptions {
   reconnectInterval?: number;
   maxReconnectAttempts?: number;
   heartbeatInterval?: number;
+  /** Optional application protocols; defaults to the tab-scoped API key protocol. */
+  protocols?: string[];
 }
 
 export interface UseWebSocketReturn {
@@ -51,7 +57,14 @@ export function useWebSocket({
   reconnectInterval = 3000,
   maxReconnectAttempts = 10,
   heartbeatInterval = 25000,
+  protocols,
 }: UseWebSocketOptions): UseWebSocketReturn {
+  const { apiKey } = useApiCredential();
+  const effectiveProtocols = useMemo(
+    () => protocols ?? buildWebSocketProtocols(apiKey),
+    [protocols, apiKey],
+  );
+  const protocolSignature = effectiveProtocols.join(",");
   const [status, setStatus] = useState<ConnectionStatus>("disconnected");
   const [lastMessage, setLastMessage] = useState<WebSocketMessage | null>(null);
   const [reconnectAttempts, setReconnectAttempts] = useState(0);
@@ -93,7 +106,10 @@ export function useWebSocket({
     setStatus("connecting");
 
     try {
-      wsRef.current = new WebSocket(url);
+      wsRef.current = new WebSocket(
+        url,
+        effectiveProtocols.length > 0 ? effectiveProtocols : undefined,
+      );
 
       wsRef.current.onopen = () => {
         if (!mountedRef.current) return;
@@ -152,6 +168,7 @@ export function useWebSocket({
     reconnectAttempts,
     clearTimers,
     startHeartbeat,
+    protocolSignature,
   ]);
 
   const disconnect = useCallback(() => {
@@ -181,7 +198,7 @@ export function useWebSocket({
       mountedRef.current = false;
       disconnect();
     };
-  }, [url]); // Only reconnect if URL changes
+  }, [url, protocolSignature]); // Reconnect if URL or tab credential changes
 
   return {
     status,

--- a/client/src/lib/__tests__/api-credential.test.ts
+++ b/client/src/lib/__tests__/api-credential.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  API_CREDENTIAL_SESSION_KEY,
+  OXSCADA_WEBSOCKET_AUTH_PREFIX,
+  OXSCADA_WEBSOCKET_PROTOCOL,
+  _resetApiCredentialForTests,
+  apiFetch,
+  buildApiHeaders,
+  buildWebSocketProtocols,
+  getApiCredential,
+  setApiCredential,
+} from "../api-credential";
+
+describe("browser API credential plumbing", () => {
+  beforeEach(() => {
+    _resetApiCredentialForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the credential tab-scoped in sessionStorage", () => {
+    setApiCredential("  oxs_session_secret  ");
+
+    expect(getApiCredential()).toBe("oxs_session_secret");
+    expect(sessionStorage.getItem(API_CREDENTIAL_SESSION_KEY)).toBe("oxs_session_secret");
+    expect(localStorage.getItem(API_CREDENTIAL_SESSION_KEY)).toBeNull();
+  });
+
+  it("adds X-API-Key only to same-origin API requests", () => {
+    const apiHeaders = buildApiHeaders("/api/sites", undefined, "read-key");
+    const externalHeaders = buildApiHeaders(
+      "https://example.invalid/api/sites",
+      undefined,
+      "read-key",
+    );
+
+    expect(apiHeaders.get("X-API-Key")).toBe("read-key");
+    expect(externalHeaders.has("X-API-Key")).toBe(false);
+  });
+
+  it("does not overwrite a caller-provided API key", () => {
+    const headers = buildApiHeaders(
+      "/api/sites",
+      { headers: { "X-API-Key": "explicit-key" } },
+      "session-key",
+    );
+    expect(headers.get("X-API-Key")).toBe("explicit-key");
+  });
+
+  it("constructs a stable protocol plus an encoded credential protocol", () => {
+    expect(buildWebSocketProtocols("secret")).toEqual([
+      OXSCADA_WEBSOCKET_PROTOCOL,
+      `${OXSCADA_WEBSOCKET_AUTH_PREFIX}c2VjcmV0`,
+    ]);
+    expect(buildWebSocketProtocols("")).toEqual([]);
+  });
+
+  it("apiFetch delegates with the session header", async () => {
+    setApiCredential("session-key");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+
+    await apiFetch("/api/sites", { method: "GET" });
+
+    const init = fetchMock.mock.calls[0][1];
+    expect(new Headers(init?.headers).get("X-API-Key")).toBe("session-key");
+  });
+});

--- a/client/src/lib/api-credential.ts
+++ b/client/src/lib/api-credential.ts
@@ -1,0 +1,142 @@
+import { useSyncExternalStore } from "react";
+
+export const API_CREDENTIAL_SESSION_KEY = "oxscada.api-key";
+export const OXSCADA_WEBSOCKET_PROTOCOL = "oxscada.v1";
+export const OXSCADA_WEBSOCKET_AUTH_PREFIX = "oxscada.api-key.";
+
+let inMemoryCredential: string | undefined;
+let hydrated = false;
+const listeners = new Set<() => void>();
+
+function browserSessionStorage(): Storage | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return undefined;
+  }
+}
+function hydrate(): void {
+  if (hydrated) return;
+  hydrated = true;
+  const stored = browserSessionStorage()?.getItem(API_CREDENTIAL_SESSION_KEY)?.trim();
+  inMemoryCredential = stored || undefined;
+}
+
+function emitChange(): void {
+  for (const listener of listeners) listener();
+}
+
+export function getApiCredential(): string {
+  hydrate();
+  return inMemoryCredential ?? "";
+}
+
+export function setApiCredential(value: string): void {
+  const next = value.trim();
+  hydrated = true;
+  inMemoryCredential = next || undefined;
+  const storage = browserSessionStorage();
+  try {
+    if (next) storage?.setItem(API_CREDENTIAL_SESSION_KEY, next);
+    else storage?.removeItem(API_CREDENTIAL_SESSION_KEY);
+  } catch {
+    // The in-memory credential remains usable when storage is unavailable.
+  }
+  emitChange();
+}
+
+export function clearApiCredential(): void {
+  setApiCredential("");
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useApiCredential(): {
+  apiKey: string;
+  setApiKey: (value: string) => void;
+  clearApiKey: () => void;
+} {
+  const apiKey = useSyncExternalStore(subscribe, getApiCredential, () => "");
+  return {
+    apiKey,
+    setApiKey: setApiCredential,
+    clearApiKey: clearApiCredential,
+  };
+}
+
+function isSameOriginApiRequest(input: RequestInfo | URL): boolean {
+  const raw = input instanceof Request ? input.url : input.toString();
+  if (raw.startsWith("/api") && (raw.length === 4 || raw[4] === "/" || raw[4] === "?")) {
+    return true;
+  }
+  if (typeof window === "undefined") return false;
+  try {
+    const url = new URL(raw, window.location.origin);
+    return url.origin === window.location.origin &&
+      (url.pathname === "/api" || url.pathname.startsWith("/api/"));
+  } catch {
+    return false;
+  }
+}
+
+/** Add X-API-Key only to same-origin /api requests. */
+export function buildApiHeaders(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  apiKey = getApiCredential(),
+): Headers {
+  const headers = new Headers(input instanceof Request ? input.headers : undefined);
+  new Headers(init?.headers).forEach((value, name) => headers.set(name, value));
+  if (apiKey && isSameOriginApiRequest(input) && !headers.has("X-API-Key")) {
+    headers.set("X-API-Key", apiKey);
+  }
+  return headers;
+}
+
+export function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    headers: buildApiHeaders(input, init),
+  });
+}
+
+function base64UrlEncodeUtf8(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  if (bytes.length === 0 || bytes.length > 512) {
+    throw new Error("API key must contain between 1 and 512 UTF-8 bytes");
+  }
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/u, "");
+}
+
+/**
+ * Browser-safe credential transport for the WebSocket HTTP upgrade.
+ * The stable application protocol is negotiated; the credential token is not.
+ */
+export function buildWebSocketProtocols(apiKey = getApiCredential()): string[] {
+  if (!apiKey) return [];
+  return [
+    OXSCADA_WEBSOCKET_PROTOCOL,
+    `${OXSCADA_WEBSOCKET_AUTH_PREFIX}${base64UrlEncodeUtf8(apiKey)}`,
+  ];
+}
+
+/** Test-only reset for module and session state. */
+export function _resetApiCredentialForTests(): void {
+  hydrated = true;
+  inMemoryCredential = undefined;
+  try {
+    browserSessionStorage()?.removeItem(API_CREDENTIAL_SESSION_KEY);
+  } catch {
+    // ignored
+  }
+  emitChange();
+}

--- a/client/src/pages/admin/AnchorBackend.tsx
+++ b/client/src/pages/admin/AnchorBackend.tsx
@@ -14,6 +14,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
+import { apiFetch, useApiCredential } from '../../lib/api-credential';
 
 type Backend = 'l2' | 'node' | 'both';
 
@@ -77,8 +78,7 @@ const AnchorBackend: React.FC = () => {
   const [history, setHistory] = useState<SwitchHistoryEntry[]>([]);
   const [target, setTarget] = useState<Backend>('node');
   const [eventsPerMinute, setEventsPerMinute] = useState<number>(120);
-  // Kept only in component memory. Never persisted to localStorage or a URL.
-  const [apiKey, setApiKey] = useState<string>('');
+  const { apiKey } = useApiCredential();
 
   const [dryRun, setDryRun] = useState<DryRunResponse | null>(null);
   const [showConfirm, setShowConfirm] = useState(false);
@@ -93,9 +93,7 @@ const AnchorBackend: React.FC = () => {
     }
     try {
       setError(null);
-      const res = await fetch(API_BASE, {
-        headers: { 'X-API-Key': apiKey },
-      });
+      const res = await apiFetch(API_BASE);
       if (!res.ok) throw new Error('Failed to load anchor backend status');
       const data: StatusResponse = await res.json();
       setCurrentBackend(data.backend);
@@ -111,9 +109,9 @@ const AnchorBackend: React.FC = () => {
     setNotice(null);
     setDryRun(null);
     try {
-      const res = await fetch(API_BASE, {
+      const res = await apiFetch(API_BASE, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ backend: target, dryRun: true, eventsPerMinute }),
       });
       const data = await res.json();
@@ -131,9 +129,9 @@ const AnchorBackend: React.FC = () => {
     setBusy(true);
     setError(null);
     try {
-      const res = await fetch(API_BASE, {
+      const res = await apiFetch(API_BASE, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           backend: dryRun.proposedBackend,
           dryRun: false,
@@ -184,22 +182,13 @@ const AnchorBackend: React.FC = () => {
       <div style={{ padding: 20, backgroundColor: '#111827', borderRadius: 8, marginBottom: 24 }}>
         <div style={{ fontSize: 14, color: '#888', marginBottom: 8 }}>Operator authentication</div>
         <div style={{ display: 'flex', gap: 12, alignItems: 'flex-end', flexWrap: 'wrap' }}>
-          <label style={{ display: 'flex', flexDirection: 'column', fontSize: 13, color: '#888', gap: 4 }}>
-            API key
-            <input
-              type="password"
-              autoComplete="off"
-              value={apiKey}
-              placeholder="X-API-Key"
-              onChange={(e) => setApiKey(e.target.value)}
-              style={inputStyle}
-            />
-          </label>
           <button onClick={() => void loadStatus()} disabled={busy || !apiKey} style={primaryButtonStyle(busy || !apiKey)}>
-            Authenticate
+            Load authenticated status
           </button>
           <span style={{ color: '#888', fontSize: 12 }}>
-            Audit identity comes from the server-owned key record.
+            {apiKey
+              ? 'Using the tab-scoped credential from the application header.'
+              : 'Set a tab-scoped credential in the application header first.'}
           </span>
         </div>
       </div>

--- a/client/src/pages/pid-view.tsx
+++ b/client/src/pages/pid-view.tsx
@@ -10,6 +10,7 @@ import type { PIDDiagram } from '@shared/types/pid';
 import { PIDCanvas } from '../components/pid/PIDCanvas';
 import { PIDDataProvider } from '../components/pid/PIDDataBinding';
 import { PIDEditor } from '../components/pid/PIDEditor';
+import { apiFetch } from '../lib/api-credential';
 
 // =============================================================================
 // DEMO DIAGRAM (used when no API data available)
@@ -127,7 +128,7 @@ const PIDViewPage: React.FC = () => {
       return;
     }
 
-    fetch(`/api/pid/diagrams/${diagramId}`)
+    apiFetch(`/api/pid/diagrams/${diagramId}`)
       .then(res => {
         if (!res.ok) throw new Error('Failed to load diagram');
         return res.json();
@@ -138,7 +139,7 @@ const PIDViewPage: React.FC = () => {
 
   const handleSave = async (updated: PIDDiagram) => {
     try {
-      const res = await fetch(`/api/pid/diagrams/${updated.id}`, {
+      const res = await apiFetch(`/api/pid/diagrams/${updated.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(updated),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       - DATABASE_URL=postgresql://postgres:password@postgres:5432/scada_db
       - REDIS_URL=redis://redis:6379
       - BLOCKCHAIN_RPC_URL=http://hardhat:8545
-      - ENABLE_API_KEYS=${ENABLE_API_KEYS:-false}
-      - API_KEYS=${API_KEYS:-}
+      - ENABLE_API_KEYS=${ENABLE_API_KEYS:-true}
+      - API_KEYS_FILE=/run/secrets/api_keys
       - OXSCADA_REPLICA_COUNT=1
       - CORS_ORIGINS=http://localhost:3000,http://localhost:5173
       - RATE_LIMIT_WINDOW_MS=60000
@@ -33,6 +33,8 @@ services:
       - scada-network
     volumes:
       - scada-data:/app/data
+    secrets:
+      - api_keys
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/api/health"]
       interval: 30s
@@ -154,3 +156,7 @@ volumes:
     name: scada-grafana-data
   scada-data:
     name: scada-app-data
+
+secrets:
+  api_keys:
+    file: ${API_KEYS_FILE:?Set API_KEYS_FILE to a bootstrap API-key secret file}

--- a/docker/edge/Dockerfile
+++ b/docker/edge/Dockerfile
@@ -57,6 +57,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 
 # Default environment
 ENV NODE_ENV=production \
+    ENABLE_API_KEYS=true \
     PORT=5000 \
     LOG_LEVEL=warn \
     GATEWAY_MODE=edge

--- a/docker/edge/docker-compose.yml
+++ b/docker/edge/docker-compose.yml
@@ -25,6 +25,8 @@ services:
     environment:
       - NODE_ENV=production
       - DATABASE_URL=postgresql://scada:scada@db:5432/scada
+      - ENABLE_API_KEYS=${ENABLE_API_KEYS:-true}
+      - API_KEYS_FILE=/run/secrets/api_keys
       - GATEWAY_MODE=edge
       - LOG_LEVEL=${LOG_LEVEL:-warn}
       - OPCUA_ENDPOINT=${OPCUA_ENDPOINT:-opc.tcp://host.docker.internal:4840}
@@ -41,6 +43,8 @@ services:
           memory: 128M
     networks:
       - scada-edge
+    secrets:
+      - api_keys
 
   # ---------------------------------------------------------------------------
   # PostgreSQL (lightweight edge database)
@@ -74,3 +78,7 @@ networks:
 
 volumes:
   pgdata:
+
+secrets:
+  api_keys:
+    file: ${API_KEYS_FILE:?Set API_KEYS_FILE to a bootstrap API-key secret file}

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -16,7 +16,8 @@ COPY shared/ ./shared/
 RUN npm run build --workspace=server 2>/dev/null || npx tsc --project tsconfig.json
 
 FROM base AS production
-ENV NODE_ENV=production
+ENV NODE_ENV=production \
+    ENABLE_API_KEYS=true
 USER node
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist

--- a/docs/deploy/full-stack-helm.md
+++ b/docs/deploy/full-stack-helm.md
@@ -14,7 +14,7 @@ routes are usable:
 ```bash
 kubectl create namespace oxscada --dry-run=client -o yaml | kubectl apply -f -
 kubectl -n oxscada create secret generic oxscada-api-keys \
-  --from-literal=API_KEYS='<generated-key>:anchor-operations:operator+anchor.admin'
+  --from-literal=API_KEYS='<generated-key>:bootstrap-admin:admin'
 ```
 
 ```bash
@@ -22,7 +22,8 @@ helm install oxscada ./helm/oxscada-full -n oxscada --create-namespace \
   --set-string server.apiKeys.existingSecret=oxscada-api-keys
 ```
 
-The chart references the existing Secret and never ships a default credential.
+Global authentication is on by default; rendering fails until the existing
+Secret name is supplied. The chart never ships a default credential.
 See [Control-Plane API Keys](../security/control-plane-api-keys.md) for secure
 key generation, required operator and service scopes, global gateway
 authentication, and rotation guidance.

--- a/docs/k8s/application-deployment.md
+++ b/docs/k8s/application-deployment.md
@@ -9,6 +9,19 @@ Kubernetes deployments for the three core 0xSCADA services: server, client, and 
 - `k8s/app/gateway-deployment.yaml` — API gateway (2 replicas)
 
 ## Deployment
+
+Create the API-key bootstrap Secret before applying the raw manifests:
+
+```bash
+kubectl create namespace oxscada --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n oxscada create secret generic oxscada-api-keys \
+  --from-literal=API_KEYS='<generated-key>:bootstrap-admin:admin'
+```
+
+Generate the key with a cryptographically secure secret generator and keep it
+outside source control. The server deployment intentionally fails to start
+when the Secret or `API_KEYS` entry is absent.
+
 ```bash
 kubectl apply -f k8s/app/ -n oxscada
 ```

--- a/docs/k8s/helm-chart.md
+++ b/docs/k8s/helm-chart.md
@@ -38,7 +38,7 @@ helm upgrade oxscada ./helm/oxscada -n oxscada
 | `server.replicaCount` | 2 | Server replicas |
 | `server.apiKeys.existingSecret` | `""` | Existing Secret containing `API_KEYS` |
 | `server.apiKeys.secretKey` | `API_KEYS` | Key within the existing Secret |
-| `server.apiKeys.enableGlobalAuth` | `false` | Require keys on all non-public API routes |
+| `server.apiKeys.enableGlobalAuth` | `true` | Require keys on all non-public API routes |
 | `ingress.enabled` | true | Enable ingress |
 | `ingress.host` | oxscada.example.com | Hostname |
 | `blockchain.enabled` | true | Deploy validators |

--- a/docs/security/api-gateway-keys.md
+++ b/docs/security/api-gateway-keys.md
@@ -1,0 +1,71 @@
+# API Gateway Keys
+
+0xSCADA reads API-key records from the `API_KEYS` environment variable. Each
+record uses this format, with multiple records separated by commas:
+
+```text
+key:name:scope+scope
+```
+
+Generate key material with a cryptographically secure secret generator and
+inject it at deployment time. Do not commit real keys to values files, Compose
+files, or `.env` templates.
+
+Missing scopes grant no scoped privileges. Grant `admin` to a key that must use
+the gateway's key-management endpoints, and use `*` only for a deliberately
+unrestricted key:
+
+```text
+<generated-key>:operations-console:admin
+```
+
+Clients send credentials only in the `X-API-Key` header. Query-string keys are
+rejected because URLs commonly appear in browser history, proxy logs, and
+access logs.
+
+```bash
+curl -H "X-API-Key: ${OPERATOR_KEY}" \
+  https://oxscada.example.com/api/sites
+```
+
+Set `ENABLE_API_KEYS=true` to require a configured key for every non-public
+API route. Health and API-documentation routes remain public.
+
+## Docker Compose
+
+The root `docker-compose.yml` reads `API_KEYS` and `ENABLE_API_KEYS` from the
+host environment or a local `.env` file. It contains no default credential:
+
+```bash
+export OPERATOR_KEY="$(openssl rand -hex 32)"
+export API_KEYS="${OPERATOR_KEY}:operations-console:admin"
+export ENABLE_API_KEYS=true
+docker compose up -d
+```
+
+Treat a local `.env` as a secret file and do not commit it.
+
+## Helm
+
+Both charts read `API_KEYS` from an existing Kubernetes Secret. The charts do
+not render credentials into a Helm-managed Secret or ConfigMap:
+
+```bash
+OPERATOR_KEY="$(openssl rand -hex 32)"
+API_KEYS_VALUE="${OPERATOR_KEY}:operations-console:admin"
+
+kubectl -n oxscada create secret generic oxscada-api-keys \
+  --from-literal=API_KEYS="${API_KEYS_VALUE}"
+
+helm upgrade --install oxscada ./helm/oxscada \
+  --namespace oxscada --create-namespace \
+  --set-string server.apiKeys.existingSecret=oxscada-api-keys \
+  --set server.apiKeys.enableGlobalAuth=true
+```
+
+Use `./helm/oxscada-full` in the same command for the full-stack chart. Set
+`server.apiKeys.secretKey` when the existing Secret uses a key other than
+`API_KEYS`.
+
+Rotate keys by updating the Secret and restarting the server Deployment so
+the pod receives the new environment value.

--- a/docs/security/api-gateway-keys.md
+++ b/docs/security/api-gateway-keys.md
@@ -1,7 +1,8 @@
 # API Gateway Keys
 
-0xSCADA reads API-key records from the `API_KEYS` environment variable. Each
-record uses this format, with multiple records separated by commas:
+0xSCADA reads API-key records from `API_KEYS`, or from the file named by
+`API_KEYS_FILE`. Each record uses this format, with multiple records separated
+by commas:
 
 ```text
 key:name:scope+scope
@@ -11,13 +12,44 @@ Generate key material with a cryptographically secure secret generator and
 inject it at deployment time. Do not commit real keys to values files, Compose
 files, or `.env` templates.
 
-Missing scopes grant no scoped privileges. Grant `admin` to a key that must use
-the gateway's key-management endpoints, and use `*` only for a deliberately
-unrestricted key:
+Missing scopes grant no scoped privileges. The key-generation API also rejects
+missing or empty scopes. A bootstrap administrator can create narrower keys:
 
 ```text
 <generated-key>:operations-console:admin
 ```
+
+`admin` and `*` bypass route scope checks. Reserve both for bootstrap or
+break-glass use.
+
+API-generated keys currently live in the serving process only: they do not
+survive a restart or replicate to another pod. Use that endpoint only for
+single-process development until a shared credential store is selected. For
+multi-replica production, provision every required key through the shared
+Docker/Kubernetes secret and restart the deployment after rotation.
+
+## Scope policy
+
+All `POST`, `PUT`, `PATCH`, and `DELETE` requests require `write` unless a
+narrower control-route policy applies:
+
+| Scope | Access |
+|---|---|
+| `read` | Conventional least-privilege grant for REST clients; also permits WebSocket streams |
+| `stream.read` | WebSocket streams without general REST-read naming |
+| `write` | Ordinary API mutations |
+| `alarms.write` | Alarm evaluation/injection/suppression family |
+| `geometry.write` | Geometry rule and recalibration mutations |
+| `operator+anchor.admin` | Anchor-backend inspection and switching |
+| `safety.resume` | Blueprint safe-state resume |
+| `tuning.write`, `tuning.approve` | Tuning changes and human approvals |
+| `control.write` | Digital-twin control operations |
+| `security.admin` | HSM control operations |
+| `websocket.admin` | Streaming-client administration |
+
+The server-owned policy inventory is
+`server/middleware/control-route-policy.ts`. Feature routers may enforce a
+stricter policy in addition to this gateway floor.
 
 Clients send credentials only in the `X-API-Key` header. Query-string keys are
 rejected because URLs commonly appear in browser history, proxy logs, and
@@ -28,39 +60,72 @@ curl -H "X-API-Key: ${OPERATOR_KEY}" \
   https://oxscada.example.com/api/sites
 ```
 
-Set `ENABLE_API_KEYS=true` to require a configured key for every non-public
-API route. Health and API-documentation routes remain public.
+When `ENABLE_API_KEYS=true`, startup fails if neither `API_KEYS` nor
+`API_KEYS_FILE` yields a bootstrap key. Health, readiness, and API-documentation
+routes remain public.
+
+## Browser client and WebSockets
+
+The first-party React client has a masked **Session API key** control in its
+header. It stores the key in memory and `sessionStorage`, adds `X-API-Key` only
+to same-origin `/api` requests, and clears the key when the tab session ends.
+It never puts a key in a URL.
+
+Browser WebSocket APIs cannot add `X-API-Key`. For `/ws` and `/ws/tags`, the
+client sends a stable `oxscada.v1` subprotocol and a second
+`oxscada.api-key.<base64url-key>` token. The server parses and validates that
+token during the HTTP upgrade, checks `read` or `stream.read`, and negotiates
+only the stable protocol. Query credentials are rejected.
+
+Base64url is transport encoding, not encryption. Configure reverse proxies to
+forward but never log `Sec-WebSocket-Protocol`, because the credential token is
+a bearer secret even though the server does not echo it.
+
+The gateway currently authenticates, but does not further scope, ordinary
+`GET` requests; the `read` name documents caller intent and is enforced for
+stream upgrades. Mutations always pass through the policy table above.
+
+This is bearer-key plumbing, not protection from compromised page JavaScript.
+An XSS payload running in the 0xSCADA origin can read `sessionStorage` and use
+the in-memory key. Deploy with a strict Content Security Policy, avoid
+third-party scripts, grant the UI only the scopes it needs, and prefer short
+key lifetimes. TLS is mandatory because both REST and WebSocket credentials
+travel in request headers.
 
 ## Docker Compose
 
-The root `docker-compose.yml` reads `API_KEYS` and `ENABLE_API_KEYS` from the
-host environment or a local `.env` file. It contains no default credential:
+The production root `docker-compose.yml` enables authentication by default and
+requires a Docker secret file:
 
 ```bash
-export OPERATOR_KEY="$(openssl rand -hex 32)"
-export API_KEYS="${OPERATOR_KEY}:operations-console:admin"
-export ENABLE_API_KEYS=true
+umask 077
+mkdir -p .secrets
+BOOTSTRAP_KEY="$(openssl rand -hex 32)"
+printf '%s' "${BOOTSTRAP_KEY}:bootstrap-admin:admin" > .secrets/api-keys
+
+export API_KEYS_FILE="$PWD/.secrets/api-keys"
 docker compose up -d
 ```
 
-Treat a local `.env` as a secret file and do not commit it.
+The file is mounted read-only at `/run/secrets/api_keys`; key material is not
+placed in the Compose YAML or process environment. Never commit `.secrets`.
 
 ## Helm
 
-Both charts read `API_KEYS` from an existing Kubernetes Secret. The charts do
-not render credentials into a Helm-managed Secret or ConfigMap:
+Both charts enable global authentication by default and require
+`server.apiKeys.existingSecret` at render time. They never render credentials
+into a Helm-managed Secret or ConfigMap:
 
 ```bash
 OPERATOR_KEY="$(openssl rand -hex 32)"
-API_KEYS_VALUE="${OPERATOR_KEY}:operations-console:admin"
+API_KEYS_VALUE="${OPERATOR_KEY}:bootstrap-admin:admin"
 
 kubectl -n oxscada create secret generic oxscada-api-keys \
   --from-literal=API_KEYS="${API_KEYS_VALUE}"
 
 helm upgrade --install oxscada ./helm/oxscada \
   --namespace oxscada --create-namespace \
-  --set-string server.apiKeys.existingSecret=oxscada-api-keys \
-  --set server.apiKeys.enableGlobalAuth=true
+  --set-string server.apiKeys.existingSecret=oxscada-api-keys
 ```
 
 Use `./helm/oxscada-full` in the same command for the full-stack chart. Set

--- a/docs/security/api-gateway-keys.md
+++ b/docs/security/api-gateway-keys.md
@@ -38,7 +38,8 @@ narrower control-route policy applies:
 | `read` | Conventional least-privilege grant for REST clients; also permits WebSocket streams |
 | `stream.read` | WebSocket streams without general REST-read naming |
 | `write` | Ordinary API mutations |
-| `alarms.write` | Alarm evaluation/injection/suppression family |
+| `alarms.write` | Legacy `/api/alarms` evaluation/injection/suppression family |
+| `alarms.ingest`, `alarms.acknowledge`, `alarms.clear`, `alarms.configure` | Alarm-correlation ingestion, lifecycle actions, and configuration; feature routes require the exact action scope |
 | `geometry.write` | Geometry rule and recalibration mutations |
 | `operator+anchor.admin` | Anchor-backend inspection and switching |
 | `safety.resume` | Blueprint safe-state resume |

--- a/docs/security/control-plane-api-keys.md
+++ b/docs/security/control-plane-api-keys.md
@@ -1,7 +1,8 @@
 # Control-Plane API Keys
 
-0xSCADA reads API key records from the `API_KEYS` environment variable. A
-record has the following format, and multiple records are comma-separated:
+0xSCADA reads API key records from `API_KEYS` or the file named by
+`API_KEYS_FILE`. A record has the following format, and multiple records are
+comma-separated:
 
 ```text
 key:name:scope+scope
@@ -32,17 +33,18 @@ curl -H "X-API-Key: ${OPERATOR_KEY}" \
 
 ## Docker Compose
 
-The root `docker-compose.yml` takes `API_KEYS` and `ENABLE_API_KEYS` from the
-host environment (or a local `.env` file). It contains no default credential.
-Control-plane routes use `API_KEYS` even when global gateway authentication is
-disabled.
+The production root `docker-compose.yml` enables global authentication and
+requires a Docker secret file. Control-plane routes remain fail closed even
+when a development process explicitly disables global gateway authentication.
 
 ```bash
+umask 077
+mkdir -p .secrets
 OPERATOR_KEY="$(openssl rand -hex 32)"
-export API_KEYS="${OPERATOR_KEY}:anchor-operations:operator+anchor.admin"
-
-# Optional: require a valid API key on all non-public API routes.
-export ENABLE_API_KEYS=true
+printf '%s' \
+  "${OPERATOR_KEY}:anchor-operations:operator+anchor.admin+read+stream.read" \
+  > .secrets/api-keys
+export API_KEYS_FILE="$PWD/.secrets/api-keys"
 docker compose up -d
 ```
 
@@ -71,8 +73,13 @@ helm upgrade --install oxscada ./helm/oxscada \
 
 Use `./helm/oxscada-full` in the same command for the full-stack chart. Set
 `server.apiKeys.secretKey` if the existing Secret uses a key other than
-`API_KEYS`. Set `server.apiKeys.enableGlobalAuth=true` only when every
-non-public API client is prepared to send a configured key.
+`API_KEYS`. Global authentication defaults to true, and Helm rendering fails
+until `server.apiKeys.existingSecret` is supplied.
+
+The first-party browser client sends REST keys via `X-API-Key` and WebSocket
+keys via the validated `Sec-WebSocket-Protocol` scheme documented in
+[API Gateway Keys](api-gateway-keys.md). Keys live only in memory and
+`sessionStorage`; review that document's XSS and TLS threat model before use.
 
 Rotate keys by updating the Secret and restarting the server Deployment so the
 pod receives the new environment value:
@@ -80,3 +87,7 @@ pod receives the new environment value:
 ```bash
 kubectl -n oxscada rollout restart deployment/oxscada-server
 ```
+
+The API key-generation endpoint is process-local and ephemeral. Do not use it
+as the source of production credentials in a multi-replica deployment until a
+shared credential store is implemented.

--- a/gateway/helm-chart.test.ts
+++ b/gateway/helm-chart.test.ts
@@ -192,10 +192,28 @@ describe("gateway Helm chart hardening", () => {
       // real parent templates and values under test.
       removeUnavailableLocalDependencies(fullChartPath);
 
-      const simpleDefaults = gatewayDeployment(renderChart(
+      const bootstrapSecretOverrides = [
+        "--set-string",
+        "server.apiKeys.existingSecret=render-test-api-keys",
+      ];
+      expect(() => renderChart(
         "oxscada",
         simpleChartPath,
         ["--set", "postgresql.enabled=false"],
+      )).toThrow(/server\.apiKeys\.existingSecret is required/u);
+      expect(() => renderChart(
+        "oxscada-full",
+        fullChartPath,
+      )).toThrow(/server\.apiKeys\.existingSecret is required/u);
+
+      const simpleDefaults = gatewayDeployment(renderChart(
+        "oxscada",
+        simpleChartPath,
+        [
+          "--set",
+          "postgresql.enabled=false",
+          ...bootstrapSecretOverrides,
+        ],
       ));
       expect(simpleDefaults.metadata?.name).toBe("oxscada-gateway");
       expectGatewayRuntime(simpleDefaults, 8080, "http://oxscada-server:5000");
@@ -210,6 +228,7 @@ describe("gateway Helm chart hardening", () => {
           "gateway.port=18080",
           "--set-string",
           "gateway.serverUrl=https://upstream.internal:8443",
+          ...bootstrapSecretOverrides,
         ],
       ));
       expectGatewayRuntime(
@@ -221,6 +240,7 @@ describe("gateway Helm chart hardening", () => {
       const fullDefaults = gatewayDeployment(renderChart(
         "oxscada-full",
         fullChartPath,
+        bootstrapSecretOverrides,
       ));
       expect(fullDefaults.metadata?.name).toBe("oxscada-full-gateway");
       expectGatewayRuntime(
@@ -237,6 +257,7 @@ describe("gateway Helm chart hardening", () => {
           "gateway.port=28080",
           "--set-string",
           "gateway.serverUrl=https://full-upstream.internal:9443",
+          ...bootstrapSecretOverrides,
         ],
       ));
       expectGatewayRuntime(

--- a/helm/oxscada-full/templates/server-deployment.yaml
+++ b/helm/oxscada-full/templates/server-deployment.yaml
@@ -32,12 +32,20 @@ spec:
               value: "{{ .Values.server.replicaCount }}"
             - name: ENABLE_API_KEYS
               value: {{ .Values.server.apiKeys.enableGlobalAuth | quote }}
+            {{- if .Values.server.apiKeys.enableGlobalAuth }}
+            - name: API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "server.apiKeys.existingSecret is required when API-key authentication is enabled" .Values.server.apiKeys.existingSecret | quote }}
+                  key: {{ $.Values.server.apiKeys.secretKey | quote }}
+            {{- else }}
             {{- with .Values.server.apiKeys.existingSecret }}
             - name: API_KEYS
               valueFrom:
                 secretKeyRef:
                   name: {{ . | quote }}
                   key: {{ $.Values.server.apiKeys.secretKey | quote }}
+            {{- end }}
             {{- end }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}

--- a/helm/oxscada-full/values.yaml
+++ b/helm/oxscada-full/values.yaml
@@ -21,7 +21,7 @@ server:
     secretKey: API_KEYS
     # Enables API key authentication for the entire API gateway. Control-plane
     # routes require API_KEYS independently of this setting.
-    enableGlobalAuth: false
+    enableGlobalAuth: true
   resources:
     requests:
       cpu: 250m

--- a/helm/oxscada/templates/deployment.yaml
+++ b/helm/oxscada/templates/deployment.yaml
@@ -35,12 +35,20 @@ spec:
               value: "{{ $component.replicaCount }}"
             - name: ENABLE_API_KEYS
               value: {{ $component.apiKeys.enableGlobalAuth | quote }}
+            {{- if $component.apiKeys.enableGlobalAuth }}
+            - name: API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "server.apiKeys.existingSecret is required when API-key authentication is enabled" $component.apiKeys.existingSecret | quote }}
+                  key: {{ $component.apiKeys.secretKey | quote }}
+            {{- else }}
             {{- with $component.apiKeys.existingSecret }}
             - name: API_KEYS
               valueFrom:
                 secretKeyRef:
                   name: {{ . | quote }}
                   key: {{ $component.apiKeys.secretKey | quote }}
+            {{- end }}
             {{- end }}
           {{ else if eq $name "gateway" }}
           env:

--- a/helm/oxscada/values.yaml
+++ b/helm/oxscada/values.yaml
@@ -10,10 +10,12 @@ server:
     tag: latest
   port: 5000
   apiKeys:
-    # Existing Secret containing API_KEYS. The chart never generates a default
-    # credential. Control-plane routes remain fail-closed when this is empty.
+    # API_KEYS is read from this pre-created Secret; the chart never generates
+    # or stores an API credential. Control-plane routes remain fail-closed when
+    # this is empty.
     existingSecret: ""
     secretKey: API_KEYS
+    # Require an API key on every non-public route.
     enableGlobalAuth: false
   resources:
     requests:

--- a/helm/oxscada/values.yaml
+++ b/helm/oxscada/values.yaml
@@ -16,7 +16,7 @@ server:
     existingSecret: ""
     secretKey: API_KEYS
     # Require an API key on every non-public route.
-    enableGlobalAuth: false
+    enableGlobalAuth: true
   resources:
     requests:
       cpu: 200m

--- a/k8s/app/server-deployment.yaml
+++ b/k8s/app/server-deployment.yaml
@@ -40,6 +40,13 @@ spec:
               value: production
             - name: PORT
               value: "5000"
+            - name: ENABLE_API_KEYS
+              value: "true"
+            - name: API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: oxscada-api-keys
+                  key: API_KEYS
           resources:
             requests:
               cpu: 200m

--- a/server/__tests__/fuzz/api-gateway.fuzz.test.ts
+++ b/server/__tests__/fuzz/api-gateway.fuzz.test.ts
@@ -119,14 +119,21 @@ describe('Fuzz: ApiKeyManager', () => {
   it('should generate keys that pass validation', () => {
     fc.assert(
       fc.property(
-        fc.string({ minLength: 1, maxLength: 255 }),
-        fc.array(fc.string({ minLength: 1, maxLength: 50 }), { minLength: 1, maxLength: 10 }),
+        fc.string({ minLength: 1, maxLength: 255 })
+          .filter((value) => value.trim().length > 0),
+        fc.array(
+          fc.string({ minLength: 1, maxLength: 50 })
+            .filter((value) => value.trim().length > 0),
+          { minLength: 1, maxLength: 10 },
+        ),
         (name, scopes) => {
           const record = manager.generate(name, scopes);
           expect(record.key).toMatch(/^oxs_/);
           expect(record.key.length).toBe(4 + 64); // prefix + 32 bytes hex
-          expect(record.name).toBe(name);
-          expect(record.scopes).toEqual(scopes);
+          expect(record.name).toBe(name.trim());
+          expect(record.scopes).toEqual(
+            Array.from(new Set(scopes.map((scope) => scope.trim()))),
+          );
 
           // Should be findable in the map
           const keys = manager.getKeysMap();

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,7 +6,8 @@ import { securityHeaders } from "./middleware/security";
 import { log, logError } from "./logger";
 import { healthRouter, healthManager } from "./health";
 import { registerSwaggerRoutes } from "./openapi";
-import { setupApiGateway } from "./middleware/api-gateway";
+import { apiKeyAuthEnabled, setupApiGateway } from "./middleware/api-gateway";
+import { requestLoggingMiddleware } from "./middleware/request-logging";
 import { initializeDatabase } from "./storage";
 // Stateful startup services must stay in the static graph. On Node 20, tsx can
 // give import() a separate module instance from static consumers (#541).
@@ -41,7 +42,7 @@ const gatewayRateLimit = {
 };
 const gatewayConfig = {
   rateLimit: gatewayRateLimit,
-  enableApiKeyAuth: process.env.ENABLE_API_KEYS === 'true',
+  enableApiKeyAuth: apiKeyAuthEnabled(),
   publicRoutes: ['/api/health', '/api/healthz', '/api/readyz', '/api/docs'],
   corsOrigins: (process.env.CORS_ORIGINS || 'http://localhost:3000,http://localhost:5173').split(','),
 };
@@ -65,35 +66,13 @@ app.use(
 
 app.use(express.urlencoded({ extended: false }));
 
+// Install response capture before the gateway's own routes so one-time
+// credentials can be returned while being explicitly redacted from logs.
+app.use(requestLoggingMiddleware());
+
 // Activate the configured gateway after parsing so its payload guard can
 // inspect request bodies. Health probes were mounted above and remain public.
-setupApiGateway(app, gatewayConfig);
-
-app.use((req, res, next) => {
-  const start = Date.now();
-  const path = req.path;
-  let capturedJsonResponse: Record<string, any> | undefined = undefined;
-
-  const originalResJson = res.json;
-  res.json = function (bodyJson, ...args) {
-    capturedJsonResponse = bodyJson;
-    return originalResJson.apply(res, [bodyJson, ...args]);
-  };
-
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    if (path.startsWith("/api")) {
-      let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
-      if (capturedJsonResponse) {
-        logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
-      }
-
-      log(logLine);
-    }
-  });
-
-  next();
-});
+const apiKeyManager = setupApiGateway(app, gatewayConfig);
 
 (async () => {
   // Initialize the database first — downstream services and health checks
@@ -158,7 +137,12 @@ app.use((req, res, next) => {
     log("Initialized demo gateway drivers for development mode");
   }
   
-  await registerRoutes(httpServer, app);
+  await registerRoutes(httpServer, app, {
+    websocketAuth: {
+      required: gatewayConfig.enableApiKeyAuth,
+      apiKeys: apiKeyManager.getKeysMap(),
+    },
+  });
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { serveStatic } from "./static";
 import { createServer } from "http";
-import { securityHeaders, rateLimit } from "./middleware/security";
+import { securityHeaders } from "./middleware/security";
 import { log, logError } from "./logger";
 import { healthRouter, healthManager } from "./health";
 import { registerSwaggerRoutes } from "./openapi";
@@ -25,9 +25,9 @@ export { log } from "./logger";
 const app = express();
 const httpServer = createServer(app);
 
-// Apply security headers and rate limiting
+// Apply security headers. API rate limiting is installed by setupApiGateway
+// after body parsing so one gateway owns authentication and quota state.
 app.use(securityHeaders);
-app.use("/api/", rateLimit({ windowMs: 60_000, maxRequests: 100 }));
 
 // Health/readiness probes — mounted before auth so k8s probes work
 // unauthenticated. Mounted under /api to match the public-route allowlist
@@ -64,6 +64,10 @@ app.use(
 );
 
 app.use(express.urlencoded({ extended: false }));
+
+// Activate the configured gateway after parsing so its payload guard can
+// inspect request bodies. Health probes were mounted above and remain public.
+setupApiGateway(app, gatewayConfig);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/index.ts
+++ b/server/index.ts
@@ -30,11 +30,6 @@ const httpServer = createServer(app);
 // after body parsing so one gateway owns authentication and quota state.
 app.use(securityHeaders);
 
-// Health/readiness probes — mounted before auth so k8s probes work
-// unauthenticated. Mounted under /api to match the public-route allowlist
-// (/api/health, /api/healthz, /api/readyz).
-app.use('/api', healthRouter);
-
 // API Gateway middleware (#256) — sets up rate limiting, API key auth, CORS, request IDs
 const gatewayRateLimit = {
   windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || '60000', 10),
@@ -46,9 +41,6 @@ const gatewayConfig = {
   publicRoutes: ['/api/health', '/api/healthz', '/api/readyz', '/api/docs'],
   corsOrigins: (process.env.CORS_ORIGINS || 'http://localhost:3000,http://localhost:5173').split(','),
 };
-
-// Wire OpenAPI docs to gateway config so Swagger UI reflects live settings
-registerSwaggerRoutes(app, gatewayConfig);
 
 declare module "http" {
   interface IncomingMessage {
@@ -71,8 +63,14 @@ app.use(express.urlencoded({ extended: false }));
 app.use(requestLoggingMiddleware());
 
 // Activate the configured gateway after parsing so its payload guard can
-// inspect request bodies. Health probes were mounted above and remain public.
+// inspect request bodies.
 const apiKeyManager = setupApiGateway(app, gatewayConfig);
+
+// Register every /api route behind the gateway pipeline. The exact probe/docs
+// allowlist skips authentication only; those routes still receive request IDs,
+// CORS, logging, and rate limiting. /api/metrics is intentionally not public.
+app.use('/api', healthRouter);
+registerSwaggerRoutes(app, gatewayConfig);
 
 (async () => {
   // Initialize the database first — downstream services and health checks

--- a/server/middleware/__tests__/api-gateway.test.ts
+++ b/server/middleware/__tests__/api-gateway.test.ts
@@ -2,11 +2,17 @@
  * Tests for [12.2] API Gateway & Rate Limiting
  */
 import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   SlidingWindowRateLimiter,
   ApiKeyManager,
   apiKeyMiddleware,
+  apiKeyAuthEnabled,
+  setupApiGateway,
 } from '../api-gateway';
+import express from 'express';
 
 describe('SlidingWindowRateLimiter', () => {
   let limiter: SlidingWindowRateLimiter;
@@ -99,12 +105,98 @@ describe('ApiKeyManager', () => {
     expect(keys.get('anotherkey')?.scopes).toEqual(['*']);
   });
 
+  it('refuses to generate a key without an explicit scope', () => {
+    expect(() => manager.generate('scope-less', [])).toThrow(
+      'At least one explicit API key scope is required',
+    );
+  });
+
   it('loads a scope-less environment key without implicit privileges', () => {
     process.env.API_KEYS = 'unscoped-key:legacy-client';
     manager.loadFromEnv();
     delete process.env.API_KEYS;
 
     expect(manager.getKeysMap().get('unscoped-key')?.scopes).toEqual([]);
+  });
+});
+
+describe('fail-closed gateway configuration', () => {
+  it('enables authentication by default only in production', () => {
+    expect(apiKeyAuthEnabled({ NODE_ENV: 'production' })).toBe(true);
+    expect(apiKeyAuthEnabled({ NODE_ENV: 'development' })).toBe(false);
+    expect(apiKeyAuthEnabled({ NODE_ENV: 'test' })).toBe(false);
+    expect(() => apiKeyAuthEnabled({
+      NODE_ENV: 'production',
+      ENABLE_API_KEYS: 'yes',
+    })).toThrow('must be either "true" or "false"');
+  });
+
+  it('refuses to start enabled authentication without a bootstrap key', () => {
+    const previousKeys = process.env.API_KEYS;
+    const previousFile = process.env.API_KEYS_FILE;
+    delete process.env.API_KEYS;
+    delete process.env.API_KEYS_FILE;
+    try {
+      expect(() => setupApiGateway(express(), {
+        enableApiKeyAuth: true,
+        apiKeys: new Map(),
+      })).toThrow('no bootstrap key is configured');
+    } finally {
+      if (previousKeys === undefined) delete process.env.API_KEYS;
+      else process.env.API_KEYS = previousKeys;
+      if (previousFile === undefined) delete process.env.API_KEYS_FILE;
+      else process.env.API_KEYS_FILE = previousFile;
+    }
+  });
+
+  it('makes direct gateway setup fail closed by default in production', () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    const previousEnabled = process.env.ENABLE_API_KEYS;
+    const previousKeys = process.env.API_KEYS;
+    const previousFile = process.env.API_KEYS_FILE;
+    process.env.NODE_ENV = 'production';
+    delete process.env.ENABLE_API_KEYS;
+    delete process.env.API_KEYS;
+    delete process.env.API_KEYS_FILE;
+
+    try {
+      expect(() => setupApiGateway(express(), {
+        apiKeys: new Map(),
+      })).toThrow('no bootstrap key is configured');
+    } finally {
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+      if (previousEnabled === undefined) delete process.env.ENABLE_API_KEYS;
+      else process.env.ENABLE_API_KEYS = previousEnabled;
+      if (previousKeys === undefined) delete process.env.API_KEYS;
+      else process.env.API_KEYS = previousKeys;
+      if (previousFile === undefined) delete process.env.API_KEYS_FILE;
+      else process.env.API_KEYS_FILE = previousFile;
+    }
+  });
+
+  it('loads a required bootstrap key from a mounted secret file', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'oxscada-api-keys-'));
+    const secretFile = join(directory, 'api-keys');
+    const previousKeys = process.env.API_KEYS;
+    const previousFile = process.env.API_KEYS_FILE;
+    writeFileSync(secretFile, 'file-key:bootstrap:admin', { mode: 0o600 });
+    delete process.env.API_KEYS;
+    process.env.API_KEYS_FILE = secretFile;
+
+    try {
+      const manager = setupApiGateway(express(), {
+        enableApiKeyAuth: true,
+        apiKeys: new Map(),
+      });
+      expect(manager.getKeysMap().get('file-key')?.scopes).toEqual(['admin']);
+    } finally {
+      if (previousKeys === undefined) delete process.env.API_KEYS;
+      else process.env.API_KEYS = previousKeys;
+      if (previousFile === undefined) delete process.env.API_KEYS_FILE;
+      else process.env.API_KEYS_FILE = previousFile;
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 });
 

--- a/server/middleware/__tests__/api-gateway.test.ts
+++ b/server/middleware/__tests__/api-gateway.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   SlidingWindowRateLimiter,
   ApiKeyManager,
+  apiKeyMiddleware,
 } from '../api-gateway';
 
 describe('SlidingWindowRateLimiter', () => {
@@ -96,5 +97,84 @@ describe('ApiKeyManager', () => {
     expect(keys.has('testkey123')).toBe(true);
     expect(keys.get('testkey123')?.scopes).toEqual(['read', 'write']);
     expect(keys.get('anotherkey')?.scopes).toEqual(['*']);
+  });
+
+  it('loads a scope-less environment key without implicit privileges', () => {
+    process.env.API_KEYS = 'unscoped-key:legacy-client';
+    manager.loadFromEnv();
+    delete process.env.API_KEYS;
+
+    expect(manager.getKeysMap().get('unscoped-key')?.scopes).toEqual([]);
+  });
+});
+
+describe('apiKeyMiddleware', () => {
+  const record = {
+    key: 'header-key',
+    name: 'operator',
+    scopes: ['operator'],
+    createdAt: new Date(),
+  };
+
+  function invoke(
+    originalUrl: string,
+    headers: Record<string, string> = {},
+    publicRoutes: string[] = [],
+  ) {
+    let statusCode = 200;
+    let body: unknown;
+    let nextCalled = false;
+    const req = {
+      originalUrl,
+      headers,
+      query: Object.fromEntries(new URL(originalUrl, 'http://local').searchParams),
+    } as never;
+    const res = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(value: unknown) {
+        body = value;
+        return this;
+      },
+    } as never;
+    apiKeyMiddleware(
+      new Map([[record.key, record]]),
+      publicRoutes,
+    )(req, res, () => {
+      nextCalled = true;
+    });
+    return { statusCode, body, nextCalled, req };
+  }
+
+  it('matches public routes against the full original API path', () => {
+    expect(invoke('/api/health', {}, ['/api/health'])).toMatchObject({
+      statusCode: 200,
+      nextCalled: true,
+    });
+  });
+
+  it('does not treat a public-route prefix collision as public', () => {
+    expect(invoke('/api/health-admin', {}, ['/api/health'])).toMatchObject({
+      statusCode: 401,
+      nextCalled: false,
+    });
+  });
+
+  it('rejects query-string API keys', () => {
+    expect(invoke('/api/private?api_key=header-key')).toMatchObject({
+      statusCode: 401,
+      nextCalled: false,
+    });
+  });
+
+  it('accepts and attaches a valid X-API-Key header', () => {
+    const result = invoke('/api/private', { 'x-api-key': 'header-key' });
+    expect(result).toMatchObject({ statusCode: 200, nextCalled: true });
+    expect(result.req).toMatchObject({
+      apiKeyName: 'operator',
+      apiKeyRecord: record,
+    });
   });
 });

--- a/server/middleware/__tests__/control-route-policy.test.ts
+++ b/server/middleware/__tests__/control-route-policy.test.ts
@@ -25,6 +25,12 @@ const records: ApiKeyRecord[] = [
     createdAt: new Date(),
   },
   {
+    key: "alarm-ingest-key",
+    name: "alarm-ingester",
+    scopes: ["alarms.ingest"],
+    createdAt: new Date(),
+  },
+  {
     key: "tuning-write-key",
     name: "tuning-writer",
     scopes: ["tuning.write"],
@@ -57,6 +63,9 @@ async function startApp(logs: string[] = []): Promise<string> {
   app.post("/api/sites", (_req, res) => res.status(201).json({ created: true }));
   app.post("/api/alarms/phi/check", (_req, res) =>
     res.status(201).json({ checked: true })
+  );
+  app.post("/api/alarm-correlation/alarms", (_req, res) =>
+    res.status(201).json({ ingested: true })
   );
   app.post("/api/tuning/loops/loop-1/tune/relay", (_req, res) =>
     res.status(201).json({ proposed: true })
@@ -110,6 +119,7 @@ describe("control route policy inventory", () => {
         "tuning-proposal-decision",
         "tuning-control",
         "alarm-control",
+        "alarm-correlation-control",
         "geometry-control",
       ]),
     );
@@ -119,6 +129,17 @@ describe("control route policy inventory", () => {
     expect(mutationPolicyFor("POST", "/api/sites")?.scopes).toEqual(["write"]);
     expect(mutationPolicyFor("POST", "/API/SITES")?.scopes).toEqual(["write"]);
     expect(mutationPolicyFor("GET", "/api/sites")).toBeUndefined();
+  });
+
+  it("maps alarm-correlation mutations to its exact action-scope floor", () => {
+    expect(
+      mutationPolicyFor("POST", "/api/alarm-correlation/alarms")?.scopes,
+    ).toEqual([
+      "alarms.ingest",
+      "alarms.acknowledge",
+      "alarms.clear",
+      "alarms.configure",
+    ]);
   });
 });
 
@@ -174,6 +195,19 @@ describe("mutating REST authorization", () => {
     expect((await fetch(`${baseUrl}/api/sites`, {
       method: "POST",
       headers: { "X-API-Key": "alarm-key" },
+    })).status).toBe(403);
+  });
+
+  it("accepts an exact alarm-correlation action scope but rejects generic write", async () => {
+    const baseUrl = await startApp();
+    const path = "/api/alarm-correlation/alarms";
+    expect((await fetch(`${baseUrl}${path}`, {
+      method: "POST",
+      headers: { "X-API-Key": "alarm-ingest-key" },
+    })).status).toBe(201);
+    expect((await fetch(`${baseUrl}${path}`, {
+      method: "POST",
+      headers: { "X-API-Key": "write-key" },
     })).status).toBe(403);
   });
 

--- a/server/middleware/__tests__/control-route-policy.test.ts
+++ b/server/middleware/__tests__/control-route-policy.test.ts
@@ -24,6 +24,18 @@ const records: ApiKeyRecord[] = [
     scopes: ["read", "alarms.write"],
     createdAt: new Date(),
   },
+  {
+    key: "tuning-write-key",
+    name: "tuning-writer",
+    scopes: ["tuning.write"],
+    createdAt: new Date(),
+  },
+  {
+    key: "tuning-approve-key",
+    name: "tuning-approver",
+    scopes: ["tuning.approve"],
+    createdAt: new Date(),
+  },
   { key: "admin-key", name: "admin", scopes: ["admin"], createdAt: new Date() },
 ];
 
@@ -45,6 +57,12 @@ async function startApp(logs: string[] = []): Promise<string> {
   app.post("/api/sites", (_req, res) => res.status(201).json({ created: true }));
   app.post("/api/alarms/phi/check", (_req, res) =>
     res.status(201).json({ checked: true })
+  );
+  app.post("/api/tuning/loops/loop-1/tune/relay", (_req, res) =>
+    res.status(201).json({ proposed: true })
+  );
+  app.post("/api/tuning/proposals/proposal-1/approve", (_req, res) =>
+    res.status(200).json({ approved: true })
   );
 
   const server = createServer(app);
@@ -89,6 +107,7 @@ describe("control route policy inventory", () => {
       expect.arrayContaining([
         "anchor-backend-control",
         "safe-state-resume",
+        "tuning-proposal-decision",
         "tuning-control",
         "alarm-control",
         "geometry-control",
@@ -155,6 +174,30 @@ describe("mutating REST authorization", () => {
     expect((await fetch(`${baseUrl}/api/sites`, {
       method: "POST",
       headers: { "X-API-Key": "alarm-key" },
+    })).status).toBe(403);
+  });
+
+  it("separates tuning proposal creation from human approval authority", async () => {
+    const baseUrl = await startApp();
+    const proposePath = "/api/tuning/loops/loop-1/tune/relay";
+    const approvePath = "/api/tuning/proposals/proposal-1/approve";
+
+    expect((await fetch(`${baseUrl}${proposePath}`, {
+      method: "POST",
+      headers: { "X-API-Key": "tuning-write-key" },
+    })).status).toBe(201);
+    expect((await fetch(`${baseUrl}${approvePath}`, {
+      method: "POST",
+      headers: { "X-API-Key": "tuning-write-key" },
+    })).status).toBe(403);
+
+    expect((await fetch(`${baseUrl}${approvePath}`, {
+      method: "POST",
+      headers: { "X-API-Key": "tuning-approve-key" },
+    })).status).toBe(200);
+    expect((await fetch(`${baseUrl}${proposePath}`, {
+      method: "POST",
+      headers: { "X-API-Key": "tuning-approve-key" },
     })).status).toBe(403);
   });
 

--- a/server/middleware/__tests__/control-route-policy.test.ts
+++ b/server/middleware/__tests__/control-route-policy.test.ts
@@ -1,0 +1,207 @@
+import express from "express";
+import { createServer, request as httpRequest, type Server } from "http";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  setupApiGateway,
+  type ApiKeyRecord,
+} from "../api-gateway";
+import {
+  CONTROL_ROUTE_POLICIES,
+  mutationPolicyFor,
+} from "../control-route-policy";
+import {
+  SENSITIVE_PATH_SEGMENT_MARKER,
+  SENSITIVE_RESPONSE_LOG_MARKER,
+  requestLoggingMiddleware,
+} from "../request-logging";
+
+const records: ApiKeyRecord[] = [
+  { key: "read-key", name: "reader", scopes: ["read"], createdAt: new Date() },
+  { key: "write-key", name: "writer", scopes: ["write"], createdAt: new Date() },
+  {
+    key: "alarm-key",
+    name: "alarm-operator",
+    scopes: ["read", "alarms.write"],
+    createdAt: new Date(),
+  },
+  { key: "admin-key", name: "admin", scopes: ["admin"], createdAt: new Date() },
+];
+
+const openServers: Server[] = [];
+
+async function startApp(logs: string[] = []): Promise<string> {
+  const app = express();
+  app.use(express.json());
+  app.use(requestLoggingMiddleware((line) => logs.push(line)));
+  setupApiGateway(app, {
+    enableApiKeyAuth: true,
+    apiKeys: new Map(records.map((record) => [record.key, record])),
+    publicRoutes: ["/api/healthz"],
+    rateLimit: { windowMs: 60_000, maxRequests: 1000 },
+    corsOrigins: [],
+  });
+  app.get("/api/healthz", (_req, res) => res.json({ status: "ok" }));
+  app.get("/api/sites", (_req, res) => res.json({ ok: true }));
+  app.post("/api/sites", (_req, res) => res.status(201).json({ created: true }));
+  app.post("/api/alarms/phi/check", (_req, res) =>
+    res.status(201).json({ checked: true })
+  );
+
+  const server = createServer(app);
+  openServers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Missing test address");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function absoluteFormMutation(
+  baseUrl: string,
+  path: string,
+  apiKey: string,
+): Promise<number> {
+  const target = new URL(baseUrl);
+  return new Promise<number>((resolve, reject) => {
+    const request = httpRequest({
+      hostname: target.hostname,
+      port: target.port,
+      method: "POST",
+      path: `${baseUrl}${path}`,
+      headers: { "X-API-Key": apiKey },
+    }, (response) => {
+      response.resume();
+      resolve(response.statusCode ?? 0);
+    });
+    request.once("error", reject);
+    request.end();
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(openServers.splice(0).map((server) =>
+    new Promise<void>((resolve) => server.close(() => resolve()))
+  ));
+});
+
+describe("control route policy inventory", () => {
+  it("keeps safety-sensitive route families explicit", () => {
+    expect(CONTROL_ROUTE_POLICIES.map((policy) => policy.id)).toEqual(
+      expect.arrayContaining([
+        "anchor-backend-control",
+        "safe-state-resume",
+        "tuning-control",
+        "alarm-control",
+        "geometry-control",
+      ]),
+    );
+  });
+
+  it("assigns write to unlisted mutations and nothing to reads", () => {
+    expect(mutationPolicyFor("POST", "/api/sites")?.scopes).toEqual(["write"]);
+    expect(mutationPolicyFor("POST", "/API/SITES")?.scopes).toEqual(["write"]);
+    expect(mutationPolicyFor("GET", "/api/sites")).toBeUndefined();
+  });
+});
+
+describe("mutating REST authorization", () => {
+  it("keeps health probes public when authentication is enabled", async () => {
+    const baseUrl = await startApp();
+    expect((await fetch(`${baseUrl}/api/healthz`)).status).toBe(200);
+  });
+
+  it("allows reads but denies ordinary mutations to a read-only key", async () => {
+    const baseUrl = await startApp();
+    expect((await fetch(`${baseUrl}/api/sites`, {
+      headers: { "X-API-Key": "read-key" },
+    })).status).toBe(200);
+    expect((await fetch(`${baseUrl}/api/sites`, {
+      method: "POST",
+      headers: { "X-API-Key": "read-key" },
+    })).status).toBe(403);
+  });
+
+  it("cannot bypass mutation policy with an absolute-form request target", async () => {
+    const baseUrl = await startApp();
+    expect(await absoluteFormMutation(baseUrl, "/api/sites", "read-key"))
+      .toBe(403);
+  });
+
+  it("cannot bypass mutation policy with case-variant routing", async () => {
+    const baseUrl = await startApp();
+    expect((await fetch(`${baseUrl}/API/SITES`, {
+      method: "POST",
+      headers: { "X-API-Key": "read-key" },
+    })).status).toBe(403);
+  });
+
+  it("allows a write key on ordinary mutations but not alarm control", async () => {
+    const baseUrl = await startApp();
+    expect((await fetch(`${baseUrl}/api/sites`, {
+      method: "POST",
+      headers: { "X-API-Key": "write-key" },
+    })).status).toBe(201);
+    expect((await fetch(`${baseUrl}/api/alarms/phi/check`, {
+      method: "POST",
+      headers: { "X-API-Key": "write-key" },
+    })).status).toBe(403);
+  });
+
+  it("allows the narrow alarm scope only on alarm control", async () => {
+    const baseUrl = await startApp();
+    expect((await fetch(`${baseUrl}/api/alarms/phi/check`, {
+      method: "POST",
+      headers: { "X-API-Key": "alarm-key" },
+    })).status).toBe(201);
+    expect((await fetch(`${baseUrl}/api/sites`, {
+      method: "POST",
+      headers: { "X-API-Key": "alarm-key" },
+    })).status).toBe(403);
+  });
+
+  it("requires explicit nonempty scopes and redacts a returned key from logs", async () => {
+    const logs: string[] = [];
+    const baseUrl = await startApp(logs);
+
+    const invalid = await fetch(`${baseUrl}/api/v1/gateway/keys`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "admin-key",
+      },
+      body: JSON.stringify({ name: "scope-less" }),
+    });
+    expect(invalid.status).toBe(400);
+
+    const created = await fetch(`${baseUrl}/api/v1/gateway/keys`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "admin-key",
+      },
+      body: JSON.stringify({ name: "dashboard", scopes: ["read", "stream.read"] }),
+    });
+    expect(created.status).toBe(201);
+    expect(created.headers.get("cache-control")).toBe("no-store");
+    const body = await created.json() as { key: string };
+    expect(body.key).toMatch(/^oxs_/);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(logs.join("\n")).toContain(SENSITIVE_RESPONSE_LOG_MARKER);
+    expect(logs.join("\n")).not.toContain(body.key);
+
+    const revoked = await fetch(
+      `${baseUrl}/API/V1/GATEWAY/KEYS/${encodeURIComponent(body.key)}`,
+      {
+        method: "DELETE",
+        headers: { "X-API-Key": "admin-key" },
+      },
+    );
+    expect(revoked.status).toBe(200);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(logs.join("\n")).toContain(
+      `/API/V1/GATEWAY/KEYS/${SENSITIVE_PATH_SEGMENT_MARKER}`,
+    );
+    expect(logs.join("\n")).not.toContain(body.key);
+  });
+});

--- a/server/middleware/__tests__/deployment-auth-defaults.test.ts
+++ b/server/middleware/__tests__/deployment-auth-defaults.test.ts
@@ -18,12 +18,17 @@ describe("production deployment API-key defaults", () => {
   });
 
   it("requires a file-backed bootstrap secret in Docker Compose", () => {
-    const compose = repositoryFile("docker-compose.yml");
-    expect(compose).toContain("ENABLE_API_KEYS=${ENABLE_API_KEYS:-true}");
-    expect(compose).toContain("API_KEYS_FILE=/run/secrets/api_keys");
-    expect(compose).toContain(
-      "${API_KEYS_FILE:?Set API_KEYS_FILE to a bootstrap API-key secret file}",
-    );
+    for (const composeFile of [
+      "docker-compose.yml",
+      "docker/edge/docker-compose.yml",
+    ]) {
+      const compose = repositoryFile(composeFile);
+      expect(compose).toContain("ENABLE_API_KEYS=${ENABLE_API_KEYS:-true}");
+      expect(compose).toContain("API_KEYS_FILE=/run/secrets/api_keys");
+      expect(compose).toContain(
+        "${API_KEYS_FILE:?Set API_KEYS_FILE to a bootstrap API-key secret file}",
+      );
+    }
   });
 
   it("defaults both Helm charts on and requires an existing Secret", () => {
@@ -44,5 +49,14 @@ describe("production deployment API-key defaults", () => {
         "server.apiKeys.existingSecret is required when API-key authentication is enabled",
       );
     }
+  });
+
+  it("injects a required bootstrap key into the raw Kubernetes deployment", () => {
+    const deployment = repositoryFile("k8s/app/server-deployment.yaml");
+    expect(deployment).toContain("name: ENABLE_API_KEYS");
+    expect(deployment).toContain('value: "true"');
+    expect(deployment).toContain("name: API_KEYS");
+    expect(deployment).toContain("name: oxscada-api-keys");
+    expect(deployment).toContain("key: API_KEYS");
   });
 });

--- a/server/middleware/__tests__/deployment-auth-defaults.test.ts
+++ b/server/middleware/__tests__/deployment-auth-defaults.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function repositoryFile(path: string): string {
+  return readFileSync(resolve(process.cwd(), path), "utf8");
+}
+
+describe("production deployment API-key defaults", () => {
+  it("enables authentication in each production Docker image", () => {
+    for (const dockerfile of [
+      "Dockerfile",
+      "docker/server/Dockerfile",
+      "docker/edge/Dockerfile",
+    ]) {
+      expect(repositoryFile(dockerfile)).toContain("ENABLE_API_KEYS=true");
+    }
+  });
+
+  it("requires a file-backed bootstrap secret in Docker Compose", () => {
+    const compose = repositoryFile("docker-compose.yml");
+    expect(compose).toContain("ENABLE_API_KEYS=${ENABLE_API_KEYS:-true}");
+    expect(compose).toContain("API_KEYS_FILE=/run/secrets/api_keys");
+    expect(compose).toContain(
+      "${API_KEYS_FILE:?Set API_KEYS_FILE to a bootstrap API-key secret file}",
+    );
+  });
+
+  it("defaults both Helm charts on and requires an existing Secret", () => {
+    for (const valuesFile of [
+      "helm/oxscada/values.yaml",
+      "helm/oxscada-full/values.yaml",
+    ]) {
+      expect(repositoryFile(valuesFile)).toMatch(
+        /enableGlobalAuth:\s*true/u,
+      );
+    }
+
+    for (const templateFile of [
+      "helm/oxscada/templates/deployment.yaml",
+      "helm/oxscada-full/templates/server-deployment.yaml",
+    ]) {
+      expect(repositoryFile(templateFile)).toContain(
+        "server.apiKeys.existingSecret is required when API-key authentication is enabled",
+      );
+    }
+  });
+});

--- a/server/middleware/__tests__/deployment-auth-defaults.test.ts
+++ b/server/middleware/__tests__/deployment-auth-defaults.test.ts
@@ -7,6 +7,22 @@ function repositoryFile(path: string): string {
 }
 
 describe("production deployment API-key defaults", () => {
+  it("registers all API routes behind the gateway pipeline", () => {
+    const startup = repositoryFile("server/index.ts");
+    const gatewayIndex = startup.indexOf(
+      "const apiKeyManager = setupApiGateway(app, gatewayConfig);",
+    );
+    const healthIndex = startup.indexOf("app.use('/api', healthRouter);");
+    const swaggerIndex = startup.indexOf(
+      "registerSwaggerRoutes(app, gatewayConfig);",
+    );
+
+    expect(gatewayIndex).toBeGreaterThanOrEqual(0);
+    expect(healthIndex).toBeGreaterThan(gatewayIndex);
+    expect(swaggerIndex).toBeGreaterThan(gatewayIndex);
+    expect(startup).not.toContain("'/api/metrics'");
+  });
+
   it("enables authentication in each production Docker image", () => {
     for (const dockerfile of [
       "Dockerfile",

--- a/server/middleware/api-gateway.ts
+++ b/server/middleware/api-gateway.ts
@@ -10,12 +10,14 @@
 
 import { Request, Response, NextFunction, Router, Express } from 'express';
 import crypto from 'crypto';
+import { readFileSync } from 'fs';
 import { z, ZodSchema } from 'zod';
 import {
   createRateLimiter,
   type CreateRateLimiterOptions,
   type RateLimitConfig,
 } from './rate-limiter';
+import { mutationAuthorizationMiddleware } from './control-route-policy';
 
 // Limiter implementations live in ./rate-limiter (issue #447); re-exported
 // here so existing imports keep working.
@@ -58,6 +60,20 @@ const DEFAULT_CONFIG: ApiGatewayConfig = {
   trustedProxies: [],
   publicRoutes: ['/api/health', '/api/healthz', '/api/readyz'],
 };
+
+/**
+ * Production is fail-closed when ENABLE_API_KEYS is omitted. Development and
+ * tests remain explicitly opt-in; malformed values abort startup.
+ */
+export function apiKeyAuthEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const configured = env.ENABLE_API_KEYS?.trim().toLowerCase();
+  if (configured === 'true') return true;
+  if (configured === 'false') return false;
+  if (configured) {
+    throw new Error('ENABLE_API_KEYS must be either "true" or "false"');
+  }
+  return env.NODE_ENV === 'production';
+}
 
 // --- Middleware Functions ---
 
@@ -170,7 +186,10 @@ export function requireScope(...scopes: string[]) {
       return;
     }
 
-    const hasScope = scopes.some(s => record.scopes.includes(s) || record.scopes.includes('*'));
+    const hasScope =
+      record.scopes.includes('*') ||
+      record.scopes.includes('admin') ||
+      scopes.some(s => record.scopes.includes(s));
     if (!hasScope) {
       res.status(403).json({ error: 'Insufficient scope', required: scopes, granted: record.scopes });
       return;
@@ -289,11 +308,28 @@ export class ApiKeyManager {
 
   /** Generate a new API key */
   generate(name: string, scopes: string[], expiresInDays?: number): ApiKeyRecord {
+    const normalizedName = name.trim();
+    const normalizedScopes = Array.from(new Set(
+      scopes.map((scope) => scope.trim()).filter(Boolean),
+    ));
+    if (!normalizedName) {
+      throw new Error('API key name must be non-empty');
+    }
+    if (normalizedScopes.length === 0) {
+      throw new Error('At least one explicit API key scope is required');
+    }
+    if (
+      expiresInDays !== undefined &&
+      (!Number.isInteger(expiresInDays) || expiresInDays <= 0)
+    ) {
+      throw new Error('expiresInDays must be a positive integer');
+    }
+
     const key = `oxs_${crypto.randomBytes(32).toString('hex')}`;
     const record: ApiKeyRecord = {
       key,
-      name,
-      scopes,
+      name: normalizedName,
+      scopes: normalizedScopes,
       createdAt: new Date(),
       expiresAt: expiresInDays
         ? new Date(Date.now() + expiresInDays * 86_400_000)
@@ -321,7 +357,22 @@ export class ApiKeyManager {
 
   /** Load keys from environment variable (comma-separated key:name:scopes) */
   loadFromEnv(envVar = 'API_KEYS'): void {
-    const raw = process.env[envVar];
+    const inline = process.env[envVar]?.trim();
+    const secretFile = envVar === 'API_KEYS'
+      ? process.env.API_KEYS_FILE?.trim()
+      : undefined;
+    let raw = inline;
+
+    if (!raw && secretFile) {
+      try {
+        raw = readFileSync(secretFile, 'utf8').trim();
+      } catch (error) {
+        throw new Error(
+          `Unable to read API key secret file "${secretFile}": ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
     if (!raw) return;
 
     for (const entry of raw.split(',')) {
@@ -352,6 +403,7 @@ export function setupApiGateway(app: Express, config: Partial<ApiGatewayConfig> 
     ...DEFAULT_CONFIG,
     ...config,
     apiKeys: config.apiKeys ?? DEFAULT_CONFIG.apiKeys,
+    enableApiKeyAuth: config.enableApiKeyAuth ?? apiKeyAuthEnabled(),
   };
 
   const keyManager = new ApiKeyManager();
@@ -362,12 +414,20 @@ export function setupApiGateway(app: Express, config: Partial<ApiGatewayConfig> 
     keyManager.getKeysMap().set(k, v);
   }
 
+  if (cfg.enableApiKeyAuth && keyManager.getKeysMap().size === 0) {
+    throw new Error(
+      'API key authentication is enabled but no bootstrap key is configured. ' +
+      'Set API_KEYS or API_KEYS_FILE before starting the server.',
+    );
+  }
+
   // Order matters
   app.use(requestIdMiddleware());
   app.use(corsMiddleware(cfg.corsOrigins));
   app.use('/api/', rateLimitMiddleware(cfg.rateLimit));
   if (cfg.enableApiKeyAuth) {
     app.use('/api/', apiKeyMiddleware(keyManager.getKeysMap(), cfg.publicRoutes));
+    app.use('/api/', mutationAuthorizationMiddleware());
   }
   app.use(requestValidation());
 
@@ -377,12 +437,29 @@ export function setupApiGateway(app: Express, config: Partial<ApiGatewayConfig> 
   });
 
   app.post('/api/v1/gateway/keys', requireScope('admin'), (req, res) => {
-    const { name, scopes, expiresInDays } = req.body;
-    if (!name) {
-      res.status(400).json({ error: 'name is required' });
+    const parsed = z.object({
+      name: z.string().trim().min(1).max(100),
+      scopes: z.array(z.string().trim().min(1).max(100)).min(1),
+      expiresInDays: z.number().int().positive().max(3650).optional(),
+    }).strict().safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'name and at least one explicit scope are required',
+        details: parsed.error.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        })),
+      });
       return;
     }
-    const record = keyManager.generate(name, scopes || ['*'], expiresInDays);
+
+    const { name, scopes, expiresInDays } = parsed.data;
+    const record = keyManager.generate(name, scopes, expiresInDays);
+    // The plaintext credential is returned once to the caller but must never
+    // be serialized by the response logger.
+    res.locals.sensitiveResponse = true;
+    res.setHeader('Cache-Control', 'no-store');
     res.status(201).json({ key: record.key, name: record.name, scopes: record.scopes, expiresAt: record.expiresAt });
   });
 

--- a/server/middleware/api-gateway.ts
+++ b/server/middleware/api-gateway.ts
@@ -127,13 +127,18 @@ export function rateLimitMiddleware(config: RateLimitConfig, limiterOptions?: Cr
 export function apiKeyMiddleware(keys: Map<string, ApiKeyRecord>, publicRoutes: string[] = []) {
   return (req: Request, res: Response, next: NextFunction): void => {
     // Skip auth for public routes
-    if (publicRoutes.some(route => req.path.startsWith(route))) {
+    const requestPath = req.originalUrl.split('?', 1)[0];
+    if (publicRoutes.some(route =>
+      requestPath === route || requestPath.startsWith(`${route}/`)
+    )) {
       return next();
     }
 
-    const key = (req.headers['x-api-key'] as string) || req.query.api_key as string;
+    // Query-string credentials leak through browser history, proxies, and
+    // access logs. Accept API keys only through the standard request header.
+    const key = req.headers['x-api-key'] as string | undefined;
     if (!key) {
-      res.status(401).json({ error: 'Missing API key. Provide via X-API-Key header or api_key query parameter.' });
+      res.status(401).json({ error: 'Missing API key. Provide via X-API-Key header.' });
       return;
     }
 
@@ -323,6 +328,7 @@ export class ApiKeyManager {
       const [key, name, scopeStr] = entry.trim().split(':');
       if (key && name) {
         // Missing scopes must never silently create an all-powerful key.
+        // Operators can grant `*` explicitly when that is truly intended.
         const scopes = scopeStr ? scopeStr.split('+').filter(Boolean) : [];
         this.keys.set(key, {
           key,

--- a/server/middleware/control-plane-auth.ts
+++ b/server/middleware/control-plane-auth.ts
@@ -32,16 +32,19 @@ export interface ControlPlaneAccess {
   scopes?: readonly string[];
 }
 
-let cachedApiKeysRaw: string | undefined;
+let cachedApiKeysSignature: string | undefined;
 let cachedApiKeys = new Map<string, ApiKeyRecord>();
 
 function configuredApiKeys(): Map<string, ApiKeyRecord> {
-  const raw = process.env.API_KEYS;
-  if (raw === cachedApiKeysRaw) return cachedApiKeys;
+  const signature = JSON.stringify([
+    process.env.API_KEYS ?? null,
+    process.env.API_KEYS_FILE ?? null,
+  ]);
+  if (signature === cachedApiKeysSignature) return cachedApiKeys;
 
   const manager = new ApiKeyManager();
   manager.loadFromEnv();
-  cachedApiKeysRaw = raw;
+  cachedApiKeysSignature = signature;
   cachedApiKeys = manager.getKeysMap();
   return cachedApiKeys;
 }
@@ -145,6 +148,6 @@ export function controlPlanePrincipal(req: Request): ControlPlanePrincipal {
 
 /** Test hook for environment-isolated authentication tests. */
 export function _resetControlPlaneAuthCache(): void {
-  cachedApiKeysRaw = undefined;
+  cachedApiKeysSignature = undefined;
   cachedApiKeys = new Map();
 }

--- a/server/middleware/control-route-policy.ts
+++ b/server/middleware/control-route-policy.ts
@@ -55,6 +55,19 @@ export const CONTROL_ROUTE_POLICIES: readonly ControlRoutePolicy[] = Object.free
     description: "Change tuning envelopes or create tuning proposals.",
   },
   {
+    id: "alarm-correlation-control",
+    pathPrefix: "/api/alarm-correlation",
+    scopes: Object.freeze([
+      "alarms.ingest",
+      "alarms.acknowledge",
+      "alarms.clear",
+      "alarms.configure",
+    ]),
+    description:
+      "Mutate alarm-correlation input, lifecycle, rules, topology, or policy. "
+      + "Route-local guards enforce the exact per-action scope.",
+  },
+  {
     id: "alarm-control",
     pathPrefix: "/api/alarms",
     scopes: Object.freeze(["alarms.write"]),

--- a/server/middleware/control-route-policy.ts
+++ b/server/middleware/control-route-policy.ts
@@ -43,10 +43,16 @@ export const CONTROL_ROUTE_POLICIES: readonly ControlRoutePolicy[] = Object.free
     description: "Resume a blueprint from a fail-closed safe state.",
   },
   {
+    id: "tuning-proposal-decision",
+    pathPrefix: "/api/tuning/proposals",
+    scopes: Object.freeze(["tuning.approve"]),
+    description: "Approve or reject a pending tuning proposal.",
+  },
+  {
     id: "tuning-control",
     pathPrefix: "/api/tuning",
-    scopes: Object.freeze(["tuning.write", "tuning.approve"]),
-    description: "Change tuning envelopes, proposals, or approval state.",
+    scopes: Object.freeze(["tuning.write"]),
+    description: "Change tuning envelopes or create tuning proposals.",
   },
   {
     id: "alarm-control",

--- a/server/middleware/control-route-policy.ts
+++ b/server/middleware/control-route-policy.ts
@@ -1,0 +1,155 @@
+/**
+ * Central authorization inventory for mutating HTTP routes.
+ *
+ * Every mutating /api request receives at least the default `write` policy.
+ * Safety-sensitive prefixes are listed explicitly with narrower scopes. Route
+ * modules may add a stricter guard; this inventory is the gateway-level floor.
+ */
+
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import type { ApiKeyRecord } from "./api-gateway";
+
+export const MUTATING_HTTP_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+export interface ControlRoutePolicy {
+  id: string;
+  pathPrefix: string;
+  scopes: readonly string[];
+  description: string;
+}
+/**
+ * Ordered most-specific first. Prefixes match only complete path segments.
+ *
+ * Future focused feature branches already use the tuning and safe-state
+ * prefixes below, so merging them cannot silently fall back to broad `write`.
+ */
+export const CONTROL_ROUTE_POLICIES: readonly ControlRoutePolicy[] = Object.freeze([
+  {
+    id: "gateway-key-administration",
+    pathPrefix: "/api/v1/gateway/keys",
+    scopes: Object.freeze(["admin"]),
+    description: "Create and revoke API credentials.",
+  },
+  {
+    id: "anchor-backend-control",
+    pathPrefix: "/api/admin/anchor-backend",
+    scopes: Object.freeze(["anchor.admin"]),
+    description: "Change the live event anchoring backend.",
+  },
+  {
+    id: "safe-state-resume",
+    pathPrefix: "/api/blueprint-safe-state",
+    scopes: Object.freeze(["safety.resume"]),
+    description: "Resume a blueprint from a fail-closed safe state.",
+  },
+  {
+    id: "tuning-control",
+    pathPrefix: "/api/tuning",
+    scopes: Object.freeze(["tuning.write", "tuning.approve"]),
+    description: "Change tuning envelopes, proposals, or approval state.",
+  },
+  {
+    id: "alarm-control",
+    pathPrefix: "/api/alarms",
+    scopes: Object.freeze(["alarms.write"]),
+    description: "Inject, evaluate, acknowledge, or suppress alarms.",
+  },
+  {
+    id: "geometry-control",
+    pathPrefix: "/api/geometry",
+    scopes: Object.freeze(["geometry.write"]),
+    description: "Change classification rules or trigger recalibration.",
+  },
+  {
+    id: "digital-twin-control",
+    pathPrefix: "/api/intelligence/digitaltwin/operate",
+    scopes: Object.freeze(["control.write"]),
+    description: "Operate a digital twin against control inputs.",
+  },
+  {
+    id: "hsm-control",
+    pathPrefix: "/api/security/hsm/operation",
+    scopes: Object.freeze(["security.admin"]),
+    description: "Execute an HSM-backed security operation.",
+  },
+  {
+    id: "websocket-administration",
+    pathPrefix: "/api/ws/clients",
+    scopes: Object.freeze(["websocket.admin"]),
+    description: "Disconnect or otherwise administer streaming clients.",
+  },
+]);
+
+export const DEFAULT_MUTATION_POLICY: ControlRoutePolicy = Object.freeze({
+  id: "default-api-mutation",
+  pathPrefix: "/api",
+  scopes: Object.freeze(["write"]),
+  description: "Create, update, or delete an API resource.",
+});
+
+function requestPath(req: Request): string {
+  // Use Express's parsed mount path rather than raw `originalUrl`. HTTP
+  // proxies may send an absolute-form request target; matching the raw value
+  // would let that valid request bypass a `/api` prefix policy.
+  return `${req.baseUrl}${req.path}` || "/";
+}
+
+function pathMatchesPrefix(path: string, prefix: string): boolean {
+  // Express routing is case-insensitive unless explicitly configured
+  // otherwise, so authorization matching must be equally case-insensitive.
+  const normalizedPath = path.toLowerCase();
+  const normalizedPrefix = prefix.toLowerCase();
+  return normalizedPath === normalizedPrefix ||
+    normalizedPath.startsWith(`${normalizedPrefix}/`);
+}
+
+export function mutationPolicyFor(
+  method: string,
+  path: string,
+): ControlRoutePolicy | undefined {
+  if (!MUTATING_HTTP_METHODS.has(method.toUpperCase())) return undefined;
+  if (!pathMatchesPrefix(path, "/api")) return undefined;
+
+  return CONTROL_ROUTE_POLICIES.find((policy) =>
+    pathMatchesPrefix(path, policy.pathPrefix)
+  ) ?? DEFAULT_MUTATION_POLICY;
+}
+
+function isPrivileged(record: ApiKeyRecord): boolean {
+  return record.scopes.includes("*") || record.scopes.includes("admin");
+}
+
+function permits(record: ApiKeyRecord, policy: ControlRoutePolicy): boolean {
+  return isPrivileged(record) ||
+    policy.scopes.some((scope) => record.scopes.includes(scope));
+}
+
+/**
+ * Enforce the central mutation policy after API-key authentication.
+ */
+export function mutationAuthorizationMiddleware(): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const policy = mutationPolicyFor(req.method, requestPath(req));
+    if (!policy) {
+      next();
+      return;
+    }
+
+    const record = (req as Request & { apiKeyRecord?: ApiKeyRecord }).apiKeyRecord;
+    if (!record) {
+      res.status(401).json({ error: "Authentication required" });
+      return;
+    }
+
+    if (!permits(record, policy)) {
+      res.status(403).json({
+        error: "Insufficient scope",
+        policy: policy.id,
+        required: policy.scopes,
+      });
+      return;
+    }
+
+    next();
+  };
+}

--- a/server/middleware/request-logging.ts
+++ b/server/middleware/request-logging.ts
@@ -1,0 +1,82 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import { log } from "../logger";
+
+export const SENSITIVE_RESPONSE_LOG_MARKER = "[sensitive response redacted]";
+export const SENSITIVE_PATH_SEGMENT_MARKER = "[redacted]";
+
+declare global {
+  namespace Express {
+    interface Locals {
+      sensitiveResponse?: boolean;
+    }
+  }
+}
+
+export interface RequestLogDetails {
+  method: string;
+  path: string;
+  statusCode: number;
+  durationMs: number;
+  responseBody?: unknown;
+  sensitiveResponse?: boolean;
+}
+
+/**
+ * Key revocation identifies the credential in the route path. Preserve the
+ * route shape for operations while ensuring the bearer secret never reaches
+ * access logs.
+ */
+export function redactSensitiveRequestPath(path: string): string {
+  return path.replace(
+    /^(\/api\/v1\/gateway\/keys\/)[^/]+(?=\/?$)/iu,
+    `$1${SENSITIVE_PATH_SEGMENT_MARKER}`,
+  );
+}
+
+/** Build a deterministic log line without ever serializing marked secrets. */
+export function formatRequestLog(details: RequestLogDetails): string {
+  let line =
+    `${details.method} ${details.path} ${details.statusCode} in ${details.durationMs}ms`;
+
+  if (details.sensitiveResponse) {
+    return `${line} :: ${SENSITIVE_RESPONSE_LOG_MARKER}`;
+  }
+  if (details.responseBody !== undefined) {
+    line += ` :: ${JSON.stringify(details.responseBody)}`;
+  }
+  return line;
+}
+
+/**
+ * Capture JSON responses for API request logging. Handlers that return a
+ * one-time credential set `res.locals.sensitiveResponse` before responding.
+ */
+export function requestLoggingMiddleware(
+  writeLog: (line: string) => void = log,
+): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const startedAt = Date.now();
+    const path = req.path;
+    let capturedJsonResponse: unknown;
+
+    const originalJson = res.json;
+    res.json = function captureJson(body, ...args) {
+      capturedJsonResponse = body;
+      return originalJson.apply(res, [body, ...args]);
+    };
+
+    res.on("finish", () => {
+      if (!path.toLowerCase().startsWith("/api")) return;
+      writeLog(formatRequestLog({
+        method: req.method,
+        path: redactSensitiveRequestPath(path),
+        statusCode: res.statusCode,
+        durationMs: Date.now() - startedAt,
+        responseBody: capturedJsonResponse,
+        sensitiveResponse: res.locals.sensitiveResponse === true,
+      }));
+    });
+
+    next();
+  };
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -29,10 +29,16 @@ import { getFluxPublisher } from "./services/flux";
 
 import { tagStreamServer } from "./websocket/tag-stream";
 import { unifiedStreamServer } from "./websocket/unified-stream";
+import type { WebSocketAuthOptions } from "./websocket/upgrade-auth";
+
+export interface RouteRegistrationOptions {
+  websocketAuth?: WebSocketAuthOptions;
+}
 
 export async function registerRoutes(
   httpServer: Server,
-  app: Express
+  app: Express,
+  options: RouteRegistrationOptions = {},
 ): Promise<Server> {
 
   // ==========================================================================
@@ -79,9 +85,14 @@ export async function registerRoutes(
   // ==========================================================================
   // WEBSOCKET EVENT STREAM
   // ==========================================================================
-  // WebSocket servers initialize if available
-  try { tagStreamServer?.initialize(httpServer, "/ws/tags"); } catch {}
-  try { unifiedStreamServer?.initialize(httpServer, "/ws"); } catch {}  // unified endpoint (#255)
+  // Authentication runs in the HTTP upgrade handler because WebSocket
+  // handshakes bypass Express middleware.
+  const websocketAuth = options.websocketAuth ?? {
+    required: false,
+    apiKeys: new Map(),
+  };
+  tagStreamServer.initialize(httpServer, "/ws/tags", websocketAuth);
+  unifiedStreamServer.initialize(httpServer, "/ws", websocketAuth); // unified endpoint (#255)
 
   // WebSocket metrics endpoint. The legacy event-stream server was removed;
   // only the tag and unified streams report (#446, #479).

--- a/server/routes/alarms.ts
+++ b/server/routes/alarms.ts
@@ -1,17 +1,12 @@
 import { Router } from "express";
 import { PhiAlertingService } from "../services/geometry/phi-alerting";
 import { getFluxPublisher } from "../services/flux";
+import { requireControlPlaneAccess } from "../middleware/control-plane-auth";
 
 const router = Router();
-
-// Auth middleware placeholder — same pattern as other protected routes
-function requireAuth(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) {
-  // TODO: implement real auth check (JWT / session validation)
-  // For now, allow all requests through (placeholder)
-  next();
-}
-
-router.use(requireAuth);
+const requireAlarmWrite = requireControlPlaneAccess({
+  scopes: ["alarms.write"],
+});
 
 // Phi alerting instance — must be initialized explicitly via initPhiAlerting()
 let _phiAlerting: PhiAlertingService | null = null;
@@ -54,7 +49,7 @@ router.get("/phi/history", async (req, res) => {
   res.json({ history: getPhiAlerting().getHistory() });
 });
 
-router.post("/phi/check", async (req, res) => {
+router.post("/phi/check", requireAlarmWrite, async (_req, res) => {
   const alarm = getPhiAlerting().check();
   res.json({ alarm: alarm || null, message: alarm ? "Alarm raised" : "Phi within thresholds" });
 });

--- a/server/routes/geometry.ts
+++ b/server/routes/geometry.ts
@@ -11,32 +11,19 @@
  * POST /api/geometry/recalibrate      — re-classify all entities (#336)
  */
 
-import { Router, type Request, type Response, type NextFunction } from "express";
+import { Router, type Request, type Response } from "express";
 import { FluxPublisher } from "../services/flux/index.js";
 import { FANO_LINES, isFanoRelated, geometricSimilarity } from "../services/geometry/fano.js";
 import { decodeClassIndex, Quadrant, Triality, type ClassComponents } from "../services/geometry/types.js";
 import { classify, classifyEntity } from "../services/geometry/classifier.js";
+import { requireControlPlaneAccess } from "../middleware/control-plane-auth";
 
 /** Max allowed regex pattern length to mitigate ReDoS */
 const MAX_REGEX_PATTERN_LENGTH = 200;
 
-/** Simple auth middleware — checks for Bearer token or session */
-function requireAuth(req: Request, res: Response, next: NextFunction): void {
-  const authHeader = req.headers.authorization;
-  if (authHeader && authHeader.startsWith("Bearer ")) {
-    // Token-based auth — delegate to existing auth infrastructure
-    next();
-    return;
-  }
-  // Session-based auth
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- session types vary by auth middleware
-  const r = req as Request & { session?: { userId?: string }; user?: unknown };
-  if (r.session?.userId || r.user) {
-    next();
-    return;
-  }
-  res.status(401).json({ error: "Authentication required" });
-}
+const requireGeometryWrite = requireControlPlaneAccess({
+  scopes: ["geometry.write"],
+});
 
 /** Validate and sanitize a regex pattern string */
 function validateRegexPattern(pattern: string): { valid: boolean; error?: string } {
@@ -285,7 +272,7 @@ export function geometryRoutes(fluxPublisher: FluxPublisher | null): Router {
   });
 
   // ── Custom classification rules (#336) ─────────────────────────────────────
-  router.post("/rules", requireAuth, (req: Request, res: Response) => {
+  router.post("/rules", requireGeometryWrite, (req: Request, res: Response) => {
     const { pattern, quadrant, triality, slot } = req.body || {};
     if (!pattern || typeof pattern !== "string") {
       return res.status(400).json({ error: "pattern (string) is required" });
@@ -319,7 +306,7 @@ export function geometryRoutes(fluxPublisher: FluxPublisher | null): Router {
   });
 
   // ── Recalibrate all entities (#336) ────────────────────────────────────────
-  router.post("/recalibrate", requireAuth, (_req: Request, res: Response) => {
+  router.post("/recalibrate", requireGeometryWrite, (_req: Request, res: Response) => {
     if (!fluxPublisher) {
       return res.status(503).json({ error: "Flux publisher not configured" });
     }

--- a/server/websocket/__tests__/upgrade-auth.test.ts
+++ b/server/websocket/__tests__/upgrade-auth.test.ts
@@ -1,0 +1,118 @@
+import { createServer, type Server } from "http";
+import { WebSocket } from "ws";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ApiKeyRecord } from "../../middleware/api-gateway";
+import { TagStreamServer } from "../tag-stream";
+import { UnifiedStreamServer } from "../unified-stream";
+import {
+  OXSCADA_WEBSOCKET_AUTH_PREFIX,
+  OXSCADA_WEBSOCKET_PROTOCOL,
+  type WebSocketAuthOptions,
+} from "../upgrade-auth";
+
+type StreamServer = TagStreamServer | UnifiedStreamServer;
+
+const apiKeys = new Map<string, ApiKeyRecord>([
+  [
+    "read-key",
+    {
+      key: "read-key",
+      name: "dashboard",
+      scopes: ["read", "stream.read"],
+      createdAt: new Date(),
+    },
+  ],
+  [
+    "write-only-key",
+    {
+      key: "write-only-key",
+      name: "writer",
+      scopes: ["write"],
+      createdAt: new Date(),
+    },
+  ],
+]);
+const auth: WebSocketAuthOptions = { required: true, apiKeys };
+const openServers: Array<{ http: Server; stream: StreamServer }> = [];
+const openClients: WebSocket[] = [];
+
+function credentialProtocol(key: string): string {
+  return `${OXSCADA_WEBSOCKET_AUTH_PREFIX}${Buffer.from(key).toString("base64url")}`;
+}
+async function start(
+  kind: "tags" | "unified",
+): Promise<{ url: string; stream: StreamServer }> {
+  const http = createServer();
+  const stream = kind === "tags" ? new TagStreamServer() : new UnifiedStreamServer();
+  const path = kind === "tags" ? "/ws/tags" : "/ws";
+  stream.initialize(http, path, auth);
+  openServers.push({ http, stream });
+  await new Promise<void>((resolve) => http.listen(0, "127.0.0.1", resolve));
+  const address = http.address();
+  if (!address || typeof address === "string") throw new Error("Missing test address");
+  return { url: `ws://127.0.0.1:${address.port}${path}`, stream };
+}
+
+async function rejectedStatus(url: string, protocols?: string[]): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const client = new WebSocket(url, protocols);
+    client.once("open", () => reject(new Error("WebSocket unexpectedly opened")));
+    client.once("unexpected-response", (_request, response) => {
+      response.resume();
+      resolve(response.statusCode ?? 0);
+    });
+    client.once("error", () => {
+      // `unexpected-response` is the assertion channel for rejected upgrades.
+    });
+  });
+}
+
+async function connect(url: string, key: string): Promise<WebSocket> {
+  const client = new WebSocket(url, [
+    OXSCADA_WEBSOCKET_PROTOCOL,
+    credentialProtocol(key),
+  ]);
+  openClients.push(client);
+  await new Promise<void>((resolve, reject) => {
+    client.once("open", resolve);
+    client.once("error", reject);
+  });
+  return client;
+}
+
+afterEach(async () => {
+  for (const client of openClients.splice(0)) client.close();
+  await Promise.all(openServers.splice(0).map(async ({ http, stream }) => {
+    stream.destroy();
+    await new Promise<void>((resolve) => http.close(() => resolve()));
+  }));
+});
+
+for (const kind of ["tags", "unified"] as const) {
+  describe(`${kind} WebSocket HTTP upgrade authentication`, () => {
+    it("rejects a missing credential", async () => {
+      const { url } = await start(kind);
+      expect(await rejectedStatus(url)).toBe(401);
+    });
+
+    it("rejects credentials in a query string", async () => {
+      const { url } = await start(kind);
+      expect(await rejectedStatus(`${url}?api_key=read-key`)).toBe(400);
+      expect(await rejectedStatus(`${url}?ACCESS-TOKEN=read-key`)).toBe(400);
+    });
+
+    it("rejects a key without a streaming read scope", async () => {
+      const { url } = await start(kind);
+      expect(await rejectedStatus(url, [
+        OXSCADA_WEBSOCKET_PROTOCOL,
+        credentialProtocol("write-only-key"),
+      ])).toBe(403);
+    });
+
+    it("accepts a scoped key and negotiates only the stable protocol", async () => {
+      const { url } = await start(kind);
+      const client = await connect(url, "read-key");
+      expect(client.protocol).toBe(OXSCADA_WEBSOCKET_PROTOCOL);
+    });
+  });
+}

--- a/server/websocket/tag-stream.ts
+++ b/server/websocket/tag-stream.ts
@@ -10,7 +10,15 @@
 
 import { WebSocket, WebSocketServer } from "ws";
 import type { Server as HttpServer, IncomingMessage } from "http";
+import type { Duplex } from "stream";
 import { URL } from "url";
+import {
+  authorizeWebSocketUpgrade,
+  rejectWebSocketUpgrade,
+  selectOxscadaWebSocketProtocol,
+  type AuthenticatedWebSocketRequest,
+  type WebSocketAuthOptions,
+} from "./upgrade-auth";
 
 // --- Types ---
 
@@ -46,18 +54,42 @@ export class TagStreamServer {
   private totalUpdates = 0;
   private startTime = Date.now();
   private pingInterval?: ReturnType<typeof setInterval>;
+  private httpServer?: HttpServer;
+  private upgradeHandler?: (
+    request: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+  ) => void;
 
-  initialize(httpServer: HttpServer, path = "/ws/tags"): void {
-    this.wss = new WebSocketServer({ noServer: true });
+  initialize(
+    httpServer: HttpServer,
+    path = "/ws/tags",
+    auth: WebSocketAuthOptions = { required: false, apiKeys: new Map() },
+  ): void {
+    this.wss = new WebSocketServer({
+      noServer: true,
+      handleProtocols: selectOxscadaWebSocketProtocol,
+    });
+    this.httpServer = httpServer;
 
-    httpServer.on("upgrade", (request: IncomingMessage, socket, head) => {
+    this.upgradeHandler = (request: IncomingMessage, socket: Duplex, head: Buffer) => {
       const reqUrl = new URL(request.url || "/", `http://${request.headers.host}`);
       if (reqUrl.pathname !== path) return; // let other WSS handle
+
+      const decision = authorizeWebSocketUpgrade(
+        request as AuthenticatedWebSocketRequest,
+        auth,
+      );
+      if (!decision.ok) {
+        rejectWebSocketUpgrade(socket, decision);
+        return;
+      }
 
       this.wss!.handleUpgrade(request, socket, head, (ws) => {
         this.wss!.emit("connection", ws, request);
       });
-    });
+    };
+    httpServer.on("upgrade", this.upgradeHandler);
 
     this.wss.on("connection", (ws: WebSocket, request: IncomingMessage) => {
       const clientId = crypto.randomUUID();
@@ -233,11 +265,16 @@ export class TagStreamServer {
 
   destroy(): void {
     if (this.pingInterval) clearInterval(this.pingInterval);
+    if (this.httpServer && this.upgradeHandler) {
+      this.httpServer.off("upgrade", this.upgradeHandler);
+    }
     for (const client of this.clients.values()) {
       client.ws.close(1000);
     }
     this.clients.clear();
     this.wss?.close();
+    this.httpServer = undefined;
+    this.upgradeHandler = undefined;
   }
 }
 

--- a/server/websocket/unified-stream.ts
+++ b/server/websocket/unified-stream.ts
@@ -16,9 +16,17 @@
 
 import { WebSocket, WebSocketServer } from 'ws';
 import type { Server as HttpServer, IncomingMessage } from 'http';
+import type { Duplex } from 'stream';
 import { URL } from 'url';
 import { tagStreamServer, type TagUpdate } from './tag-stream.js';
 import type { EventFilters, WebSocketMetrics } from './types.js';
+import {
+  authorizeWebSocketUpgrade,
+  rejectWebSocketUpgrade,
+  selectOxscadaWebSocketProtocol,
+  type AuthenticatedWebSocketRequest,
+  type WebSocketAuthOptions,
+} from './upgrade-auth.js';
 
 // ── Unified Message Schema ───────────────────────────────────────────────────
 
@@ -39,6 +47,7 @@ export interface UnifiedClient {
   eventFilters: Partial<EventFilters>;
   connectedAt: Date;
   isAlive: boolean;
+  authenticated: boolean;
   messagesSent: number;
   messagesReceived: number;
 }
@@ -51,24 +60,48 @@ export class UnifiedStreamServer {
   private startTime = Date.now();
   private pingInterval?: ReturnType<typeof setInterval>;
   private totalEventsDelivered = 0;
+  private httpServer?: HttpServer;
+  private upgradeHandler?: (
+    request: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+  ) => void;
 
   /**
    * Attach to an HTTP server and listen on the given path (default /ws).
    * Also wires into the existing TagStreamServer for tag data.
    */
-  initialize(httpServer: HttpServer, path = '/ws'): void {
-    this.wss = new WebSocketServer({ noServer: true });
+  initialize(
+    httpServer: HttpServer,
+    path = '/ws',
+    auth: WebSocketAuthOptions = { required: false, apiKeys: new Map() },
+  ): void {
+    this.wss = new WebSocketServer({
+      noServer: true,
+      handleProtocols: selectOxscadaWebSocketProtocol,
+    });
+    this.httpServer = httpServer;
 
-    httpServer.on('upgrade', (request: IncomingMessage, socket, head) => {
+    this.upgradeHandler = (request: IncomingMessage, socket: Duplex, head: Buffer) => {
       const reqUrl = new URL(request.url || '/', `http://${request.headers.host}`);
       if (reqUrl.pathname !== path) return; // let tag-stream / event-stream handle their own paths
+
+      const decision = authorizeWebSocketUpgrade(
+        request as AuthenticatedWebSocketRequest,
+        auth,
+      );
+      if (!decision.ok) {
+        rejectWebSocketUpgrade(socket, decision);
+        return;
+      }
 
       this.wss!.handleUpgrade(request, socket, head, (ws) => {
         this.wss!.emit('connection', ws, request);
       });
-    });
+    };
+    httpServer.on('upgrade', this.upgradeHandler);
 
-    this.wss.on('connection', (ws: WebSocket, _request: IncomingMessage) => {
+    this.wss.on('connection', (ws: WebSocket, request: AuthenticatedWebSocketRequest) => {
       const clientId = crypto.randomUUID();
       const client: UnifiedClient = {
         id: clientId,
@@ -78,6 +111,7 @@ export class UnifiedStreamServer {
         eventFilters: {},
         connectedAt: new Date(),
         isAlive: true,
+        authenticated: !!request.apiKeyRecord,
         messagesSent: 0,
         messagesReceived: 0,
       };
@@ -232,7 +266,8 @@ export class UnifiedStreamServer {
     return {
       activeConnections: this.clients.size,
       totalConnections: this.clients.size,
-      authenticatedConnections: 0,
+      authenticatedConnections: Array.from(this.clients.values())
+        .filter((client) => client.authenticated).length,
       totalSubscriptions: Array.from(this.clients.values())
         .reduce((sum, c) => sum + c.subscribedChannels.size, 0),
       totalEventsDelivered: this.totalEventsDelivered,
@@ -269,9 +304,14 @@ export class UnifiedStreamServer {
 
   destroy(): void {
     if (this.pingInterval) clearInterval(this.pingInterval);
+    if (this.httpServer && this.upgradeHandler) {
+      this.httpServer.off('upgrade', this.upgradeHandler);
+    }
     for (const client of this.clients.values()) client.ws.close(1000);
     this.clients.clear();
     this.wss?.close();
+    this.httpServer = undefined;
+    this.upgradeHandler = undefined;
   }
 
   // ── Private Helpers ────────────────────────────────────────────────────────

--- a/server/websocket/upgrade-auth.ts
+++ b/server/websocket/upgrade-auth.ts
@@ -1,0 +1,159 @@
+/**
+ * API-key authentication for browser WebSocket upgrade requests.
+ *
+ * Browsers cannot set X-API-Key on `new WebSocket()`. They can set negotiated
+ * subprotocol tokens, so the client sends:
+ *   - oxscada.v1
+ *   - oxscada.api-key.<base64url(UTF-8 key)>
+ *
+ * The server validates the credential before `handleUpgrade` and negotiates
+ * only the stable `oxscada.v1` protocol. Credentials in URL query strings are
+ * rejected because URLs are routinely logged.
+ */
+
+import type { IncomingMessage } from "http";
+import type { Duplex } from "stream";
+import type { ApiKeyRecord } from "../middleware/api-gateway";
+
+export const OXSCADA_WEBSOCKET_PROTOCOL = "oxscada.v1";
+export const OXSCADA_WEBSOCKET_AUTH_PREFIX = "oxscada.api-key.";
+export const DEFAULT_WEBSOCKET_SCOPES = Object.freeze(["stream.read", "read"]);
+
+export interface WebSocketAuthOptions {
+  required: boolean;
+  apiKeys: ReadonlyMap<string, ApiKeyRecord>;
+  acceptedScopes?: readonly string[];
+}
+export type WebSocketUpgradeDecision =
+  | { ok: true; record?: ApiKeyRecord }
+  | { ok: false; status: 400 | 401 | 403; error: string };
+
+export interface AuthenticatedWebSocketRequest extends IncomingMessage {
+  apiKeyRecord?: ApiKeyRecord;
+}
+
+const FORBIDDEN_QUERY_CREDENTIAL_NAMES = new Set([
+  "apikey",
+  "accesstoken",
+  "token",
+  "authorization",
+]);
+
+function protocolTokens(request: IncomingMessage): string[] {
+  const raw = request.headers["sec-websocket-protocol"];
+  const combined = Array.isArray(raw) ? raw.join(",") : raw ?? "";
+  return combined.split(",").map((token) => token.trim()).filter(Boolean);
+}
+
+function decodeCredentialProtocol(token: string): string | undefined {
+  if (!token.startsWith(OXSCADA_WEBSOCKET_AUTH_PREFIX)) return undefined;
+  const encoded = token.slice(OXSCADA_WEBSOCKET_AUTH_PREFIX.length);
+  if (!encoded || encoded.length > 2048 || !/^[A-Za-z0-9_-]+$/.test(encoded)) {
+    return undefined;
+  }
+
+  try {
+    const bytes = Buffer.from(encoded, "base64url");
+    if (bytes.length === 0 || bytes.length > 512) return undefined;
+    if (bytes.toString("base64url") !== encoded) return undefined;
+    const key = bytes.toString("utf8");
+    if (!key || Buffer.from(key, "utf8").compare(bytes) !== 0) return undefined;
+    if (/[\u0000-\u001f\u007f]/.test(key)) return undefined;
+    return key;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasAcceptedScope(
+  record: ApiKeyRecord,
+  acceptedScopes: readonly string[],
+): boolean {
+  return record.scopes.includes("*") ||
+    record.scopes.includes("admin") ||
+    acceptedScopes.some((scope) => record.scopes.includes(scope));
+}
+
+export function authorizeWebSocketUpgrade(
+  request: AuthenticatedWebSocketRequest,
+  options: WebSocketAuthOptions,
+): WebSocketUpgradeDecision {
+  const requestUrl = new URL(request.url || "/", `http://${request.headers.host || "localhost"}`);
+  const hasQueryCredential = Array.from(requestUrl.searchParams.keys())
+    .some((name) => FORBIDDEN_QUERY_CREDENTIAL_NAMES.has(
+      name.toLowerCase().replace(/[-_]/gu, ""),
+    ));
+  if (hasQueryCredential) {
+    return {
+      ok: false,
+      status: 400,
+      error: "WebSocket credentials are not accepted in the URL.",
+    };
+  }
+
+  const protocols = protocolTokens(request);
+  const credentialTokens = protocols.filter((token) =>
+    token.startsWith(OXSCADA_WEBSOCKET_AUTH_PREFIX)
+  );
+  if (credentialTokens.length > 1) {
+    return { ok: false, status: 400, error: "Multiple WebSocket credentials supplied." };
+  }
+
+  if (credentialTokens.length === 0) {
+    return options.required
+      ? { ok: false, status: 401, error: "WebSocket authentication required." }
+      : { ok: true };
+  }
+
+  if (!protocols.includes(OXSCADA_WEBSOCKET_PROTOCOL)) {
+    return {
+      ok: false,
+      status: 400,
+      error: `WebSocket protocol ${OXSCADA_WEBSOCKET_PROTOCOL} is required.`,
+    };
+  }
+
+  const key = decodeCredentialProtocol(credentialTokens[0]);
+  const record = key ? options.apiKeys.get(key) : undefined;
+  if (!record || (record.expiresAt && record.expiresAt.getTime() <= Date.now())) {
+    return { ok: false, status: 401, error: "Invalid or expired WebSocket credential." };
+  }
+
+  const acceptedScopes = options.acceptedScopes ?? DEFAULT_WEBSOCKET_SCOPES;
+  if (!hasAcceptedScope(record, acceptedScopes)) {
+    return {
+      ok: false,
+      status: 403,
+      error: "WebSocket credential lacks a streaming read scope.",
+    };
+  }
+
+  request.apiKeyRecord = record;
+  return { ok: true, record };
+}
+
+export function selectOxscadaWebSocketProtocol(protocols: Set<string>): string | false {
+  return protocols.has(OXSCADA_WEBSOCKET_PROTOCOL)
+    ? OXSCADA_WEBSOCKET_PROTOCOL
+    : false;
+}
+
+export function rejectWebSocketUpgrade(
+  socket: Duplex,
+  decision: Exclude<WebSocketUpgradeDecision, { ok: true }>,
+): void {
+  const statusText = decision.status === 400
+    ? "Bad Request"
+    : decision.status === 401
+      ? "Unauthorized"
+      : "Forbidden";
+  const body = JSON.stringify({ error: decision.error });
+  socket.end(
+    `HTTP/1.1 ${decision.status} ${statusText}\r\n` +
+    "Connection: close\r\n" +
+    "Content-Type: application/json\r\n" +
+    `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+    "\r\n" +
+    body,
+  );
+}


### PR DESCRIPTION
## Summary

Address the API-key gateway and control-plane security blockers from the #514/#520 reviews as one focused security change.

- activate the gateway in the server composition root and fail closed in production when no bootstrap key exists
- default production Docker/Compose/Helm/raw-Kubernetes paths to authenticated operation with operator-supplied Secrets
- reject query-string credentials and public-route prefix collisions
- enforce a central authorization floor for every mutating `/api` request, with narrow scopes for anchor, legacy alarm, alarm-correlation actions, geometry, safe-state, tuning, HSM, and other control operations
- separate `tuning.write` from `tuning.approve` so a proposal author cannot approve a gain change
- replace the alarm/geometry auth stubs with real scoped guards
- redact generated credentials and revocation paths from logs; mark one-time key responses `no-store`
- authenticate `/ws` and `/ws/tags` before upgrade using a browser-compatible subprotocol credential, rejecting URL credentials
- require explicit nonempty scopes for generated keys
- add tab-scoped React credential plumbing for same-origin REST and WebSocket calls
- preserve #552's header-to-principal binding while rebasing onto current `main`

## Security behavior

Health/readiness and API documentation remain unauthenticated but still traverse request IDs, CORS, logging, and rate limiting. `/api/metrics` and every other non-public API route require a valid key in production. Mutations additionally require the route-family scope (or an explicit `admin`/`*` grant). Alarm-correlation routes accept the action-scope family at the central floor and enforce the exact action scope in their feature-local guards.

Credentials are accepted only through `X-API-Key` for HTTP and the documented WebSocket subprotocol for browser upgrades. Generated keys are process-local today and are documented as unsuitable for multi-replica production until a shared key store is selected. Static bootstrap keys remain Secret-backed across replicas.

## Validation

Validated on head `4ae4afc45` against current `main` `34e4bd4c0`:

- focused gateway/authorization/WebSocket/client/startup tests: 58/58
- full unit suite: 1,407 passed, 4 skipped
- integration startup suite: 5/5
- `npm run typecheck`: pass
- `npm run build`: pass
- `npm audit --audit-level=moderate`: 0 vulnerabilities
- `git diff --check`: pass
- `git range-diff`: all five security commits patch-equivalent across the late mainline dependency/workflow merges
- `helm/oxscada`: dependency build, lint, and render pass with an existing bootstrap Secret; default render correctly rejects a missing Secret
- `helm/oxscada-full`: the changed auth template was linted/rendered in a dependency-neutral validation copy; the repository's pre-existing missing local subcharts prevent a clean full-chart dependency build and are tracked separately in #548
- exact-head GitHub CI: all required checks pass, including Helm Gateway Render and integration tests

An independent adversarial rebase review found the health/Swagger ordering regression, which is corrected on this head. The final re-review found no remaining #520 blocker.