### PR TITLE
test(anchor): run AnchorPipeline against live Anvil (#505)

### DIFF
--- a/.github/workflows/anchor-pipeline-anvil.yml
+++ b/.github/workflows/anchor-pipeline-anvil.yml
@@ -1,0 +1,102 @@
+name: Anchor Pipeline Live Anvil E2E
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/anchor-pipeline-anvil.yml'
+      - 'contracts/EventAnchor.sol'
+      - 'foundry.toml'
+      - 'server/integrity/**'
+      - 'test/integrity/anchor-pipeline-anvil.test.ts'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    branches: [main]
+    paths:
+      - 'contracts/EventAnchor.sol'
+      - 'foundry.toml'
+      - 'server/integrity/**'
+      - 'test/integrity/anchor-pipeline-anvil.test.ts'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: anchor-pipeline-anvil-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-anvil:
+    name: AnchorPipeline → EventAnchor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - run: npm ci
+
+      - name: Compile EventAnchor
+        run: forge build
+
+      - name: Start Anvil and capture its ephemeral signer
+        shell: bash
+        run: |
+          set -euo pipefail
+          anvil \
+            --host 127.0.0.1 \
+            --port 8545 \
+            --block-time 1 \
+            > "$RUNNER_TEMP/anvil.log" 2>&1 &
+          echo "ANVIL_PID=$!" >> "$GITHUB_ENV"
+
+          for attempt in $(seq 1 30); do
+            if cast chain-id --rpc-url http://127.0.0.1:8545 >/dev/null 2>&1; then
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "Anvil did not become ready" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+
+          anvil_private_key="$(
+            awk '
+              /Private Keys/ { in_keys = 1; next }
+              in_keys && $1 == "(0)" { print $2; exit }
+            ' "$RUNNER_TEMP/anvil.log"
+          )"
+          if ! [[ "$anvil_private_key" =~ ^0x[0-9a-fA-F]{64}$ ]]; then
+            echo "Could not derive Anvil signer from local process output" >&2
+            exit 1
+          fi
+          echo "::add-mask::$anvil_private_key"
+          echo "ANVIL_PRIVATE_KEY=$anvil_private_key" >> "$GITHUB_ENV"
+          echo "ANVIL_RPC_URL=http://127.0.0.1:8545" >> "$GITHUB_ENV"
+
+      - name: Run live anchor-chain test
+        env:
+          ANCHOR_LIVE_E2E: '1'
+        run: npx vitest run test/integrity/anchor-pipeline-anvil.test.ts --reporter=verbose
+
+      - name: Stop Anvil
+        if: always()
+        shell: bash
+        run: |
+          if [ -n "${ANVIL_PID:-}" ]; then
+            kill "$ANVIL_PID" 2>/dev/null || true
+          fi

--- a/test/integrity/anchor-pipeline-anvil.test.ts
+++ b/test/integrity/anchor-pipeline-anvil.test.ts
@@ -61,6 +61,20 @@ function scadaEvent(index: number, timestamp: number): SCADAEvent {
   };
 }
 
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, canonicalize(nested)]),
+    );
+  }
+  return value;
+}
+
 function expectedMerkleRoot(events: SCADAEvent[]): string {
   const hashes = events.map((event) => {
     const canonical = JSON.stringify({
@@ -68,7 +82,7 @@ function expectedMerkleRoot(events: SCADAEvent[]): string {
       timestamp: event.timestamp,
       type: event.type,
       source: event.source,
-      data: event.data,
+      data: canonicalize(event.data),
     });
     return createHash('sha256').update(canonical, 'utf8').digest('hex');
   });

--- a/test/integrity/anchor-pipeline-anvil.test.ts
+++ b/test/integrity/anchor-pipeline-anvil.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Live-chain end-to-end test for issue #505.
+ *
+ * The regular AnchorPipeline tests inject a contract double. This suite deploys
+ * the real EventAnchor bytecode to Anvil, sends a real signed pipeline batch
+ * through AnchorRelayerService, and reads the committed root back over JSON-RPC.
+ *
+ * It is intentionally opt-in so the normal unit suite does not require Foundry.
+ * `.github/workflows/anchor-pipeline-anvil.yml` is the required CI entry point.
+ */
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import {
+  Contract,
+  ContractFactory,
+  JsonRpcProvider,
+  Wallet,
+  type InterfaceAbi,
+} from 'ethers';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AnchorPipeline } from '../../server/integrity/anchor-pipeline';
+import { MerkleTreeBuilder } from '../../server/integrity/merkle';
+import type { SCADAEvent } from '../../server/integrity/pipeline';
+
+interface FoundryArtifact {
+  abi: InterfaceAbi;
+  bytecode: { object: string };
+}
+
+interface AnchorSuccess {
+  request: {
+    merkleRoot: string;
+    batchId: number;
+    eventCount: number;
+  };
+  result: {
+    success: boolean;
+    transactionHash?: string;
+  };
+}
+
+const liveE2E = process.env.ANCHOR_LIVE_E2E === '1' ? describe : describe.skip;
+const pipelines: AnchorPipeline[] = [];
+
+function requiredEnvironment(name: 'ANVIL_RPC_URL' | 'ANVIL_PRIVATE_KEY'): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required when ANCHOR_LIVE_E2E=1`);
+  }
+  return value;
+}
+
+function scadaEvent(index: number, timestamp: number): SCADAEvent {
+  return {
+    id: `live-event-${index}`,
+    timestamp,
+    type: 'reading',
+    source: 'anvil-e2e-sensor',
+    data: { value: 100 + index, quality: 'good' },
+  };
+}
+
+function expectedMerkleRoot(events: SCADAEvent[]): string {
+  const hashes = events.map((event) => {
+    const canonical = JSON.stringify({
+      id: event.id,
+      timestamp: event.timestamp,
+      type: event.type,
+      source: event.source,
+      data: event.data,
+    });
+    return createHash('sha256').update(canonical, 'utf8').digest('hex');
+  });
+  return `0x${MerkleTreeBuilder.buildFromEventHashes(hashes).root}`;
+}
+
+function waitForAnchor(pipeline: AnchorPipeline): Promise<AnchorSuccess> {
+  return new Promise((resolvePromise, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error('Timed out waiting for AnchorPipeline confirmation')),
+      30_000,
+    );
+
+    pipeline.relayer.once('anchorSuccess', (event: AnchorSuccess) => {
+      clearTimeout(timeout);
+      resolvePromise(event);
+    });
+    pipeline.relayer.once('anchorFailed', (event: unknown) => {
+      clearTimeout(timeout);
+      reject(new Error(`AnchorPipeline failed: ${JSON.stringify(event)}`));
+    });
+  });
+}
+
+afterEach(async () => {
+  while (pipelines.length > 0) {
+    await pipelines.pop()!.stop();
+  }
+});
+
+liveE2E('AnchorPipeline → live EventAnchor', () => {
+  it('deploys, anchors the ingested batch root, and verifies it on-chain', async () => {
+    const rpcUrl = requiredEnvironment('ANVIL_RPC_URL');
+    const privateKey = requiredEnvironment('ANVIL_PRIVATE_KEY');
+    const provider = new JsonRpcProvider(rpcUrl);
+    const deployer = new Wallet(privateKey, provider);
+
+    const artifactPath = resolve('out/EventAnchor.sol/EventAnchor.json');
+    const artifact = JSON.parse(await readFile(artifactPath, 'utf8')) as FoundryArtifact;
+    const bytecode = artifact.bytecode.object.startsWith('0x')
+      ? artifact.bytecode.object
+      : `0x${artifact.bytecode.object}`;
+
+    const factory = new ContractFactory(artifact.abi, bytecode, deployer);
+    const deployed = await factory.deploy(deployer.address);
+    await deployed.waitForDeployment();
+    const contractAddress = await deployed.getAddress();
+
+    const pipeline = new AnchorPipeline({
+      pipeline: {
+        windowSizeMs: 60_000,
+        maxBatchSize: 3,
+      },
+      relayer: {
+        rpcUrl,
+        chainId: 31_337,
+        contractAddress,
+        privateKey,
+        confirmationBlocks: 1,
+        maxRetries: 1,
+        baseDelayMs: 100,
+        maxDelayMs: 100,
+      },
+    });
+    pipelines.push(pipeline);
+    await pipeline.start();
+
+    const anchored = waitForAnchor(pipeline);
+    const baseTimestamp = 1_700_000_000_000;
+    const events = [0, 1, 2].map((index) => scadaEvent(index, baseTimestamp + index));
+    for (const event of events) {
+      await pipeline.ingestEvent(event);
+    }
+    const success = await anchored;
+
+    const expectedRoot = expectedMerkleRoot(events);
+    expect(success.result.success).toBe(true);
+    expect(success.result.transactionHash).toMatch(/^0x[0-9a-f]{64}$/i);
+    expect(success.request).toMatchObject({
+      merkleRoot: expectedRoot,
+      batchId: 1,
+      eventCount: events.length,
+    });
+
+    const eventAnchor = new Contract(contractAddress, artifact.abi, provider);
+    const [exists, batchId] = await eventAnchor.verify(expectedRoot);
+    expect(exists).toBe(true);
+    expect(batchId).toBe(1n);
+
+    const stored = await eventAnchor.getAnchor(1);
+    expect(stored.merkleRoot).toBe(expectedRoot);
+    expect(stored.eventCount).toBe(BigInt(events.length));
+    expect(stored.exists).toBe(true);
+  }, 45_000);
+});


### PR DESCRIPTION
## Summary

Implement the independently actionable CI half of #505: deploy the real `EventAnchor.sol` contract to a live Anvil chain, send an ingested SCADA batch through the real `AnchorPipeline`/signer/relayer path, and verify the committed Merkle root through the contract ABI.

This PR **does not close #505**. The production sensor-event source and L2/NATS parity still require the product/architecture decision described in the issue.

## What the test proves

- Foundry compiles the repository's real `EventAnchor.sol`.
- An ephemeral Anvil signer deploys the contract and owns the anchor path.
- Three real `SCADAEvent` values flow through canonical hashing, batching, Merkle construction, RSA signing, signature verification, ethers transaction submission, and confirmation.
- The submitted root equals an independently computed canonical Merkle root.
- `verify(root)` returns `(true, 1)` on-chain.
- `getAnchor(1)` returns the same root and event count.

## Security/CI details

- No static Anvil private key is committed. CI derives the ephemeral signer from the local Anvil process, validates its format, and masks it before exporting it.
- The normal unit suite skips this opt-in test; the dedicated workflow is the required live-chain entry point.
- Workflow permissions are read-only.

## Validation

- Dedicated GitHub `AnchorPipeline → EventAnchor` live-Anvil job: **passed**
- GitHub Type Check, Unit Tests, Build, Lint, and Security Audit: **passed**
- Local full TypeScript typecheck: passed
- Workflow YAML parse and job assertion: passed
- `git diff --check`: passed

The repository-wide Integration check remains dependent on the separate #516 baseline repair.