### PR TITLE
fix(ci): align event-batch latency with its timer

### DIFF
--- a/server/kernel/event-batcher.ts
+++ b/server/kernel/event-batcher.ts
@@ -151,8 +151,11 @@ export class EventBatcher extends EventEmitter {
 
       // Start batch timer if this is the first event
       if (this.eventQueue.length === 1) {
-        this.startBatchTimer();
+        // Capture the latency origin before scheduling. Node timers use a
+        // monotonic clock while Date.now() is millisecond-rounded; recording
+        // this afterwards can make a 100 ms timeout report 99 ms in CI.
         this.currentBatchStartTime = Date.now();
+        this.startBatchTimer();
       }
 
       // Check if we should flush due to count threshold. Flushing is deferred


### PR DESCRIPTION
## Summary

Fix the unrelated timing race exposed by the #532 unit run without modifying the watchdog feature branch.

## Root cause

`EventBatcher` scheduled its timeout before recording `currentBatchStartTime`. Node timers use a monotonic clock while `Date.now()` is millisecond-rounded, so a nominal 100 ms timeout could legitimately report 99 ms when the latency origin was captured just after scheduling. The existing assertion requires the reported latency to be at least the configured timeout.

## Fix

Capture `currentBatchStartTime` before scheduling the timeout. The metric and timer now share the same causal origin, and the batcher's behavior is otherwise unchanged.

## Validation

- Focused `event-batcher` suite run 10 consecutive times: 10/10 files, 240/240 tests passed
- Full TypeScript typecheck: passed
- Full build: passed
- `git diff --check`: passed

## Scope

One source file; no watchdog or #532 code changes.