### PR TITLE
fix(ci): make the summary honor security and integration failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,15 +239,17 @@ jobs:
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test, build]
+    needs: [lint, typecheck, security, test, build, integration-test]
     if: always()
     steps:
       - name: Check results
         run: |
           if [ "${{ needs.lint.result }}" != "success" ] || \
              [ "${{ needs.typecheck.result }}" != "success" ] || \
+             [ "${{ needs.security.result }}" != "success" ] || \
              [ "${{ needs.test.result }}" != "success" ] || \
-             [ "${{ needs.build.result }}" != "success" ]; then
+             [ "${{ needs.build.result }}" != "success" ] || \
+             [ "${{ needs.integration-test.result }}" != "success" ]; then
             echo "❌ CI failed"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Keep the required `CI Complete` summary honest when a late-stage or security job fails.

- add `security` to the summary job dependencies and result check
- add `integration-test` to the summary job dependencies and result check
- retain `if: always()` so the summary still runs and reports a deterministic failure after an upstream job fails

This is intentionally separate from the Docker-image repairs: the Docker matrix is event-gated today, while these two jobs run on every pull request and must be reflected in the required summary.

## Validation

- workflow YAML parses successfully
- `ci-complete.needs` resolves to lint, typecheck, security, test, build, and integration-test
- `git diff --check` passes