### PR TITLE
fix(ci): enforce high-severity dependency audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - run: npm ci
-      - name: npm audit (production)
-        run: npm audit --production --audit-level=high || true
-      - name: Check for known vulnerabilities
-        run: npx audit-ci --high || true
+      - name: Enforce npm audit (high and critical)
+        run: npm audit --audit-level=high
 
   docker:
     name: Docker Build (${{ matrix.service }})


### PR DESCRIPTION
## Summary

Make the existing Security Audit job authoritative instead of informational.

- remove `|| true` from the audit path so high/critical findings fail the job
- replace two redundant scans with the lockfile-native `npm audit --audit-level=high`
- cover all locked dependencies, including development tooling, rather than silently ignoring a compromised build-time package
- remove the unpinned `npx audit-ci` download from CI

This is intentionally separate from #542: this PR makes the Security Audit result meaningful; #542 only propagates that result into `CI Complete`.

## Validation

- exact command under npm 10.9.8: 785 dependencies audited, zero findings, exit 0
- workflow YAML parses successfully
- independent review confirmed high and critical findings produce a nonzero exit
- dry merge-tree check with #542: no conflict
- `git diff --check`: pass