### PR TITLE
fix(server): keep startup singletons in one Node 20 module graph (#541)

### DIFF
--- a/server/__tests__/startup-singleton-imports.test.ts
+++ b/server/__tests__/startup-singleton-imports.test.ts
@@ -1,0 +1,88 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import ts from "typescript";
+import { describe, expect, test } from "vitest";
+
+interface ImportGraph {
+  staticImports: string[];
+  dynamicImports: string[];
+}
+
+async function readImportGraph(relativePath: string): Promise<ImportGraph> {
+  const sourceText = await readFile(path.resolve(relativePath), "utf8");
+  const sourceFile = ts.createSourceFile(
+    relativePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const staticImports: string[] = [];
+  const dynamicImports: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      staticImports.push(node.moduleSpecifier.text);
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      dynamicImports.push(node.arguments[0].text);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return { staticImports, dynamicImports };
+}
+
+describe("startup singleton module identity", () => {
+  test.each([
+    {
+      file: "server/index.ts",
+      modules: [
+        "./simulator",
+        "./agents",
+        "./gateway/store-and-forward",
+        "./bridge",
+        "./gateway",
+        "./services/flux",
+        "./services/nats",
+        "./bridge/anchor-backend",
+      ],
+    },
+    {
+      file: "server/health/index.ts",
+      modules: [
+        "../simulator",
+        "../gateway/store-and-forward",
+        "../bridge",
+      ],
+    },
+    {
+      file: "server/gateway/index.ts",
+      modules: ["./store-and-forward"],
+    },
+  ])("$file keeps stateful startup modules in the static graph", async ({
+    file,
+    modules,
+  }) => {
+    const graph = await readImportGraph(file);
+
+    // With tsx on Node 20, import() can evaluate a second copy of a module
+    // already loaded by the static CJS graph. Startup initializers and serving
+    // consumers must therefore use static imports for every shared singleton.
+    expect(
+      graph.dynamicImports.filter((specifier) => modules.includes(specifier)),
+    ).toEqual([]);
+    expect(graph.staticImports).toEqual(expect.arrayContaining(modules));
+  });
+});

--- a/server/gateway/index.ts
+++ b/server/gateway/index.ts
@@ -3,6 +3,8 @@
  * Handles protocol drivers for industrial communication
  */
 
+import { storeAndForwardService } from './store-and-forward';
+
 // Protocol Types Union
 export type ProtocolType = 
   | 'DNP3_TCP'
@@ -64,7 +66,6 @@ export class GatewayManager {
    */
   async storeData(data: any, driverId: string): Promise<void> {
     try {
-      const { storeAndForwardService } = await import('./store-and-forward');
       await storeAndForwardService.store(data, driverId);
     } catch (error) {
       console.error(`Failed to store data for driver ${driverId}:`, error);

--- a/server/health/index.ts
+++ b/server/health/index.ts
@@ -12,6 +12,9 @@ import { HealthManager, createDatabaseCheck, createBlockchainCheck, createGatewa
 import { storage } from '../storage';
 import { blockchainService } from '../blockchain';
 import { registry, metricsHandler } from '../metrics';
+import { fieldSimulator } from '../simulator';
+import { storeAndForwardService } from '../gateway/store-and-forward';
+import { getBridgeHealthStatus } from '../bridge';
 
 // ── Prometheus health gauges ─────────────────────────────────────────────────
 // These gauges let Prometheus scrape health status as numeric metrics.
@@ -65,8 +68,7 @@ healthManager.register(
 healthManager.registerSimple(
   'simulator',
   async () => {
-    // Just verify the import resolves — the simulator self-reports via events
-    const { fieldSimulator } = await import('../simulator');
+    // Just verify the singleton resolves — the simulator self-reports via events
     return fieldSimulator != null;
   },
   /* required */ false,
@@ -105,7 +107,6 @@ healthManager.registerSimple(
   'store-and-forward',
   async () => {
     try {
-      const { storeAndForwardService } = await import('../gateway/store-and-forward');
       const status = await storeAndForwardService.healthCheck();
       return status.healthy;
     } catch {
@@ -120,7 +121,6 @@ healthManager.registerSimple(
   'bridges',
   async () => {
     try {
-      const { getBridgeHealthStatus } = await import('../bridge');
       const status = await getBridgeHealthStatus();
       return status.eventAnchor.healthy && status.stateSync.healthy;
     } catch {

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,16 @@ import { healthRouter, healthManager } from "./health";
 import { registerSwaggerRoutes } from "./openapi";
 import { setupApiGateway } from "./middleware/api-gateway";
 import { initializeDatabase } from "./storage";
+// Stateful startup services must stay in the static graph. On Node 20, tsx can
+// give import() a separate module instance from static consumers (#541).
+import { fieldSimulator } from "./simulator";
+import { initializeDefaultAgents, startDefaultAgents } from "./agents";
+import { storeAndForwardService } from "./gateway/store-and-forward";
+import { initializeBridges } from "./bridge";
+import { gatewayManager } from "./gateway";
+import { startFluxIntegration } from "./services/flux";
+import { natsPublisher } from "./services/nats";
+import { logAnchorBackendBootState } from "./bridge/anchor-backend";
 
 // Re-export log for backward compatibility
 export { log } from "./logger";
@@ -87,27 +97,21 @@ app.use((req, res, next) => {
   await initializeDatabase();
   log("Database initialized");
 
-  const { fieldSimulator } = await import("./simulator");
   await fieldSimulator.initialize();
   
-  const { initializeDefaultAgents, startDefaultAgents } = await import("./agents");
   await initializeDefaultAgents();
   await startDefaultAgents();
   
   // Initialize edge store-and-forward service
-  const { storeAndForwardService } = await import("./gateway/store-and-forward");
   await storeAndForwardService.initialize();
   log("Edge store-and-forward service initialized");
 
   // Initialize bridge modules (event-anchor, state-sync)
-  const { initializeBridges } = await import("./bridge");
   await initializeBridges();
   log("Bridge modules (event-anchor, state-sync) initialized");
 
   // Initialize demo gateway in development mode
   if (process.env.NODE_ENV === "development") {
-    const { gatewayManager } = await import("./gateway");
-    
     // Create demo DNP3 TCP driver
     gatewayManager.addDriver({
       id: "demo-dnp3-tcp",
@@ -185,20 +189,16 @@ app.use((req, res, next) => {
     async () => {
       log(`serving on port ${port}`);
       
-      const { fieldSimulator } = await import("./simulator");
       fieldSimulator.start();
 
       // Start Flux state engine integration (ADR-0015, Issue #260)
-      const { startFluxIntegration } = await import("./services/flux");
       startFluxIntegration();
 
       // Connect to NATS for SCADA event publishing
-      const { natsPublisher } = await import("./services/nats");
       await natsPublisher.connect();
 
       // Record the boot-resolved anchor routing: runtime switches (#455) are
       // process-local, so a restart reverts to env and this makes that visible.
-      const { logAnchorBackendBootState } = await import("./bridge/anchor-backend");
       logAnchorBackendBootState();
 
       // Start periodic health monitoring (every 30 s)


### PR DESCRIPTION
## Summary

Close the Node 20 `tsx` CJS/ESM split-module bug proven in #541 without attempting a repository-wide ESM migration.

- move every mutable startup dependency in `server/index.ts` onto the static import graph
- move the matching health and gateway consumers onto that same graph
- keep only the conditional, dev-only Vite loader dynamic
- add an AST regression guard that rejects future literal `import()` use for these shared startup singletons

The affected state includes the field simulator, agents startup, store-and-forward service, gateway manager, bridge/anchor state, Flux singleton closures, and NATS publisher. Initialization and serving/health consumers now resolve through one module instance on Node 20.

Closes #541.

## Reproduction evidence

Under Node 20.20.2 with `tsx`, loading the same TypeScript singleton through the static CJS graph and `import()` produced different objects (`same: false`). The pre-fix branch failed all three regression cases, identifying 9 dynamic startup imports, 3 health consumers, and 1 gateway consumer. Node 22/24 did not reproduce the identity split, matching the CI-only behavior described in the issue.

## Validation

- Node 20 regression guard: 3/3
- Node 20 startup integration: 5/5
- Node 20 full unit suite: 1,346 passed, 3 skipped
- post-main-merge regression guard: 3/3
- post-main-merge integration startup: 5/5
- Node 18/20 direct loading of every changed static module: pass
- `npm run typecheck`: pass
- `npm run build`: pass
- `git diff --check`: pass
- independent second pass found no missed shared startup consumer, import-cycle side effect, or compatibility blocker

The structural guard covers literal module specifiers; computed/aliased dynamic imports would require extending the guard if introduced later.