### PR TITLE
fix(gateway): run a standalone reverse proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,26 @@ jobs:
       - name: Enforce npm audit (high and critical)
         run: npm audit --audit-level=high
 
+  helm-gateway:
+    name: Helm Gateway Render
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.17.3
+      - run: npm ci
+      - name: Register the simple chart dependency repository
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami --force-update
+      - name: Render and verify the gateway Deployment
+        run: npx vitest run gateway/helm-chart.test.ts
+        env:
+          RUN_HELM_RENDER_TEST: '1'
+
   docker:
     name: Docker Build (${{ matrix.service }})
     runs-on: ubuntu-latest
@@ -237,7 +257,7 @@ jobs:
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, security, test, build, integration-test]
+    needs: [lint, typecheck, security, helm-gateway, test, build, integration-test]
     if: always()
     steps:
       - name: Check results
@@ -245,6 +265,7 @@ jobs:
           if [ "${{ needs.lint.result }}" != "success" ] || \
              [ "${{ needs.typecheck.result }}" != "success" ] || \
              [ "${{ needs.security.result }}" != "success" ] || \
+             [ "${{ needs.helm-gateway.result }}" != "success" ] || \
              [ "${{ needs.test.result }}" != "success" ] || \
              [ "${{ needs.build.result }}" != "success" ] || \
              [ "${{ needs.integration-test.result }}" != "success" ]; then

--- a/docker/gateway/Dockerfile
+++ b/docker/gateway/Dockerfile
@@ -1,30 +1,27 @@
-# 0xSCADA Gateway Service
-FROM node:20-alpine AS base
+# 0xSCADA standalone HTTP/WebSocket gateway
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY gateway/ ./gateway/
+RUN npm run build:gateway
+
+FROM node:20-alpine AS production
 WORKDIR /app
 RUN apk add --no-cache dumb-init
 
-FROM base AS deps
-COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+ENV NODE_ENV=production \
+    HOST=0.0.0.0 \
+    PORT=8080
 
-FROM base AS build
-COPY package.json package-lock.json ./
-RUN npm ci
-COPY tsconfig.json ./
-COPY server/ ./server/
-COPY shared/ ./shared/
-RUN npm run build --workspace=server 2>/dev/null || npx tsc --project tsconfig.json
+COPY --from=build --chown=node:node /app/dist/gateway/index.cjs ./dist/gateway/index.cjs
 
-FROM base AS production
-ENV NODE_ENV=production
 USER node
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=build /app/dist ./dist
-COPY package.json ./
-
 EXPOSE 8080
+
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://localhost:8080/health || exit 1
 
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["node", "dist/server/gateway.js"]
+CMD ["node", "dist/gateway/index.cjs"]

--- a/docs/k8s/application-deployment.md
+++ b/docs/k8s/application-deployment.md
@@ -19,8 +19,19 @@ Client (nginx:80) → Server (:5000) → PostgreSQL (:5432)
 Gateway (:8080) → Server (:5000)
 ```
 
+The gateway is a stateless HTTP/WebSocket reverse proxy. `SERVER_URL` is
+required and must be one fixed `http://` or `https://` origin without embedded
+credentials, a path, query, or fragment. HTTP traffic is forwarded unchanged
+to that origin, and WebSocket upgrades are accepted only on `/ws` and
+`/ws/tags`.
+
+`GET /health` is a process-only liveness check and remains healthy while the
+server is unavailable. `GET /readyz` checks the configured server's
+`/api/healthz` endpoint and is the Kubernetes readiness probe. Request bodies
+larger than 10 MiB are rejected by the gateway.
+
 ## Features
-- Health checks (liveness + readiness) on all pods
+- Separate process liveness and upstream-aware readiness checks
 - Resource limits and requests
 - Security contexts (non-root, read-only FS, no privilege escalation)
 - Rolling update strategy

--- a/docs/k8s/container-images.md
+++ b/docs/k8s/container-images.md
@@ -31,3 +31,7 @@ oxscada container push -t v1.0.0
 - Read-only root filesystem
 - Health checks on all images
 - `dumb-init` for proper signal handling
+
+The gateway image contains only the bundled `dist/gateway/index.cjs` runtime
+artifact. Set its required `SERVER_URL` environment variable to the fixed
+0xSCADA server origin; the image does not start or import the server process.

--- a/gateway/helm-chart.test.ts
+++ b/gateway/helm-chart.test.ts
@@ -1,6 +1,15 @@
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { load } from "js-yaml";
+import { dump, load, loadAll } from "js-yaml";
 import { describe, expect, it } from "vitest";
 
 interface ChartValues {
@@ -12,13 +21,136 @@ interface ChartValues {
   containerSecurityContext?: Record<string, unknown>;
 }
 
+interface ContainerManifest {
+  name?: string;
+  env?: Array<{ name?: string; value?: string }>;
+  ports?: Array<{ containerPort?: number; name?: string }>;
+  securityContext?: Record<string, unknown>;
+  livenessProbe?: { httpGet?: { path?: string; port?: number } };
+  readinessProbe?: { httpGet?: { path?: string; port?: number } };
+}
+
+interface KubernetesManifest {
+  kind?: string;
+  metadata?: { name?: string };
+  spec?: {
+    template?: {
+      spec?: {
+        securityContext?: Record<string, unknown>;
+        containers?: ContainerManifest[];
+      };
+    };
+  };
+}
+
 const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
 
 function readValues(path: string): ChartValues {
-  return load(readFileSync(`${repositoryRoot}${path}`, "utf8")) as ChartValues;
+  return load(readFileSync(join(repositoryRoot, path), "utf8")) as ChartValues;
 }
 
-describe("simple Helm chart gateway hardening", () => {
+function renderChart(
+  releaseName: string,
+  chartPath: string,
+  overrides: string[] = [],
+): KubernetesManifest[] {
+  const helmBinary = process.env.HELM_BINARY || "helm";
+  const rendered = execFileSync(
+    helmBinary,
+    [
+      "template",
+      releaseName,
+      chartPath,
+      ...overrides,
+    ],
+    { encoding: "utf8" },
+  );
+  const manifests: KubernetesManifest[] = [];
+  loadAll(rendered, (manifest) => {
+    if (manifest && typeof manifest === "object") {
+      manifests.push(manifest as KubernetesManifest);
+    }
+  });
+  return manifests;
+}
+
+function gatewayDeployment(manifests: KubernetesManifest[]): KubernetesManifest {
+  const matches = manifests.filter(
+    (manifest) =>
+      manifest.kind === "Deployment"
+      && manifest.spec?.template?.spec?.containers?.some(
+        (container) => container.name === "gateway",
+      ),
+  );
+  expect(matches).toHaveLength(1);
+  return matches[0]!;
+}
+
+function gatewayContainer(deployment: KubernetesManifest): ContainerManifest {
+  const matches = deployment.spec?.template?.spec?.containers?.filter(
+    (container) => container.name === "gateway",
+  ) ?? [];
+  expect(matches).toHaveLength(1);
+  return matches[0]!;
+}
+
+function environment(
+  container: ContainerManifest,
+): Record<string, string | undefined> {
+  return Object.fromEntries(
+    (container.env ?? []).map((entry) => [entry.name, entry.value]),
+  );
+}
+
+function expectGatewayRuntime(
+  deployment: KubernetesManifest,
+  port: number,
+  serverUrl: string,
+): void {
+  const container = gatewayContainer(deployment);
+  expect(deployment.spec?.template?.spec?.securityContext).toEqual({
+    fsGroup: 1000,
+    runAsNonRoot: true,
+    runAsUser: 1000,
+    seccompProfile: { type: "RuntimeDefault" },
+  });
+  expect(container.securityContext).toEqual({
+    allowPrivilegeEscalation: false,
+    capabilities: { drop: ["ALL"] },
+    readOnlyRootFilesystem: true,
+  });
+  expect(container.ports).toEqual(expect.arrayContaining([
+    expect.objectContaining({ containerPort: port }),
+  ]));
+  expect(environment(container)).toMatchObject({
+    PORT: String(port),
+    SERVER_URL: serverUrl,
+  });
+  expect(container.livenessProbe?.httpGet).toEqual({
+    path: "/health",
+    port,
+  });
+  expect(container.readinessProbe?.httpGet).toEqual({
+    path: "/readyz",
+    port,
+  });
+}
+
+function removeUnavailableLocalDependencies(chartPath: string): void {
+  const metadataPath = join(chartPath, "Chart.yaml");
+  const metadata = load(readFileSync(metadataPath, "utf8")) as Record<string, unknown>;
+  const dependencies = Array.isArray(metadata.dependencies)
+    ? metadata.dependencies
+    : [];
+  metadata.dependencies = dependencies.filter((dependency) => {
+    if (!dependency || typeof dependency !== "object") return true;
+    const repository = (dependency as Record<string, unknown>).repository;
+    return typeof repository !== "string" || !repository.startsWith("file://");
+  });
+  writeFileSync(metadataPath, dump(metadata, { lineWidth: -1 }), "utf8");
+}
+
+describe("gateway Helm chart hardening", () => {
   it("applies defaults equivalent to the full chart gateway", () => {
     const simple = readValues("helm/oxscada/values.yaml");
     const full = readValues("helm/oxscada-full/values.yaml");
@@ -38,16 +170,82 @@ describe("simple Helm chart gateway hardening", () => {
     expect(simple.containerSecurityContext).toEqual(full.gateway?.securityContext);
   });
 
-  it("wires the shared hardened defaults into the ranged gateway deployment", () => {
-    const template = readFileSync(
-      `${repositoryRoot}helm/oxscada/templates/deployment.yaml`,
-      "utf8",
-    );
+  const renderIt = process.env.RUN_HELM_RENDER_TEST === "1" ? it : it.skip;
 
-    expect(template).toContain(
-      'dict "server" .Values.server "client" .Values.client "gateway" .Values.gateway',
-    );
-    expect(template).toContain("toYaml $.Values.securityContext | nindent 8");
-    expect(template).toContain("toYaml $.Values.containerSecurityContext | nindent 12");
-  });
+  renderIt("renders hardened defaults and gateway runtime wiring", () => {
+    const scratchRoot = mkdtempSync(join(tmpdir(), "oxscada-helm-render-"));
+    const simpleChartPath = join(scratchRoot, "oxscada");
+    const fullChartPath = join(scratchRoot, "oxscada-full");
+    try {
+      cpSync(join(repositoryRoot, "helm/oxscada"), simpleChartPath, { recursive: true });
+      execFileSync(
+        process.env.HELM_BINARY || "helm",
+        ["dependency", "build", simpleChartPath],
+        { stdio: "pipe" },
+      );
+      cpSync(join(repositoryRoot, "helm/oxscada-full"), fullChartPath, {
+        recursive: true,
+      });
+      // The repository does not contain the full chart's declared file://
+      // subcharts (tracked in #548). Remove only those unavailable dependency
+      // declarations in the scratch copy so Helm still parses and renders the
+      // real parent templates and values under test.
+      removeUnavailableLocalDependencies(fullChartPath);
+
+      const simpleDefaults = gatewayDeployment(renderChart(
+        "oxscada",
+        simpleChartPath,
+        ["--set", "postgresql.enabled=false"],
+      ));
+      expect(simpleDefaults.metadata?.name).toBe("oxscada-gateway");
+      expectGatewayRuntime(simpleDefaults, 8080, "http://oxscada-server:5000");
+
+      const simpleOverrides = gatewayDeployment(renderChart(
+        "oxscada",
+        simpleChartPath,
+        [
+          "--set",
+          "postgresql.enabled=false",
+          "--set",
+          "gateway.port=18080",
+          "--set-string",
+          "gateway.serverUrl=https://upstream.internal:8443",
+        ],
+      ));
+      expectGatewayRuntime(
+        simpleOverrides,
+        18080,
+        "https://upstream.internal:8443",
+      );
+
+      const fullDefaults = gatewayDeployment(renderChart(
+        "oxscada-full",
+        fullChartPath,
+      ));
+      expect(fullDefaults.metadata?.name).toBe("oxscada-full-gateway");
+      expectGatewayRuntime(
+        fullDefaults,
+        8080,
+        "http://oxscada-full-server:3000",
+      );
+
+      const fullOverrides = gatewayDeployment(renderChart(
+        "oxscada-full",
+        fullChartPath,
+        [
+          "--set",
+          "gateway.port=28080",
+          "--set-string",
+          "gateway.serverUrl=https://full-upstream.internal:9443",
+        ],
+      ));
+      expectGatewayRuntime(
+        fullOverrides,
+        28080,
+        "https://full-upstream.internal:9443",
+      );
+    } finally {
+      rmSync(scratchRoot, { recursive: true, force: true });
+    }
+  }, 90_000);
 });

--- a/gateway/helm-chart.test.ts
+++ b/gateway/helm-chart.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { load } from "js-yaml";
+import { describe, expect, it } from "vitest";
+
+interface ChartValues {
+  gateway?: {
+    podSecurityContext?: Record<string, unknown>;
+    securityContext?: Record<string, unknown>;
+  };
+  securityContext?: Record<string, unknown>;
+  containerSecurityContext?: Record<string, unknown>;
+}
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+
+function readValues(path: string): ChartValues {
+  return load(readFileSync(`${repositoryRoot}${path}`, "utf8")) as ChartValues;
+}
+
+describe("simple Helm chart gateway hardening", () => {
+  it("applies defaults equivalent to the full chart gateway", () => {
+    const simple = readValues("helm/oxscada/values.yaml");
+    const full = readValues("helm/oxscada-full/values.yaml");
+
+    expect(simple.securityContext).toEqual({
+      runAsNonRoot: true,
+      runAsUser: 1000,
+      fsGroup: 1000,
+      seccompProfile: { type: "RuntimeDefault" },
+    });
+    expect(simple.containerSecurityContext).toEqual({
+      allowPrivilegeEscalation: false,
+      readOnlyRootFilesystem: true,
+      capabilities: { drop: ["ALL"] },
+    });
+    expect(simple.securityContext).toEqual(full.gateway?.podSecurityContext);
+    expect(simple.containerSecurityContext).toEqual(full.gateway?.securityContext);
+  });
+
+  it("wires the shared hardened defaults into the ranged gateway deployment", () => {
+    const template = readFileSync(
+      `${repositoryRoot}helm/oxscada/templates/deployment.yaml`,
+      "utf8",
+    );
+
+    expect(template).toContain(
+      'dict "server" .Values.server "client" .Values.client "gateway" .Values.gateway',
+    );
+    expect(template).toContain("toYaml $.Values.securityContext | nindent 8");
+    expect(template).toContain("toYaml $.Values.containerSecurityContext | nindent 12");
+  });
+});

--- a/gateway/index.ts
+++ b/gateway/index.ts
@@ -1,0 +1,54 @@
+import { createGatewayProxy } from "./proxy";
+
+function parsePort(value: string | undefined): number {
+  const raw = value ?? "8080";
+  if (!/^\d+$/.test(raw)) throw new Error("PORT must be an integer");
+  const port = Number(raw);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("PORT must be between 1 and 65535");
+  }
+  return port;
+}
+
+function requiredServerUrl(value: string | undefined): string {
+  if (!value?.trim()) throw new Error("SERVER_URL is required");
+  return value.trim();
+}
+
+try {
+  const port = parsePort(process.env.PORT);
+  const host = process.env.HOST?.trim() || "0.0.0.0";
+  const gateway = createGatewayProxy({
+    serverUrl: requiredServerUrl(process.env.SERVER_URL),
+  });
+  let shuttingDown = false;
+
+  gateway.server.listen(port, host, () => {
+    console.log(`0xSCADA gateway listening on ${host}:${port}`);
+  });
+  gateway.server.once("error", () => {
+    console.error("0xSCADA gateway listener failed");
+    process.exitCode = 1;
+  });
+
+  const shutdown = (signal: NodeJS.Signals) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`0xSCADA gateway received ${signal}; shutting down`);
+    void gateway.close().then(
+      () => {
+        process.exitCode = 0;
+      },
+      () => {
+        process.exitCode = 1;
+      },
+    );
+  };
+
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+} catch (error) {
+  const message = error instanceof Error ? error.message : "invalid configuration";
+  console.error(`0xSCADA gateway failed to start: ${message}`);
+  process.exitCode = 1;
+}

--- a/gateway/proxy.test.ts
+++ b/gateway/proxy.test.ts
@@ -323,6 +323,55 @@ describe("HTTP proxy", () => {
     expect(result.headers.connection).toBe("close");
   });
 
+  it("never reuses an upstream socket after an incomplete declared upload", async () => {
+    const seenPaths: string[] = [];
+    const upstream = createServer((incoming, response) => {
+      seenPaths.push(incoming.url ?? "");
+      if (incoming.url === "/early") {
+        response.writeHead(401);
+        response.end("denied");
+        return;
+      }
+      incoming.resume();
+      incoming.once("end", () => response.end("next-ok"));
+    });
+    const upstreamOrigin = await listen(upstream);
+    const { origin } = await startGateway(upstreamOrigin, {
+      serverUrl: upstreamOrigin,
+      timeouts: { requestBodyMs: 250, responseHeadersMs: 250 },
+    });
+    const target = new URL(origin);
+
+    const early = await new Promise<CapturedResponse>((resolve, reject) => {
+      const clientRequest = createServerRequest({
+        hostname: target.hostname,
+        port: target.port,
+        method: "POST",
+        path: "/early",
+        headers: { "content-length": "100" },
+      }, (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.once("end", () => resolve({
+          statusCode: response.statusCode ?? 0,
+          headers: response.headers,
+          chunks,
+          body: Buffer.concat(chunks).toString(),
+        }));
+      });
+      clientRequest.once("error", reject);
+      clientRequest.write("partial");
+    });
+
+    expect(early.statusCode).toBe(401);
+    expect(early.headers.connection).toBe("close");
+
+    const next = await request(origin, "/next");
+    expect(next.statusCode).toBe(200);
+    expect(next.body).toBe("next-ok");
+    expect(seenPaths).toEqual(["/early", "/next"]);
+  });
+
   it("bounds incomplete request bodies and closes the client connection", async () => {
     const upstream = createServer((incoming) => incoming.resume());
     const upstreamOrigin = await listen(upstream);

--- a/gateway/proxy.test.ts
+++ b/gateway/proxy.test.ts
@@ -1,0 +1,531 @@
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import { connect } from "node:net";
+import { once } from "node:events";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import {
+  MAX_REQUEST_BODY_BYTES,
+  createGatewayProxy,
+  parseServerUrl,
+  type GatewayProxy,
+} from "./proxy";
+
+interface CapturedResponse {
+  statusCode: number;
+  headers: IncomingHttpHeaders;
+  chunks: Buffer[];
+  body: string;
+}
+
+const cleanup: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const close of cleanup.splice(0).reverse()) await close();
+});
+
+async function listen(server: Server): Promise<string> {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("server did not bind");
+  cleanup.push(async () => {
+    server.closeAllConnections?.();
+    if (server.listening) {
+      server.close();
+      await once(server, "close");
+    }
+  });
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function startGateway(
+  serverUrl: string,
+  overrides: Parameters<typeof createGatewayProxy>[0] = { serverUrl },
+): Promise<{ gateway: GatewayProxy; origin: string }> {
+  const gateway = createGatewayProxy({ ...overrides, serverUrl });
+  gateway.server.listen(0, "127.0.0.1");
+  await once(gateway.server, "listening");
+  const address = gateway.server.address();
+  if (!address || typeof address === "string") throw new Error("gateway did not bind");
+  cleanup.push(() => gateway.close(0));
+  return { gateway, origin: `http://127.0.0.1:${address.port}` };
+}
+
+async function request(
+  origin: string,
+  path: string,
+  options: {
+    method?: string;
+    headers?: Record<string, string | string[]>;
+    chunks?: Array<string | Buffer>;
+  } = {},
+): Promise<CapturedResponse> {
+  const target = new URL(path, origin);
+  return new Promise((resolve, reject) => {
+    const clientRequest = createServerRequest({
+      hostname: target.hostname,
+      port: target.port,
+      method: options.method ?? "GET",
+      path: `${target.pathname}${target.search}`,
+      headers: options.headers,
+    }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer) => chunks.push(chunk));
+      response.once("end", () => {
+        resolve({
+          statusCode: response.statusCode ?? 0,
+          headers: response.headers,
+          chunks,
+          body: Buffer.concat(chunks).toString(),
+        });
+      });
+    });
+    clientRequest.once("error", reject);
+    for (const chunk of options.chunks ?? []) clientRequest.write(chunk);
+    clientRequest.end();
+  });
+}
+
+// Keep the test helper visibly separate from createServer, which is used for
+// upstream fixtures.
+import { request as createServerRequest } from "node:http";
+
+async function reserveUnusedOrigin(): Promise<string> {
+  const server = createServer();
+  const origin = await listen(server);
+  server.close();
+  await once(server, "close");
+  cleanup.pop();
+  return origin;
+}
+
+async function rawRequest(origin: string, requestText: string): Promise<string> {
+  const target = new URL(origin);
+  return new Promise((resolve, reject) => {
+    const socket = connect(Number(target.port), target.hostname);
+    const chunks: Buffer[] = [];
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve(Buffer.concat(chunks).toString());
+    };
+    socket.once("connect", () => socket.write(requestText));
+    socket.on("data", (chunk) => chunks.push(chunk));
+    socket.once("end", finish);
+    socket.once("close", finish);
+    socket.once("error", reject);
+  });
+}
+
+describe("SERVER_URL validation", () => {
+  it("accepts only a fixed credential-free HTTP(S) origin", () => {
+    expect(parseServerUrl("https://server.internal:8443").origin)
+      .toBe("https://server.internal:8443");
+    for (const invalid of [
+      "ftp://server.internal",
+      "http://user:secret@server.internal",
+      "http://server.internal/base",
+      "http://server.internal?token=secret",
+      "not a url",
+    ]) {
+      expect(() => parseServerUrl(invalid)).toThrow();
+    }
+  });
+
+  it("declares a 10 MiB default upload cap", () => {
+    expect(MAX_REQUEST_BODY_BYTES).toBe(10 * 1024 * 1024);
+  });
+});
+
+describe("HTTP proxy", () => {
+  it("keeps local liveness healthy while the upstream is unavailable", async () => {
+    const upstream = await reserveUnusedOrigin();
+    const { origin } = await startGateway(upstream, {
+      serverUrl: upstream,
+      timeouts: { connectMs: 100, readinessMs: 100 },
+    });
+
+    const health = await request(origin, "/health?probe=liveness");
+    expect(health.statusCode).toBe(200);
+    expect(JSON.parse(health.body)).toEqual({ status: "ok" });
+
+    const readiness = await request(origin, "/readyz");
+    expect(readiness.statusCode).toBe(503);
+    expect(JSON.parse(readiness.body)).toEqual({ status: "not ready" });
+  });
+
+  it("does not let local probe routes bypass bounded-body handling", async () => {
+    let upstreamRequests = 0;
+    const upstream = createServer((_incoming, response) => {
+      upstreamRequests += 1;
+      response.end("unexpected");
+    });
+    const upstreamOrigin = await listen(upstream);
+    const { origin } = await startGateway(upstreamOrigin, {
+      serverUrl: upstreamOrigin,
+      maxRequestBodyBytes: 8,
+    });
+
+    const declared = await request(origin, "/health", {
+      method: "GET",
+      headers: { "content-length": "9" },
+      chunks: ["123456789"],
+    });
+    expect(declared.statusCode).toBe(413);
+
+    const chunked = await request(origin, "/readyz", {
+      method: "GET",
+      chunks: ["body"],
+    });
+    expect(chunked.statusCode).toBe(400);
+    expect(upstreamRequests).toBe(0);
+  });
+
+  it("streams requests and responses while preserving end-to-end headers", async () => {
+    let captured:
+      | { method?: string; url?: string; headers: IncomingHttpHeaders; body: string }
+      | undefined;
+    const upstream = createServer((incoming, response) => {
+      if (incoming.url === "/api/healthz") {
+        response.writeHead(200).end('{"status":"alive"}');
+        return;
+      }
+
+      const body: Buffer[] = [];
+      incoming.on("data", (chunk: Buffer) => body.push(chunk));
+      incoming.once("end", () => {
+        captured = {
+          method: incoming.method,
+          url: incoming.url,
+          headers: incoming.headers,
+          body: Buffer.concat(body).toString(),
+        };
+        response.statusCode = 201;
+        response.setHeader("access-control-allow-origin", "https://operator.example");
+        response.setHeader("set-cookie", ["session=one; HttpOnly", "theme=dark"]);
+        response.setHeader("x-request-id", "request-123");
+        response.setHeader("connection", "keep-alive, x-remove-response");
+        response.setHeader("x-remove-response", "must-not-pass");
+        response.write("first-");
+        setTimeout(() => response.end("second"), 10);
+      });
+    });
+    const upstreamOrigin = await listen(upstream);
+    const { origin } = await startGateway(upstreamOrigin);
+
+    const readiness = await request(origin, "/readyz");
+    expect(readiness.statusCode).toBe(200);
+
+    const result = await request(origin, "/api/tags?plant=line-1", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer operator-secret",
+        "x-api-key": "api-secret",
+        cookie: "session=operator",
+        origin: "https://operator.example",
+        "x-request-id": "request-123",
+        connection: "keep-alive, x-remove-request",
+        "x-remove-request": "must-not-pass",
+        "content-type": "text/plain",
+      },
+      chunks: ["payload"],
+    });
+
+    expect(captured).toMatchObject({
+      method: "POST",
+      url: "/api/tags?plant=line-1",
+      body: "payload",
+    });
+    expect(captured?.headers.authorization).toBe("Bearer operator-secret");
+    expect(captured?.headers["x-api-key"]).toBe("api-secret");
+    expect(captured?.headers.cookie).toBe("session=operator");
+    expect(captured?.headers.origin).toBe("https://operator.example");
+    expect(captured?.headers["x-request-id"]).toBe("request-123");
+    expect(captured?.headers["x-remove-request"]).toBeUndefined();
+
+    expect(result.statusCode).toBe(201);
+    expect(result.body).toBe("first-second");
+    expect(result.chunks.length).toBeGreaterThanOrEqual(2);
+    expect(result.headers["set-cookie"]).toEqual([
+      "session=one; HttpOnly",
+      "theme=dark",
+    ]);
+    expect(result.headers["access-control-allow-origin"]).toBe("https://operator.example");
+    expect(result.headers["x-request-id"]).toBe("request-123");
+    expect(result.headers["x-remove-response"]).toBeUndefined();
+  });
+
+  it("rejects declared and chunked bodies over the configured cap", async () => {
+    let completedUpstreamRequests = 0;
+    const upstream = createServer((incoming, response) => {
+      incoming.resume();
+      incoming.once("end", () => {
+        completedUpstreamRequests += 1;
+        response.end("unexpected");
+      });
+    });
+    const upstreamOrigin = await listen(upstream);
+    const { origin } = await startGateway(upstreamOrigin, {
+      serverUrl: upstreamOrigin,
+      maxRequestBodyBytes: 8,
+    });
+
+    const declared = await request(origin, "/declared", {
+      method: "POST",
+      headers: { "content-length": "9" },
+      chunks: ["123456789"],
+    });
+    expect(declared.statusCode).toBe(413);
+
+    const chunked = await request(origin, "/chunked", {
+      method: "POST",
+      chunks: ["12345", "67890"],
+    });
+    expect(chunked.statusCode).toBe(413);
+    expect(completedUpstreamRequests).toBe(0);
+  });
+
+  it("forwards an early upstream response without waiting for the upload", async () => {
+    const upstream = createServer((_incoming, response) => {
+      response.writeHead(401);
+      response.end("denied");
+    });
+    const upstreamOrigin = await listen(upstream);
+    const { origin } = await startGateway(upstreamOrigin, {
+      serverUrl: upstreamOrigin,
+      timeouts: { requestBodyMs: 250 },
+    });
+    const target = new URL(origin);
+
+    const result = await new Promise<CapturedResponse>((resolve, reject) => {
+      const clientRequest = createServerRequest({
+        hostname: target.hostname,
+        port: target.port,
+        method: "POST",
+        path: "/early",
+      }, (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.once("end", () => resolve({
+          statusCode: response.statusCode ?? 0,
+          headers: response.headers,
+          chunks,
+          body: Buffer.concat(chunks).toString(),
+        }));
+      });
+      clientRequest.once("error", reject);
+      clientRequest.write("partial");
+    });
+
+    expect(result.statusCode).toBe(401);
+    expect(result.body).toBe("denied");
+    expect(result.headers.connection).toBe("close");
+  });
+
+  it("bounds incomplete request bodies and closes the client connection", async () => {
+    const upstream = createServer((incoming) => incoming.resume());
+    const upstreamOrigin = await listen(upstream);
+    const { origin } = await startGateway(upstreamOrigin, {
+      serverUrl: upstreamOrigin,
+      timeouts: { requestBodyMs: 75 },
+    });
+    const target = new URL(origin);
+
+    const result = await new Promise<CapturedResponse>((resolve, reject) => {
+      const clientRequest = createServerRequest({
+        hostname: target.hostname,
+        port: target.port,
+        method: "POST",
+        path: "/slow-upload",
+      }, (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.once("end", () => resolve({
+          statusCode: response.statusCode ?? 0,
+          headers: response.headers,
+          chunks,
+          body: Buffer.concat(chunks).toString(),
+        }));
+      });
+      clientRequest.once("error", reject);
+      clientRequest.write("partial");
+    });
+
+    expect(result.statusCode).toBe(504);
+    expect(result.headers.connection).toBe("close");
+  });
+
+  it("returns generic 502 and 504 responses without exposing the target", async () => {
+    const unavailable = await reserveUnusedOrigin();
+    const disconnected = await startGateway(unavailable, {
+      serverUrl: unavailable,
+      timeouts: { connectMs: 100, responseHeadersMs: 200 },
+    });
+    const badGateway = await request(disconnected.origin, "/api/data");
+    expect(badGateway.statusCode).toBe(502);
+    expect(badGateway.body).toContain("Bad gateway");
+    expect(badGateway.body).not.toContain(new URL(unavailable).host);
+
+    const slowUpstream = createServer(() => {
+      // Intentionally never send response headers.
+    });
+    const slowOrigin = await listen(slowUpstream);
+    const slowGateway = await startGateway(slowOrigin, {
+      serverUrl: slowOrigin,
+      timeouts: { connectMs: 100, responseHeadersMs: 75 },
+    });
+    const timeout = await request(slowGateway.origin, "/api/slow");
+    expect(timeout.statusCode).toBe(504);
+    expect(timeout.body).toContain("Gateway timeout");
+    expect(timeout.body).not.toContain(new URL(slowOrigin).host);
+  });
+
+  it("rejects absolute-form HTTP targets without contacting their origin", async () => {
+    let upstreamRequests = 0;
+    const upstream = createServer((_incoming, response) => {
+      upstreamRequests += 1;
+      response.end("unexpected");
+    });
+    const upstreamOrigin = await listen(upstream);
+    const { origin } = await startGateway(upstreamOrigin);
+    const target = new URL(origin);
+
+    const raw = await rawRequest(
+      origin,
+      "GET http://attacker.example/private HTTP/1.1\r\n"
+      + `Host: ${target.host}\r\n`
+      + "Connection: close\r\n\r\n",
+    );
+    expect(raw).toContain("400 Bad Request");
+
+    const unescaped = await rawRequest(
+      origin,
+      "GET /café HTTP/1.1\r\n"
+      + `Host: ${target.host}\r\n`
+      + "Connection: close\r\n\r\n",
+    );
+    expect(unescaped).toContain("400 Bad Request");
+    expect((await request(origin, "/health")).statusCode).toBe(200);
+    expect(upstreamRequests).toBe(0);
+  });
+});
+
+describe("WebSocket proxy", () => {
+  it.each(["/ws", "/ws/tags"])(
+    "tunnels %s and preserves auth, origin, request IDs, and subprotocols",
+    async (path) => {
+      let capturedHeaders: IncomingHttpHeaders | undefined;
+      let capturedUrl: string | undefined;
+      const upstream = createServer();
+      const websocketServer = new WebSocketServer({
+        noServer: true,
+        handleProtocols: (protocols) => protocols.has("scada.v1") ? "scada.v1" : false,
+      });
+      upstream.on("upgrade", (incoming, socket, head) => {
+        capturedHeaders = incoming.headers;
+        capturedUrl = incoming.url;
+        websocketServer.handleUpgrade(incoming, socket, head, (websocket) => {
+          websocketServer.emit("connection", websocket, incoming);
+        });
+      });
+      websocketServer.on("connection", (websocket) => {
+        websocket.send("connected");
+        websocket.on("message", (message) => websocket.send(`echo:${message.toString()}`));
+      });
+      cleanup.push(async () => {
+        for (const client of websocketServer.clients) client.terminate();
+        websocketServer.close();
+      });
+
+      const upstreamOrigin = await listen(upstream);
+      const { origin } = await startGateway(upstreamOrigin);
+      const websocket = new WebSocket(
+        `${origin.replace("http:", "ws:")}${path}?plant=line-1`,
+        ["scada.v1", "fallback"],
+        {
+          headers: {
+            authorization: "Bearer websocket-secret",
+            "x-api-key": "websocket-api-key",
+            cookie: "session=websocket",
+            origin: "https://operator.example",
+            "x-request-id": "websocket-request-123",
+          },
+        },
+      );
+      cleanup.push(async () => websocket.terminate());
+
+      const welcomePromise = once(websocket, "message");
+      await once(websocket, "open");
+      expect(websocket.protocol).toBe("scada.v1");
+      const [welcome] = await welcomePromise;
+      expect(welcome.toString()).toBe("connected");
+      const echoPromise = once(websocket, "message");
+      websocket.send("ping");
+      const [echo] = await echoPromise;
+      expect(echo.toString()).toBe("echo:ping");
+
+      expect(capturedUrl).toBe(`${path}?plant=line-1`);
+      expect(capturedHeaders?.authorization).toBe("Bearer websocket-secret");
+      expect(capturedHeaders?.["x-api-key"]).toBe("websocket-api-key");
+      expect(capturedHeaders?.cookie).toBe("session=websocket");
+      expect(capturedHeaders?.origin).toBe("https://operator.example");
+      expect(capturedHeaders?.["x-request-id"]).toBe("websocket-request-123");
+      expect(capturedHeaders?.["sec-websocket-protocol"]).toBe("scada.v1,fallback");
+    },
+  );
+
+  it("rejects upgrades outside the two fixed WebSocket routes", async () => {
+    let upstreamUpgrades = 0;
+    const upstream = createServer();
+    upstream.on("upgrade", () => {
+      upstreamUpgrades += 1;
+    });
+    const upstreamOrigin = await listen(upstream);
+    const { origin } = await startGateway(upstreamOrigin);
+    const target = new URL(origin);
+    const response = await rawRequest(
+      origin,
+      "GET /ws/admin HTTP/1.1\r\n"
+      + `Host: ${target.host}\r\n`
+      + "Connection: Upgrade\r\n"
+      + "Upgrade: websocket\r\n"
+      + "Sec-WebSocket-Version: 13\r\n"
+      + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n",
+    );
+
+    expect(response).toContain("404 Not Found");
+    expect(upstreamUpgrades).toBe(0);
+  });
+
+  it("closes a rejected upgrade whose upstream response aborts mid-body", async () => {
+    const upstream = createServer();
+    upstream.on("upgrade", (_incoming, socket) => {
+      socket.write(
+        "HTTP/1.1 401 Unauthorized\r\n"
+        + "Content-Length: 50\r\n"
+        + "Content-Type: text/plain\r\n"
+        + "Connection: close\r\n\r\n"
+        + "hello",
+      );
+      setTimeout(() => socket.destroy(), 10);
+    });
+    const upstreamOrigin = await listen(upstream);
+    const { origin } = await startGateway(upstreamOrigin);
+    const target = new URL(origin);
+
+    const response = await rawRequest(
+      origin,
+      "GET /ws HTTP/1.1\r\n"
+      + `Host: ${target.host}\r\n`
+      + "Connection: Upgrade\r\n"
+      + "Upgrade: websocket\r\n"
+      + "Sec-WebSocket-Version: 13\r\n"
+      + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n",
+    );
+
+    expect(response).toContain("401 Unauthorized");
+    expect(response).toContain("hello");
+    expect(response.match(/HTTP\/1\.1/g)).toHaveLength(1);
+  });
+});

--- a/gateway/proxy.test.ts
+++ b/gateway/proxy.test.ts
@@ -223,9 +223,18 @@ describe("HTTP proxy", () => {
         authorization: "Bearer operator-secret",
         "x-api-key": "api-secret",
         cookie: "session=operator",
+        host: "gateway.operator.example:8443",
         origin: "https://operator.example",
         "x-request-id": "request-123",
-        connection: "keep-alive, x-remove-request",
+        forwarded: "for=198.51.100.9;proto=https;host=spoofed.example",
+        "x-forwarded-for": "198.51.100.9, 203.0.113.7",
+        "x-forwarded-client-cert": "By=spiffe://spoofed.example",
+        "x-forwarded-host": "spoofed.example",
+        "x-forwarded-port": "443",
+        "x-forwarded-prefix": "/trusted",
+        "x-forwarded-proto": "https",
+        connection:
+          "keep-alive, x-remove-request, x-forwarded-for, x-forwarded-host, x-forwarded-proto",
         "x-remove-request": "must-not-pass",
         "content-type": "text/plain",
       },
@@ -243,6 +252,14 @@ describe("HTTP proxy", () => {
     expect(captured?.headers.origin).toBe("https://operator.example");
     expect(captured?.headers["x-request-id"]).toBe("request-123");
     expect(captured?.headers["x-remove-request"]).toBeUndefined();
+    expect(captured?.headers.forwarded).toBeUndefined();
+    expect(captured?.headers.host).toBe(new URL(upstreamOrigin).host);
+    expect(captured?.headers["x-forwarded-for"]).toBe("127.0.0.1");
+    expect(captured?.headers["x-forwarded-proto"]).toBe("http");
+    expect(captured?.headers["x-forwarded-host"]).toBe("gateway.operator.example:8443");
+    expect(captured?.headers["x-forwarded-client-cert"]).toBeUndefined();
+    expect(captured?.headers["x-forwarded-port"]).toBeUndefined();
+    expect(captured?.headers["x-forwarded-prefix"]).toBeUndefined();
 
     expect(result.statusCode).toBe(201);
     expect(result.body).toBe("first-second");
@@ -497,8 +514,16 @@ describe("WebSocket proxy", () => {
             authorization: "Bearer websocket-secret",
             "x-api-key": "websocket-api-key",
             cookie: "session=websocket",
+            host: "gateway.operator.example:9443",
             origin: "https://operator.example",
             "x-request-id": "websocket-request-123",
+            forwarded: "for=198.51.100.9;proto=https;host=spoofed.example",
+            "x-forwarded-for": "198.51.100.9",
+            "x-forwarded-client-cert": "By=spiffe://spoofed.example",
+            "x-forwarded-host": "spoofed.example",
+            "x-forwarded-port": "443",
+            "x-forwarded-prefix": "/trusted",
+            "x-forwarded-proto": "https",
           },
         },
       );
@@ -521,6 +546,14 @@ describe("WebSocket proxy", () => {
       expect(capturedHeaders?.origin).toBe("https://operator.example");
       expect(capturedHeaders?.["x-request-id"]).toBe("websocket-request-123");
       expect(capturedHeaders?.["sec-websocket-protocol"]).toBe("scada.v1,fallback");
+      expect(capturedHeaders?.forwarded).toBeUndefined();
+      expect(capturedHeaders?.host).toBe(new URL(upstreamOrigin).host);
+      expect(capturedHeaders?.["x-forwarded-for"]).toBe("127.0.0.1");
+      expect(capturedHeaders?.["x-forwarded-proto"]).toBe("http");
+      expect(capturedHeaders?.["x-forwarded-host"]).toBe("gateway.operator.example:9443");
+      expect(capturedHeaders?.["x-forwarded-client-cert"]).toBeUndefined();
+      expect(capturedHeaders?.["x-forwarded-port"]).toBeUndefined();
+      expect(capturedHeaders?.["x-forwarded-prefix"]).toBeUndefined();
     },
   );
 

--- a/gateway/proxy.ts
+++ b/gateway/proxy.ts
@@ -37,6 +37,11 @@ const HOP_BY_HOP_HEADERS = new Set([
   "upgrade",
 ]);
 
+function isForwardingHeader(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return normalized === "forwarded" || normalized.startsWith("x-forwarded-");
+}
+
 const WEBSOCKET_PATHS = new Set(["/ws", "/ws/tags"]);
 
 export interface GatewayTimeouts {
@@ -181,7 +186,10 @@ function connectionTokens(headers: IncomingHttpHeaders): Set<string> {
   return tokens;
 }
 
-function filterHeaders(headers: IncomingHttpHeaders): OutgoingHttpHeaders {
+function filterHeaders(
+  headers: IncomingHttpHeaders,
+  stripForwardingHeaders = false,
+): OutgoingHttpHeaders {
   const nominatedHeaders = connectionTokens(headers);
   const filtered: OutgoingHttpHeaders = {};
 
@@ -191,6 +199,7 @@ function filterHeaders(headers: IncomingHttpHeaders): OutgoingHttpHeaders {
       value === undefined
       || HOP_BY_HOP_HEADERS.has(normalized)
       || nominatedHeaders.has(normalized)
+      || (stripForwardingHeaders && isForwardingHeader(normalized))
     ) {
       continue;
     }
@@ -198,6 +207,23 @@ function filterHeaders(headers: IncomingHttpHeaders): OutgoingHttpHeaders {
   }
 
   return filtered;
+}
+
+/**
+ * Replace, rather than append to, caller-controlled forwarding metadata.
+ * Deployments that intentionally trust a load balancer must add that trust
+ * boundary explicitly instead of allowing an arbitrary client to create it.
+ */
+function forwardRequestHeaders(request: IncomingMessage): OutgoingHttpHeaders {
+  const headers = filterHeaders(request.headers, true);
+  const inboundSocket = request.socket as Socket & { encrypted?: boolean };
+  const remoteAddress = request.socket.remoteAddress;
+  const requestedHost = request.headers.host;
+
+  if (remoteAddress) headers["x-forwarded-for"] = remoteAddress;
+  headers["x-forwarded-proto"] = inboundSocket.encrypted === true ? "https" : "http";
+  if (requestedHost) headers["x-forwarded-host"] = requestedHost;
+  return headers;
 }
 
 function filterRawHeaders(rawHeaders: string[]): string[] {
@@ -501,7 +527,7 @@ function proxyHttpRequest(
         target,
         request.method,
         path,
-        filterHeaders(request.headers),
+        forwardRequestHeaders(request),
         agent,
       ),
       (incoming) => {
@@ -702,7 +728,7 @@ function proxyWebSocket(
   let state: "pending" | "upgraded" | "ordinary-response" | "terminal" = "pending";
   let timedOut = false;
   let ordinaryResponse: IncomingMessage | undefined;
-  const headers = filterHeaders(request.headers);
+  const headers = forwardRequestHeaders(request);
   headers.connection = "Upgrade";
   headers.upgrade = "websocket";
 

--- a/gateway/proxy.ts
+++ b/gateway/proxy.ts
@@ -1,0 +1,960 @@
+import {
+  Agent as HttpAgent,
+  type IncomingHttpHeaders,
+  type IncomingMessage,
+  type OutgoingHttpHeaders,
+  type RequestOptions,
+  type Server,
+  type ServerResponse,
+  createServer,
+  request as httpRequest,
+} from "node:http";
+import {
+  Agent as HttpsAgent,
+  request as httpsRequest,
+} from "node:https";
+import type { Socket } from "node:net";
+import type { Duplex } from "node:stream";
+
+export const MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024;
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
+const DEFAULT_RESPONSE_HEADERS_TIMEOUT_MS = 15_000;
+const DEFAULT_REQUEST_BODY_TIMEOUT_MS = 30_000;
+const DEFAULT_UPSTREAM_IDLE_TIMEOUT_MS = 30_000;
+const DEFAULT_READINESS_TIMEOUT_MS = 2_000;
+const DEFAULT_SHUTDOWN_GRACE_MS = 5_000;
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const WEBSOCKET_PATHS = new Set(["/ws", "/ws/tags"]);
+
+export interface GatewayTimeouts {
+  connectMs?: number;
+  responseHeadersMs?: number;
+  requestBodyMs?: number;
+  upstreamIdleMs?: number;
+  readinessMs?: number;
+}
+
+export interface GatewayProxyOptions {
+  serverUrl: string | URL;
+  maxRequestBodyBytes?: number;
+  timeouts?: GatewayTimeouts;
+}
+
+interface ResolvedTimeouts {
+  connectMs: number;
+  responseHeadersMs: number;
+  requestBodyMs: number;
+  upstreamIdleMs: number;
+  readinessMs: number;
+}
+
+interface ParsedRequestTarget {
+  path: string;
+  pathname: string;
+}
+
+interface Deadline {
+  start(): void;
+  clear(): void;
+}
+
+type UpstreamRequest = ReturnType<typeof httpRequest>;
+
+export interface GatewayProxy {
+  readonly server: Server;
+  readonly targetOrigin: string;
+  close(graceMs?: number): Promise<void>;
+}
+
+class ProxyTimeoutError extends Error {}
+class BodyLimitError extends Error {}
+
+function positiveInteger(value: number | undefined, fallback: number, name: string): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return resolved;
+}
+
+function resolveTimeouts(timeouts: GatewayTimeouts = {}): ResolvedTimeouts {
+  return {
+    connectMs: positiveInteger(timeouts.connectMs, DEFAULT_CONNECT_TIMEOUT_MS, "connect timeout"),
+    responseHeadersMs: positiveInteger(
+      timeouts.responseHeadersMs,
+      DEFAULT_RESPONSE_HEADERS_TIMEOUT_MS,
+      "response headers timeout",
+    ),
+    requestBodyMs: positiveInteger(
+      timeouts.requestBodyMs,
+      DEFAULT_REQUEST_BODY_TIMEOUT_MS,
+      "request body timeout",
+    ),
+    upstreamIdleMs: positiveInteger(
+      timeouts.upstreamIdleMs,
+      DEFAULT_UPSTREAM_IDLE_TIMEOUT_MS,
+      "upstream idle timeout",
+    ),
+    readinessMs: positiveInteger(
+      timeouts.readinessMs,
+      DEFAULT_READINESS_TIMEOUT_MS,
+      "readiness timeout",
+    ),
+  };
+}
+
+/**
+ * Resolve the one configured upstream. Incoming requests can never replace this
+ * origin: absolute-form and authority-form request targets are rejected below.
+ */
+export function parseServerUrl(value: string | URL): URL {
+  let target: URL;
+  try {
+    target = value instanceof URL ? new URL(value.href) : new URL(value);
+  } catch {
+    throw new Error("SERVER_URL must be a valid URL");
+  }
+
+  if (target.protocol !== "http:" && target.protocol !== "https:") {
+    throw new Error("SERVER_URL must use http or https");
+  }
+  if (!target.hostname) {
+    throw new Error("SERVER_URL must include a host");
+  }
+  if (target.username || target.password) {
+    throw new Error("SERVER_URL must not contain credentials");
+  }
+  if (target.search || target.hash) {
+    throw new Error("SERVER_URL must not contain a query or fragment");
+  }
+  if (target.pathname !== "/" && target.pathname !== "") {
+    throw new Error("SERVER_URL must be an origin without a path");
+  }
+
+  target.pathname = "/";
+  return target;
+}
+
+function parseRequestTarget(rawUrl: string | undefined): ParsedRequestTarget | null {
+  if (
+    !rawUrl
+    || !rawUrl.startsWith("/")
+    || rawUrl.startsWith("//")
+    || rawUrl.includes("\r")
+    || rawUrl.includes("\n")
+  ) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(rawUrl, "http://gateway.invalid");
+    if (parsed.origin !== "http://gateway.invalid") return null;
+    return { path: rawUrl, pathname: parsed.pathname };
+  } catch {
+    return null;
+  }
+}
+
+function connectionTokens(headers: IncomingHttpHeaders): Set<string> {
+  const tokens = new Set<string>();
+  const values = headers.connection;
+  const rawValues = Array.isArray(values) ? values : values ? [values] : [];
+  for (const value of rawValues) {
+    for (const token of value.split(",")) {
+      const normalized = token.trim().toLowerCase();
+      if (normalized) tokens.add(normalized);
+    }
+  }
+  return tokens;
+}
+
+function filterHeaders(headers: IncomingHttpHeaders): OutgoingHttpHeaders {
+  const nominatedHeaders = connectionTokens(headers);
+  const filtered: OutgoingHttpHeaders = {};
+
+  for (const [name, value] of Object.entries(headers)) {
+    const normalized = name.toLowerCase();
+    if (
+      value === undefined
+      || HOP_BY_HOP_HEADERS.has(normalized)
+      || nominatedHeaders.has(normalized)
+    ) {
+      continue;
+    }
+    filtered[name] = value;
+  }
+
+  return filtered;
+}
+
+function filterRawHeaders(rawHeaders: string[]): string[] {
+  const headers: IncomingHttpHeaders = {};
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    const name = rawHeaders[index]?.toLowerCase();
+    const value = rawHeaders[index + 1];
+    if (!name || value === undefined) continue;
+    const current = headers[name];
+    if (current === undefined) {
+      headers[name] = value;
+    } else if (Array.isArray(current)) {
+      current.push(value);
+    } else {
+      headers[name] = [current, value];
+    }
+  }
+
+  const nominatedHeaders = connectionTokens(headers);
+  const filtered: string[] = [];
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    const name = rawHeaders[index];
+    const value = rawHeaders[index + 1];
+    if (!name || value === undefined) continue;
+    const normalized = name.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(normalized) || nominatedHeaders.has(normalized)) continue;
+    filtered.push(name, value);
+  }
+  return filtered;
+}
+
+function parseContentLength(value: string | string[] | undefined): number | null {
+  if (value === undefined) return null;
+  if (Array.isArray(value) || !/^\d+$/.test(value)) {
+    throw new Error("invalid content length");
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new Error("invalid content length");
+  return parsed;
+}
+
+function rejectLocalEndpointBody(
+  request: IncomingMessage,
+  response: ServerResponse,
+  maxRequestBodyBytes: number,
+): boolean {
+  let declaredLength: number | null;
+  try {
+    declaredLength = parseContentLength(request.headers["content-length"]);
+  } catch {
+    request.resume();
+    sendJson(response, 400, { error: "Invalid request" }, request.method === "HEAD", true);
+    return true;
+  }
+
+  if (declaredLength !== null && declaredLength > maxRequestBodyBytes) {
+    request.resume();
+    sendJson(
+      response,
+      413,
+      { error: "Request body too large" },
+      request.method === "HEAD",
+      true,
+    );
+    return true;
+  }
+
+  if (
+    (declaredLength !== null && declaredLength > 0)
+    || request.headers["transfer-encoding"] !== undefined
+  ) {
+    request.resume();
+    sendJson(
+      response,
+      400,
+      { error: "Request body not allowed" },
+      request.method === "HEAD",
+      true,
+    );
+    return true;
+  }
+
+  return false;
+}
+
+function sendJson(
+  response: ServerResponse,
+  statusCode: number,
+  payload: Record<string, string>,
+  headOnly = false,
+  closeConnection = false,
+): void {
+  if (response.destroyed || response.writableEnded) return;
+  const body = Buffer.from(JSON.stringify(payload));
+  response.writeHead(statusCode, {
+    "cache-control": "no-store",
+    ...(closeConnection ? { connection: "close" } : {}),
+    "content-length": body.byteLength,
+    "content-type": "application/json; charset=utf-8",
+  });
+  response.end(headOnly ? undefined : body);
+}
+
+function rawError(socket: Duplex, statusCode: number, status: string, message: string): void {
+  if (socket.destroyed) return;
+  const body = Buffer.from(JSON.stringify({ error: message }));
+  socket.end(
+    `HTTP/1.1 ${statusCode} ${status}\r\n`
+    + "Cache-Control: no-store\r\n"
+    + "Connection: close\r\n"
+    + `Content-Length: ${body.byteLength}\r\n`
+    + "Content-Type: application/json; charset=utf-8\r\n"
+    + `\r\n${body.toString()}`,
+  );
+}
+
+function disableSocketTimeout(socket: Duplex): void {
+  const timeoutSocket = socket as Duplex & { setTimeout?: (timeout: number) => unknown };
+  timeoutSocket.setTimeout?.(0);
+}
+
+function createRequestOptions(
+  target: URL,
+  method: string | undefined,
+  path: string,
+  headers: OutgoingHttpHeaders,
+  agent: HttpAgent | HttpsAgent,
+): RequestOptions {
+  return {
+    agent,
+    headers: {
+      ...headers,
+      host: target.host,
+    },
+    hostname: target.hostname,
+    method,
+    path,
+    port: target.port || undefined,
+    protocol: target.protocol,
+  };
+}
+
+function transportRequest(
+  target: URL,
+  options: RequestOptions,
+  callback?: (response: IncomingMessage) => void,
+): UpstreamRequest {
+  return target.protocol === "https:"
+    ? httpsRequest(options, callback)
+    : httpRequest(options, callback);
+}
+
+function armConnectTimeout(
+  request: UpstreamRequest,
+  timeoutMs: number,
+  onTimeout: () => void,
+): () => void {
+  let timer: NodeJS.Timeout | undefined;
+  const clear = () => {
+    if (timer) clearTimeout(timer);
+    timer = undefined;
+  };
+
+  request.once("socket", (socket) => {
+    if (!socket.connecting) return;
+    timer = setTimeout(onTimeout, timeoutMs);
+    timer.unref();
+    socket.once("connect", clear);
+  });
+  request.once("response", clear);
+  request.once("upgrade", clear);
+  request.once("error", clear);
+  return clear;
+}
+
+function armResponseHeadersTimeout(
+  request: UpstreamRequest,
+  timeoutMs: number,
+  onTimeout: () => void,
+): Deadline {
+  let timer: NodeJS.Timeout | undefined;
+  let completed = false;
+  const start = () => {
+    if (timer || completed) return;
+    timer = setTimeout(onTimeout, timeoutMs);
+    timer.unref();
+  };
+  const clear = () => {
+    completed = true;
+    if (timer) clearTimeout(timer);
+    timer = undefined;
+  };
+  request.once("response", clear);
+  request.once("upgrade", clear);
+  request.once("error", clear);
+  return { start, clear };
+}
+
+async function checkReadiness(
+  target: URL,
+  agent: HttpAgent | HttpsAgent,
+  timeoutMs: number,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (ready: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(ready);
+    };
+    const request = transportRequest(
+      target,
+      createRequestOptions(
+        target,
+        "GET",
+        "/api/healthz",
+        { accept: "application/json" },
+        agent,
+      ),
+      (response) => {
+        response.resume();
+        response.once("end", () => finish(
+          response.statusCode !== undefined
+          && response.statusCode >= 200
+          && response.statusCode < 300,
+        ));
+        response.once("aborted", () => finish(false));
+        response.once("error", () => finish(false));
+      },
+    );
+    const timer = setTimeout(() => {
+      request.destroy(new ProxyTimeoutError("readiness timeout"));
+      finish(false);
+    }, timeoutMs);
+    timer.unref();
+    request.once("error", () => finish(false));
+    request.end();
+  });
+}
+
+function proxyHttpRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  target: URL,
+  path: string,
+  agent: HttpAgent | HttpsAgent,
+  maxRequestBodyBytes: number,
+  timeouts: ResolvedTimeouts,
+): void {
+  let declaredLength: number | null;
+  try {
+    declaredLength = parseContentLength(request.headers["content-length"]);
+  } catch {
+    request.resume();
+    sendJson(
+      response,
+      400,
+      { error: "Invalid request" },
+      request.method === "HEAD",
+      true,
+    );
+    return;
+  }
+
+  if (declaredLength !== null && declaredLength > maxRequestBodyBytes) {
+    request.resume();
+    sendJson(
+      response,
+      413,
+      { error: "Request body too large" },
+      request.method === "HEAD",
+      true,
+    );
+    return;
+  }
+
+  let receivedBytes = 0;
+  let bodyComplete = false;
+  let responseStarted = false;
+  let failureHandled = false;
+  let discardRemainingBody = false;
+  let upstreamBodyEnded = false;
+  let bodyTimer: NodeJS.Timeout | undefined;
+  let upstreamResponse: IncomingMessage | undefined;
+
+  const forwardUpstreamResponse = (incoming: IncomingMessage, closeConnection: boolean) => {
+    responseStarted = true;
+    const headers = filterHeaders(incoming.headers);
+    if (closeConnection) headers.connection = "close";
+    response.writeHead(incoming.statusCode ?? 502, headers);
+    incoming.pipe(response);
+    incoming.resume();
+  };
+
+  let upstreamRequest: UpstreamRequest;
+  try {
+    upstreamRequest = transportRequest(
+      target,
+      createRequestOptions(
+        target,
+        request.method,
+        path,
+        filterHeaders(request.headers),
+        agent,
+      ),
+      (incoming) => {
+        upstreamResponse = incoming;
+        const responseArrivedEarly = !bodyComplete;
+        if (responseArrivedEarly) {
+          discardRemainingBody = true;
+          request.resume();
+          if (!upstreamBodyEnded) {
+            upstreamBodyEnded = true;
+            upstreamRequest.end();
+          }
+        }
+        let upstreamResponseTimedOut = false;
+        incoming.setTimeout(timeouts.upstreamIdleMs, () => {
+          upstreamResponseTimedOut = true;
+          incoming.destroy(new ProxyTimeoutError("upstream idle timeout"));
+        });
+        incoming.once("aborted", () => {
+          if (responseStarted) {
+            if (!response.writableEnded) response.destroy();
+          } else {
+            fail(
+              upstreamResponseTimedOut
+                ? new ProxyTimeoutError("upstream idle timeout")
+                : new Error("upstream response aborted"),
+            );
+          }
+        });
+        incoming.once("error", (error) => {
+          if (responseStarted) {
+            if (!response.writableEnded) response.destroy();
+          } else {
+            fail(error);
+          }
+        });
+        forwardUpstreamResponse(incoming, responseArrivedEarly);
+      },
+    );
+  } catch {
+    request.resume();
+    sendJson(
+      response,
+      400,
+      { error: "Invalid request" },
+      request.method === "HEAD",
+      true,
+    );
+    return;
+  }
+
+  function fail(error: Error): void {
+    if (failureHandled) return;
+    failureHandled = true;
+    if (bodyTimer) clearTimeout(bodyTimer);
+    request.unpipe();
+    request.resume();
+    upstreamResponse?.destroy();
+    if (responseStarted || response.headersSent) {
+      if (!response.writableEnded) response.destroy();
+      return;
+    }
+    if (error instanceof BodyLimitError) {
+      sendJson(
+        response,
+        413,
+        { error: "Request body too large" },
+        request.method === "HEAD",
+        true,
+      );
+    } else if (error instanceof ProxyTimeoutError) {
+      sendJson(
+        response,
+        504,
+        { error: "Gateway timeout" },
+        request.method === "HEAD",
+        !bodyComplete,
+      );
+    } else {
+      sendJson(
+        response,
+        502,
+        { error: "Bad gateway" },
+        request.method === "HEAD",
+        !bodyComplete,
+      );
+    }
+  }
+
+  const clearConnectTimer = armConnectTimeout(upstreamRequest, timeouts.connectMs, () => {
+    upstreamRequest.destroy(new ProxyTimeoutError("connect timeout"));
+  });
+  const clearHeadersTimer = armResponseHeadersTimeout(
+    upstreamRequest,
+    timeouts.responseHeadersMs,
+    () => upstreamRequest.destroy(new ProxyTimeoutError("response headers timeout")),
+  );
+
+  bodyTimer = setTimeout(() => {
+    if (!bodyComplete) upstreamRequest.destroy(new ProxyTimeoutError("request body timeout"));
+  }, timeouts.requestBodyMs);
+  bodyTimer.unref();
+
+  request.on("data", (chunk: Buffer) => {
+    receivedBytes += chunk.byteLength;
+    if (receivedBytes > maxRequestBodyBytes) {
+      upstreamRequest.destroy(new BodyLimitError("body limit exceeded"));
+      return;
+    }
+    if (!discardRemainingBody && !upstreamRequest.write(chunk)) {
+      request.pause();
+      upstreamRequest.once("drain", () => request.resume());
+    }
+  });
+  request.once("end", () => {
+    bodyComplete = true;
+    if (bodyTimer) clearTimeout(bodyTimer);
+    clearHeadersTimer.start();
+    if (!upstreamBodyEnded) {
+      upstreamBodyEnded = true;
+      upstreamRequest.end();
+    }
+  });
+  request.once("aborted", () => {
+    if (bodyTimer) clearTimeout(bodyTimer);
+    upstreamRequest.destroy();
+  });
+  request.once("error", (error) => upstreamRequest.destroy(error));
+  response.once("close", () => {
+    if (!response.writableEnded) upstreamRequest.destroy();
+  });
+  upstreamRequest.once("error", (error) => {
+    clearConnectTimer();
+    clearHeadersTimer.clear();
+    fail(error);
+  });
+}
+
+function writeUpgradeResponse(
+  clientSocket: Duplex,
+  upstreamResponse: IncomingMessage,
+): void {
+  const rawHeaders = filterRawHeaders(upstreamResponse.rawHeaders);
+  let responseHead = `HTTP/1.1 ${upstreamResponse.statusCode ?? 101} ${upstreamResponse.statusMessage ?? "Switching Protocols"}\r\n`;
+  responseHead += "Connection: Upgrade\r\nUpgrade: websocket\r\n";
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    responseHead += `${rawHeaders[index]}: ${rawHeaders[index + 1]}\r\n`;
+  }
+  clientSocket.write(`${responseHead}\r\n`);
+}
+
+function writeOrdinaryUpgradeResponse(
+  clientSocket: Duplex,
+  upstreamResponse: IncomingMessage,
+): void {
+  const rawHeaders = filterRawHeaders(upstreamResponse.rawHeaders);
+  let responseHead = `HTTP/1.1 ${upstreamResponse.statusCode ?? 502} ${upstreamResponse.statusMessage ?? ""}\r\n`;
+  responseHead += "Connection: close\r\n";
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    responseHead += `${rawHeaders[index]}: ${rawHeaders[index + 1]}\r\n`;
+  }
+  clientSocket.write(`${responseHead}\r\n`);
+  upstreamResponse.pipe(clientSocket);
+}
+
+function proxyWebSocket(
+  request: IncomingMessage,
+  clientSocket: Duplex,
+  head: Buffer,
+  target: URL,
+  path: string,
+  agent: HttpAgent | HttpsAgent,
+  timeouts: ResolvedTimeouts,
+  upstreamSockets: Set<Duplex>,
+): void {
+  const upgrade = request.headers.upgrade;
+  const connection = request.headers.connection;
+  if (
+    request.method !== "GET"
+    || typeof upgrade !== "string"
+    || upgrade.toLowerCase() !== "websocket"
+    || typeof connection !== "string"
+    || !connection.toLowerCase().split(",").some((token) => token.trim() === "upgrade")
+  ) {
+    rawError(clientSocket, 400, "Bad Request", "Invalid WebSocket upgrade");
+    return;
+  }
+
+  let state: "pending" | "upgraded" | "ordinary-response" | "terminal" = "pending";
+  let timedOut = false;
+  let ordinaryResponse: IncomingMessage | undefined;
+  const headers = filterHeaders(request.headers);
+  headers.connection = "Upgrade";
+  headers.upgrade = "websocket";
+
+  let upstreamRequest: UpstreamRequest;
+  try {
+    upstreamRequest = transportRequest(
+      target,
+      createRequestOptions(target, "GET", path, headers, agent),
+    );
+  } catch {
+    rawError(clientSocket, 400, "Bad Request", "Invalid request");
+    return;
+  }
+  const connectTimer = armConnectTimeout(upstreamRequest, timeouts.connectMs, () => {
+    timedOut = true;
+    upstreamRequest.destroy(new ProxyTimeoutError("connect timeout"));
+  });
+  const headerTimer = armResponseHeadersTimeout(
+    upstreamRequest,
+    timeouts.responseHeadersMs,
+    () => {
+      timedOut = true;
+      upstreamRequest.destroy(new ProxyTimeoutError("response headers timeout"));
+    },
+  );
+  headerTimer.start();
+
+  upstreamRequest.once("upgrade", (upstreamResponse, upstreamSocket, upstreamHead) => {
+    if (state !== "pending") {
+      upstreamSocket.destroy();
+      return;
+    }
+    state = "upgraded";
+    connectTimer();
+    headerTimer.clear();
+    upstreamRequest.setTimeout(0);
+    disableSocketTimeout(upstreamSocket);
+    disableSocketTimeout(clientSocket);
+    upstreamSockets.add(upstreamSocket);
+    upstreamSocket.once("close", () => upstreamSockets.delete(upstreamSocket));
+
+    writeUpgradeResponse(clientSocket, upstreamResponse);
+    if (upstreamHead.length > 0) clientSocket.write(upstreamHead);
+    if (head.length > 0) upstreamSocket.write(head);
+    clientSocket.pipe(upstreamSocket);
+    upstreamSocket.pipe(clientSocket);
+
+    clientSocket.once("error", () => upstreamSocket.destroy());
+    upstreamSocket.once("error", () => clientSocket.destroy());
+    clientSocket.once("close", () => upstreamSocket.destroy());
+    upstreamSocket.once("close", () => clientSocket.destroy());
+  });
+
+  upstreamRequest.once("response", (upstreamResponse) => {
+    if (state !== "pending") {
+      upstreamResponse.destroy();
+      return;
+    }
+    state = "ordinary-response";
+    ordinaryResponse = upstreamResponse;
+    connectTimer();
+    headerTimer.clear();
+    upstreamResponse.setTimeout(timeouts.upstreamIdleMs, () => {
+      upstreamResponse.destroy(new ProxyTimeoutError("upstream idle timeout"));
+      clientSocket.destroy();
+    });
+    const abortOrdinaryResponse = () => {
+      state = "terminal";
+      clientSocket.destroy();
+    };
+    upstreamResponse.once("aborted", abortOrdinaryResponse);
+    upstreamResponse.once("error", abortOrdinaryResponse);
+    upstreamResponse.once("end", () => {
+      state = "terminal";
+    });
+    writeOrdinaryUpgradeResponse(clientSocket, upstreamResponse);
+  });
+
+  upstreamRequest.once("error", () => {
+    connectTimer();
+    headerTimer.clear();
+    if (state === "pending") {
+      state = "terminal";
+      rawError(
+        clientSocket,
+        timedOut ? 504 : 502,
+        timedOut ? "Gateway Timeout" : "Bad Gateway",
+        timedOut ? "Gateway timeout" : "Bad gateway",
+      );
+    }
+  });
+  clientSocket.once("close", () => {
+    if (state === "pending") upstreamRequest.destroy();
+    ordinaryResponse?.destroy();
+  });
+  upstreamRequest.end();
+}
+
+export function createGatewayProxy(options: GatewayProxyOptions): GatewayProxy {
+  const target = parseServerUrl(options.serverUrl);
+  const timeouts = resolveTimeouts(options.timeouts);
+  const maxRequestBodyBytes = positiveInteger(
+    options.maxRequestBodyBytes,
+    MAX_REQUEST_BODY_BYTES,
+    "max request body bytes",
+  );
+  const httpAgent = new HttpAgent({
+    keepAlive: true,
+    maxSockets: 256,
+    timeout: timeouts.upstreamIdleMs,
+  });
+  const httpsAgent = new HttpsAgent({
+    keepAlive: true,
+    maxSockets: 256,
+    timeout: timeouts.upstreamIdleMs,
+  });
+  const agent = target.protocol === "https:" ? httpsAgent : httpAgent;
+  const clientSockets = new Set<Socket>();
+  const upgradeSockets = new Set<Duplex>();
+  const upstreamSockets = new Set<Duplex>();
+
+  const server = createServer((request, response) => {
+    const requestTarget = parseRequestTarget(request.url);
+    if (!requestTarget) {
+      request.resume();
+      sendJson(
+        response,
+        400,
+        { error: "Invalid request target" },
+        request.method === "HEAD",
+        true,
+      );
+      return;
+    }
+
+    if (
+      requestTarget.pathname === "/health"
+      && (request.method === "GET" || request.method === "HEAD")
+    ) {
+      if (rejectLocalEndpointBody(request, response, maxRequestBodyBytes)) return;
+      request.resume();
+      sendJson(response, 200, { status: "ok" }, request.method === "HEAD");
+      return;
+    }
+
+    if (
+      requestTarget.pathname === "/readyz"
+      && (request.method === "GET" || request.method === "HEAD")
+    ) {
+      if (rejectLocalEndpointBody(request, response, maxRequestBodyBytes)) return;
+      request.resume();
+      void checkReadiness(target, agent, timeouts.readinessMs).then((ready) => {
+        sendJson(
+          response,
+          ready ? 200 : 503,
+          { status: ready ? "ready" : "not ready" },
+          request.method === "HEAD",
+        );
+      });
+      return;
+    }
+
+    proxyHttpRequest(
+      request,
+      response,
+      target,
+      requestTarget.path,
+      agent,
+      maxRequestBodyBytes,
+      timeouts,
+    );
+  });
+  server.headersTimeout = Math.min(timeouts.requestBodyMs, 15_000);
+  server.requestTimeout = timeouts.requestBodyMs;
+  server.keepAliveTimeout = 5_000;
+
+  server.on("connection", (socket) => {
+    clientSockets.add(socket);
+    socket.once("close", () => clientSockets.delete(socket));
+  });
+
+  server.on("connect", (_request, socket) => {
+    socket.once("error", () => {});
+    rawError(socket, 405, "Method Not Allowed", "CONNECT is not supported");
+  });
+
+  server.on("upgrade", (request, socket, head) => {
+    socket.once("error", () => {});
+    upgradeSockets.add(socket);
+    socket.once("close", () => upgradeSockets.delete(socket));
+    const requestTarget = parseRequestTarget(request.url);
+    if (!requestTarget) {
+      rawError(socket, 400, "Bad Request", "Invalid request target");
+      return;
+    }
+    if (!WEBSOCKET_PATHS.has(requestTarget.pathname)) {
+      rawError(socket, 404, "Not Found", "WebSocket route not found");
+      return;
+    }
+    proxyWebSocket(
+      request,
+      socket,
+      head,
+      target,
+      requestTarget.path,
+      agent,
+      timeouts,
+      upstreamSockets,
+    );
+  });
+
+  return {
+    server,
+    targetOrigin: target.origin,
+    async close(graceMs = DEFAULT_SHUTDOWN_GRACE_MS): Promise<void> {
+      if (!Number.isSafeInteger(graceMs) || graceMs < 0) {
+        throw new Error("shutdown grace must be a non-negative integer");
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        if (!server.listening) {
+          for (const socket of clientSockets) socket.destroy();
+          for (const socket of upstreamSockets) socket.destroy();
+          httpAgent.destroy();
+          httpsAgent.destroy();
+          resolve();
+          return;
+        }
+
+        let serverClosed = false;
+        let forceElapsed = upgradeSockets.size === 0 && upstreamSockets.size === 0;
+        let closeError: Error | undefined;
+        let completed = false;
+        const finish = () => {
+          if (completed || !serverClosed || !forceElapsed) return;
+          completed = true;
+          clearTimeout(forceTimer);
+          httpAgent.destroy();
+          httpsAgent.destroy();
+          if (closeError) reject(closeError);
+          else resolve();
+        };
+        const forceTimer = setTimeout(() => {
+          for (const socket of clientSockets) socket.destroy();
+          for (const socket of upstreamSockets) socket.destroy();
+          server.closeAllConnections?.();
+          forceElapsed = true;
+          finish();
+        }, graceMs);
+        forceTimer.unref();
+
+        server.close((error) => {
+          serverClosed = true;
+          closeError = error;
+          if (upgradeSockets.size === 0 && upstreamSockets.size === 0) {
+            forceElapsed = true;
+          }
+          finish();
+        });
+        server.closeIdleConnections?.();
+      });
+    },
+  };
+}

--- a/gateway/proxy.ts
+++ b/gateway/proxy.ts
@@ -510,6 +510,15 @@ function proxyHttpRequest(
         if (responseArrivedEarly) {
           discardRemainingBody = true;
           request.resume();
+          // A response can arrive before a declared Content-Length upload is
+          // complete (for example, an immediate 401). Ending the client
+          // request does not fill the missing bytes, so that upstream socket
+          // must never return to the keep-alive pool: a later request would
+          // otherwise be parsed as the remainder of this request body.
+          if (declaredLength !== null && receivedBytes < declaredLength) {
+            upstreamRequest.shouldKeepAlive = false;
+            incoming.once("end", () => incoming.socket.destroy());
+          }
           if (!upstreamBodyEnded) {
             upstreamBodyEnded = true;
             upstreamRequest.end();

--- a/helm/oxscada-full/templates/gateway-deployment.yaml
+++ b/helm/oxscada-full/templates/gateway-deployment.yaml
@@ -15,14 +15,35 @@ spec:
       labels:
         app.kubernetes.io/component: gateway
     spec:
+      securityContext:
+        {{- toYaml .Values.gateway.podSecurityContext | nindent 8 }}
       containers:
         - name: gateway
           image: "{{ .Values.global.imageRegistry }}/gateway:{{ .Values.gateway.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.gateway.port }}
+          env:
+            - name: PORT
+              value: {{ .Values.gateway.port | quote }}
+            - name: SERVER_URL
+              value: {{ default (printf "http://%s-server:%v" (include "oxscada-full.fullname" .) .Values.server.port) .Values.gateway.serverUrl | quote }}
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.gateway.securityContext | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.gateway.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: {{ .Values.gateway.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service

--- a/helm/oxscada-full/values.yaml
+++ b/helm/oxscada-full/values.yaml
@@ -57,6 +57,20 @@ gateway:
     repository: "{{ .Values.global.imageRegistry }}/gateway"
     tag: latest
   port: 8080
+  # Optional fixed upstream origin. When empty, the chart targets its server
+  # Service at http://<release>-server:<server.port>.
+  serverUrl: ""
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
   resources:
     requests:
       cpu: 100m

--- a/helm/oxscada/templates/deployment.yaml
+++ b/helm/oxscada/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
                   name: {{ . | quote }}
                   key: {{ $component.apiKeys.secretKey | quote }}
             {{- end }}
+          {{ else if eq $name "gateway" }}
+          env:
+            - name: PORT
+              value: {{ $component.port | quote }}
+            - name: SERVER_URL
+              value: {{ default (printf "http://oxscada-server:%v" $.Values.server.port) $component.serverUrl | quote }}
           {{ end }}
           resources:
             {{- toYaml $component.resources | nindent 12 }}
@@ -55,7 +61,7 @@ spec:
             periodSeconds: 20
           readinessProbe:
             httpGet:
-              path: /health
+              path: {{ if eq $name "gateway" }}/readyz{{ else }}/health{{ end }}
               port: {{ $component.port }}
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/helm/oxscada/values.yaml
+++ b/helm/oxscada/values.yaml
@@ -118,6 +118,8 @@ observability:
 networkPolicies:
   enabled: true
 
+# Shared pod defaults for server, client, and gateway. Keep these aligned with
+# helm/oxscada-full's gateway.podSecurityContext.
 securityContext:
   runAsNonRoot: true
   runAsUser: 1000
@@ -125,6 +127,8 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+# Shared container defaults for server, client, and gateway. Keep these aligned
+# with helm/oxscada-full's gateway.securityContext.
 containerSecurityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true

--- a/helm/oxscada/values.yaml
+++ b/helm/oxscada/values.yaml
@@ -43,6 +43,9 @@ gateway:
     repository: oxscada-gateway
     tag: latest
   port: 8080
+  # Optional fixed upstream origin. When empty, the chart targets the server
+  # Service at http://oxscada-server:<server.port>.
+  serverUrl: ""
   resources:
     requests:
       cpu: 100m

--- a/k8s/app/gateway-deployment.yaml
+++ b/k8s/app/gateway-deployment.yaml
@@ -54,7 +54,7 @@ spec:
             periodSeconds: 20
           readinessProbe:
             httpGet:
-              path: /health
+              path: /readyz
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@vitejs/plugin-react": "^4.2.0",
         "@vitest/coverage-v8": "^4.0.18",
         "drizzle-kit": "^0.31.9",
+        "esbuild": "0.28.1",
         "fast-check": "^3.23.2",
         "jsdom": "^29.1.1",
         "tsx": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/server/index.js",
   "scripts": {
     "build": "tsc",
+    "build:gateway": "esbuild gateway/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/gateway/index.cjs",
     "dev": "NODE_ENV=development tsx server/index.ts",
     "dev:setup": "npm run dev:db && npm run dev",
     "dev:db": "echo 'Setting up development database...' && node -e \"console.log('Database will be created automatically on first run')\"",
@@ -59,6 +60,7 @@
     "@vitejs/plugin-react": "^4.2.0",
     "@vitest/coverage-v8": "^4.0.18",
     "drizzle-kit": "^0.31.9",
+    "esbuild": "0.28.1",
     "fast-check": "^3.23.2",
     "jsdom": "^29.1.1",
     "tsx": "^4.7.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     "server/**/*",
     "client/**/*",
     "shared/**/*",
+    "gateway/**/*",
     "*.ts",
     "*.tsx"
   ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
           environment: "node",
           globals: true,
           include: [
-            "{server,cli,shared}/**/*.{test,spec}.{ts,tsx}",
+            "{server,cli,shared,gateway}/**/*.{test,spec}.{ts,tsx}",
             "test/**/*.{test,spec}.{ts,tsx}",
           ],
           // Excluded from the default unit run (they belong to the separate


### PR DESCRIPTION
## Summary

- build the gateway image as a standalone Node 20 HTTP/WebSocket reverse proxy instead of importing or starting the full server
- require one fixed, credential-free `SERVER_URL`; expose local `/health` and upstream-backed `/readyz`
- stream HTTP requests/responses and the `/ws` + `/ws/tags` upgrades while preserving authorization, cookies, origin, and WebSocket subprotocols
- strip hop-by-hop headers, reject unsupported request-target forms, bound request bodies and timeouts, return generic proxy errors, and drain on shutdown
- make incomplete declared-length uploads retire their upstream socket so a later request cannot be consumed as body bytes
- align the gateway Dockerfile, Kubernetes manifests, Helm values/templates, and deployment docs with the standalone runtime

## Review follow-up

- HTTP and WebSocket forwarding remove caller-controlled `Forwarded` and every `X-Forwarded-*` variant, then regenerate `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-Host` from the immediate gateway connection and inbound Host header.
- Both Helm charts are now rendered through Helm 3.17.3 at default and overridden values in a required CI job. Parsed gateway Deployments must contain the non-root UID/GID, `RuntimeDefault` seccomp, no privilege escalation, read-only root filesystem, dropped capabilities, correct `PORT`/`SERVER_URL`, and `/health` + `/readyz` probes. The full chart's unavailable `file://` subcharts are removed only from the scratch render copy; #548 tracks supplying those dependencies.
- The exact PR head `dc6862fe9e42ee75b54455bcc9c9c7c661896322` completed a real BuildKit image build in [`Docker Build (gateway)`](https://github.com/modhaneel072/0xSCADA/actions/runs/30056592959/job/89369718955). The overall fork workflow is red because the pre-existing client/server/validator image jobs fail independently; the gateway image job itself passed.

## Validation

- gateway proxy + real Helm-render suites: 17/17 passed
- full unit suite: 1,362 passed, 4 skipped
- live integration suite: 5/5 passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm run build:gateway`: passed (26.0 KiB self-contained bundle)
- `npm audit --audit-level=high`: 0 vulnerabilities
- `git diff --check origin/main...HEAD`: passed
- required [`Helm Gateway Render`](https://github.com/NickFlach/0xSCADA/actions/runs/30056593623/job/89369490750): passed on a fresh Ubuntu runner
- independent raw HTTP/1.1 reproduction confirmed the incomplete-upload request and the following request use separate upstream sockets
- exact-head `Docker Build (gateway)`: passed

## Trust boundary and remaining scope

- Authentication is preserved and forwarded; the upstream server remains authoritative for authentication and authorization.
- Forwarded client provenance intentionally describes the gateway's immediate peer. A deployment that wants to trust a load balancer must add an explicit trusted-proxy policy rather than implicitly accepting caller-supplied forwarding metadata.
- `/readyz` remains unauthenticated for orchestrator probes and performs one timeout-bounded request to the single fixed upstream origin.
- The simple chart and the full chart's parent gateway template are covered. The pre-existing missing local dependencies in `helm/oxscada-full` remain tracked separately in #548.
- WebSocket connection limits and idle policy remain the responsibility of the upstream/deployment layer.
