### PR TITLE
fix(auth): bind control-plane principals to header keys (#545)

### DIFF
--- a/server/middleware/__tests__/control-plane-auth.test.ts
+++ b/server/middleware/__tests__/control-plane-auth.test.ts
@@ -1,0 +1,150 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import express from "express";
+import { createServer, type Server } from "node:http";
+
+import {
+  apiKeyMiddleware,
+  type ApiKeyRecord,
+} from "../api-gateway";
+import {
+  controlPlanePrincipal,
+  requireControlPlaneAccess,
+} from "../control-plane-auth";
+
+interface TestServer {
+  server: Server;
+  baseUrl: string;
+}
+
+const now = new Date();
+const keys = new Map<string, ApiKeyRecord>([
+  [
+    "write-key",
+    {
+      key: "write-key",
+      name: "control-writer",
+      scopes: ["control.write"],
+      createdAt: now,
+    },
+  ],
+  [
+    "read-key",
+    {
+      key: "read-key",
+      name: "control-reader",
+      scopes: ["control.read"],
+      createdAt: now,
+    },
+  ],
+]);
+
+function startServer(): Promise<TestServer> {
+  const app = express();
+  const requireControlWrite = requireControlPlaneAccess({
+    scopes: ["control.write"],
+  });
+  const sendPrincipal: express.RequestHandler = (req, res) => {
+    res.json({ principal: controlPlanePrincipal(req).name });
+  };
+
+  app.use(apiKeyMiddleware(keys));
+  app.get("/protected", requireControlWrite, sendPrincipal);
+  app.get(
+    "/mismatched-attached-record",
+    (req, _res, next) => {
+      (req as express.Request & { apiKeyRecord?: ApiKeyRecord }).apiKeyRecord =
+        keys.get("write-key");
+      next();
+    },
+    requireControlWrite,
+    sendPrincipal,
+  );
+  app.get(
+    "/expired-attached-record",
+    (req, _res, next) => {
+      (req as express.Request & { apiKeyRecord?: ApiKeyRecord }).apiKeyRecord = {
+        ...keys.get("write-key")!,
+        expiresAt: new Date(0),
+      };
+      next();
+    },
+    requireControlWrite,
+    sendPrincipal,
+  );
+
+  return new Promise((resolve) => {
+    const server = createServer(app);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe("control-plane authentication composition", () => {
+  let testServer: TestServer;
+
+  beforeAll(async () => {
+    testServer = await startServer();
+  });
+
+  afterAll(async () => {
+    await closeServer(testServer.server);
+  });
+
+  it("rejects a query-string credential even if the global gateway attached it", async () => {
+    const response = await fetch(
+      `${testServer.baseUrl}/protected?api_key=write-key`,
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("accepts a matching X-API-Key and exposes its server-owned principal", async () => {
+    const response = await fetch(`${testServer.baseUrl}/protected`, {
+      headers: { "x-api-key": "write-key" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      principal: "control-writer",
+    });
+  });
+
+  it("rejects a valid but under-scoped X-API-Key", async () => {
+    const response = await fetch(`${testServer.baseUrl}/protected`, {
+      headers: { "x-api-key": "read-key" },
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects an attached record that does not match the header credential", async () => {
+    const response = await fetch(
+      `${testServer.baseUrl}/mismatched-attached-record`,
+      { headers: { "x-api-key": "read-key" } },
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rechecks expiration on a matching attached record", async () => {
+    const response = await fetch(
+      `${testServer.baseUrl}/expired-attached-record`,
+      { headers: { "x-api-key": "write-key" } },
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/server/middleware/control-plane-auth.ts
+++ b/server/middleware/control-plane-auth.ts
@@ -62,13 +62,22 @@ function rolesFor(record: ApiKeyRecord): string[] {
 }
 
 function authenticate(req: Request): ApiKeyRecord | undefined {
-  const attached = (req as Request & { apiKeyRecord?: ApiKeyRecord }).apiKeyRecord;
-  if (attached) return attached;
-
   // Credentials in a query string leak into access logs and browser history.
   // Sensitive routes intentionally accept only the standard header form.
   const key = req.header("x-api-key");
   if (!key) return undefined;
+
+  const attached = (req as Request & { apiKeyRecord?: ApiKeyRecord }).apiKeyRecord;
+  if (attached) {
+    // A preceding gateway may attach a record from a credential source with a
+    // different trust policy. Re-bind that record to the exact header value
+    // before accepting it at the control-plane boundary.
+    if (attached.key !== key) return undefined;
+    if (attached.expiresAt && attached.expiresAt.getTime() <= Date.now()) {
+      return undefined;
+    }
+    return attached;
+  }
 
   const record = configuredApiKeys().get(key);
   if (!record) return undefined;


### PR DESCRIPTION
## Summary

Closes one independently reviewable part of #545: a control-plane guard could trust a gateway-attached API-key record before proving that the request supplied the same key in `X-API-Key`.

On current `main`, the generic gateway accepts `?api_key=` and attaches `req.apiKeyRecord`. A sensitive router using `requireControlPlaneAccess()` would then accept that attached record even though the router's documented invariant is header-only authentication.

## Fix

- Require `X-API-Key` before consulting any attached gateway record.
- Accept an attached record only when its key exactly matches the header.
- Recheck expiration at the control-plane boundary.
- Preserve support for dynamically generated keys attached by the global gateway and for direct `API_KEYS` lookup when the global gateway is not mounted.

## Regression proof

The new real Express composition test mounts `apiKeyMiddleware()` before `requireControlPlaneAccess()`:

- Before the fix, `GET /protected?api_key=write-key` returned **200**; the regression test failed (`expected 401, received 200`).
- After the fix, query-only, mismatched attached-record, and expired attached-record cases return **401**.
- A matching header key still reaches the handler with the server-owned principal.
- A valid but under-scoped header key still returns **403**.

## Validation

- Focused control-plane + existing anchor HTTP tests: 10/10 passed.
- Full unit suite: 1,351 passed, 3 skipped.
- Integration suite: 5/5 passed.
- `npm run typecheck`: passed.
- `npm run build`: passed.
- `npm audit --audit-level=high`: 0 vulnerabilities.
- `git diff --check`: passed.

## Scope boundary

This does **not** claim to close all of #545 and does not replace #520. #520 still owns removal of query credentials at the global gateway, production fail-closed defaults, WebSocket auth, and deployment/client plumbing. This patch makes every existing/future route-local control-plane guard independently enforce its header-only contract.

Refs #545