### PR TITLE
chore(deps): configure dependabot groups and defer breaking majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+# Dependabot configuration.
+#
+# Rationale: the default (ungrouped, majors-included) config repeatedly produced
+# a single npm group PR that could not merge because it bundled breaking major
+# upgrades (e.g. vite 8, tailwindcss 4, js-yaml 5) alongside safe minor/patch
+# bumps. This config groups the safe updates so they flow and merge on their
+# own, and suppresses the specific majors that require a coordinated migration
+# until a maintainer takes them on individually.
+version: 2
+updates:
+  # Root application (server + React frontend + contracts tooling)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # vite 8 is blocked until @vitejs/plugin-react ships a vite-8 peer range;
+      # bump both together in a dedicated PR, then remove this ignore.
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      # tailwindcss 4 is a CSS-first rewrite (config + stylesheet migration);
+      # handle as a dedicated migration PR, then remove this ignore.
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
+      # js-yaml 5 changes default schema/API; review every load/dump call site
+      # in a dedicated PR, then remove this ignore.
+      - dependency-name: "js-yaml"
+        update-types: ["version-update:semver-major"]
+
+  # CLI package
+  - package-ecosystem: "npm"
+    directory: "/cli"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      cli-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` (none existed — dependabot was running on defaults).

**Problem:** the default config repeatedly recreated a single npm group PR (#536 → #553) that could not merge because it bundled three breaking major upgrades — **vite 8** (ERESOLVE vs `@vitejs/plugin-react`'s vite-7 peer), **tailwindcss 4** (CSS-first rewrite), **js-yaml 5** (schema/API change) — alongside safe minor/patch bumps. Every recreate failed CI at `npm ci`/type-check.

**Fix:**
- Group npm **minor + patch** updates for `/` and `/cli` so the safe bumps flow and merge on their own.
- `ignore` the three known-hard majors (vite/tailwindcss/js-yaml) until each is taken on as a dedicated migration PR — comments in the file say to remove the ignore once migrated.
- Add a grouped **github-actions** ecosystem (the repo had no dependabot coverage for workflow actions at all).

After this merges, dependabot will supersede #553 with a clean minor/patch-only group on its next run. 🤖 Generated with [Claude Code](https://claude.com/claude-code)