### PR TITLE
fix(server): emit a runnable Docker bundle

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -13,7 +13,7 @@ RUN npm ci
 COPY tsconfig.json ./
 COPY server/ ./server/
 COPY shared/ ./shared/
-RUN npm run build --workspace=server 2>/dev/null || npx tsc --project tsconfig.json
+RUN npm run build:server
 
 FROM base AS production
 ENV NODE_ENV=production
@@ -25,7 +25,7 @@ COPY package.json ./
 
 EXPOSE 5000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -qO- http://localhost:5000/health || exit 1
+  CMD wget -qO- http://localhost:5000/api/healthz || exit 1
 
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["node", "dist/server/index.js"]
+CMD ["node", "dist/server/index.cjs"]

--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
   "name": "0xscada",
   "version": "1.0.0",
   "description": "Industrial SCADA system with blockchain-backed audit trails",
-  "main": "dist/server/index.js",
+  "main": "dist/server/index.cjs",
   "scripts": {
     "build": "tsc",
     "build:gateway": "esbuild gateway/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/gateway/index.cjs",
+    "build:server": "esbuild server/index.ts --bundle --platform=node --target=node20 --format=cjs --packages=external --outfile=dist/server/index.cjs",
     "dev": "NODE_ENV=development tsx server/index.ts",
     "dev:setup": "npm run dev:db && npm run dev",
     "dev:db": "echo 'Setting up development database...' && node -e \"console.log('Database will be created automatically on first run')\"",
-    "start": "node dist/server/index.js",
+    "start": "node dist/server/index.cjs",
     "test": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary

- add an emitting `build:server` target that bundles the server and shared TypeScript with esbuild
- keep npm packages external so production `node_modules` supplies native/runtime dependencies such as SQLite
- make the server image build and launch the explicit CommonJS artifact
- point the container liveness check at the mounted `/api/healthz` endpoint

## Root cause

The current-main [Docker Build (server)](https://github.com/NickFlach/0xSCADA/actions/runs/30057518057/job/89372454036) runs `tsc` successfully, but the repository `tsconfig.json` has `noEmit: true`. Docker then fails when it tries to copy the missing `/app/dist` directory.

This PR replaces that silent no-op build path with an explicit server bundle. Externalizing package imports avoids embedding native modules while still bundling repository-local server/shared code and path aliases.

## Scope

This addresses only the server-image portion of #555. It does not change or claim to fix the separate client or validator image failures.

## Validation

- `npm ci` (0 audit findings)
- `npm run build:server` (emitted `dist/server/index.cjs`, 492.3 KiB)
- `npm run typecheck`
- `npx vitest run server/__tests__/startup-singleton-imports.test.ts server/health/__tests__/health-manager.test.ts` (12/12)
- pruned to production dependencies, booted the emitted bundle, and verified `GET /api/healthz` returned `200 {"status":"alive"}`
- exact-head [Docker Build (server)](https://github.com/modhaneel072/0xSCADA/actions/runs/30058231708/job/89374547254) passed on commit `31b69c895`

The overall fork run remains red only for the separate, pre-existing client and validator failures tracked in #555.
