### PR TITLE
fix(client): repair Docker build inputs and output path

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -3,14 +3,14 @@ FROM node:20-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
-COPY tsconfig.json vite.config.ts postcss.config.js ./
+COPY tsconfig.json vite.config.ts ./
 COPY client/ ./client/
 COPY shared/ ./shared/
 RUN npm run build --workspace=client 2>/dev/null || npx vite build
 
 FROM nginx:1.25-alpine AS production
 RUN apk add --no-cache curl
-COPY --from=build /app/dist/client /usr/share/nginx/html
+COPY --from=build /app/client/dist /usr/share/nginx/html
 COPY docker/client/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80


### PR DESCRIPTION
## Summary

Repairs only the client image build identified in #555.

- stops copying the nonexistent and unused `postcss.config.js`
- copies the Vite output from its actual location, `/app/client/dist`, into nginx

This addresses the client portion of #555 only. It does not close #555; the server and validator failures remain separate work.

## Root cause

The current `main` run fails at `docker/client/Dockerfile:6` because BuildKit cannot calculate a checksum for `/postcss.config.js`. The repository has no PostCSS config or client CSS pipeline that consumes one, so removing that input is the smallest accurate fix.

After unblocking that layer, the production stage would also copy from `/app/dist/client`, while `vite build` emits `client/dist` because the configured Vite root is `client`. The Dockerfile now uses the emitted path.

Evidence: https://github.com/NickFlach/0xSCADA/actions/runs/30057518057/job/89372454031

## Validation

- `npm ci` (734 packages audited, 0 vulnerabilities)
- `npx vite build` (59 modules; output verified at `client/dist/index.html`)
- `npm run typecheck`
- `git diff --check`
- exact-head GitHub Actions `Docker Build (client)`: **success**  
  https://github.com/modhaneel072/0xSCADA/actions/runs/30058322363/job/89374839931

The aggregate fork run remains red only because the independently tracked `server` and `validator` Docker jobs from #555 still fail on their pre-existing `/app/dist` problem. Gateway, client, and all non-Docker checks passed.
