### PR TITLE
[13.2] Repair alarm correlation on current main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX=100
 
+# Alarm correlation remains advisory/process-local until issue #573 lands.
+# Set true only for an explicit single-process evaluation before enabling
+# suppression through the authenticated configuration endpoint.
+ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION=false
+
 # Flux State Engine Integration (ADR-0015, Issue #260)
 # Set FLUX_URL to enable. Leave blank to disable.
 FLUX_URL=

--- a/client/src/hooks/use-tag-stream.ts
+++ b/client/src/hooks/use-tag-stream.ts
@@ -24,9 +24,24 @@ export interface AlarmEvent {
   id: string;
   name: string;
   severity: "critical" | "high" | "medium" | "low" | "info";
-  state: "active" | "acknowledged" | "cleared";
-  tagValue?: number;
+  state: "active" | "acknowledged" | "cleared" | "shelved" | "suppressed";
+  tagId?: string;
+  equipmentId?: string;
+  siteId?: string;
+  message?: string;
+  timestamp: number;
+  tagValue?: number | string;
   triggeredAt: string;
+  acknowledgedBy?: string;
+  clearedBy?: string;
+  correlation: {
+    groupId: string | null;
+    groupState: "open" | "closed" | null;
+    rootCauseAlarmId: string | null;
+    suppressed: boolean;
+    isRootCause: boolean;
+    coordinationMode: "process-local";
+  };
 }
 
 export interface PipelineHealth {

--- a/client/src/pages/live-dashboard.tsx
+++ b/client/src/pages/live-dashboard.tsx
@@ -41,6 +41,7 @@ const StatusBadge: React.FC<{ status: string }> = ({ status }) => {
     degraded: '#f59e0b', uncertain: '#f59e0b',
     unhealthy: '#ef4444', bad: '#ef4444', disconnected: '#ef4444',
     active: '#ef4444', acknowledged: '#f59e0b', cleared: '#6b7280',
+    suppressed: '#64748b', shelved: '#64748b',
   };
   return (
     <span style={{
@@ -85,8 +86,13 @@ const TagTable: React.FC<{ tags: Map<string, TagValue> }> = ({ tags }) => (
 
 const AlarmList: React.FC<{ alarms: AlarmEvent[] }> = ({ alarms }) => {
   const severityOrder = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+  const suppressedCount = alarms.filter((alarm) =>
+    (alarm as any).state === 'suppressed'
+  ).length;
   const sorted = [...alarms]
-    .filter((a) => (a as any).state !== 'cleared')
+    .filter((a) =>
+      (a as any).state !== 'cleared' && (a as any).state !== 'suppressed'
+    )
     .sort((a, b) => (severityOrder as any)[(a as any).severity] - (severityOrder as any)[(b as any).severity]);
 
   return (
@@ -108,6 +114,11 @@ const AlarmList: React.FC<{ alarms: AlarmEvent[] }> = ({ alarms }) => {
         </div>
       ))}
       {sorted.length === 0 && <p style={{ textAlign: 'center', color: '#666', padding: 20 }}>No active alarms</p>}
+      {suppressedCount > 0 && (
+        <p style={{ textAlign: 'center', color: '#94a3b8', fontSize: 11 }}>
+          {suppressedCount} consequential alarm{suppressedCount === 1 ? '' : 's'} grouped under a root cause
+        </p>
+      )}
     </div>
   );
 };

--- a/docs/security/control-plane-api-keys.md
+++ b/docs/security/control-plane-api-keys.md
@@ -31,6 +31,32 @@ curl -H "X-API-Key: ${OPERATOR_KEY}" \
   https://oxscada.example.com/api/admin/anchor-backend
 ```
 
+## Alarm-correlation grants
+
+Alarm correlation uses separate grants so an observer, producer, operator, or
+configuration client receives only the capability it needs:
+
+| Grant | Capability |
+| --- | --- |
+| `alarms.read` | Read groups, root cause, rules, topology, policy, metrics, and status |
+| `alarms.ingest` | Ingest raw active alarms |
+| `alarms.acknowledge` | Acknowledge a tracked alarm |
+| `alarms.clear` | Clear a tracked alarm |
+| `alarms.configure` | Change rules, topology, or suppression policy |
+
+For example, a dedicated ingest key can be configured without any lifecycle or
+configuration authority:
+
+```text
+<generated-ingest-key>:alarm-ingester:alarms.ingest
+```
+
+Correlation state is process-local until
+[#573](https://github.com/NickFlach/0xSCADA/issues/573) lands, so suppression
+defaults off. Enabling it also requires the explicit
+`ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION=true` startup flag; use that
+escape hatch only for a single-process evaluation.
+
 ## Docker Compose
 
 The production root `docker-compose.yml` enables global authentication and

--- a/server/__tests__/alarm-correlation-auth-http.test.ts
+++ b/server/__tests__/alarm-correlation-auth-http.test.ts
@@ -1,0 +1,446 @@
+import { createServer, type Server } from "node:http";
+import express from "express";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { _resetControlPlaneAuthCache } from "../middleware/control-plane-auth";
+import { alarmCorrelationRoutes } from "../routes/alarm-correlation";
+
+interface TestServer {
+  server: Server;
+  baseUrl: string;
+}
+
+type AlarmScope = "read" | "ingest" | "acknowledge" | "clear" | "configure";
+
+interface RouteCase {
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  path: string;
+  scope: AlarmScope;
+  authorizedStatus: number;
+  body?: Record<string, unknown>;
+}
+
+const routeCases: RouteCase[] = [
+  { method: "GET", path: "/groups", scope: "read", authorizedStatus: 200 },
+  { method: "GET", path: "/groups/unknown", scope: "read", authorizedStatus: 404 },
+  {
+    method: "GET",
+    path: "/groups/unknown/root-cause",
+    scope: "read",
+    authorizedStatus: 404,
+  },
+  { method: "GET", path: "/rules", scope: "read", authorizedStatus: 200 },
+  { method: "GET", path: "/topology", scope: "read", authorizedStatus: 200 },
+  {
+    method: "GET",
+    path: "/suppression-policy",
+    scope: "read",
+    authorizedStatus: 200,
+  },
+  { method: "GET", path: "/metrics", scope: "read", authorizedStatus: 200 },
+  { method: "GET", path: "/status", scope: "read", authorizedStatus: 200 },
+  {
+    method: "POST",
+    path: "/alarms",
+    scope: "ingest",
+    body: { alarms: [] },
+    authorizedStatus: 400,
+  },
+  {
+    method: "POST",
+    path: "/alarms/unknown/acknowledge",
+    scope: "acknowledge",
+    authorizedStatus: 404,
+  },
+  {
+    method: "POST",
+    path: "/alarms/unknown/clear",
+    scope: "clear",
+    authorizedStatus: 404,
+  },
+  {
+    method: "PUT",
+    path: "/rules/test-rule",
+    scope: "configure",
+    body: {},
+    authorizedStatus: 400,
+  },
+  {
+    method: "DELETE",
+    path: "/rules/unknown",
+    scope: "configure",
+    authorizedStatus: 404,
+  },
+  {
+    method: "POST",
+    path: "/rules/unknown/enable",
+    scope: "configure",
+    authorizedStatus: 404,
+  },
+  {
+    method: "POST",
+    path: "/rules/unknown/disable",
+    scope: "configure",
+    authorizedStatus: 404,
+  },
+  {
+    method: "PUT",
+    path: "/topology",
+    scope: "configure",
+    body: { nodes: [] },
+    authorizedStatus: 400,
+  },
+  {
+    method: "DELETE",
+    path: "/topology/unknown",
+    scope: "configure",
+    authorizedStatus: 404,
+  },
+  {
+    method: "PUT",
+    path: "/suppression-policy",
+    scope: "configure",
+    body: {},
+    authorizedStatus: 400,
+  },
+];
+
+const keys: Record<AlarmScope, string> = {
+  read: "read-key",
+  ingest: "ingest-key",
+  acknowledge: "acknowledge-key",
+  clear: "clear-key",
+  configure: "configure-key",
+};
+
+const crossScope: Record<AlarmScope, string> = {
+  read: keys.ingest,
+  ingest: keys.configure,
+  acknowledge: keys.clear,
+  clear: keys.acknowledge,
+  configure: keys.read,
+};
+
+function startServer(): Promise<TestServer> {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/alarm-correlation", alarmCorrelationRoutes);
+  return new Promise((resolve) => {
+    const server = createServer(app);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function request(
+  testServer: TestServer,
+  route: RouteCase,
+  apiKey?: string,
+): Promise<Response> {
+  const headers: Record<string, string> = {};
+  if (apiKey) headers["x-api-key"] = apiKey;
+  if (route.body !== undefined) headers["content-type"] = "application/json";
+
+  return fetch(`${testServer.baseUrl}/api/alarm-correlation${route.path}`, {
+    method: route.method,
+    headers,
+    body: route.body === undefined ? undefined : JSON.stringify(route.body),
+  });
+}
+
+describe("alarm-correlation HTTP authorization", () => {
+  const originalApiKeys = process.env.API_KEYS;
+  let testServer: TestServer;
+
+  beforeAll(async () => {
+    process.env.API_KEYS = [
+      "read-key:alarm-reader:alarms.read",
+      "ingest-key:alarm-ingester:alarms.ingest",
+      "acknowledge-key:alarm-acknowledger:alarms.acknowledge",
+      "clear-key:alarm-clearer:alarms.clear",
+      "configure-key:alarm-configurer:alarms.configure",
+      "other-key:unrelated-client:other.read",
+    ].join(",");
+    _resetControlPlaneAuthCache();
+    testServer = await startServer();
+  });
+
+  afterAll(async () => {
+    await closeServer(testServer.server);
+    if (originalApiKeys === undefined) delete process.env.API_KEYS;
+    else process.env.API_KEYS = originalApiKeys;
+    _resetControlPlaneAuthCache();
+  });
+
+  it.each(routeCases)("returns 401 for anonymous $method $path", async (route) => {
+    const response = await request(testServer, route);
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects invalid and query-string credentials", async () => {
+    const invalid = await request(testServer, routeCases[0], "invalid-key");
+    expect(invalid.status).toBe(401);
+
+    const queryOnly = await fetch(
+      `${testServer.baseUrl}/api/alarm-correlation/status?api_key=${keys.read}`,
+    );
+    expect(queryOnly.status).toBe(401);
+  });
+
+  it.each(routeCases)(
+    "rejects a cross-action scope for $method $path",
+    async (route) => {
+      const response = await request(testServer, route, crossScope[route.scope]);
+      expect(response.status).toBe(403);
+    },
+  );
+
+  it.each(routeCases)(
+    "allows the exact scope to reach $method $path",
+    async (route) => {
+      const response = await request(testServer, route, keys[route.scope]);
+      expect(response.status).toBe(route.authorizedStatus);
+    },
+  );
+
+  it("derives source and lifecycle attribution from server-owned principals", async () => {
+    const now = Date.now();
+    for (const body of [
+      {
+        alarms: [{
+          id: "auth-root",
+          tagId: "AUTH-LOOP.TRIP",
+          timestamp: now,
+          severity: "high",
+        }],
+      },
+      {
+        alarms: [{
+          id: "auth-member",
+          tagId: "AUTH-LOOP.TRIP",
+          timestamp: now + 100,
+          severity: "medium",
+        }],
+      },
+    ]) {
+      const response = await request(
+        testServer,
+        {
+          method: "POST",
+          path: "/alarms",
+          scope: "ingest",
+          authorizedStatus: 200,
+          body,
+        },
+        keys.ingest,
+      );
+      expect(response.status).toBe(200);
+    }
+
+    const groupsResponse = await request(testServer, routeCases[0], keys.read);
+    const groupsBody = await groupsResponse.json() as {
+      groups: Array<{
+        id: string;
+        alarmIds: string[];
+        suppressedAlarmIds: string[];
+        alarms: Array<Record<string, unknown>>;
+      }>;
+    };
+    const group = groupsBody.groups.find((candidate) =>
+      candidate.alarmIds.includes("auth-root")
+    );
+    expect(group).toBeDefined();
+    expect(group?.alarms).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "auth-root",
+        source: "api:alarm-ingester",
+      }),
+      expect.objectContaining({
+        id: "auth-member",
+        source: "api:alarm-ingester",
+      }),
+    ]));
+
+    const acknowledge = await request(
+      testServer,
+      {
+        method: "POST",
+        path: "/alarms/auth-member/acknowledge",
+        scope: "acknowledge",
+        authorizedStatus: 200,
+      },
+      keys.acknowledge,
+    );
+    expect(await acknowledge.json()).toEqual({
+      acknowledged: true,
+      acknowledgedBy: "alarm-acknowledger",
+    });
+
+    const clear = await request(
+      testServer,
+      {
+        method: "POST",
+        path: "/alarms/auth-root/clear",
+        scope: "clear",
+        authorizedStatus: 200,
+      },
+      keys.clear,
+    );
+    expect(await clear.json()).toMatchObject({
+      cleared: true,
+      clearedBy: "alarm-clearer",
+    });
+
+    const groupResponse = await request(
+      testServer,
+      {
+        method: "GET",
+        path: `/groups/${group?.id}`,
+        scope: "read",
+        authorizedStatus: 200,
+      },
+      keys.read,
+    );
+    const updated = await groupResponse.json() as {
+      suppressedAlarmIds: string[];
+      alarms: Array<Record<string, unknown>>;
+    };
+    expect(updated.suppressedAlarmIds).not.toContain("auth-member");
+    expect(updated.alarms).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "auth-root",
+        state: "cleared",
+        clearedBy: "alarm-clearer",
+      }),
+      expect.objectContaining({
+        id: "auth-member",
+        state: "acknowledged",
+        acknowledgedBy: "alarm-acknowledger",
+      }),
+    ]));
+  });
+
+  it("rejects spoofed source/lifecycle fields and future alarms before mutation", async () => {
+    const spoofed = await request(
+      testServer,
+      {
+        method: "POST",
+        path: "/alarms",
+        scope: "ingest",
+        authorizedStatus: 400,
+        body: {
+          alarms: [{
+            id: "spoofed",
+            tagId: "SPOOFED.TRIP",
+            timestamp: Date.now(),
+            source: "simulator",
+            state: "suppressed",
+          }],
+        },
+      },
+      keys.ingest,
+    );
+    expect(spoofed.status).toBe(400);
+
+    const future = await request(
+      testServer,
+      {
+        method: "POST",
+        path: "/alarms",
+        scope: "ingest",
+        authorizedStatus: 200,
+        body: {
+          alarms: [{
+            id: "future-not-mutated",
+            tagId: "FUTURE.TRIP",
+            timestamp: Date.now() + 2 * 60 * 60 * 1000,
+          }],
+        },
+      },
+      keys.ingest,
+    );
+    expect(await future.json()).toMatchObject({
+      ingested: 0,
+      rejected: [expect.objectContaining({
+        reason: "timestamp too far in the future",
+      })],
+    });
+
+    const accepted = await request(
+      testServer,
+      {
+        method: "POST",
+        path: "/alarms",
+        scope: "ingest",
+        authorizedStatus: 200,
+        body: {
+          alarms: [{
+            id: "future-not-mutated",
+            tagId: "FUTURE.TRIP",
+            timestamp: Date.now(),
+          }],
+        },
+      },
+      keys.ingest,
+    );
+    const acceptedBody = await accepted.json() as {
+      ingested: number;
+      results: Array<{ reason: string }>;
+    };
+    expect(acceptedBody.ingested).toBe(1);
+    expect(acceptedBody.results[0]?.reason).not.toMatch(/duplicate/);
+  });
+
+  it("returns a conflict for duplicate alarm ids", async () => {
+    const body = {
+      alarms: [{
+        id: "duplicate-http",
+        tagId: "DUPLICATE.ALARM",
+        timestamp: Date.now(),
+      }],
+    };
+    const route: RouteCase = {
+      method: "POST",
+      path: "/alarms",
+      scope: "ingest",
+      authorizedStatus: 200,
+      body,
+    };
+
+    expect((await request(testServer, route, keys.ingest)).status).toBe(200);
+    const duplicate = await request(testServer, route, keys.ingest);
+    expect(duplicate.status).toBe(409);
+    expect(await duplicate.json()).toMatchObject({
+      ingested: 0,
+      rejected: [expect.objectContaining({
+        reason: expect.stringMatching(/duplicate alarm id/),
+      })],
+    });
+  });
+
+  it("keeps suppression fail-safe without explicit ephemeral opt-in", async () => {
+    const response = await request(
+      testServer,
+      {
+        method: "PUT",
+        path: "/suppression-policy",
+        scope: "configure",
+        authorizedStatus: 409,
+        body: { enabled: true },
+      },
+      keys.configure,
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      coordinationMode: "process-local",
+    });
+  });
+});

--- a/server/__tests__/alarm-correlation-auth-http.test.ts
+++ b/server/__tests__/alarm-correlation-auth-http.test.ts
@@ -566,6 +566,164 @@ describe("alarm-correlation HTTP authorization", () => {
     expect(validBody.results[0]?.reason).not.toMatch(/duplicate/);
   });
 
+  it("reconciles suppression immediately through topology PUT and DELETE routes", async () => {
+    const originalOptIn =
+      process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION;
+    process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION = "true";
+    const rootEquipment = "HTTP-TOPOLOGY-ROOT";
+    const memberEquipment = "HTTP-TOPOLOGY-MEMBER";
+    const rootAlarm = "http-topology-root-alarm";
+    const memberAlarm = "http-topology-member-alarm";
+
+    const configure = (
+      method: "PUT" | "DELETE",
+      path: string,
+      body?: Record<string, unknown>,
+    ) => request(
+      testServer,
+      {
+        method,
+        path,
+        scope: "configure",
+        authorizedStatus: 200,
+        body,
+      },
+      keys.configure,
+    );
+    const readGroup = async (groupId: string) => {
+      const response = await request(
+        testServer,
+        {
+          method: "GET",
+          path: `/groups/${groupId}`,
+          scope: "read",
+          authorizedStatus: 200,
+        },
+        keys.read,
+      );
+      expect(response.status).toBe(200);
+      return response.json() as Promise<{
+        alarmIds: string[];
+        suppressedAlarmIds: string[];
+        alarms: Array<{ id: string; state: string }>;
+      }>;
+    };
+
+    try {
+      const initialTopology = await configure("PUT", "/topology", {
+        nodes: [
+          {
+            equipmentId: rootEquipment,
+            siteId: "site-a",
+            causalDownstream: [memberEquipment],
+          },
+          {
+            equipmentId: memberEquipment,
+            siteId: "site-a",
+            causalDownstream: [],
+          },
+        ],
+      });
+      expect(initialTopology.status).toBe(200);
+
+      const enabled = await configure("PUT", "/suppression-policy", {
+        enabled: true,
+      });
+      expect(enabled.status).toBe(200);
+
+      const now = Date.now();
+      for (const alarm of [
+        {
+          id: rootAlarm,
+          tagId: `${rootEquipment}.TRIP`,
+          equipmentId: rootEquipment,
+          timestamp: now,
+          severity: "high",
+        },
+        {
+          id: memberAlarm,
+          tagId: `${memberEquipment}.TRIP`,
+          equipmentId: memberEquipment,
+          timestamp: now + 100,
+          severity: "medium",
+        },
+      ]) {
+        const response = await request(
+          testServer,
+          {
+            method: "POST",
+            path: "/alarms",
+            scope: "ingest",
+            authorizedStatus: 200,
+            body: { alarms: [alarm] },
+          },
+          keys.ingest,
+        );
+        expect(response.status).toBe(200);
+      }
+
+      const groupsResponse = await request(
+        testServer,
+        routeCases[0],
+        keys.read,
+      );
+      const groupsBody = await groupsResponse.json() as {
+        groups: Array<{ id: string; alarmIds: string[] }>;
+      };
+      const groupId = groupsBody.groups.find(
+        (group) => group.alarmIds.includes(rootAlarm),
+      )?.id;
+      expect(groupId).toBeDefined();
+
+      let group = await readGroup(groupId!);
+      expect(group.suppressedAlarmIds).toEqual([memberAlarm]);
+
+      const removed = await configure(
+        "DELETE",
+        `/topology/${memberEquipment}`,
+      );
+      expect(removed.status).toBe(200);
+      group = await readGroup(groupId!);
+      expect(group.suppressedAlarmIds).toEqual([]);
+      expect(group.alarms.find((alarm) => alarm.id === memberAlarm)?.state)
+        .toBe("active");
+
+      const restoredSameSite = await configure("PUT", "/topology", {
+        nodes: [{
+          equipmentId: memberEquipment,
+          siteId: "site-a",
+          causalDownstream: [],
+        }],
+      });
+      expect(restoredSameSite.status).toBe(200);
+      group = await readGroup(groupId!);
+      expect(group.suppressedAlarmIds).toEqual([memberAlarm]);
+
+      const movedCrossSite = await configure("PUT", "/topology", {
+        nodes: [{
+          equipmentId: memberEquipment,
+          siteId: "site-b",
+          causalDownstream: [],
+        }],
+      });
+      expect(movedCrossSite.status).toBe(200);
+      group = await readGroup(groupId!);
+      expect(group.suppressedAlarmIds).toEqual([]);
+      expect(group.alarms.find((alarm) => alarm.id === memberAlarm)?.state)
+        .toBe("active");
+    } finally {
+      await configure("PUT", "/suppression-policy", { enabled: false });
+      await configure("DELETE", `/topology/${memberEquipment}`);
+      await configure("DELETE", `/topology/${rootEquipment}`);
+      if (originalOptIn === undefined) {
+        delete process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION;
+      } else {
+        process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION =
+          originalOptIn;
+      }
+    }
+  });
+
   it("keeps suppression fail-safe without explicit ephemeral opt-in", async () => {
     const response = await request(
       testServer,

--- a/server/__tests__/alarm-correlation-auth-http.test.ts
+++ b/server/__tests__/alarm-correlation-auth-http.test.ts
@@ -164,6 +164,7 @@ describe("alarm-correlation HTTP authorization", () => {
       "read-key:alarm-reader:alarms.read",
       "ingest-key:alarm-ingester:alarms.ingest",
       "acknowledge-key:alarm-acknowledger:alarms.acknowledge",
+      "acknowledge-key-b:alarm-acknowledger-b:alarms.acknowledge",
       "clear-key:alarm-clearer:alarms.clear",
       "configure-key:alarm-configurer:alarms.configure",
       "other-key:unrelated-client:other.read",
@@ -283,6 +284,21 @@ describe("alarm-correlation HTTP authorization", () => {
       acknowledgedBy: "alarm-acknowledger",
     });
 
+    const repeatAcknowledge = await request(
+      testServer,
+      {
+        method: "POST",
+        path: "/alarms/auth-member/acknowledge",
+        scope: "acknowledge",
+        authorizedStatus: 200,
+      },
+      "acknowledge-key-b",
+    );
+    expect(await repeatAcknowledge.json()).toEqual({
+      acknowledged: true,
+      acknowledgedBy: "alarm-acknowledger",
+    });
+
     const clear = await request(
       testServer,
       {
@@ -340,6 +356,7 @@ describe("alarm-correlation HTTP authorization", () => {
             id: "spoofed",
             tagId: "SPOOFED.TRIP",
             timestamp: Date.now(),
+            severity: "medium",
             source: "simulator",
             state: "suppressed",
           }],
@@ -361,6 +378,7 @@ describe("alarm-correlation HTTP authorization", () => {
             id: "future-not-mutated",
             tagId: "FUTURE.TRIP",
             timestamp: Date.now() + 2 * 60 * 60 * 1000,
+            severity: "medium",
           }],
         },
       },
@@ -385,6 +403,7 @@ describe("alarm-correlation HTTP authorization", () => {
             id: "future-not-mutated",
             tagId: "FUTURE.TRIP",
             timestamp: Date.now(),
+            severity: "medium",
           }],
         },
       },
@@ -404,6 +423,7 @@ describe("alarm-correlation HTTP authorization", () => {
         id: "duplicate-http",
         tagId: "DUPLICATE.ALARM",
         timestamp: Date.now(),
+        severity: "medium",
       }],
     };
     const route: RouteCase = {
@@ -423,6 +443,127 @@ describe("alarm-correlation HTTP authorization", () => {
         reason: expect.stringMatching(/duplicate alarm id/),
       })],
     });
+  });
+
+  it("requires a recognized REST severity before any alarm can be ingested", async () => {
+    for (const [id, severity] of [
+      ["missing-rest-severity", undefined],
+      ["blank-rest-severity", ""],
+      ["unknown-rest-severity", "catastrophic"],
+    ] as const) {
+      const invalid = await request(
+        testServer,
+        {
+          method: "POST",
+          path: "/alarms",
+          scope: "ingest",
+          authorizedStatus: 400,
+          body: {
+            alarms: [{
+              id,
+              tagId: "SEVERITY.ALARM",
+              timestamp: Date.now(),
+              ...(severity === undefined ? {} : { severity }),
+            }],
+          },
+        },
+        keys.ingest,
+      );
+      expect(invalid.status, id).toBe(400);
+
+      const validRetry = await request(
+        testServer,
+        {
+          method: "POST",
+          path: "/alarms",
+          scope: "ingest",
+          authorizedStatus: 200,
+          body: {
+            alarms: [{
+              id,
+              tagId: `SEVERITY.${id}`,
+              equipmentId: id,
+              timestamp: Date.now(),
+              severity: "critical",
+            }],
+          },
+        },
+        keys.ingest,
+      );
+      expect(validRetry.status, id).toBe(200);
+      expect(await validRetry.json(), id).toMatchObject({ ingested: 1 });
+    }
+  });
+
+  it("rejects Date-invalid timestamps before mutation and allows the same id retry", async () => {
+    const metricsRoute: RouteCase = {
+      method: "GET",
+      path: "/metrics",
+      scope: "read",
+      authorizedStatus: 200,
+    };
+    const before = await (
+      await request(testServer, metricsRoute, keys.read)
+    ).json() as {
+      alarmsIngested: number;
+      trackedAlarms: number;
+    };
+    const invalid = await request(
+      testServer,
+      {
+        method: "POST",
+        path: "/alarms",
+        scope: "ingest",
+        authorizedStatus: 400,
+        body: {
+          alarms: [{
+            id: "date-overflow-http",
+            tagId: "DATE.OVERFLOW",
+            timestamp: -1e300,
+            severity: "medium",
+          }],
+        },
+      },
+      keys.ingest,
+    );
+    expect(invalid.status).toBe(400);
+
+    const afterInvalid = await (
+      await request(testServer, metricsRoute, keys.read)
+    ).json() as {
+      alarmsIngested: number;
+      trackedAlarms: number;
+    };
+    expect(afterInvalid).toMatchObject({
+      alarmsIngested: before.alarmsIngested,
+      trackedAlarms: before.trackedAlarms,
+    });
+
+    const validRetry = await request(
+      testServer,
+      {
+        method: "POST",
+        path: "/alarms",
+        scope: "ingest",
+        authorizedStatus: 200,
+        body: {
+          alarms: [{
+            id: "date-overflow-http",
+            tagId: "DATE.OVERFLOW",
+            timestamp: Date.now(),
+            severity: "medium",
+          }],
+        },
+      },
+      keys.ingest,
+    );
+    expect(validRetry.status).toBe(200);
+    const validBody = await validRetry.json() as {
+      ingested: number;
+      results: Array<{ reason: string }>;
+    };
+    expect(validBody.ingested).toBe(1);
+    expect(validBody.results[0]?.reason).not.toMatch(/duplicate/);
   });
 
   it("keeps suppression fail-safe without explicit ephemeral opt-in", async () => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -31,6 +31,7 @@ import { getFluxPublisher } from "./services/flux";
 
 import { tagStreamServer } from "./websocket/tag-stream";
 import { unifiedStreamServer } from "./websocket/unified-stream";
+import { cachedEventBridge } from "./websocket/cached-event-bridge";
 import type { WebSocketAuthOptions } from "./websocket/upgrade-auth";
 
 export interface RouteRegistrationOptions {
@@ -96,6 +97,7 @@ export async function registerRoutes(
   };
   tagStreamServer.initialize(httpServer, "/ws/tags", websocketAuth);
   unifiedStreamServer.initialize(httpServer, "/ws", websocketAuth); // unified endpoint (#255)
+  cachedEventBridge.initializeLocalAlarmFanout();
 
   // Start alarm-correlation idle-group sweeps (#213). Registered here rather
   // than in services/initializeServices(), which no startup path invokes.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,8 @@ import pidRoutes from "./routes/pid";
 import { fluxRoutes } from "./routes/flux";
 import { gatewayRoutes } from "./routes/gateway";
 import { intelligenceRoutes } from "./routes/intelligence";
+import { alarmCorrelationRoutes } from "./routes/alarm-correlation";
+import { alarmCorrelationService } from "./services/alarm-correlation";
 import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
@@ -59,6 +61,7 @@ export async function registerRoutes(
 
   // P1 Wiring: Intelligence, Governance, and Security modules
   app.use("/api/intelligence", intelligenceRoutes);
+  app.use("/api/alarm-correlation", alarmCorrelationRoutes);  // ADR-0013 [13.2] (#213)
   app.use("/api/governance", governanceRoutes);
   app.use("/api/security", securityRoutes);
   app.use("/api/geometry", geometryRoutes(getFluxPublisher()));
@@ -93,6 +96,10 @@ export async function registerRoutes(
   };
   tagStreamServer.initialize(httpServer, "/ws/tags", websocketAuth);
   unifiedStreamServer.initialize(httpServer, "/ws", websocketAuth); // unified endpoint (#255)
+
+  // Start alarm-correlation idle-group sweeps (#213). Registered here rather
+  // than in services/initializeServices(), which no startup path invokes.
+  void alarmCorrelationService.initialize();
 
   // WebSocket metrics endpoint. The legacy event-stream server was removed;
   // only the tag and unified streams report (#446, #479).

--- a/server/routes/alarm-correlation.ts
+++ b/server/routes/alarm-correlation.ts
@@ -14,7 +14,10 @@ import {
   controlPlanePrincipal,
   requireControlPlaneAccess,
 } from "../middleware/control-plane-auth";
-import { alarmCorrelationService } from "../services/alarm-correlation";
+import {
+  alarmCorrelationService,
+  normalizeAlarmTimestamp,
+} from "../services/alarm-correlation";
 import { validateRule } from "../services/alarm-correlation/rules";
 import type { CorrelationRule } from "@shared/types/alarm-correlation";
 
@@ -56,13 +59,17 @@ const AlarmInputSchema = z
     equipmentId: z.string().max(256).optional(),
     siteId: z.string().max(64).optional(),
     processArea: z.string().max(256).optional(),
-    severity: SeveritySchema.optional(),
+    severity: SeveritySchema,
     state: z.literal("active").optional(),
     message: z.string().max(2048).optional(),
-    timestamp: z.union([
-      z.number().finite(),
-      z.string().min(1).max(64),
-    ]),
+    timestamp: z
+      .union([
+        z.number().finite(),
+        z.string().min(1).max(64),
+      ])
+      .refine((timestamp) => normalizeAlarmTimestamp(timestamp) !== null, {
+        message: "timestamp must be within the JavaScript Date range",
+      }),
     value: BoundedValueSchema.optional(),
     limit: BoundedValueSchema.optional(),
   })
@@ -144,9 +151,7 @@ const GroupQuerySchema = z.object({
 }).strict();
 
 function parseTimestamp(timestamp: string | number): number | null {
-  if (typeof timestamp === "number") return timestamp;
-  const parsed = Date.parse(timestamp);
-  return Number.isFinite(parsed) ? parsed : null;
+  return normalizeAlarmTimestamp(timestamp);
 }
 
 // ── Alarm ingestion & lifecycle ────────────────────────────────────────────
@@ -215,7 +220,10 @@ router.post(
     if (!ok) {
       return res.status(404).json({ error: `Alarm ${req.params.alarmId} not tracked` });
     }
-    res.json({ acknowledged: true, acknowledgedBy: principal.name });
+    res.json({
+      acknowledged: true,
+      acknowledgedBy: engine.getAlarm(req.params.alarmId)?.acknowledgedBy,
+    });
   },
 );
 

--- a/server/routes/alarm-correlation.ts
+++ b/server/routes/alarm-correlation.ts
@@ -314,6 +314,7 @@ router.put("/topology", requireAlarmConfigure, (req, res) => {
   }
   try {
     const nodes = engine.topology.upsertMany(parsed.data.nodes);
+    engine.reconcileTopology();
     res.json({ upserted: nodes.length, nodes });
   } catch (error) {
     res.status(400).json({ error: error instanceof Error ? error.message : "invalid topology" });
@@ -329,6 +330,7 @@ router.delete(
         error: `Equipment ${req.params.equipmentId} not found`,
       });
     }
+    engine.reconcileTopology();
     res.json({ removed: true });
   },
 );

--- a/server/routes/alarm-correlation.ts
+++ b/server/routes/alarm-correlation.ts
@@ -9,63 +9,107 @@
 
 import { Router } from "express";
 import { z } from "zod";
-import { fromZodError } from "zod-validation-error";
+import { fromZodError } from "zod-validation-error/v3";
+import {
+  controlPlanePrincipal,
+  requireControlPlaneAccess,
+} from "../middleware/control-plane-auth";
 import { alarmCorrelationService } from "../services/alarm-correlation";
 import { validateRule } from "../services/alarm-correlation/rules";
 import type { CorrelationRule } from "@shared/types/alarm-correlation";
 
 const router = Router();
 const engine = alarmCorrelationService.engine;
-
-// Auth middleware placeholder — same pattern as other protected routes
-function requireAuth(
-  req: import("express").Request,
-  res: import("express").Response,
-  next: import("express").NextFunction
-) {
-  // TODO: implement real auth check (JWT / session validation)
-  next();
-}
-router.use(requireAuth);
+const requireAlarmRead = requireControlPlaneAccess({
+  scopes: ["alarms.read"],
+});
+const requireAlarmIngest = requireControlPlaneAccess({
+  scopes: ["alarms.ingest"],
+});
+const requireAlarmAcknowledge = requireControlPlaneAccess({
+  scopes: ["alarms.acknowledge"],
+});
+const requireAlarmClear = requireControlPlaneAccess({
+  scopes: ["alarms.clear"],
+});
+const requireAlarmConfigure = requireControlPlaneAccess({
+  scopes: ["alarms.configure"],
+});
 
 // ── Schemas ────────────────────────────────────────────────────────────────
 
 const MAX_FUTURE_SKEW_MS = 60 * 60 * 1000;
+const MAX_RULE_WINDOW_MS = 24 * 60 * 60 * 1000;
+const MAX_TOPOLOGY_DISTANCE = 64;
 
 const SeveritySchema = z.enum(["critical", "high", "medium", "low", "info"]);
+const BoundedValueSchema = z.union([
+  z.number().finite(),
+  z.string().max(256),
+]);
 
 const AlarmInputSchema = z
   .object({
-    id: z.string().min(1).optional(),
-    name: z.string().optional(),
-    tagId: z.string().optional(),
-    equipmentId: z.string().optional(),
-    siteId: z.string().optional(),
-    processArea: z.string().optional(),
-    severity: z.string().optional(),
-    state: z.string().optional(),
-    message: z.string().optional(),
-    timestamp: z.union([z.number().finite(), z.string().min(1)]),
-    value: z.union([z.number(), z.string()]).optional(),
-    limit: z.union([z.number(), z.string()]).optional(),
-    source: z.string().optional(),
+    id: z.string().min(1).max(128).optional(),
+    name: z.string().max(256).optional(),
+    tagId: z.string().max(256).optional(),
+    equipmentId: z.string().max(256).optional(),
+    siteId: z.string().max(64).optional(),
+    processArea: z.string().max(256).optional(),
+    severity: SeveritySchema.optional(),
+    state: z.literal("active").optional(),
+    message: z.string().max(2048).optional(),
+    timestamp: z.union([
+      z.number().finite(),
+      z.string().min(1).max(64),
+    ]),
+    value: BoundedValueSchema.optional(),
+    limit: BoundedValueSchema.optional(),
   })
+  .strict()
   .refine((a) => a.id || a.tagId, {
     message: "alarm requires at least an id or a tagId",
   });
 
 const IngestSchema = z.object({
-  alarms: z.array(AlarmInputSchema).min(1).max(1000),
-});
+  alarms: z.array(AlarmInputSchema).min(1).max(500),
+}).strict();
 
-const RuleSchema = z.object({
+const RuleBaseSchema = {
   id: z.string().min(1).max(128),
   name: z.string().min(1).max(256),
-  type: z.enum(["causal", "hierarchy", "temporal"]),
   enabled: z.boolean().default(true),
   priority: z.number().int().min(0).max(10_000),
-  config: z.record(z.unknown()),
-});
+};
+
+const WindowSchema = z.number().int().min(1).max(MAX_RULE_WINDOW_MS);
+
+const RuleSchema = z.discriminatedUnion("type", [
+  z.object({
+    ...RuleBaseSchema,
+    type: z.literal("causal"),
+    config: z.object({
+      windowMs: WindowSchema,
+      maxHops: z.number().int().min(1).max(MAX_TOPOLOGY_DISTANCE),
+    }).strict(),
+  }).strict(),
+  z.object({
+    ...RuleBaseSchema,
+    type: z.literal("hierarchy"),
+    config: z.object({
+      windowMs: WindowSchema,
+      maxDistance: z.number().int().min(1).max(MAX_TOPOLOGY_DISTANCE),
+    }).strict(),
+  }).strict(),
+  z.object({
+    ...RuleBaseSchema,
+    type: z.literal("temporal"),
+    config: z.object({
+      windowMs: WindowSchema,
+      scope: z.enum(["same-tag", "same-equipment", "process-area"]),
+    }).strict(),
+  }).strict(),
+]);
 
 const TopologySchema = z.object({
   nodes: z
@@ -77,66 +121,107 @@ const TopologySchema = z.object({
         causalDownstream: z.array(z.string().min(1).max(256)).max(64).default([]),
         siteId: z.string().max(64).optional(),
         processArea: z.string().max(256).optional(),
-      })
+      }).strict()
     )
     .min(1)
     .max(1000),
-});
+}).strict();
 
 const SuppressionPolicySchema = z
   .object({
     enabled: z.boolean(),
     neverSuppressAtOrAbove: SeveritySchema,
-    unsuppressOnRootClear: z.boolean(),
+    unsuppressOnRootClear: z.literal(true),
   })
-  .partial();
+  .partial()
+  .strict()
+  .refine((policy) => Object.keys(policy).length > 0, {
+    message: "at least one suppression-policy field is required",
+  });
 
 const GroupQuerySchema = z.object({
   state: z.enum(["open", "closed"]).optional(),
-});
+}).strict();
+
+function parseTimestamp(timestamp: string | number): number | null {
+  if (typeof timestamp === "number") return timestamp;
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : null;
+}
 
 // ── Alarm ingestion & lifecycle ────────────────────────────────────────────
 
-router.post("/alarms", (req, res) => {
+router.post("/alarms", requireAlarmIngest, (req, res) => {
   const parsed = IngestSchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ error: fromZodError(parsed.error).message });
   }
 
   const now = Date.now();
+  const principal = controlPlanePrincipal(req);
   const results = [];
   const rejected = [];
   for (const input of parsed.data.alarms) {
-    const outcome = alarmCorrelationService.ingest(input as Record<string, unknown>);
-    if (!outcome) {
+    const timestamp = parseTimestamp(input.timestamp);
+    if (timestamp === null) {
       rejected.push({ input, reason: "unparseable timestamp" });
       continue;
     }
-    if (outcome.alarm.timestamp > now + MAX_FUTURE_SKEW_MS) {
+    if (timestamp > now + MAX_FUTURE_SKEW_MS) {
       rejected.push({ input, reason: "timestamp too far in the future" });
+      continue;
+    }
+    const outcome = alarmCorrelationService.ingest({
+      ...input,
+      timestamp,
+      state: "active",
+      source: `api:${principal.name}`,
+    });
+    if (!outcome) {
+      rejected.push({ input, reason: "invalid alarm" });
+      continue;
+    }
+    if (outcome.result.action === "duplicate") {
+      rejected.push({ input, reason: outcome.result.reason });
       continue;
     }
     results.push(outcome.result);
   }
-  res.json({ ingested: results.length, results, rejected });
+  const duplicateConflict =
+    results.length === 0
+    && rejected.some(({ reason }) => reason.includes("duplicate alarm id"));
+  res.status(duplicateConflict ? 409 : 200).json({
+    ingested: results.length,
+    results,
+    rejected,
+  });
 });
 
-router.post("/alarms/:alarmId/clear", (req, res) => {
-  const outcome = engine.alarmCleared(req.params.alarmId);
+router.post("/alarms/:alarmId/clear", requireAlarmClear, (req, res) => {
+  const principal = controlPlanePrincipal(req);
+  const outcome = engine.alarmCleared(req.params.alarmId, principal.name);
+  if (!outcome.cleared) {
+    return res.status(404).json({ error: `Alarm ${req.params.alarmId} not tracked` });
+  }
   res.json(outcome);
 });
 
-router.post("/alarms/:alarmId/acknowledge", (req, res) => {
-  const ok = engine.alarmAcknowledged(req.params.alarmId);
-  if (!ok) {
-    return res.status(404).json({ error: `Alarm ${req.params.alarmId} not tracked` });
-  }
-  res.json({ acknowledged: true });
-});
+router.post(
+  "/alarms/:alarmId/acknowledge",
+  requireAlarmAcknowledge,
+  (req, res) => {
+    const principal = controlPlanePrincipal(req);
+    const ok = engine.alarmAcknowledged(req.params.alarmId, principal.name);
+    if (!ok) {
+      return res.status(404).json({ error: `Alarm ${req.params.alarmId} not tracked` });
+    }
+    res.json({ acknowledged: true, acknowledgedBy: principal.name });
+  },
+);
 
 // ── Groups & root cause ────────────────────────────────────────────────────
 
-router.get("/groups", (req, res) => {
+router.get("/groups", requireAlarmRead, (req, res) => {
   const parsed = GroupQuerySchema.safeParse(req.query);
   if (!parsed.success) {
     return res.status(400).json({ error: fromZodError(parsed.error).message });
@@ -144,7 +229,7 @@ router.get("/groups", (req, res) => {
   res.json({ groups: engine.getGroups(parsed.data) });
 });
 
-router.get("/groups/:groupId", (req, res) => {
+router.get("/groups/:groupId", requireAlarmRead, (req, res) => {
   const group = engine.getGroup(req.params.groupId);
   if (!group) {
     return res.status(404).json({ error: `Group ${req.params.groupId} not found` });
@@ -152,7 +237,7 @@ router.get("/groups/:groupId", (req, res) => {
   res.json(group);
 });
 
-router.get("/groups/:groupId/root-cause", (req, res) => {
+router.get("/groups/:groupId/root-cause", requireAlarmRead, (req, res) => {
   const rootCause = engine.getRootCause(req.params.groupId);
   if (!rootCause) {
     return res.status(404).json({ error: `Group ${req.params.groupId} not found` });
@@ -162,12 +247,16 @@ router.get("/groups/:groupId/root-cause", (req, res) => {
 
 // ── Rules engine ───────────────────────────────────────────────────────────
 
-router.get("/rules", (_req, res) => {
+router.get("/rules", requireAlarmRead, (_req, res) => {
   res.json({ rules: engine.rules.list() });
 });
 
-router.put("/rules/:ruleId", (req, res) => {
-  const parsed = RuleSchema.safeParse({ ...req.body, id: req.params.ruleId });
+router.put("/rules/:ruleId", requireAlarmConfigure, (req, res) => {
+  const body =
+    req.body && typeof req.body === "object" && !Array.isArray(req.body)
+      ? req.body
+      : {};
+  const parsed = RuleSchema.safeParse({ ...body, id: req.params.ruleId });
   if (!parsed.success) {
     return res.status(400).json({ error: fromZodError(parsed.error).message });
   }
@@ -176,23 +265,29 @@ router.put("/rules/:ruleId", (req, res) => {
   if (error) {
     return res.status(400).json({ error });
   }
-  res.json(engine.rules.upsert(rule));
+  try {
+    res.json(engine.rules.upsert(rule));
+  } catch (upsertError) {
+    res.status(400).json({
+      error: upsertError instanceof Error ? upsertError.message : "invalid rule",
+    });
+  }
 });
 
-router.delete("/rules/:ruleId", (req, res) => {
+router.delete("/rules/:ruleId", requireAlarmConfigure, (req, res) => {
   if (!engine.rules.remove(req.params.ruleId)) {
     return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
   }
   res.json({ removed: true });
 });
 
-router.post("/rules/:ruleId/enable", (req, res) => {
+router.post("/rules/:ruleId/enable", requireAlarmConfigure, (req, res) => {
   const rule = engine.rules.setEnabled(req.params.ruleId, true);
   if (!rule) return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
   res.json(rule);
 });
 
-router.post("/rules/:ruleId/disable", (req, res) => {
+router.post("/rules/:ruleId/disable", requireAlarmConfigure, (req, res) => {
   const rule = engine.rules.setEnabled(req.params.ruleId, false);
   if (!rule) return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
   res.json(rule);
@@ -200,11 +295,11 @@ router.post("/rules/:ruleId/disable", (req, res) => {
 
 // ── Equipment topology ─────────────────────────────────────────────────────
 
-router.get("/topology", (_req, res) => {
+router.get("/topology", requireAlarmRead, (_req, res) => {
   res.json({ nodes: engine.topology.list() });
 });
 
-router.put("/topology", (req, res) => {
+router.put("/topology", requireAlarmConfigure, (req, res) => {
   const parsed = TopologySchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ error: fromZodError(parsed.error).message });
@@ -217,34 +312,58 @@ router.put("/topology", (req, res) => {
   }
 });
 
-router.delete("/topology/:equipmentId", (req, res) => {
-  if (!engine.topology.remove(req.params.equipmentId)) {
-    return res.status(404).json({ error: `Equipment ${req.params.equipmentId} not found` });
-  }
-  res.json({ removed: true });
-});
+router.delete(
+  "/topology/:equipmentId",
+  requireAlarmConfigure,
+  (req, res) => {
+    if (!engine.topology.remove(req.params.equipmentId)) {
+      return res.status(404).json({
+        error: `Equipment ${req.params.equipmentId} not found`,
+      });
+    }
+    res.json({ removed: true });
+  },
+);
 
 // ── Suppression policy ─────────────────────────────────────────────────────
 
-router.get("/suppression-policy", (_req, res) => {
+router.get("/suppression-policy", requireAlarmRead, (_req, res) => {
   res.json(engine.getSuppressionPolicy());
 });
 
-router.put("/suppression-policy", (req, res) => {
+router.put("/suppression-policy", requireAlarmConfigure, (req, res) => {
   const parsed = SuppressionPolicySchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ error: fromZodError(parsed.error).message });
   }
-  res.json(engine.setSuppressionPolicy(parsed.data));
+  if (
+    parsed.data.enabled === true
+    && process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION !== "true"
+  ) {
+    return res.status(409).json({
+      error:
+        "Suppression is disabled until durable, replica-coordinated state is available. "
+        + "Set ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION=true only for an "
+        + "explicit single-process evaluation.",
+      coordinationMode: "process-local",
+    });
+  }
+  try {
+    res.json(engine.setSuppressionPolicy(parsed.data));
+  } catch (error) {
+    res.status(400).json({
+      error: error instanceof Error ? error.message : "invalid suppression policy",
+    });
+  }
 });
 
 // ── Metrics & status ───────────────────────────────────────────────────────
 
-router.get("/metrics", (_req, res) => {
+router.get("/metrics", requireAlarmRead, (_req, res) => {
   res.json(engine.getMetrics());
 });
 
-router.get("/status", async (_req, res) => {
+router.get("/status", requireAlarmRead, async (_req, res) => {
   const health = await alarmCorrelationService.healthCheck();
   res.json({ ...engine.getMetrics(), ...health });
 });

--- a/server/routes/alarm-correlation.ts
+++ b/server/routes/alarm-correlation.ts
@@ -1,0 +1,252 @@
+/**
+ * Alarm Correlation API
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * REST surface for the alarm correlation engine: alarm ingestion and
+ * lifecycle, correlated groups and root causes, the correlation rules
+ * engine, equipment topology, and suppression policy.
+ */
+
+import { Router } from "express";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+import { alarmCorrelationService } from "../services/alarm-correlation";
+import { validateRule } from "../services/alarm-correlation/rules";
+import type { CorrelationRule } from "@shared/types/alarm-correlation";
+
+const router = Router();
+const engine = alarmCorrelationService.engine;
+
+// Auth middleware placeholder — same pattern as other protected routes
+function requireAuth(
+  req: import("express").Request,
+  res: import("express").Response,
+  next: import("express").NextFunction
+) {
+  // TODO: implement real auth check (JWT / session validation)
+  next();
+}
+router.use(requireAuth);
+
+// ── Schemas ────────────────────────────────────────────────────────────────
+
+const MAX_FUTURE_SKEW_MS = 60 * 60 * 1000;
+
+const SeveritySchema = z.enum(["critical", "high", "medium", "low", "info"]);
+
+const AlarmInputSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    name: z.string().optional(),
+    tagId: z.string().optional(),
+    equipmentId: z.string().optional(),
+    siteId: z.string().optional(),
+    processArea: z.string().optional(),
+    severity: z.string().optional(),
+    state: z.string().optional(),
+    message: z.string().optional(),
+    timestamp: z.union([z.number().finite(), z.string().min(1)]),
+    value: z.union([z.number(), z.string()]).optional(),
+    limit: z.union([z.number(), z.string()]).optional(),
+    source: z.string().optional(),
+  })
+  .refine((a) => a.id || a.tagId, {
+    message: "alarm requires at least an id or a tagId",
+  });
+
+const IngestSchema = z.object({
+  alarms: z.array(AlarmInputSchema).min(1).max(1000),
+});
+
+const RuleSchema = z.object({
+  id: z.string().min(1).max(128),
+  name: z.string().min(1).max(256),
+  type: z.enum(["causal", "hierarchy", "temporal"]),
+  enabled: z.boolean().default(true),
+  priority: z.number().int().min(0).max(10_000),
+  config: z.record(z.unknown()),
+});
+
+const TopologySchema = z.object({
+  nodes: z
+    .array(
+      z.object({
+        equipmentId: z.string().min(1).max(256),
+        name: z.string().max(256).optional(),
+        parentId: z.string().max(256).optional(),
+        causalDownstream: z.array(z.string().min(1).max(256)).max(64).default([]),
+        siteId: z.string().max(64).optional(),
+        processArea: z.string().max(256).optional(),
+      })
+    )
+    .min(1)
+    .max(1000),
+});
+
+const SuppressionPolicySchema = z
+  .object({
+    enabled: z.boolean(),
+    neverSuppressAtOrAbove: SeveritySchema,
+    unsuppressOnRootClear: z.boolean(),
+  })
+  .partial();
+
+const GroupQuerySchema = z.object({
+  state: z.enum(["open", "closed"]).optional(),
+});
+
+// ── Alarm ingestion & lifecycle ────────────────────────────────────────────
+
+router.post("/alarms", (req, res) => {
+  const parsed = IngestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+
+  const now = Date.now();
+  const results = [];
+  const rejected = [];
+  for (const input of parsed.data.alarms) {
+    const outcome = alarmCorrelationService.ingest(input as Record<string, unknown>);
+    if (!outcome) {
+      rejected.push({ input, reason: "unparseable timestamp" });
+      continue;
+    }
+    if (outcome.alarm.timestamp > now + MAX_FUTURE_SKEW_MS) {
+      rejected.push({ input, reason: "timestamp too far in the future" });
+      continue;
+    }
+    results.push(outcome.result);
+  }
+  res.json({ ingested: results.length, results, rejected });
+});
+
+router.post("/alarms/:alarmId/clear", (req, res) => {
+  const outcome = engine.alarmCleared(req.params.alarmId);
+  res.json(outcome);
+});
+
+router.post("/alarms/:alarmId/acknowledge", (req, res) => {
+  const ok = engine.alarmAcknowledged(req.params.alarmId);
+  if (!ok) {
+    return res.status(404).json({ error: `Alarm ${req.params.alarmId} not tracked` });
+  }
+  res.json({ acknowledged: true });
+});
+
+// ── Groups & root cause ────────────────────────────────────────────────────
+
+router.get("/groups", (req, res) => {
+  const parsed = GroupQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  res.json({ groups: engine.getGroups(parsed.data) });
+});
+
+router.get("/groups/:groupId", (req, res) => {
+  const group = engine.getGroup(req.params.groupId);
+  if (!group) {
+    return res.status(404).json({ error: `Group ${req.params.groupId} not found` });
+  }
+  res.json(group);
+});
+
+router.get("/groups/:groupId/root-cause", (req, res) => {
+  const rootCause = engine.getRootCause(req.params.groupId);
+  if (!rootCause) {
+    return res.status(404).json({ error: `Group ${req.params.groupId} not found` });
+  }
+  res.json(rootCause);
+});
+
+// ── Rules engine ───────────────────────────────────────────────────────────
+
+router.get("/rules", (_req, res) => {
+  res.json({ rules: engine.rules.list() });
+});
+
+router.put("/rules/:ruleId", (req, res) => {
+  const parsed = RuleSchema.safeParse({ ...req.body, id: req.params.ruleId });
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  const rule = parsed.data as unknown as CorrelationRule;
+  const error = validateRule(rule);
+  if (error) {
+    return res.status(400).json({ error });
+  }
+  res.json(engine.rules.upsert(rule));
+});
+
+router.delete("/rules/:ruleId", (req, res) => {
+  if (!engine.rules.remove(req.params.ruleId)) {
+    return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
+  }
+  res.json({ removed: true });
+});
+
+router.post("/rules/:ruleId/enable", (req, res) => {
+  const rule = engine.rules.setEnabled(req.params.ruleId, true);
+  if (!rule) return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
+  res.json(rule);
+});
+
+router.post("/rules/:ruleId/disable", (req, res) => {
+  const rule = engine.rules.setEnabled(req.params.ruleId, false);
+  if (!rule) return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
+  res.json(rule);
+});
+
+// ── Equipment topology ─────────────────────────────────────────────────────
+
+router.get("/topology", (_req, res) => {
+  res.json({ nodes: engine.topology.list() });
+});
+
+router.put("/topology", (req, res) => {
+  const parsed = TopologySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  try {
+    const nodes = engine.topology.upsertMany(parsed.data.nodes);
+    res.json({ upserted: nodes.length, nodes });
+  } catch (error) {
+    res.status(400).json({ error: error instanceof Error ? error.message : "invalid topology" });
+  }
+});
+
+router.delete("/topology/:equipmentId", (req, res) => {
+  if (!engine.topology.remove(req.params.equipmentId)) {
+    return res.status(404).json({ error: `Equipment ${req.params.equipmentId} not found` });
+  }
+  res.json({ removed: true });
+});
+
+// ── Suppression policy ─────────────────────────────────────────────────────
+
+router.get("/suppression-policy", (_req, res) => {
+  res.json(engine.getSuppressionPolicy());
+});
+
+router.put("/suppression-policy", (req, res) => {
+  const parsed = SuppressionPolicySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: fromZodError(parsed.error).message });
+  }
+  res.json(engine.setSuppressionPolicy(parsed.data));
+});
+
+// ── Metrics & status ───────────────────────────────────────────────────────
+
+router.get("/metrics", (_req, res) => {
+  res.json(engine.getMetrics());
+});
+
+router.get("/status", async (_req, res) => {
+  const health = await alarmCorrelationService.healthCheck();
+  res.json({ ...engine.getMetrics(), ...health });
+});
+
+export { router as alarmCorrelationRoutes };

--- a/server/services/alarm-correlation/__tests__/alarm-correlation.test.ts
+++ b/server/services/alarm-correlation/__tests__/alarm-correlation.test.ts
@@ -918,6 +918,62 @@ describe('AlarmCorrelationEngine', () => {
     expect(metrics.suppressionRate).toBeGreaterThanOrEqual(0);
     expect(metrics.suppressionRate).toBeLessThanOrEqual(1);
   });
+
+  it('bounds suppression identity bookkeeping to retained groups under churn', () => {
+    const engine = new AlarmCorrelationEngine({
+      maxGroups: 1,
+      suppressionPolicy: { enabled: true },
+    });
+    const churnGroups = 2000;
+
+    for (let index = 0; index < churnGroups; index++) {
+      const timestamp = index * 10_000;
+      engine.ingest(alarm({
+        id: `churn-root-${index}`,
+        tagId: `CHURN-${index}.ALARM`,
+        timestamp,
+        severity: 'high',
+      }));
+      engine.ingest(alarm({
+        id: `churn-member-${index}`,
+        tagId: `CHURN-${index}.ALARM`,
+        timestamp: timestamp + 100,
+        severity: 'medium',
+      }));
+    }
+
+    expect(engine.getGroups()).toHaveLength(1);
+    expect(engine.getMetrics()).toMatchObject({
+      alarmsIngested: churnGroups * 2,
+      alarmsSuppressed: churnGroups,
+      trackedAlarms: 2,
+      suppressionRate: 0.5,
+    });
+
+    // Reusing an id from the first evicted group counts a new retained alarm
+    // instance, proving its prior bookkeeping entry was released.
+    engine.ingest(alarm({
+      id: 'churn-root-0',
+      tagId: 'CHURN-REUSED.ALARM',
+      timestamp: churnGroups * 10_000,
+      severity: 'high',
+    }));
+    engine.ingest(alarm({
+      id: 'churn-member-0',
+      tagId: 'CHURN-REUSED.ALARM',
+      timestamp: churnGroups * 10_000 + 100,
+      severity: 'medium',
+    }));
+    const afterReuse = engine.getMetrics();
+    expect(afterReuse).toMatchObject({
+      alarmsIngested: churnGroups * 2 + 2,
+      alarmsSuppressed: churnGroups + 1,
+      trackedAlarms: 2,
+    });
+    expect(Number.isFinite(afterReuse.suppressionRate)).toBe(true);
+    expect(afterReuse.suppressionRate).toBeGreaterThanOrEqual(0);
+    expect(afterReuse.suppressionRate).toBeLessThanOrEqual(1);
+  });
 });
 
 // ── Normalization & service ───────────────────────────────────────────────
@@ -964,6 +1020,23 @@ describe('normalizeAlarm', () => {
     expect(normalizeSeverity('WARNING')).toBe('medium');
     expect(normalizeSeverity('alarm')).toBe('high');
     expect(normalizeSeverity(undefined)).toBe('info');
+  });
+
+  it('maps missing live severity to the fail-safe floor but preserves explicit info', () => {
+    for (const severity of [undefined, '', '   ']) {
+      expect(normalizeAlarm({
+        id: `missing-${String(severity)}`,
+        tagId: 'MISSING.SEVERITY',
+        timestamp: 1,
+        ...(severity === undefined ? {} : { severity }),
+      })?.severity).toBe('critical');
+    }
+    expect(normalizeAlarm({
+      id: 'explicit-info',
+      tagId: 'EXPLICIT.INFO',
+      timestamp: 1,
+      severity: 'info',
+    })?.severity).toBe('info');
   });
 
   it('rejects alarms without a usable timestamp', () => {

--- a/server/services/alarm-correlation/__tests__/alarm-correlation.test.ts
+++ b/server/services/alarm-correlation/__tests__/alarm-correlation.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Alarm Correlation Engine tests
+ * ADR-0013 [13.2] — Issue #213
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { CorrelatedAlarm } from '@shared/types/alarm-correlation';
+import { EquipmentTopology } from '../topology';
+import { CorrelationRulesEngine, validateRule, DEFAULT_RULES } from '../rules';
+import { AlarmCorrelationEngine } from '../engine';
+import {
+  AlarmCorrelationService,
+  normalizeAlarm,
+  normalizeSeverity,
+  resolveEquipmentFromTag,
+} from '../index';
+
+let alarmCounter = 0;
+function alarm(overrides: Partial<CorrelatedAlarm>): CorrelatedAlarm {
+  return {
+    id: overrides.id ?? `A-${++alarmCounter}`,
+    name: 'test alarm',
+    tagId: 'TAG.EVENT',
+    severity: 'medium',
+    state: 'active',
+    message: 'test',
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+/** Feeder → breaker → motor causal chain under one substation */
+function plantTopology(): EquipmentTopology {
+  const topology = new EquipmentTopology();
+  topology.upsertMany([
+    { equipmentId: 'SUB-1', causalDownstream: [] },
+    { equipmentId: 'FDR-1', parentId: 'SUB-1', causalDownstream: ['BK-1'] },
+    { equipmentId: 'BK-1', parentId: 'SUB-1', causalDownstream: ['MTR-1'] },
+    { equipmentId: 'MTR-1', parentId: 'SUB-1', causalDownstream: [] },
+    { equipmentId: 'UNRELATED', causalDownstream: [] },
+  ]);
+  return topology;
+}
+
+// ── Topology ──────────────────────────────────────────────────────────────
+
+describe('EquipmentTopology', () => {
+  it('rejects hierarchy cycles at registration', () => {
+    const t = new EquipmentTopology();
+    t.upsert({ equipmentId: 'a', parentId: 'b', causalDownstream: [] });
+    expect(() =>
+      t.upsert({ equipmentId: 'b', parentId: 'a', causalDownstream: [] })
+    ).toThrow(/cycle/);
+    // failed upsert must not leave the cyclic node behind
+    expect(t.get('b')).toBeUndefined();
+  });
+
+  it('computes hierarchy distance: parent-child 1, siblings 1, unrelated null', () => {
+    const t = plantTopology();
+    expect(t.hierarchyDistance('FDR-1', 'SUB-1')).toBe(1);
+    expect(t.hierarchyDistance('FDR-1', 'BK-1')).toBe(1);
+    expect(t.hierarchyDistance('FDR-1', 'FDR-1')).toBe(0);
+    expect(t.hierarchyDistance('FDR-1', 'UNRELATED')).toBeNull();
+  });
+
+  it('finds transitive causal reachability with hop bound', () => {
+    const t = plantTopology();
+    expect(t.isCausallyReachable('FDR-1', 'MTR-1', 5)).toBe(true); // 2 hops
+    expect(t.isCausallyReachable('FDR-1', 'MTR-1', 1)).toBe(false); // capped
+    expect(t.isCausallyReachable('MTR-1', 'FDR-1', 5)).toBe(false); // directed
+    expect(t.isCausallyRelated('MTR-1', 'FDR-1', 5)).toBe(true); // either direction
+  });
+
+  it('survives causal cycles (recirculation loops)', () => {
+    const t = new EquipmentTopology();
+    t.upsert({ equipmentId: 'p1', causalDownstream: ['p2'] });
+    t.upsert({ equipmentId: 'p2', causalDownstream: ['p1', 'p3'] });
+    t.upsert({ equipmentId: 'p3', causalDownstream: [] });
+    expect(t.isCausallyReachable('p1', 'p3', 10)).toBe(true);
+    expect(t.isCausallyReachable('p3', 'p1', 10)).toBe(false);
+  });
+
+  it('measures causal dominance', () => {
+    const t = plantTopology();
+    expect(t.causalDominance('FDR-1', ['BK-1', 'MTR-1', 'UNRELATED'], 5)).toBe(2);
+    expect(t.causalDominance('MTR-1', ['FDR-1', 'BK-1'], 5)).toBe(0);
+  });
+});
+
+// ── Rules ─────────────────────────────────────────────────────────────────
+
+describe('CorrelationRulesEngine', () => {
+  it('validates rule configs', () => {
+    expect(
+      validateRule({
+        id: 'r',
+        name: 'r',
+        type: 'causal',
+        enabled: true,
+        priority: 1,
+        config: { windowMs: 1000 } as never,
+      })
+    ).toMatch(/maxHops/);
+    expect(
+      validateRule({
+        id: 'r',
+        name: 'r',
+        type: 'temporal',
+        enabled: true,
+        priority: 1,
+        config: { windowMs: 1000, scope: 'everything' } as never,
+      })
+    ).toMatch(/scope/);
+  });
+
+  it('evaluates rules in priority order and skips disabled ones', () => {
+    const rules = new CorrelationRulesEngine();
+    expect(rules.list().map((r) => r.id)).toEqual(DEFAULT_RULES.map((r) => r.id));
+    rules.setEnabled('default-causal', false);
+    const t = plantTopology();
+    const a = alarm({ equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 });
+    const b = alarm({ equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 2000 });
+    // causal disabled → falls through to hierarchy (siblings under SUB-1)
+    const matched = rules.evaluatePair(a, b, t);
+    expect(matched?.id).toBe('default-hierarchy');
+  });
+
+  it('never pairs unrelated equipment on bare temporal proximity', () => {
+    const rules = new CorrelationRulesEngine();
+    const t = plantTopology();
+    const a = alarm({ equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 });
+    const b = alarm({ equipmentId: 'UNRELATED', tagId: 'UNRELATED.TRIP', timestamp: 1001 });
+    expect(rules.evaluatePair(a, b, t)).toBeNull();
+  });
+
+  it('pairs same-process-area alarms under a scoped temporal rule', () => {
+    const rules = new CorrelationRulesEngine();
+    rules.upsert({
+      id: 'area',
+      name: 'area burst',
+      type: 'temporal',
+      enabled: true,
+      priority: 50,
+      config: { windowMs: 5000, scope: 'process-area' },
+    });
+    const t = new EquipmentTopology();
+    const a = alarm({ processArea: 'unit-100', tagId: 'X.1', timestamp: 0 });
+    const b = alarm({ processArea: 'unit-100', tagId: 'Y.1', timestamp: 100 });
+    expect(rules.evaluatePair(a, b, t)?.id).toBe('area');
+  });
+});
+
+// ── Engine ────────────────────────────────────────────────────────────────
+
+describe('AlarmCorrelationEngine', () => {
+  it('groups a causal chain and elects the upstream cause as root', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    const events: string[] = [];
+    engine.on('group-created', () => events.push('created'));
+
+    const r1 = engine.ingest(
+      alarm({ id: 'feeder', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 })
+    );
+    expect(r1.action).toBe('standalone');
+
+    const r2 = engine.ingest(
+      alarm({ id: 'breaker', equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 2000 })
+    );
+    expect(r2.action).toBe('formed-group');
+
+    const r3 = engine.ingest(
+      alarm({ id: 'motor', equipmentId: 'MTR-1', tagId: 'MTR-1.STALL', timestamp: 3000 })
+    );
+    expect(r3.action).toBe('joined-group');
+    expect(r3.groupId).toBe(r2.groupId);
+
+    const group = engine.getGroup(r2.groupId!)!;
+    expect(group.rootCauseAlarmId).toBe('feeder');
+    expect(group.alarmIds).toEqual(['feeder', 'breaker', 'motor']);
+    expect(events).toEqual(['created']);
+
+    const rootCause = engine.getRootCause(group.id)!;
+    expect(rootCause.alarm.id).toBe('feeder');
+    expect(rootCause.causalDominance).toBe(2);
+  });
+
+  it('re-elects the root when an earlier upstream cause arrives late (out-of-order)', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    const rootChanges: unknown[] = [];
+    engine.on('root-cause-changed', (e) => rootChanges.push(e));
+
+    engine.ingest(alarm({ id: 'motor', equipmentId: 'MTR-1', tagId: 'MTR-1.STALL', timestamp: 5000 }));
+    engine.ingest(alarm({ id: 'breaker', equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 5200 }));
+    // Upstream cause with the earliest event time arrives last
+    const r = engine.ingest(
+      alarm({ id: 'feeder', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 4800 })
+    );
+    expect(r.action).toBe('joined-group');
+    expect(r.isRootCause).toBe(true);
+
+    const group = engine.getGroup(r.groupId!)!;
+    expect(group.rootCauseAlarmId).toBe('feeder');
+    expect(rootChanges.length).toBeGreaterThan(0);
+  });
+
+  it('keeps unrelated concurrent alarms in separate groups', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    engine.ingest(alarm({ id: 'a1', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 }));
+    engine.ingest(alarm({ id: 'b1', equipmentId: 'UNRELATED', tagId: 'UNRELATED.X', timestamp: 1001 }));
+    expect(engine.getGroups()).toHaveLength(0); // both standalone — never merged
+  });
+
+  it('suppresses downstream alarms but never critical ones', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    const suppressed: unknown[] = [];
+    engine.on('alarm-suppressed', (e) => suppressed.push(e));
+
+    engine.ingest(alarm({ id: 'feeder', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000, severity: 'high' }));
+    engine.ingest(alarm({ id: 'breaker', equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 1500, severity: 'medium' }));
+    engine.ingest(alarm({ id: 'motor', equipmentId: 'MTR-1', tagId: 'MTR-1.STALL', timestamp: 2000, severity: 'critical' }));
+
+    const group = engine.getGroups()[0];
+    expect(group.rootCauseAlarmId).toBe('feeder');
+    expect(group.suppressedAlarmIds).toEqual(['breaker']); // critical motor spared
+    expect(group.alarms.find((a) => a.id === 'breaker')!.state).toBe('suppressed');
+    expect(group.alarms.find((a) => a.id === 'motor')!.state).toBe('active');
+    expect(suppressed).toHaveLength(1);
+  });
+
+  it('closes the group and un-suppresses members when the root cause clears', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    const unsuppressed: unknown[] = [];
+    engine.on('alarms-unsuppressed', (e) => unsuppressed.push(e));
+
+    engine.ingest(alarm({ id: 'feeder', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 }));
+    engine.ingest(alarm({ id: 'breaker', equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 1500 }));
+
+    const outcome = engine.alarmCleared('feeder');
+    expect(outcome.groupClosed).toBeDefined();
+    expect(outcome.unsuppressed).toEqual(['breaker']);
+
+    const group = engine.getGroups({ state: 'closed' })[0];
+    expect(group.closeReason).toBe('root-cause-cleared');
+    expect(group.alarms.find((a) => a.id === 'breaker')!.state).toBe('active');
+    expect(unsuppressed).toHaveLength(1);
+  });
+
+  it('ignores duplicate alarm ids', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    engine.ingest(alarm({ id: 'dup', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 }));
+    const again = engine.ingest(alarm({ id: 'dup', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 9999 }));
+    expect(again.reason).toMatch(/duplicate/);
+    expect(engine.getMetrics().alarmsIngested).toBe(1);
+  });
+
+  it('closes idle groups on sweep and enforces the group cap', () => {
+    const engine = new AlarmCorrelationEngine({
+      topology: plantTopology(),
+      groupCloseAfterMs: 1000,
+      maxGroups: 1,
+    });
+    engine.ingest(alarm({ id: 'f1', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 }));
+    engine.ingest(alarm({ id: 'b1', equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 1500 }));
+    expect(engine.getGroups({ state: 'open' })).toHaveLength(1);
+
+    const { closedGroups } = engine.sweep(10_000);
+    expect(closedGroups).toHaveLength(1);
+
+    // A later, unrelated-to-window group forms; cap 1 evicts the closed one
+    engine.ingest(alarm({ id: 'f2', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP2', timestamp: 100_000 }));
+    engine.ingest(alarm({ id: 'b2', equipmentId: 'BK-1', tagId: 'BK-1.TRIP2', timestamp: 100_500 }));
+    expect(engine.getGroups()).toHaveLength(1);
+    expect(engine.getGroups()[0].alarmIds).toEqual(['f2', 'b2']);
+  });
+
+  it('does not admit alarms beyond the group span cap', () => {
+    const engine = new AlarmCorrelationEngine({
+      topology: plantTopology(),
+      maxGroupSpanMs: 10_000,
+    });
+    engine.rules.upsert({
+      id: 'wide',
+      name: 'wide causal',
+      type: 'causal',
+      enabled: true,
+      priority: 1,
+      config: { windowMs: 1_000_000, maxHops: 5 },
+    });
+    engine.ingest(alarm({ id: 'f', equipmentId: 'FDR-1', tagId: 'FDR-1.T', timestamp: 0 }));
+    engine.ingest(alarm({ id: 'b', equipmentId: 'BK-1', tagId: 'BK-1.T', timestamp: 100 }));
+    const late = engine.ingest(
+      alarm({ id: 'm', equipmentId: 'MTR-1', tagId: 'MTR-1.T', timestamp: 50_000 })
+    );
+    expect(late.action).not.toBe('joined-group');
+  });
+
+  it('tracks suppression rate as the fatigue KPI', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    engine.ingest(alarm({ id: 'f', equipmentId: 'FDR-1', tagId: 'FDR-1.T', timestamp: 0 }));
+    engine.ingest(alarm({ id: 'b', equipmentId: 'BK-1', tagId: 'BK-1.T', timestamp: 100 }));
+    engine.ingest(alarm({ id: 'm', equipmentId: 'MTR-1', tagId: 'MTR-1.T', timestamp: 200 }));
+    const metrics = engine.getMetrics();
+    expect(metrics.alarmsIngested).toBe(3);
+    expect(metrics.groupsCreated).toBe(1);
+    expect(metrics.alarmsSuppressed).toBe(2);
+    expect(metrics.suppressionRate).toBeCloseTo(2 / 3);
+  });
+});
+
+// ── Normalization & service ───────────────────────────────────────────────
+
+describe('normalizeAlarm', () => {
+  it('normalizes the tag-stream broadcastAlarm shape', () => {
+    const a = normalizeAlarm({
+      id: 'alm-1',
+      name: 'BK-FEEDER-01 BREAKER_TRIP',
+      severity: 'critical',
+      state: 'active',
+      tagValue: 1450,
+      triggeredAt: '2026-07-22T10:00:00.000Z',
+      tagId: 'BK-FEEDER-01.BREAKER_TRIP',
+    })!;
+    expect(a.id).toBe('alm-1');
+    expect(a.equipmentId).toBe('BK-FEEDER-01');
+    expect(a.severity).toBe('critical');
+    expect(a.timestamp).toBe(Date.parse('2026-07-22T10:00:00.000Z'));
+    expect(a.value).toBe(1450);
+  });
+
+  it('normalizes the SingularisPrime/GR::LISTEN AlarmPayload shape', () => {
+    const a = normalizeAlarm({
+      alarmId: 'AL-9',
+      alarmName: 'High pressure',
+      sourceTagId: 'PT-101.PV',
+      priority: 'high',
+      message: 'above limit',
+      triggerValue: 9.2,
+      limitValue: 8.5,
+      timestamp: 1700000000000,
+    })!;
+    expect(a.id).toBe('AL-9');
+    expect(a.tagId).toBe('PT-101.PV');
+    expect(a.equipmentId).toBe('PT-101');
+    expect(a.severity).toBe('high');
+    expect(a.limit).toBe(8.5);
+  });
+
+  it('maps DB-enum severities onto the runtime vocabulary', () => {
+    expect(normalizeSeverity('EMERGENCY')).toBe('critical');
+    expect(normalizeSeverity('CRITICAL')).toBe('critical');
+    expect(normalizeSeverity('WARNING')).toBe('medium');
+    expect(normalizeSeverity('alarm')).toBe('high');
+    expect(normalizeSeverity(undefined)).toBe('info');
+  });
+
+  it('rejects alarms without a usable timestamp', () => {
+    expect(normalizeAlarm({ id: 'x', tagId: 'T.1' })).toBeNull();
+    expect(normalizeAlarm({ id: 'x', tagId: 'T.1', timestamp: 'garbage' })).toBeNull();
+  });
+
+  it('resolves equipment from the ASSET.EVENT tag convention', () => {
+    expect(resolveEquipmentFromTag('BK-FEEDER-01.BREAKER_TRIP')).toBe('BK-FEEDER-01');
+    expect(resolveEquipmentFromTag('PLAINTAG')).toBe('PLAINTAG');
+    expect(resolveEquipmentFromTag('')).toBeUndefined();
+  });
+});
+
+describe('AlarmCorrelationService', () => {
+  it('ingests end-to-end and re-emits engine events', () => {
+    const service = new AlarmCorrelationService();
+    const created = vi.fn();
+    service.on('group-created', created);
+
+    service.engine.topology.upsertMany([
+      { equipmentId: 'BK-1', causalDownstream: ['MTR-1'] },
+      { equipmentId: 'MTR-1', causalDownstream: [] },
+    ]);
+
+    const first = service.ingest({
+      id: 'w1', tagId: 'BK-1.TRIP', severity: 'high', state: 'active',
+      timestamp: 1000, message: 'trip',
+    })!;
+    expect(first.result.action).toBe('standalone');
+
+    const second = service.ingest({
+      id: 'w2', tagId: 'MTR-1.STALL', severity: 'medium', state: 'active',
+      timestamp: 1800, message: 'stall',
+    })!;
+    expect(second.result.action).toBe('formed-group');
+    expect(second.result.suppressed).toBe(true);
+    expect(created).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports health based on initialization', async () => {
+    const service = new AlarmCorrelationService();
+    expect((await service.healthCheck()).healthy).toBe(false);
+    await service.initialize();
+    expect((await service.healthCheck()).healthy).toBe(true);
+    await service.shutdown();
+    expect((await service.healthCheck()).healthy).toBe(false);
+  });
+});

--- a/server/services/alarm-correlation/__tests__/alarm-correlation.test.ts
+++ b/server/services/alarm-correlation/__tests__/alarm-correlation.test.ts
@@ -55,6 +55,31 @@ describe('EquipmentTopology', () => {
     expect(t.get('b')).toBeUndefined();
   });
 
+  it('rolls back an entire topology batch when a later node is invalid', () => {
+    const t = new EquipmentTopology();
+    t.upsert({ equipmentId: 'existing', name: 'before', causalDownstream: [] });
+
+    expect(() =>
+      t.upsertMany([
+        {
+          equipmentId: 'existing',
+          name: 'mutated-before-failure',
+          causalDownstream: ['new-a'],
+        },
+        { equipmentId: 'new-a', parentId: 'new-b', causalDownstream: [] },
+        { equipmentId: 'new-b', parentId: 'new-a', causalDownstream: [] },
+      ])
+    ).toThrow(/cycle/);
+
+    expect(t.get('existing')).toEqual({
+      equipmentId: 'existing',
+      name: 'before',
+      causalDownstream: [],
+    });
+    expect(t.get('new-a')).toBeUndefined();
+    expect(t.get('new-b')).toBeUndefined();
+  });
+
   it('computes hierarchy distance: parent-child 1, siblings 1, unrelated null', () => {
     const t = plantTopology();
     expect(t.hierarchyDistance('FDR-1', 'SUB-1')).toBe(1);
@@ -111,6 +136,36 @@ describe('CorrelationRulesEngine', () => {
         config: { windowMs: 1000, scope: 'everything' } as never,
       })
     ).toMatch(/scope/);
+    expect(
+      validateRule({
+        id: 'r',
+        name: 'r',
+        type: 'causal',
+        enabled: true,
+        priority: 1,
+        config: { windowMs: Number.POSITIVE_INFINITY, maxHops: 1 },
+      })
+    ).toMatch(/windowMs/);
+    expect(
+      validateRule({
+        id: 'r',
+        name: 'r',
+        type: 'causal',
+        enabled: true,
+        priority: 1,
+        config: { windowMs: 1000, maxHops: 65 },
+      })
+    ).toMatch(/maxHops/);
+    expect(
+      validateRule({
+        id: 'r',
+        name: 'r',
+        type: 'hierarchy',
+        enabled: true,
+        priority: 1,
+        config: { windowMs: 1000, maxDistance: 65 },
+      })
+    ).toMatch(/maxDistance/);
   });
 
   it('evaluates rules in priority order and skips disabled ones', () => {
@@ -203,6 +258,129 @@ describe('AlarmCorrelationEngine', () => {
     expect(rootChanges.length).toBeGreaterThan(0);
   });
 
+  it('reconciles a bounded pending component across every arrival permutation', () => {
+    const permutations = [
+      ['t0', 't4', 't8'],
+      ['t0', 't8', 't4'],
+      ['t4', 't0', 't8'],
+      ['t4', 't8', 't0'],
+      ['t8', 't0', 't4'],
+      ['t8', 't4', 't0'],
+    ];
+    const timestamps: Record<string, number> = {
+      t0: 0,
+      t4: 4000,
+      t8: 8000,
+    };
+
+    for (const order of permutations) {
+      const engine = new AlarmCorrelationEngine({
+        maxGroupSpanMs: 10_000,
+        maxAlarmsPerGroup: 3,
+        suppressionPolicy: { enabled: true },
+      });
+      let finalResult;
+      for (const id of order) {
+        finalResult = engine.ingest(alarm({
+          id,
+          tagId: 'VALVE-1.CHATTER',
+          timestamp: timestamps[id],
+        }));
+      }
+
+      const groups = engine.getGroups();
+      expect(groups, order.join(',')).toHaveLength(1);
+      expect([...groups[0].alarmIds].sort(), order.join(',')).toEqual(['t0', 't4', 't8']);
+      expect(groups[0].rootCauseAlarmId, order.join(',')).toBe('t0');
+      expect(groups[0].createdAt, order.join(',')).toBe(0);
+      expect(groups[0].lastAlarmAt, order.join(',')).toBe(8000);
+      expect([...groups[0].suppressedAlarmIds].sort(), order.join(',')).toEqual(['t4', 't8']);
+
+      if (order.join(',') === 't0,t8,t4') {
+        expect(finalResult).toMatchObject({
+          alarmId: 't4',
+          isRootCause: false,
+          suppressed: true,
+        });
+      }
+    }
+  });
+
+  it('reconciles pending bridge alarms to a bounded fixpoint', () => {
+    const engine = new AlarmCorrelationEngine({
+      maxGroupSpanMs: 20_000,
+      maxAlarmsPerGroup: 5,
+    });
+    const timestamps: Record<string, number> = {
+      t0: 0,
+      t4: 4000,
+      t8: 8000,
+      t12: 12_000,
+      t16: 16_000,
+    };
+
+    for (const id of ['t0', 't8', 't16', 't4', 't12']) {
+      engine.ingest(alarm({
+        id,
+        tagId: 'VALVE-1.CHATTER',
+        timestamp: timestamps[id],
+      }));
+    }
+
+    expect(engine.getGroups()).toHaveLength(1);
+    expect([...engine.getGroups()[0].alarmIds].sort()).toEqual([
+      't0',
+      't12',
+      't16',
+      't4',
+      't8',
+    ]);
+  });
+
+  it('keeps reconciliation within group span and member caps', () => {
+    const permutations = [
+      ['t0', 't4', 't8'],
+      ['t0', 't8', 't4'],
+      ['t4', 't0', 't8'],
+      ['t4', 't8', 't0'],
+      ['t8', 't0', 't4'],
+      ['t8', 't4', 't0'],
+    ];
+    const timestamps: Record<string, number> = {
+      t0: 0,
+      t4: 4000,
+      t8: 8000,
+    };
+
+    for (const order of permutations) {
+      const spanEngine = new AlarmCorrelationEngine({
+        maxGroupSpanMs: 7000,
+        maxAlarmsPerGroup: 3,
+      });
+      const memberEngine = new AlarmCorrelationEngine({
+        maxGroupSpanMs: 10_000,
+        maxAlarmsPerGroup: 2,
+      });
+      for (const id of order) {
+        const input = alarm({
+          id,
+          tagId: 'VALVE-1.CHATTER',
+          timestamp: timestamps[id],
+        });
+        spanEngine.ingest({ ...input });
+        memberEngine.ingest({ ...input });
+      }
+
+      for (const group of spanEngine.getGroups()) {
+        expect(group.lastAlarmAt - group.createdAt, order.join(',')).toBeLessThanOrEqual(7000);
+        expect(group.alarmIds, order.join(',')).toHaveLength(2);
+      }
+      for (const group of memberEngine.getGroups()) {
+        expect(group.alarmIds.length, order.join(',')).toBeLessThanOrEqual(2);
+      }
+    }
+  });
+
   it('keeps unrelated concurrent alarms in separate groups', () => {
     const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
     engine.ingest(alarm({ id: 'a1', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 }));
@@ -210,8 +388,32 @@ describe('AlarmCorrelationEngine', () => {
     expect(engine.getGroups()).toHaveLength(0); // both standalone — never merged
   });
 
+  it('never correlates alarms across site boundaries', () => {
+    const engine = new AlarmCorrelationEngine();
+    engine.ingest(alarm({
+      id: 'site-a',
+      tagId: 'SHARED.TAG',
+      equipmentId: 'SHARED',
+      siteId: 'site-a',
+      timestamp: 1000,
+    }));
+    const second = engine.ingest(alarm({
+      id: 'site-b',
+      tagId: 'SHARED.TAG',
+      equipmentId: 'SHARED',
+      siteId: 'site-b',
+      timestamp: 1001,
+    }));
+
+    expect(second.action).toBe('standalone');
+    expect(engine.getGroups()).toHaveLength(0);
+  });
+
   it('suppresses downstream alarms but never critical ones', () => {
-    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    const engine = new AlarmCorrelationEngine({
+      topology: plantTopology(),
+      suppressionPolicy: { enabled: true },
+    });
     const suppressed: unknown[] = [];
     engine.on('alarm-suppressed', (e) => suppressed.push(e));
 
@@ -227,8 +429,27 @@ describe('AlarmCorrelationEngine', () => {
     expect(suppressed).toHaveLength(1);
   });
 
+  it('defaults suppression off and refuses unsafe closed-group suppression', () => {
+    const engine = new AlarmCorrelationEngine();
+    expect(engine.getSuppressionPolicy()).toMatchObject({
+      enabled: false,
+      unsuppressOnRootClear: true,
+    });
+    expect(() =>
+      engine.setSuppressionPolicy({ unsuppressOnRootClear: false })
+    ).toThrow(/fail-safe closure/);
+    expect(() =>
+      new AlarmCorrelationEngine({
+        suppressionPolicy: { unsuppressOnRootClear: false },
+      })
+    ).toThrow(/fail-safe closure/);
+  });
+
   it('closes the group and un-suppresses members when the root cause clears', () => {
-    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    const engine = new AlarmCorrelationEngine({
+      topology: plantTopology(),
+      suppressionPolicy: { enabled: true },
+    });
     const unsuppressed: unknown[] = [];
     engine.on('alarms-unsuppressed', (e) => unsuppressed.push(e));
 
@@ -245,10 +466,162 @@ describe('AlarmCorrelationEngine', () => {
     expect(unsuppressed).toHaveLength(1);
   });
 
-  it('ignores duplicate alarm ids', () => {
+  it('removes stale suppression records on acknowledge and clear', () => {
+    const engine = new AlarmCorrelationEngine({
+      topology: plantTopology(),
+      suppressionPolicy: { enabled: true },
+    });
+    engine.ingest(alarm({
+      id: 'feeder',
+      equipmentId: 'FDR-1',
+      tagId: 'FDR-1.TRIP',
+      timestamp: 1000,
+    }));
+    engine.ingest(alarm({
+      id: 'breaker',
+      equipmentId: 'BK-1',
+      tagId: 'BK-1.TRIP',
+      timestamp: 1500,
+    }));
+    engine.ingest(alarm({
+      id: 'motor',
+      equipmentId: 'MTR-1',
+      tagId: 'MTR-1.STALL',
+      timestamp: 2000,
+    }));
+
+    const group = engine.getGroups()[0];
+    expect(group.suppressedAlarmIds).toEqual(['breaker', 'motor']);
+
+    expect(engine.alarmAcknowledged('breaker', 'operator-alice')).toBe(true);
+    const clear = engine.alarmCleared('motor', 'operator-bob');
+    expect(clear.cleared).toBe(true);
+    expect(group.suppressedAlarmIds).toEqual([]);
+    expect(group.alarms.find((a) => a.id === 'breaker')).toMatchObject({
+      state: 'acknowledged',
+      acknowledgedBy: 'operator-alice',
+    });
+    expect(group.alarms.find((a) => a.id === 'motor')).toMatchObject({
+      state: 'cleared',
+      clearedBy: 'operator-bob',
+    });
+  });
+
+  it('does not correlate a standalone alarm after it has cleared', () => {
+    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    engine.ingest(alarm({
+      id: 'cleared-feeder',
+      equipmentId: 'FDR-1',
+      tagId: 'FDR-1.TRIP',
+      timestamp: 1000,
+    }));
+    expect(engine.alarmCleared('cleared-feeder', 'operator-alice')).toMatchObject({
+      cleared: true,
+      clearedBy: 'operator-alice',
+    });
+
+    const next = engine.ingest(alarm({
+      id: 'breaker',
+      equipmentId: 'BK-1',
+      tagId: 'BK-1.TRIP',
+      timestamp: 1500,
+    }));
+    expect(next.action).toBe('standalone');
+    expect(engine.getGroups()).toHaveLength(0);
+  });
+
+  it('reconciles existing suppression when policy is disabled or its floor changes', () => {
+    const engine = new AlarmCorrelationEngine({
+      topology: plantTopology(),
+      suppressionPolicy: { enabled: true },
+    });
+    engine.ingest(alarm({
+      id: 'feeder',
+      equipmentId: 'FDR-1',
+      tagId: 'FDR-1.TRIP',
+      timestamp: 1000,
+      severity: 'high',
+    }));
+    engine.ingest(alarm({
+      id: 'breaker',
+      equipmentId: 'BK-1',
+      tagId: 'BK-1.TRIP',
+      timestamp: 1500,
+      severity: 'medium',
+    }));
+    const group = engine.getGroups()[0];
+    const breaker = group.alarms.find((a) => a.id === 'breaker')!;
+    expect(breaker.state).toBe('suppressed');
+
+    engine.setSuppressionPolicy({ enabled: false });
+    expect(group.suppressedAlarmIds).toEqual([]);
+    expect(breaker.state).toBe('active');
+
+    engine.setSuppressionPolicy({ enabled: true });
+    expect(group.suppressedAlarmIds).toEqual(['breaker']);
+    expect(breaker.state).toBe('suppressed');
+
+    engine.setSuppressionPolicy({ neverSuppressAtOrAbove: 'medium' });
+    expect(group.suppressedAlarmIds).toEqual([]);
+    expect(breaker.state).toBe('active');
+  });
+
+  it('releases suppressed members when an idle group closes', () => {
+    const engine = new AlarmCorrelationEngine({
+      topology: plantTopology(),
+      groupCloseAfterMs: 1000,
+      suppressionPolicy: { enabled: true },
+      clock: () => 0,
+    });
+    engine.ingest(alarm({
+      id: 'feeder',
+      equipmentId: 'FDR-1',
+      tagId: 'FDR-1.TRIP',
+      timestamp: 1000,
+    }));
+    engine.ingest(alarm({
+      id: 'breaker',
+      equipmentId: 'BK-1',
+      tagId: 'BK-1.TRIP',
+      timestamp: 1500,
+    }));
+    const group = engine.getGroups()[0];
+    expect(group.suppressedAlarmIds).toEqual(['breaker']);
+
+    engine.sweep(10_000);
+    expect(group.state).toBe('closed');
+    expect(group.closeReason).toBe('idle-timeout');
+    expect(group.suppressedAlarmIds).toEqual([]);
+    expect(group.alarms.find((a) => a.id === 'breaker')?.state).toBe('active');
+
+    const clear = engine.alarmCleared('feeder', 'operator-alice');
+    expect(clear.cleared).toBe(true);
+    expect(group.suppressedAlarmIds).toEqual([]);
+  });
+
+  it('caps group membership to bound alarm-storm root-election work', () => {
+    const engine = new AlarmCorrelationEngine({
+      maxAlarmsPerGroup: 3,
+    });
+
+    for (let index = 0; index < 5; index++) {
+      engine.ingest(alarm({
+        id: `chatter-${index}`,
+        tagId: 'VALVE-1.CHATTER',
+        timestamp: index * 100,
+      }));
+    }
+
+    const sizes = engine.getGroups().map((group) => group.alarmIds.length).sort();
+    expect(sizes).toEqual([2, 3]);
+    expect(Math.max(...sizes)).toBe(3);
+  });
+
+  it('reports duplicate alarm ids without mutating metrics', () => {
     const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
     engine.ingest(alarm({ id: 'dup', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 }));
     const again = engine.ingest(alarm({ id: 'dup', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 9999 }));
+    expect(again.action).toBe('duplicate');
     expect(again.reason).toMatch(/duplicate/);
     expect(engine.getMetrics().alarmsIngested).toBe(1);
   });
@@ -258,6 +631,7 @@ describe('AlarmCorrelationEngine', () => {
       topology: plantTopology(),
       groupCloseAfterMs: 1000,
       maxGroups: 1,
+      clock: () => 0,
     });
     engine.ingest(alarm({ id: 'f1', equipmentId: 'FDR-1', tagId: 'FDR-1.TRIP', timestamp: 1000 }));
     engine.ingest(alarm({ id: 'b1', equipmentId: 'BK-1', tagId: 'BK-1.TRIP', timestamp: 1500 }));
@@ -273,12 +647,12 @@ describe('AlarmCorrelationEngine', () => {
     expect(engine.getGroups()[0].alarmIds).toEqual(['f2', 'b2']);
   });
 
-  it('does not admit alarms beyond the group span cap', () => {
-    const engine = new AlarmCorrelationEngine({
+  it('enforces the group span cap during formation and backward joins', () => {
+    const formationEngine = new AlarmCorrelationEngine({
       topology: plantTopology(),
       maxGroupSpanMs: 10_000,
     });
-    engine.rules.upsert({
+    formationEngine.rules.upsert({
       id: 'wide',
       name: 'wide causal',
       type: 'causal',
@@ -286,16 +660,51 @@ describe('AlarmCorrelationEngine', () => {
       priority: 1,
       config: { windowMs: 1_000_000, maxHops: 5 },
     });
-    engine.ingest(alarm({ id: 'f', equipmentId: 'FDR-1', tagId: 'FDR-1.T', timestamp: 0 }));
-    engine.ingest(alarm({ id: 'b', equipmentId: 'BK-1', tagId: 'BK-1.T', timestamp: 100 }));
-    const late = engine.ingest(
-      alarm({ id: 'm', equipmentId: 'MTR-1', tagId: 'MTR-1.T', timestamp: 50_000 })
+    formationEngine.ingest(
+      alarm({ id: 'formation-f', equipmentId: 'FDR-1', tagId: 'FDR-1.T', timestamp: 0 })
     );
-    expect(late.action).not.toBe('joined-group');
+    const beyondFormationSpan = formationEngine.ingest(
+      alarm({
+        id: 'formation-b',
+        equipmentId: 'BK-1',
+        tagId: 'BK-1.T',
+        timestamp: 50_000,
+      })
+    );
+    expect(beyondFormationSpan.action).toBe('standalone');
+    expect(formationEngine.getGroups()).toHaveLength(0);
+
+    const joinEngine = new AlarmCorrelationEngine({
+      topology: plantTopology(),
+      maxGroupSpanMs: 10_000,
+    });
+    joinEngine.rules.upsert({
+      id: 'wide',
+      name: 'wide causal',
+      type: 'causal',
+      enabled: true,
+      priority: 1,
+      config: { windowMs: 1_000_000, maxHops: 5 },
+    });
+    joinEngine.ingest(
+      alarm({ id: 'join-f', equipmentId: 'FDR-1', tagId: 'FDR-1.T', timestamp: 100_000 })
+    );
+    joinEngine.ingest(
+      alarm({ id: 'join-b', equipmentId: 'BK-1', tagId: 'BK-1.T', timestamp: 100_100 })
+    );
+    const backward = joinEngine.ingest(
+      alarm({ id: 'join-m', equipmentId: 'MTR-1', tagId: 'MTR-1.T', timestamp: 0 })
+    );
+
+    expect(backward.action).not.toBe('joined-group');
+    expect(joinEngine.getGroups()[0].alarmIds).toEqual(['join-f', 'join-b']);
   });
 
   it('tracks suppression rate as the fatigue KPI', () => {
-    const engine = new AlarmCorrelationEngine({ topology: plantTopology() });
+    const engine = new AlarmCorrelationEngine({
+      topology: plantTopology(),
+      suppressionPolicy: { enabled: true },
+    });
     engine.ingest(alarm({ id: 'f', equipmentId: 'FDR-1', tagId: 'FDR-1.T', timestamp: 0 }));
     engine.ingest(alarm({ id: 'b', equipmentId: 'BK-1', tagId: 'BK-1.T', timestamp: 100 }));
     engine.ingest(alarm({ id: 'm', equipmentId: 'MTR-1', tagId: 'MTR-1.T', timestamp: 200 }));
@@ -356,6 +765,18 @@ describe('normalizeAlarm', () => {
   it('rejects alarms without a usable timestamp', () => {
     expect(normalizeAlarm({ id: 'x', tagId: 'T.1' })).toBeNull();
     expect(normalizeAlarm({ id: 'x', tagId: 'T.1', timestamp: 'garbage' })).toBeNull();
+    expect(normalizeAlarm({
+      id: 'x',
+      tagId: 'T.1',
+      timestamp: 1,
+      severity: 'catastrophic',
+    })).toBeNull();
+    expect(normalizeAlarm({
+      id: 'x',
+      tagId: 'T.1',
+      timestamp: 1,
+      state: 'mystery',
+    })).toBeNull();
   });
 
   it('resolves equipment from the ASSET.EVENT tag convention', () => {
@@ -387,7 +808,8 @@ describe('AlarmCorrelationService', () => {
       timestamp: 1800, message: 'stall',
     })!;
     expect(second.result.action).toBe('formed-group');
-    expect(second.result.suppressed).toBe(true);
+    expect(second.result.suppressed).toBe(false);
+    expect(service.engine.getSuppressionPolicy().enabled).toBe(false);
     expect(created).toHaveBeenCalledTimes(1);
   });
 

--- a/server/services/alarm-correlation/__tests__/alarm-correlation.test.ts
+++ b/server/services/alarm-correlation/__tests__/alarm-correlation.test.ts
@@ -409,6 +409,134 @@ describe('AlarmCorrelationEngine', () => {
     expect(engine.getGroups()).toHaveLength(0);
   });
 
+  it('derives site boundaries from topology and fails closed on conflicts', () => {
+    const crossSiteTopology = new EquipmentTopology();
+    crossSiteTopology.upsertMany([
+      {
+        equipmentId: 'A',
+        siteId: 'site-a',
+        causalDownstream: ['B'],
+      },
+      {
+        equipmentId: 'B',
+        siteId: 'site-b',
+        causalDownstream: [],
+      },
+    ]);
+
+    for (const [description, firstSite, secondSite] of [
+      ['omitted', undefined, undefined],
+      ['conflicting', 'site-a', 'site-a'],
+    ] as const) {
+      const engine = new AlarmCorrelationEngine({
+        topology: crossSiteTopology,
+        suppressionPolicy: { enabled: true },
+      });
+      engine.ingest(alarm({
+        id: `${description}-a`,
+        equipmentId: 'A',
+        tagId: 'A.TRIP',
+        siteId: firstSite,
+        timestamp: 1000,
+        severity: 'high',
+      }));
+      const second = engine.ingest(alarm({
+        id: `${description}-b`,
+        equipmentId: 'B',
+        tagId: 'B.TRIP',
+        siteId: secondSite,
+        timestamp: 1100,
+        severity: 'medium',
+      }));
+
+      expect(second.action, description).toBe('standalone');
+      expect(engine.getGroups(), description).toHaveLength(0);
+      expect(engine.getMetrics().alarmsSuppressed, description).toBe(0);
+    }
+
+    const sameSiteTopology = new EquipmentTopology();
+    sameSiteTopology.upsertMany([
+      {
+        equipmentId: 'A',
+        siteId: 'site-a',
+        causalDownstream: ['B'],
+      },
+      {
+        equipmentId: 'B',
+        siteId: 'site-a',
+        causalDownstream: [],
+      },
+    ]);
+    const sameSite = new AlarmCorrelationEngine({
+      topology: sameSiteTopology,
+      suppressionPolicy: { enabled: true },
+    });
+    sameSite.ingest(alarm({
+      id: 'same-a',
+      equipmentId: 'A',
+      tagId: 'A.TRIP',
+      timestamp: 1000,
+      severity: 'high',
+    }));
+    expect(sameSite.ingest(alarm({
+      id: 'same-b',
+      equipmentId: 'B',
+      tagId: 'B.TRIP',
+      timestamp: 1100,
+      severity: 'medium',
+    }))).toMatchObject({
+      action: 'formed-group',
+      suppressed: true,
+    });
+  });
+
+  it('restores suppression when topology later reveals a cross-site group', () => {
+    const topology = new EquipmentTopology();
+    topology.upsertMany([
+      { equipmentId: 'A', causalDownstream: ['B'] },
+      { equipmentId: 'B', causalDownstream: [] },
+    ]);
+    const engine = new AlarmCorrelationEngine({
+      topology,
+      suppressionPolicy: { enabled: true },
+    });
+    engine.ingest(alarm({
+      id: 'root',
+      equipmentId: 'A',
+      tagId: 'A.TRIP',
+      timestamp: 1000,
+      severity: 'high',
+    }));
+    engine.ingest(alarm({
+      id: 'member',
+      equipmentId: 'B',
+      tagId: 'B.TRIP',
+      timestamp: 1100,
+      severity: 'medium',
+    }));
+    const group = engine.getGroups()[0];
+    expect(group.suppressedAlarmIds).toEqual(['member']);
+
+    topology.upsertMany([
+      { equipmentId: 'A', siteId: 'site-a', causalDownstream: ['B'] },
+      { equipmentId: 'B', siteId: 'site-b', causalDownstream: ['C'] },
+      { equipmentId: 'C', siteId: 'site-b', causalDownstream: [] },
+    ]);
+    engine.setSuppressionPolicy({ enabled: true });
+
+    expect(group.suppressedAlarmIds).toEqual([]);
+    expect(group.alarms.find((candidate) => candidate.id === 'member')?.state)
+      .toBe('active');
+    expect(engine.ingest(alarm({
+      id: 'site-b-candidate',
+      equipmentId: 'C',
+      tagId: 'C.TRIP',
+      timestamp: 1200,
+      severity: 'medium',
+    })).action).toBe('standalone');
+    expect(group.alarmIds).toEqual(['root', 'member']);
+  });
+
   it('suppresses downstream alarms but never critical ones', () => {
     const engine = new AlarmCorrelationEngine({
       topology: plantTopology(),
@@ -599,6 +727,52 @@ describe('AlarmCorrelationEngine', () => {
     expect(group.suppressedAlarmIds).toEqual([]);
   });
 
+  it('canonicalizes caller-suppressed raises and defensively restores closed groups', () => {
+    const idle = new AlarmCorrelationEngine({
+      groupCloseAfterMs: 1000,
+      clock: () => 0,
+    });
+    idle.ingest(alarm({
+      id: 'caller-root',
+      tagId: 'CALLER.ALARM',
+      state: 'suppressed',
+      timestamp: 1000,
+    }));
+    idle.ingest(alarm({
+      id: 'caller-member',
+      tagId: 'CALLER.ALARM',
+      timestamp: 1100,
+    }));
+    const idleGroup = idle.getGroups()[0];
+    expect(idleGroup.alarms.find((candidate) => candidate.id === 'caller-root')?.state)
+      .toBe('active');
+    expect(idleGroup.suppressedAlarmIds).toEqual([]);
+
+    // Simulate legacy/untrusted state that predates canonical ingestion.
+    idleGroup.alarms[1].state = 'suppressed';
+    idleGroup.suppressedAlarmIds = [];
+    idle.sweep(10_000);
+    expect(idleGroup.state).toBe('closed');
+    expect(idleGroup.alarms[1].state).toBe('active');
+    expect(idleGroup.suppressedAlarmIds).toEqual([]);
+
+    const capped = new AlarmCorrelationEngine({
+      maxGroups: 1,
+      suppressionPolicy: { enabled: false },
+    });
+    capped.ingest(alarm({ id: 'old-a', tagId: 'OLD.ALARM', timestamp: 1000 }));
+    capped.ingest(alarm({ id: 'old-b', tagId: 'OLD.ALARM', timestamp: 1100 }));
+    const evictedGroup = capped.getGroups()[0];
+    evictedGroup.alarms[1].state = 'suppressed';
+    evictedGroup.suppressedAlarmIds = [];
+
+    capped.ingest(alarm({ id: 'new-a', tagId: 'NEW.ALARM', timestamp: 100_000 }));
+    capped.ingest(alarm({ id: 'new-b', tagId: 'NEW.ALARM', timestamp: 100_100 }));
+    expect(evictedGroup.closeReason).toBe('evicted');
+    expect(evictedGroup.alarms[1].state).toBe('active');
+    expect(evictedGroup.suppressedAlarmIds).toEqual([]);
+  });
+
   it('caps group membership to bound alarm-storm root-election work', () => {
     const engine = new AlarmCorrelationEngine({
       maxAlarmsPerGroup: 3,
@@ -714,6 +888,36 @@ describe('AlarmCorrelationEngine', () => {
     expect(metrics.alarmsSuppressed).toBe(2);
     expect(metrics.suppressionRate).toBeCloseTo(2 / 3);
   });
+
+  it('counts unique suppressed alarms so repeated policy toggles stay bounded', () => {
+    const engine = new AlarmCorrelationEngine({
+      suppressionPolicy: { enabled: true },
+    });
+    engine.ingest(alarm({
+      id: 'root',
+      tagId: 'BOUNDED.ALARM',
+      timestamp: 0,
+      severity: 'high',
+    }));
+    engine.ingest(alarm({
+      id: 'member',
+      tagId: 'BOUNDED.ALARM',
+      timestamp: 100,
+      severity: 'medium',
+    }));
+
+    for (let index = 0; index < 5; index++) {
+      engine.setSuppressionPolicy({ enabled: false });
+      engine.setSuppressionPolicy({ enabled: true });
+    }
+
+    const metrics = engine.getMetrics();
+    expect(metrics.alarmsIngested).toBe(2);
+    expect(metrics.alarmsSuppressed).toBe(1);
+    expect(metrics.suppressionRate).toBe(0.5);
+    expect(metrics.suppressionRate).toBeGreaterThanOrEqual(0);
+    expect(metrics.suppressionRate).toBeLessThanOrEqual(1);
+  });
 });
 
 // ── Normalization & service ───────────────────────────────────────────────
@@ -777,6 +981,20 @@ describe('normalizeAlarm', () => {
       timestamp: 1,
       state: 'mystery',
     })).toBeNull();
+    expect(normalizeAlarm({
+      id: 'date-overflow',
+      tagId: 'T.1',
+      timestamp: -1e300,
+    })).toBeNull();
+  });
+
+  it('normalizes caller-supplied suppression back to a new active raise', () => {
+    expect(normalizeAlarm({
+      id: 'caller-suppressed',
+      tagId: 'T.1',
+      timestamp: 1,
+      state: 'suppressed',
+    })?.state).toBe('active');
   });
 
   it('resolves equipment from the ASSET.EVENT tag convention', () => {
@@ -820,5 +1038,29 @@ describe('AlarmCorrelationService', () => {
     expect((await service.healthCheck()).healthy).toBe(true);
     await service.shutdown();
     expect((await service.healthCheck()).healthy).toBe(false);
+  });
+
+  it('rejects Date-invalid timestamps before mutation and permits a valid retry', () => {
+    const service = new AlarmCorrelationService();
+    expect(service.ingest({
+      id: 'retry-after-invalid-date',
+      tagId: 'DATE.ALARM',
+      timestamp: -1e300,
+    })).toBeNull();
+    expect(service.engine.getMetrics()).toMatchObject({
+      alarmsIngested: 0,
+      trackedAlarms: 0,
+    });
+
+    const retry = service.ingest({
+      id: 'retry-after-invalid-date',
+      tagId: 'DATE.ALARM',
+      timestamp: 1000,
+    });
+    expect(retry?.result.action).toBe('standalone');
+    expect(service.engine.getMetrics()).toMatchObject({
+      alarmsIngested: 1,
+      trackedAlarms: 1,
+    });
   });
 });

--- a/server/services/alarm-correlation/engine.ts
+++ b/server/services/alarm-correlation/engine.ts
@@ -1,0 +1,512 @@
+/**
+ * Alarm Correlation Engine
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * Groups related alarms via the rules engine (causal chains, equipment
+ * hierarchy, scoped temporal proximity), elects a deterministic root
+ * cause per group, and suppresses downstream/consequential alarms with
+ * severity guards and un-suppression when the root cause clears.
+ *
+ * All correlation logic is event-time driven — wall-clock never enters
+ * grouping decisions, so replayed/backfilled alarm streams correlate
+ * identically. Wall-clock is only supplied externally to sweep() for
+ * idle-group housekeeping.
+ */
+
+import { EventEmitter } from 'events';
+import type {
+  AlarmGroup,
+  AlarmSeverity,
+  CorrelatedAlarm,
+  CorrelationMetrics,
+  CorrelationRule,
+  IngestResult,
+  RootCauseResult,
+  SuppressionPolicy,
+} from '@shared/types/alarm-correlation';
+import { EquipmentTopology } from './topology';
+import { CorrelationRulesEngine } from './rules';
+
+const SEVERITY_RANK: Record<AlarmSeverity, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+  info: 0,
+};
+
+/** Alarms this close in event time tie on "earliest" during root election */
+const ROOT_ELECTION_TIME_BUCKET_MS = 100;
+
+export const DEFAULT_SUPPRESSION_POLICY: SuppressionPolicy = {
+  enabled: true,
+  neverSuppressAtOrAbove: 'critical',
+  unsuppressOnRootClear: true,
+};
+
+export interface CorrelationEngineOptions {
+  topology?: EquipmentTopology;
+  rules?: CorrelationRulesEngine;
+  suppressionPolicy?: Partial<SuppressionPolicy>;
+  /** Open groups with no new alarms for this long (vs sweep clock) close */
+  groupCloseAfterMs?: number;
+  /** A group never admits alarms this far (event time) after its earliest member */
+  maxGroupSpanMs?: number;
+  /** Retained groups (open + closed); oldest closed evicted first */
+  maxGroups?: number;
+  /** Ungrouped alarms retained as candidate peers for future groups */
+  maxPendingAlarms?: number;
+}
+
+export class AlarmCorrelationEngine extends EventEmitter {
+  readonly topology: EquipmentTopology;
+  readonly rules: CorrelationRulesEngine;
+
+  private suppressionPolicy: SuppressionPolicy;
+  private readonly groupCloseAfterMs: number;
+  private readonly maxGroupSpanMs: number;
+  private readonly maxGroups: number;
+  private readonly maxPendingAlarms: number;
+
+  private groups: Map<string, AlarmGroup> = new Map();
+  /** Ungrouped recent alarms — candidate peers for group formation */
+  private pending: CorrelatedAlarm[] = [];
+  /** alarmId → groupId, or null while standalone/pending */
+  private alarmIndex: Map<string, string | null> = new Map();
+  private groupCounter = 0;
+
+  private metrics = {
+    alarmsIngested: 0,
+    groupsCreated: 0,
+    groupsClosed: 0,
+    alarmsSuppressed: 0,
+    alarmsUnsuppressed: 0,
+  };
+
+  constructor(options: CorrelationEngineOptions = {}) {
+    super();
+    this.topology = options.topology ?? new EquipmentTopology();
+    this.rules = options.rules ?? new CorrelationRulesEngine();
+    this.suppressionPolicy = { ...DEFAULT_SUPPRESSION_POLICY, ...options.suppressionPolicy };
+    this.groupCloseAfterMs = options.groupCloseAfterMs ?? 10 * 60 * 1000;
+    this.maxGroupSpanMs = options.maxGroupSpanMs ?? 30 * 60 * 1000;
+    this.maxGroups = options.maxGroups ?? 1000;
+    this.maxPendingAlarms = options.maxPendingAlarms ?? 2000;
+  }
+
+  // ── Ingestion & correlation ──────────────────────────────────────────
+
+  ingest(alarm: CorrelatedAlarm): IngestResult {
+    if (this.alarmIndex.has(alarm.id)) {
+      const groupId = this.alarmIndex.get(alarm.id) ?? undefined;
+      const group = groupId ? this.groups.get(groupId) : undefined;
+      return {
+        alarmId: alarm.id,
+        action: group ? 'joined-group' : 'standalone',
+        groupId,
+        suppressed: group ? group.suppressedAlarmIds.includes(alarm.id) : false,
+        isRootCause: group ? group.rootCauseAlarmId === alarm.id : false,
+        reason: 'duplicate alarm id — already ingested',
+      };
+    }
+
+    this.metrics.alarmsIngested++;
+
+    // 1. Try to join an existing open group (most recently active first)
+    const openGroups = Array.from(this.groups.values())
+      .filter((g) => g.state === 'open')
+      .sort((a, b) => b.lastAlarmAt - a.lastAlarmAt);
+
+    for (const group of openGroups) {
+      const earliest = group.alarms[0]?.timestamp ?? group.createdAt;
+      if (alarm.timestamp - earliest > this.maxGroupSpanMs) continue;
+      const rule = this.rules.evaluateJoin(alarm, group, this.topology);
+      if (rule) {
+        return this.joinGroup(alarm, group, rule);
+      }
+    }
+
+    // 2. Try to form a new group with a pending (ungrouped) alarm
+    for (let i = this.pending.length - 1; i >= 0; i--) {
+      const peer = this.pending[i];
+      const rule = this.rules.evaluatePair(alarm, peer, this.topology);
+      if (rule) {
+        return this.formGroup(alarm, peer, rule);
+      }
+    }
+
+    // 3. Standalone — buffer as a candidate peer for future alarms
+    this.pending.push(alarm);
+    this.alarmIndex.set(alarm.id, null);
+    this.prunePending(alarm.timestamp);
+    return {
+      alarmId: alarm.id,
+      action: 'standalone',
+      suppressed: false,
+      isRootCause: false,
+      reason: 'no enabled rule matched an open group or pending alarm',
+    };
+  }
+
+  // ── Alarm lifecycle updates ──────────────────────────────────────────
+
+  /**
+   * Mark an alarm cleared. Clearing a group's root cause closes the group
+   * and (per policy) un-suppresses its remaining active members.
+   */
+  alarmCleared(alarmId: string): { groupClosed?: string; unsuppressed: string[] } {
+    const groupId = this.alarmIndex.get(alarmId);
+    if (groupId === undefined) return { unsuppressed: [] };
+
+    if (groupId === null) {
+      const pendingAlarm = this.pending.find((a) => a.id === alarmId);
+      if (pendingAlarm) pendingAlarm.state = 'cleared';
+      return { unsuppressed: [] };
+    }
+
+    const group = this.groups.get(groupId);
+    if (!group) return { unsuppressed: [] };
+
+    const member = group.alarms.find((a) => a.id === alarmId);
+    if (member) member.state = 'cleared';
+
+    if (group.state === 'open' && group.rootCauseAlarmId === alarmId) {
+      const unsuppressed = this.suppressionPolicy.unsuppressOnRootClear
+        ? this.unsuppressActiveMembers(group)
+        : [];
+      this.closeGroup(group, 'root-cause-cleared');
+      return { groupClosed: group.id, unsuppressed };
+    }
+
+    this.emit('group-updated', group);
+    return { unsuppressed: [] };
+  }
+
+  alarmAcknowledged(alarmId: string): boolean {
+    const groupId = this.alarmIndex.get(alarmId);
+    if (groupId === undefined) return false;
+    const alarm =
+      groupId === null
+        ? this.pending.find((a) => a.id === alarmId)
+        : this.groups.get(groupId)?.alarms.find((a) => a.id === alarmId);
+    if (!alarm) return false;
+    if (alarm.state === 'active' || alarm.state === 'suppressed') {
+      alarm.state = 'acknowledged';
+    }
+    return true;
+  }
+
+  // ── Housekeeping (wall-clock supplied externally) ────────────────────
+
+  /** Close idle groups, prune stale pending alarms, enforce retention caps */
+  sweep(nowMs: number): { closedGroups: string[] } {
+    const closedGroups: string[] = [];
+    for (const group of this.groups.values()) {
+      if (group.state === 'open' && nowMs - group.lastAlarmAt > this.groupCloseAfterMs) {
+        this.closeGroup(group, 'idle-timeout');
+        closedGroups.push(group.id);
+      }
+    }
+    this.prunePending(nowMs);
+    this.enforceGroupCap();
+    return { closedGroups };
+  }
+
+  // ── Queries ──────────────────────────────────────────────────────────
+
+  getGroups(filter?: { state?: 'open' | 'closed' }): AlarmGroup[] {
+    let groups = Array.from(this.groups.values());
+    if (filter?.state) groups = groups.filter((g) => g.state === filter.state);
+    return groups.sort((a, b) => b.lastAlarmAt - a.lastAlarmAt);
+  }
+
+  getGroup(groupId: string): AlarmGroup | undefined {
+    return this.groups.get(groupId);
+  }
+
+  getRootCause(groupId: string): RootCauseResult | null {
+    const group = this.groups.get(groupId);
+    if (!group) return null;
+    const root = group.alarms.find((a) => a.id === group.rootCauseAlarmId);
+    if (!root) return null;
+
+    const memberEquipment = group.alarms
+      .map((a) => a.equipmentId)
+      .filter((id): id is string => !!id);
+    return {
+      groupId,
+      alarm: root,
+      causalDominance: root.equipmentId
+        ? this.topology.causalDominance(root.equipmentId, memberEquipment, 8)
+        : 0,
+      hierarchyDepth: root.equipmentId ? this.topology.depth(root.equipmentId) : 0,
+      electedBy: 'earliest-bucket, causal-dominance, hierarchy-depth, id',
+    };
+  }
+
+  setSuppressionPolicy(policy: Partial<SuppressionPolicy>): SuppressionPolicy {
+    this.suppressionPolicy = { ...this.suppressionPolicy, ...policy };
+    return this.suppressionPolicy;
+  }
+
+  getSuppressionPolicy(): SuppressionPolicy {
+    return { ...this.suppressionPolicy };
+  }
+
+  getMetrics(): CorrelationMetrics {
+    const openGroups = Array.from(this.groups.values()).filter(
+      (g) => g.state === 'open'
+    ).length;
+    return {
+      ...this.metrics,
+      suppressionRate:
+        this.metrics.alarmsIngested === 0
+          ? 0
+          : this.metrics.alarmsSuppressed / this.metrics.alarmsIngested,
+      openGroups,
+      trackedAlarms: this.alarmIndex.size,
+    };
+  }
+
+  // ── Private: group mechanics ─────────────────────────────────────────
+
+  private joinGroup(
+    alarm: CorrelatedAlarm,
+    group: AlarmGroup,
+    rule: CorrelationRule
+  ): IngestResult {
+    group.alarms.push(alarm);
+    group.alarmIds.push(alarm.id);
+    group.joinedVia[alarm.id] = rule.id;
+    group.lastAlarmAt = Math.max(group.lastAlarmAt, alarm.timestamp);
+    if (SEVERITY_RANK[alarm.severity] > SEVERITY_RANK[group.maxSeverity]) {
+      group.maxSeverity = alarm.severity;
+    }
+    this.alarmIndex.set(alarm.id, group.id);
+    this.removeFromPending(alarm.id);
+
+    const previousRoot = group.rootCauseAlarmId;
+    this.electRootCause(group);
+    if (group.rootCauseAlarmId !== previousRoot) {
+      this.emit('root-cause-changed', {
+        groupId: group.id,
+        previous: previousRoot,
+        current: group.rootCauseAlarmId,
+      });
+    }
+    this.applySuppression(group);
+    this.emit('group-updated', group);
+
+    return {
+      alarmId: alarm.id,
+      action: 'joined-group',
+      groupId: group.id,
+      ruleId: rule.id,
+      suppressed: group.suppressedAlarmIds.includes(alarm.id),
+      isRootCause: group.rootCauseAlarmId === alarm.id,
+      reason: `matched rule "${rule.name}"`,
+    };
+  }
+
+  private formGroup(
+    alarm: CorrelatedAlarm,
+    peer: CorrelatedAlarm,
+    rule: CorrelationRule
+  ): IngestResult {
+    const members = [peer, alarm].sort((a, b) => a.timestamp - b.timestamp);
+    const group: AlarmGroup = {
+      id: `ACG-${++this.groupCounter}`,
+      state: 'open',
+      alarms: members,
+      alarmIds: members.map((a) => a.id),
+      rootCauseAlarmId: members[0].id,
+      formedByRuleId: rule.id,
+      joinedVia: { [peer.id]: rule.id, [alarm.id]: rule.id },
+      suppressedAlarmIds: [],
+      maxSeverity: members.reduce<AlarmSeverity>(
+        (max, a) => (SEVERITY_RANK[a.severity] > SEVERITY_RANK[max] ? a.severity : max),
+        'info'
+      ),
+      createdAt: members[0].timestamp,
+      lastAlarmAt: members[members.length - 1].timestamp,
+    };
+
+    this.groups.set(group.id, group);
+    this.metrics.groupsCreated++;
+    this.alarmIndex.set(alarm.id, group.id);
+    this.alarmIndex.set(peer.id, group.id);
+    this.removeFromPending(peer.id);
+    this.removeFromPending(alarm.id);
+
+    this.electRootCause(group);
+    this.applySuppression(group);
+    this.enforceGroupCap();
+    this.emit('group-created', group);
+
+    return {
+      alarmId: alarm.id,
+      action: 'formed-group',
+      groupId: group.id,
+      ruleId: rule.id,
+      suppressed: group.suppressedAlarmIds.includes(alarm.id),
+      isRootCause: group.rootCauseAlarmId === alarm.id,
+      reason: `formed group with "${peer.id}" via rule "${rule.name}"`,
+    };
+  }
+
+  /**
+   * Deterministic root election (total order):
+   * earliest 100ms time bucket → highest causal dominance → shallowest
+   * hierarchy depth → lexicographically smallest id.
+   */
+  private electRootCause(group: AlarmGroup): void {
+    const memberEquipment = group.alarms
+      .map((a) => a.equipmentId)
+      .filter((id): id is string => !!id);
+
+    const scored = group.alarms.map((alarm) => ({
+      alarm,
+      bucket: Math.floor(alarm.timestamp / ROOT_ELECTION_TIME_BUCKET_MS),
+      dominance: alarm.equipmentId
+        ? this.topology.causalDominance(alarm.equipmentId, memberEquipment, 8)
+        : 0,
+      depth: alarm.equipmentId ? this.topology.depth(alarm.equipmentId) : Number.MAX_SAFE_INTEGER,
+    }));
+
+    scored.sort((a, b) => {
+      if (a.bucket !== b.bucket) return a.bucket - b.bucket;
+      if (a.dominance !== b.dominance) return b.dominance - a.dominance;
+      if (a.depth !== b.depth) return a.depth - b.depth;
+      return a.alarm.id < b.alarm.id ? -1 : 1;
+    });
+
+    group.rootCauseAlarmId = scored[0].alarm.id;
+  }
+
+  /**
+   * Root cause is never suppressed. Other members are suppressed unless
+   * severity meets the never-suppress floor or they are already
+   * cleared/acknowledged.
+   */
+  private applySuppression(group: AlarmGroup): void {
+    if (!this.suppressionPolicy.enabled) return;
+    const floor = SEVERITY_RANK[this.suppressionPolicy.neverSuppressAtOrAbove];
+
+    for (const alarm of group.alarms) {
+      const isRoot = alarm.id === group.rootCauseAlarmId;
+      const alreadySuppressed = group.suppressedAlarmIds.includes(alarm.id);
+
+      if (isRoot && alreadySuppressed) {
+        // A re-election promoted a suppressed member to root — restore it
+        group.suppressedAlarmIds = group.suppressedAlarmIds.filter((id) => id !== alarm.id);
+        if (alarm.state === 'suppressed') alarm.state = 'active';
+        this.metrics.alarmsUnsuppressed++;
+        this.emit('alarms-unsuppressed', { groupId: group.id, alarmIds: [alarm.id] });
+        continue;
+      }
+
+      if (
+        !isRoot &&
+        !alreadySuppressed &&
+        alarm.state === 'active' &&
+        SEVERITY_RANK[alarm.severity] < floor
+      ) {
+        group.suppressedAlarmIds.push(alarm.id);
+        alarm.state = 'suppressed';
+        this.metrics.alarmsSuppressed++;
+        this.emit('alarm-suppressed', {
+          groupId: group.id,
+          alarmId: alarm.id,
+          rootCauseAlarmId: group.rootCauseAlarmId,
+        });
+      }
+    }
+  }
+
+  private unsuppressActiveMembers(group: AlarmGroup): string[] {
+    const restored: string[] = [];
+    for (const alarmId of group.suppressedAlarmIds) {
+      const alarm = group.alarms.find((a) => a.id === alarmId);
+      if (alarm && alarm.state === 'suppressed') {
+        alarm.state = 'active';
+        restored.push(alarmId);
+        this.metrics.alarmsUnsuppressed++;
+      }
+    }
+    group.suppressedAlarmIds = group.suppressedAlarmIds.filter(
+      (id) => !restored.includes(id)
+    );
+    if (restored.length > 0) {
+      this.emit('alarms-unsuppressed', { groupId: group.id, alarmIds: restored });
+    }
+    return restored;
+  }
+
+  private closeGroup(group: AlarmGroup, reason: AlarmGroup['closeReason']): void {
+    if (group.state === 'closed') return;
+    group.state = 'closed';
+    group.closeReason = reason;
+    group.closedAt = group.lastAlarmAt;
+    this.metrics.groupsClosed++;
+    this.emit('group-closed', group);
+  }
+
+  private enforceGroupCap(): void {
+    if (this.groups.size <= this.maxGroups) return;
+    const closedOldestFirst = Array.from(this.groups.values())
+      .filter((g) => g.state === 'closed')
+      .sort((a, b) => a.lastAlarmAt - b.lastAlarmAt);
+    for (const group of closedOldestFirst) {
+      if (this.groups.size <= this.maxGroups) return;
+      this.evictGroup(group);
+    }
+    // Still over cap — evict oldest open groups (pathological load)
+    const openOldestFirst = Array.from(this.groups.values()).sort(
+      (a, b) => a.lastAlarmAt - b.lastAlarmAt
+    );
+    for (const group of openOldestFirst) {
+      if (this.groups.size <= this.maxGroups) return;
+      this.closeGroup(group, 'evicted');
+      this.evictGroup(group);
+    }
+  }
+
+  private evictGroup(group: AlarmGroup): void {
+    for (const alarmId of group.alarmIds) {
+      this.alarmIndex.delete(alarmId);
+    }
+    this.groups.delete(group.id);
+  }
+
+  private removeFromPending(alarmId: string): void {
+    const idx = this.pending.findIndex((a) => a.id === alarmId);
+    if (idx >= 0) this.pending.splice(idx, 1);
+  }
+
+  /** Drop pending alarms too old to pair under the widest enabled rule window */
+  private prunePending(referenceMs: number): void {
+    const maxWindow = Math.max(
+      1000,
+      ...this.rules
+        .list()
+        .filter((r) => r.enabled)
+        .map((r) => (r.config as { windowMs: number }).windowMs)
+    );
+    const cutoff = referenceMs - maxWindow * 2;
+    let removed = 0;
+    this.pending = this.pending.filter((alarm) => {
+      const keep = alarm.timestamp >= cutoff;
+      if (!keep) {
+        this.alarmIndex.delete(alarm.id);
+        removed++;
+      }
+      return keep;
+    });
+    if (this.pending.length > this.maxPendingAlarms) {
+      const excess = this.pending.splice(0, this.pending.length - this.maxPendingAlarms);
+      for (const alarm of excess) this.alarmIndex.delete(alarm.id);
+      removed += excess.length;
+    }
+    if (removed > 0) this.emit('pending-pruned', { removed });
+  }
+}

--- a/server/services/alarm-correlation/engine.ts
+++ b/server/services/alarm-correlation/engine.ts
@@ -90,8 +90,12 @@ export class AlarmCorrelationEngine extends EventEmitter {
     alarmsSuppressed: 0,
     alarmsUnsuppressed: 0,
   };
-  /** Lifetime unique alarm ids that have entered engine-owned suppression. */
-  private everSuppressedAlarmIds = new Set<string>();
+  /**
+   * Alarm ids already counted for suppression while their groups are
+   * retained. Entries are discarded with group eviction, bounding this set
+   * by the retained-group/member caps after synchronous cap enforcement.
+   */
+  private suppressionCountedAlarmIds = new Set<string>();
 
   constructor(options: CorrelationEngineOptions = {}) {
     super();
@@ -366,6 +370,24 @@ export class AlarmCorrelationEngine extends EventEmitter {
     return { ...this.suppressionPolicy };
   }
 
+  /** Re-elect roots and reapply fail-safe suppression after topology changes. */
+  reconcileTopology(): void {
+    for (const group of this.groups.values()) {
+      if (group.state !== 'open') continue;
+      const previousRoot = group.rootCauseAlarmId;
+      this.electRootCause(group);
+      if (group.rootCauseAlarmId !== previousRoot) {
+        this.emit('root-cause-changed', {
+          groupId: group.id,
+          previous: previousRoot,
+          current: group.rootCauseAlarmId,
+        });
+      }
+      this.applySuppression(group);
+      this.emit('group-updated', group);
+    }
+  }
+
   getMetrics(): CorrelationMetrics {
     const openGroups = Array.from(this.groups.values()).filter(
       (g) => g.state === 'open'
@@ -539,8 +561,8 @@ export class AlarmCorrelationEngine extends EventEmitter {
       if (!alreadySuppressed && shouldSuppress) {
         group.suppressedAlarmIds.push(alarm.id);
         alarm.state = 'suppressed';
-        if (!this.everSuppressedAlarmIds.has(alarm.id)) {
-          this.everSuppressedAlarmIds.add(alarm.id);
+        if (!this.suppressionCountedAlarmIds.has(alarm.id)) {
+          this.suppressionCountedAlarmIds.add(alarm.id);
           this.metrics.alarmsSuppressed++;
         }
         this.emit('alarm-suppressed', {
@@ -602,6 +624,7 @@ export class AlarmCorrelationEngine extends EventEmitter {
     this.unsuppressActiveMembers(group);
     for (const alarmId of group.alarmIds) {
       this.alarmIndex.delete(alarmId);
+      this.suppressionCountedAlarmIds.delete(alarmId);
     }
     this.groupLastTouchedAt.delete(group.id);
     this.groups.delete(group.id);

--- a/server/services/alarm-correlation/engine.ts
+++ b/server/services/alarm-correlation/engine.ts
@@ -90,6 +90,8 @@ export class AlarmCorrelationEngine extends EventEmitter {
     alarmsSuppressed: 0,
     alarmsUnsuppressed: 0,
   };
+  /** Lifetime unique alarm ids that have entered engine-owned suppression. */
+  private everSuppressedAlarmIds = new Set<string>();
 
   constructor(options: CorrelationEngineOptions = {}) {
     super();
@@ -122,7 +124,13 @@ export class AlarmCorrelationEngine extends EventEmitter {
 
   // ── Ingestion & correlation ──────────────────────────────────────────
 
-  ingest(alarm: CorrelatedAlarm): IngestResult {
+  ingest(input: CorrelatedAlarm): IngestResult {
+    // Suppression is engine-owned state. A newly raised alarm cannot arrive
+    // already suppressed and escape the engine's tracking/restoration path.
+    const alarm: CorrelatedAlarm =
+      input.state === 'suppressed'
+        ? { ...input, state: 'active' }
+        : input;
     if (this.alarmIndex.has(alarm.id)) {
       const groupId = this.alarmIndex.get(alarm.id) ?? undefined;
       const group = groupId ? this.groups.get(groupId) : undefined;
@@ -215,8 +223,6 @@ export class AlarmCorrelationEngine extends EventEmitter {
       pendingAlarm.state = 'cleared';
       if (actor) pendingAlarm.clearedBy = actor;
       this.emit('alarm-updated', pendingAlarm);
-      this.removeFromPending(alarmId);
-      this.alarmIndex.delete(alarmId);
       return {
         cleared: true,
         clearedBy: pendingAlarm.clearedBy,
@@ -310,6 +316,18 @@ export class AlarmCorrelationEngine extends EventEmitter {
     return this.groups.get(groupId);
   }
 
+  /** Return the canonical stored alarm for lifecycle response/readback. */
+  getAlarm(alarmId: string): CorrelatedAlarm | undefined {
+    const groupId = this.alarmIndex.get(alarmId);
+    if (groupId === undefined) return undefined;
+    if (groupId === null) {
+      return this.pending.find((alarm) => alarm.id === alarmId);
+    }
+    return this.groups
+      .get(groupId)
+      ?.alarms.find((alarm) => alarm.id === alarmId);
+  }
+
   getRootCause(groupId: string): RootCauseResult | null {
     const group = this.groups.get(groupId);
     if (!group) return null;
@@ -357,7 +375,10 @@ export class AlarmCorrelationEngine extends EventEmitter {
       suppressionRate:
         this.metrics.alarmsIngested === 0
           ? 0
-          : this.metrics.alarmsSuppressed / this.metrics.alarmsIngested,
+          : Math.min(
+            1,
+            this.metrics.alarmsSuppressed / this.metrics.alarmsIngested,
+          ),
       openGroups,
       trackedAlarms: this.alarmIndex.size,
     };
@@ -496,16 +517,21 @@ export class AlarmCorrelationEngine extends EventEmitter {
       return;
     }
     const floor = SEVERITY_RANK[this.suppressionPolicy.neverSuppressAtOrAbove];
+    const root = group.alarms.find(
+      (alarm) => alarm.id === group.rootCauseAlarmId,
+    );
 
     for (const alarm of group.alarms) {
       const isRoot = alarm.id === group.rootCauseAlarmId;
       const alreadySuppressed = group.suppressedAlarmIds.includes(alarm.id);
       const shouldSuppress =
         !isRoot
+        && !!root
+        && this.rules.areSitesCompatible(root, alarm, this.topology)
         && (alarm.state === 'active' || alarm.state === 'suppressed')
         && SEVERITY_RANK[alarm.severity] < floor;
 
-      if (alreadySuppressed && !shouldSuppress) {
+      if (!shouldSuppress && alarm.state === 'suppressed') {
         this.restoreSuppressedAlarm(group, alarm);
         continue;
       }
@@ -513,7 +539,10 @@ export class AlarmCorrelationEngine extends EventEmitter {
       if (!alreadySuppressed && shouldSuppress) {
         group.suppressedAlarmIds.push(alarm.id);
         alarm.state = 'suppressed';
-        this.metrics.alarmsSuppressed++;
+        if (!this.everSuppressedAlarmIds.has(alarm.id)) {
+          this.everSuppressedAlarmIds.add(alarm.id);
+          this.metrics.alarmsSuppressed++;
+        }
         this.emit('alarm-suppressed', {
           groupId: group.id,
           alarmId: alarm.id,
@@ -525,11 +554,10 @@ export class AlarmCorrelationEngine extends EventEmitter {
 
   private unsuppressActiveMembers(group: AlarmGroup): string[] {
     const restored: string[] = [];
-    for (const alarmId of [...group.suppressedAlarmIds]) {
-      const alarm = group.alarms.find((a) => a.id === alarmId);
-      if (alarm && alarm.state === 'suppressed') {
+    for (const alarm of group.alarms) {
+      if (alarm.state === 'suppressed') {
         alarm.state = 'active';
-        restored.push(alarmId);
+        restored.push(alarm.id);
         this.metrics.alarmsUnsuppressed++;
       }
     }

--- a/server/services/alarm-correlation/engine.ts
+++ b/server/services/alarm-correlation/engine.ts
@@ -7,13 +7,14 @@
  * cause per group, and suppresses downstream/consequential alarms with
  * severity guards and un-suppression when the root cause clears.
  *
- * All correlation logic is event-time driven — wall-clock never enters
- * grouping decisions, so replayed/backfilled alarm streams correlate
- * identically. Wall-clock is only supplied externally to sweep() for
- * idle-group housekeeping.
+ * Correlation decisions use event time, and pending connected components are
+ * reconciled deterministically when they fit one bounded group. Components
+ * split by safety caps or already-open groups may retain arrival-order
+ * partitions. Wall clock is supplied only to sweep() for housekeeping.
  */
 
 import { EventEmitter } from 'events';
+import { randomUUID } from 'node:crypto';
 import type {
   AlarmGroup,
   AlarmSeverity,
@@ -39,7 +40,7 @@ const SEVERITY_RANK: Record<AlarmSeverity, number> = {
 const ROOT_ELECTION_TIME_BUCKET_MS = 100;
 
 export const DEFAULT_SUPPRESSION_POLICY: SuppressionPolicy = {
-  enabled: true,
+  enabled: false,
   neverSuppressAtOrAbove: 'critical',
   unsuppressOnRootClear: true,
 };
@@ -56,6 +57,10 @@ export interface CorrelationEngineOptions {
   maxGroups?: number;
   /** Ungrouped alarms retained as candidate peers for future groups */
   maxPendingAlarms?: number;
+  /** Hard cap on members in one group to bound root-election work */
+  maxAlarmsPerGroup?: number;
+  /** Processing-time clock used only for lifecycle housekeeping */
+  clock?: () => number;
 }
 
 export class AlarmCorrelationEngine extends EventEmitter {
@@ -67,13 +72,16 @@ export class AlarmCorrelationEngine extends EventEmitter {
   private readonly maxGroupSpanMs: number;
   private readonly maxGroups: number;
   private readonly maxPendingAlarms: number;
+  private readonly maxAlarmsPerGroup: number;
+  private readonly clock: () => number;
 
   private groups: Map<string, AlarmGroup> = new Map();
+  private groupLastTouchedAt: Map<string, number> = new Map();
   /** Ungrouped recent alarms — candidate peers for group formation */
   private pending: CorrelatedAlarm[] = [];
+  private pendingLastTouchedAt: Map<string, number> = new Map();
   /** alarmId → groupId, or null while standalone/pending */
   private alarmIndex: Map<string, string | null> = new Map();
-  private groupCounter = 0;
 
   private metrics = {
     alarmsIngested: 0,
@@ -92,6 +100,24 @@ export class AlarmCorrelationEngine extends EventEmitter {
     this.maxGroupSpanMs = options.maxGroupSpanMs ?? 30 * 60 * 1000;
     this.maxGroups = options.maxGroups ?? 1000;
     this.maxPendingAlarms = options.maxPendingAlarms ?? 2000;
+    this.maxAlarmsPerGroup = options.maxAlarmsPerGroup ?? 128;
+    this.clock = options.clock ?? Date.now;
+    if (options.suppressionPolicy?.unsuppressOnRootClear === false) {
+      throw new Error('unsuppressOnRootClear must remain enabled for fail-safe closure');
+    }
+    for (const [name, value] of [
+      ['groupCloseAfterMs', this.groupCloseAfterMs],
+      ['maxGroupSpanMs', this.maxGroupSpanMs],
+      ['maxGroups', this.maxGroups],
+      ['maxPendingAlarms', this.maxPendingAlarms],
+    ] as const) {
+      if (!Number.isSafeInteger(value) || value < 1) {
+        throw new Error(`${name} must be a positive integer`);
+      }
+    }
+    if (!Number.isSafeInteger(this.maxAlarmsPerGroup) || this.maxAlarmsPerGroup < 2) {
+      throw new Error('maxAlarmsPerGroup must be an integer of at least 2');
+    }
   }
 
   // ── Ingestion & correlation ──────────────────────────────────────────
@@ -102,7 +128,7 @@ export class AlarmCorrelationEngine extends EventEmitter {
       const group = groupId ? this.groups.get(groupId) : undefined;
       return {
         alarmId: alarm.id,
-        action: group ? 'joined-group' : 'standalone',
+        action: 'duplicate',
         groupId,
         suppressed: group ? group.suppressedAlarmIds.includes(alarm.id) : false,
         isRootCause: group ? group.rootCauseAlarmId === alarm.id : false,
@@ -118,27 +144,37 @@ export class AlarmCorrelationEngine extends EventEmitter {
       .sort((a, b) => b.lastAlarmAt - a.lastAlarmAt);
 
     for (const group of openGroups) {
-      const earliest = group.alarms[0]?.timestamp ?? group.createdAt;
-      if (alarm.timestamp - earliest > this.maxGroupSpanMs) continue;
+      if (group.alarmIds.length >= this.maxAlarmsPerGroup) continue;
+      if (!this.withinGroupSpan(group, alarm.timestamp)) continue;
       const rule = this.rules.evaluateJoin(alarm, group, this.topology);
       if (rule) {
-        return this.joinGroup(alarm, group, rule);
+        const result = this.joinGroup(alarm, group, rule);
+        this.reconcilePending(group);
+        return this.refreshIngestResult(result, alarm, group);
       }
     }
 
     // 2. Try to form a new group with a pending (ungrouped) alarm
     for (let i = this.pending.length - 1; i >= 0; i--) {
       const peer = this.pending[i];
+      if (peer.state === 'cleared' || peer.state === 'shelved') continue;
+      if (Math.abs(alarm.timestamp - peer.timestamp) > this.maxGroupSpanMs) continue;
       const rule = this.rules.evaluatePair(alarm, peer, this.topology);
       if (rule) {
-        return this.formGroup(alarm, peer, rule);
+        const result = this.formGroup(alarm, peer, rule);
+        const group = this.groups.get(result.groupId!);
+        if (!group) return result;
+        this.reconcilePending(group);
+        return this.refreshIngestResult(result, alarm, group);
       }
     }
 
     // 3. Standalone — buffer as a candidate peer for future alarms
     this.pending.push(alarm);
+    this.pendingLastTouchedAt.set(alarm.id, this.clock());
     this.alarmIndex.set(alarm.id, null);
     this.prunePending(alarm.timestamp);
+    this.emit('alarm-updated', alarm);
     return {
       alarmId: alarm.id,
       action: 'standalone',
@@ -154,45 +190,94 @@ export class AlarmCorrelationEngine extends EventEmitter {
    * Mark an alarm cleared. Clearing a group's root cause closes the group
    * and (per policy) un-suppresses its remaining active members.
    */
-  alarmCleared(alarmId: string): { groupClosed?: string; unsuppressed: string[] } {
+  alarmCleared(
+    alarmId: string,
+    actor?: string,
+  ): {
+    cleared: boolean;
+    clearedBy?: string;
+    groupClosed?: string;
+    unsuppressed: string[];
+  } {
     const groupId = this.alarmIndex.get(alarmId);
-    if (groupId === undefined) return { unsuppressed: [] };
+    if (groupId === undefined) return { cleared: false, unsuppressed: [] };
 
     if (groupId === null) {
       const pendingAlarm = this.pending.find((a) => a.id === alarmId);
-      if (pendingAlarm) pendingAlarm.state = 'cleared';
-      return { unsuppressed: [] };
+      if (!pendingAlarm) return { cleared: false, unsuppressed: [] };
+      if (pendingAlarm.state === 'cleared') {
+        return {
+          cleared: true,
+          clearedBy: pendingAlarm.clearedBy,
+          unsuppressed: [],
+        };
+      }
+      pendingAlarm.state = 'cleared';
+      if (actor) pendingAlarm.clearedBy = actor;
+      this.emit('alarm-updated', pendingAlarm);
+      this.removeFromPending(alarmId);
+      this.alarmIndex.delete(alarmId);
+      return {
+        cleared: true,
+        clearedBy: pendingAlarm.clearedBy,
+        unsuppressed: [],
+      };
     }
 
     const group = this.groups.get(groupId);
-    if (!group) return { unsuppressed: [] };
+    if (!group) return { cleared: false, unsuppressed: [] };
 
     const member = group.alarms.find((a) => a.id === alarmId);
-    if (member) member.state = 'cleared';
+    if (!member) return { cleared: false, unsuppressed: [] };
+    if (member.state === 'cleared') {
+      return {
+        cleared: true,
+        clearedBy: member.clearedBy,
+        groupClosed: group.state === 'closed' ? group.id : undefined,
+        unsuppressed: [],
+      };
+    }
+    this.removeSuppressionRecord(group, alarmId);
+    member.state = 'cleared';
+    if (actor) member.clearedBy = actor;
 
     if (group.state === 'open' && group.rootCauseAlarmId === alarmId) {
-      const unsuppressed = this.suppressionPolicy.unsuppressOnRootClear
-        ? this.unsuppressActiveMembers(group)
-        : [];
+      const unsuppressed = this.unsuppressActiveMembers(group);
       this.closeGroup(group, 'root-cause-cleared');
-      return { groupClosed: group.id, unsuppressed };
+      return {
+        cleared: true,
+        clearedBy: member.clearedBy,
+        groupClosed: group.id,
+        unsuppressed,
+      };
     }
 
     this.emit('group-updated', group);
-    return { unsuppressed: [] };
+    return {
+      cleared: true,
+      clearedBy: member.clearedBy,
+      unsuppressed: [],
+    };
   }
 
-  alarmAcknowledged(alarmId: string): boolean {
+  alarmAcknowledged(alarmId: string, actor?: string): boolean {
     const groupId = this.alarmIndex.get(alarmId);
     if (groupId === undefined) return false;
+    const group = groupId === null ? undefined : this.groups.get(groupId);
     const alarm =
       groupId === null
         ? this.pending.find((a) => a.id === alarmId)
-        : this.groups.get(groupId)?.alarms.find((a) => a.id === alarmId);
+        : group?.alarms.find((a) => a.id === alarmId);
     if (!alarm) return false;
-    if (alarm.state === 'active' || alarm.state === 'suppressed') {
-      alarm.state = 'acknowledged';
+    if (alarm.state === 'acknowledged') return true;
+    if (alarm.state !== 'active' && alarm.state !== 'suppressed') return false;
+    if (group) {
+      this.removeSuppressionRecord(group, alarmId);
     }
+    alarm.state = 'acknowledged';
+    if (actor) alarm.acknowledgedBy = actor;
+    if (group) this.emit('group-updated', group);
+    else this.emit('alarm-updated', alarm);
     return true;
   }
 
@@ -202,12 +287,13 @@ export class AlarmCorrelationEngine extends EventEmitter {
   sweep(nowMs: number): { closedGroups: string[] } {
     const closedGroups: string[] = [];
     for (const group of this.groups.values()) {
-      if (group.state === 'open' && nowMs - group.lastAlarmAt > this.groupCloseAfterMs) {
+      const lastTouchedAt = this.groupLastTouchedAt.get(group.id) ?? nowMs;
+      if (group.state === 'open' && nowMs - lastTouchedAt > this.groupCloseAfterMs) {
         this.closeGroup(group, 'idle-timeout');
         closedGroups.push(group.id);
       }
     }
-    this.prunePending(nowMs);
+    this.prunePendingByProcessingTime(nowMs);
     this.enforceGroupCap();
     return { closedGroups };
   }
@@ -245,8 +331,17 @@ export class AlarmCorrelationEngine extends EventEmitter {
   }
 
   setSuppressionPolicy(policy: Partial<SuppressionPolicy>): SuppressionPolicy {
+    if (policy.unsuppressOnRootClear === false) {
+      throw new Error('unsuppressOnRootClear must remain enabled for fail-safe closure');
+    }
     this.suppressionPolicy = { ...this.suppressionPolicy, ...policy };
-    return this.suppressionPolicy;
+    for (const group of this.groups.values()) {
+      if (group.state === 'open') {
+        this.applySuppression(group);
+        this.emit('group-updated', group);
+      }
+    }
+    return { ...this.suppressionPolicy };
   }
 
   getSuppressionPolicy(): SuppressionPolicy {
@@ -278,7 +373,9 @@ export class AlarmCorrelationEngine extends EventEmitter {
     group.alarms.push(alarm);
     group.alarmIds.push(alarm.id);
     group.joinedVia[alarm.id] = rule.id;
+    group.createdAt = Math.min(group.createdAt, alarm.timestamp);
     group.lastAlarmAt = Math.max(group.lastAlarmAt, alarm.timestamp);
+    this.groupLastTouchedAt.set(group.id, this.clock());
     if (SEVERITY_RANK[alarm.severity] > SEVERITY_RANK[group.maxSeverity]) {
       group.maxSeverity = alarm.severity;
     }
@@ -315,7 +412,7 @@ export class AlarmCorrelationEngine extends EventEmitter {
   ): IngestResult {
     const members = [peer, alarm].sort((a, b) => a.timestamp - b.timestamp);
     const group: AlarmGroup = {
-      id: `ACG-${++this.groupCounter}`,
+      id: `ACG-${randomUUID()}`,
       state: 'open',
       alarms: members,
       alarmIds: members.map((a) => a.id),
@@ -332,6 +429,7 @@ export class AlarmCorrelationEngine extends EventEmitter {
     };
 
     this.groups.set(group.id, group);
+    this.groupLastTouchedAt.set(group.id, this.clock());
     this.metrics.groupsCreated++;
     this.alarmIndex.set(alarm.id, group.id);
     this.alarmIndex.set(peer.id, group.id);
@@ -360,11 +458,15 @@ export class AlarmCorrelationEngine extends EventEmitter {
    * hierarchy depth → lexicographically smallest id.
    */
   private electRootCause(group: AlarmGroup): void {
-    const memberEquipment = group.alarms
+    const eligibleAlarms = group.alarms.filter(
+      (alarm) => alarm.state !== 'cleared' && alarm.state !== 'shelved',
+    );
+    if (eligibleAlarms.length === 0) return;
+    const memberEquipment = [...new Set(eligibleAlarms
       .map((a) => a.equipmentId)
-      .filter((id): id is string => !!id);
+      .filter((id): id is string => !!id))];
 
-    const scored = group.alarms.map((alarm) => ({
+    const scored = eligibleAlarms.map((alarm) => ({
       alarm,
       bucket: Math.floor(alarm.timestamp / ROOT_ELECTION_TIME_BUCKET_MS),
       dominance: alarm.equipmentId
@@ -389,28 +491,26 @@ export class AlarmCorrelationEngine extends EventEmitter {
    * cleared/acknowledged.
    */
   private applySuppression(group: AlarmGroup): void {
-    if (!this.suppressionPolicy.enabled) return;
+    if (!this.suppressionPolicy.enabled) {
+      this.unsuppressActiveMembers(group);
+      return;
+    }
     const floor = SEVERITY_RANK[this.suppressionPolicy.neverSuppressAtOrAbove];
 
     for (const alarm of group.alarms) {
       const isRoot = alarm.id === group.rootCauseAlarmId;
       const alreadySuppressed = group.suppressedAlarmIds.includes(alarm.id);
+      const shouldSuppress =
+        !isRoot
+        && (alarm.state === 'active' || alarm.state === 'suppressed')
+        && SEVERITY_RANK[alarm.severity] < floor;
 
-      if (isRoot && alreadySuppressed) {
-        // A re-election promoted a suppressed member to root — restore it
-        group.suppressedAlarmIds = group.suppressedAlarmIds.filter((id) => id !== alarm.id);
-        if (alarm.state === 'suppressed') alarm.state = 'active';
-        this.metrics.alarmsUnsuppressed++;
-        this.emit('alarms-unsuppressed', { groupId: group.id, alarmIds: [alarm.id] });
+      if (alreadySuppressed && !shouldSuppress) {
+        this.restoreSuppressedAlarm(group, alarm);
         continue;
       }
 
-      if (
-        !isRoot &&
-        !alreadySuppressed &&
-        alarm.state === 'active' &&
-        SEVERITY_RANK[alarm.severity] < floor
-      ) {
+      if (!alreadySuppressed && shouldSuppress) {
         group.suppressedAlarmIds.push(alarm.id);
         alarm.state = 'suppressed';
         this.metrics.alarmsSuppressed++;
@@ -425,7 +525,7 @@ export class AlarmCorrelationEngine extends EventEmitter {
 
   private unsuppressActiveMembers(group: AlarmGroup): string[] {
     const restored: string[] = [];
-    for (const alarmId of group.suppressedAlarmIds) {
+    for (const alarmId of [...group.suppressedAlarmIds]) {
       const alarm = group.alarms.find((a) => a.id === alarmId);
       if (alarm && alarm.state === 'suppressed') {
         alarm.state = 'active';
@@ -433,9 +533,7 @@ export class AlarmCorrelationEngine extends EventEmitter {
         this.metrics.alarmsUnsuppressed++;
       }
     }
-    group.suppressedAlarmIds = group.suppressedAlarmIds.filter(
-      (id) => !restored.includes(id)
-    );
+    group.suppressedAlarmIds = [];
     if (restored.length > 0) {
       this.emit('alarms-unsuppressed', { groupId: group.id, alarmIds: restored });
     }
@@ -444,9 +542,10 @@ export class AlarmCorrelationEngine extends EventEmitter {
 
   private closeGroup(group: AlarmGroup, reason: AlarmGroup['closeReason']): void {
     if (group.state === 'closed') return;
+    this.unsuppressActiveMembers(group);
     group.state = 'closed';
     group.closeReason = reason;
-    group.closedAt = group.lastAlarmAt;
+    group.closedAt = this.clock();
     this.metrics.groupsClosed++;
     this.emit('group-closed', group);
   }
@@ -472,41 +571,131 @@ export class AlarmCorrelationEngine extends EventEmitter {
   }
 
   private evictGroup(group: AlarmGroup): void {
+    this.unsuppressActiveMembers(group);
     for (const alarmId of group.alarmIds) {
       this.alarmIndex.delete(alarmId);
     }
+    this.groupLastTouchedAt.delete(group.id);
     this.groups.delete(group.id);
   }
 
   private removeFromPending(alarmId: string): void {
     const idx = this.pending.findIndex((a) => a.id === alarmId);
     if (idx >= 0) this.pending.splice(idx, 1);
+    this.pendingLastTouchedAt.delete(alarmId);
+  }
+
+  /**
+   * Admit pending alarms that are connected to any current member. Re-scan
+   * after each pass because a newly admitted bridge may connect an older
+   * candidate. Both the group and pending collections are hard-capped.
+   */
+  private reconcilePending(group: AlarmGroup): void {
+    let admitted = true;
+    while (
+      admitted
+      && group.state === 'open'
+      && group.alarmIds.length < this.maxAlarmsPerGroup
+    ) {
+      admitted = false;
+      const candidates = [...this.pending].sort(
+        (a, b) => a.timestamp - b.timestamp || a.id.localeCompare(b.id),
+      );
+      for (const candidate of candidates) {
+        if (group.alarmIds.length >= this.maxAlarmsPerGroup) return;
+        if (this.alarmIndex.get(candidate.id) !== null) continue;
+        if (candidate.state === 'cleared' || candidate.state === 'shelved') continue;
+        if (!this.withinGroupSpan(group, candidate.timestamp)) continue;
+        const rule = this.rules.evaluateJoin(candidate, group, this.topology);
+        if (!rule) continue;
+        this.joinGroup(candidate, group, rule);
+        admitted = true;
+      }
+    }
+  }
+
+  private refreshIngestResult(
+    result: IngestResult,
+    alarm: CorrelatedAlarm,
+    group: AlarmGroup,
+  ): IngestResult {
+    return {
+      ...result,
+      suppressed: group.suppressedAlarmIds.includes(alarm.id),
+      isRootCause: group.rootCauseAlarmId === alarm.id,
+    };
+  }
+
+  private withinGroupSpan(group: AlarmGroup, timestamp: number): boolean {
+    const earliest = Math.min(group.createdAt, timestamp);
+    const latest = Math.max(group.lastAlarmAt, timestamp);
+    return latest - earliest <= this.maxGroupSpanMs;
+  }
+
+  private removeSuppressionRecord(group: AlarmGroup, alarmId: string): void {
+    group.suppressedAlarmIds = group.suppressedAlarmIds.filter(
+      (suppressedId) => suppressedId !== alarmId,
+    );
+  }
+
+  private restoreSuppressedAlarm(group: AlarmGroup, alarm: CorrelatedAlarm): void {
+    this.removeSuppressionRecord(group, alarm.id);
+    if (alarm.state !== 'suppressed') return;
+    alarm.state = 'active';
+    this.metrics.alarmsUnsuppressed++;
+    this.emit('alarms-unsuppressed', {
+      groupId: group.id,
+      alarmIds: [alarm.id],
+    });
   }
 
   /** Drop pending alarms too old to pair under the widest enabled rule window */
   private prunePending(referenceMs: number): void {
-    const maxWindow = Math.max(
-      1000,
-      ...this.rules
-        .list()
-        .filter((r) => r.enabled)
-        .map((r) => (r.config as { windowMs: number }).windowMs)
-    );
+    const maxWindow = this.maxEnabledRuleWindowMs();
     const cutoff = referenceMs - maxWindow * 2;
     let removed = 0;
     this.pending = this.pending.filter((alarm) => {
       const keep = alarm.timestamp >= cutoff;
       if (!keep) {
         this.alarmIndex.delete(alarm.id);
+        this.pendingLastTouchedAt.delete(alarm.id);
         removed++;
       }
       return keep;
     });
     if (this.pending.length > this.maxPendingAlarms) {
       const excess = this.pending.splice(0, this.pending.length - this.maxPendingAlarms);
-      for (const alarm of excess) this.alarmIndex.delete(alarm.id);
+      for (const alarm of excess) {
+        this.alarmIndex.delete(alarm.id);
+        this.pendingLastTouchedAt.delete(alarm.id);
+      }
       removed += excess.length;
     }
     if (removed > 0) this.emit('pending-pruned', { removed });
+  }
+
+  private prunePendingByProcessingTime(nowMs: number): void {
+    const cutoff = nowMs - this.maxEnabledRuleWindowMs() * 2;
+    let removed = 0;
+    this.pending = this.pending.filter((alarm) => {
+      const keep = (this.pendingLastTouchedAt.get(alarm.id) ?? nowMs) >= cutoff;
+      if (!keep) {
+        this.alarmIndex.delete(alarm.id);
+        this.pendingLastTouchedAt.delete(alarm.id);
+        removed++;
+      }
+      return keep;
+    });
+    if (removed > 0) this.emit('pending-pruned', { removed });
+  }
+
+  private maxEnabledRuleWindowMs(): number {
+    return Math.max(
+      1000,
+      ...this.rules
+        .list()
+        .filter((rule) => rule.enabled)
+        .map((rule) => (rule.config as { windowMs: number }).windowMs),
+    );
   }
 }

--- a/server/services/alarm-correlation/index.ts
+++ b/server/services/alarm-correlation/index.ts
@@ -50,7 +50,7 @@ export function normalizeSeverity(raw: unknown): AlarmSeverity {
 }
 
 function isRecognizedSeverity(raw: unknown): boolean {
-  if (raw === undefined || raw === null || raw === '') return true;
+  if (isMissingSeverity(raw)) return true;
   return [
     'critical',
     'emergency',
@@ -61,6 +61,14 @@ function isRecognizedSeverity(raw: unknown): boolean {
     'low',
     'info',
   ].includes(String(raw).toLowerCase());
+}
+
+function isMissingSeverity(raw: unknown): boolean {
+  return (
+    raw === undefined
+    || raw === null
+    || (typeof raw === 'string' && raw.trim() === '')
+  );
 }
 
 function normalizeState(raw: unknown): AlarmLifecycleState | null {
@@ -126,6 +134,12 @@ export function normalizeAlarm(raw: Record<string, unknown>): CorrelatedAlarm | 
   if (timestamp === null) return null;
   const rawSeverity = raw.severity ?? raw.priority;
   if (!isRecognizedSeverity(rawSeverity)) return null;
+  // Existing live producers may omit severity. Keep accepting those inputs,
+  // but map the unknown severity to the fail-safe floor so it can never be
+  // hidden by suppression. Explicit "info" remains a suppressible severity.
+  const severity = isMissingSeverity(rawSeverity)
+    ? 'critical'
+    : normalizeSeverity(rawSeverity);
   const state = normalizeState(raw.state);
   if (!state) return null;
 
@@ -143,7 +157,7 @@ export function normalizeAlarm(raw: Record<string, unknown>): CorrelatedAlarm | 
     equipmentId,
     siteId: typeof raw.siteId === 'string' ? raw.siteId : undefined,
     processArea: typeof raw.processArea === 'string' ? raw.processArea : undefined,
-    severity: normalizeSeverity(rawSeverity),
+    severity,
     state,
     message: String(raw.message ?? raw.name ?? raw.alarmName ?? ''),
     timestamp,

--- a/server/services/alarm-correlation/index.ts
+++ b/server/services/alarm-correlation/index.ts
@@ -1,0 +1,190 @@
+/**
+ * Alarm Correlation Service
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * Singleton wrapper around the correlation engine: normalizes the repo's
+ * divergent alarm shapes (tag-stream broadcastAlarm, SingularisPrime /
+ * GR::LISTEN AlarmPayload, DB enum vocabulary) into CorrelatedAlarm,
+ * runs periodic idle-group sweeps, and re-emits engine events for
+ * downstream consumers (WebSocket bridge, routes).
+ */
+
+import { EventEmitter } from 'events';
+
+export * from './topology';
+export * from './rules';
+export * from './engine';
+
+import type {
+  AlarmSeverity,
+  AlarmLifecycleState,
+  CorrelatedAlarm,
+  IngestResult,
+} from '@shared/types/alarm-correlation';
+import { AlarmCorrelationEngine } from './engine';
+
+/**
+ * Map any severity vocabulary seen in this repo onto the runtime one.
+ * DB enums (INFO/WARNING/CRITICAL/EMERGENCY), SPC ('warning'|'alarm'),
+ * and client severities all funnel through here.
+ */
+export function normalizeSeverity(raw: unknown): AlarmSeverity {
+  const value = String(raw ?? '').toLowerCase();
+  switch (value) {
+    case 'critical':
+    case 'emergency':
+      return 'critical';
+    case 'high':
+    case 'alarm':
+      return 'high';
+    case 'medium':
+    case 'warning':
+      return 'medium';
+    case 'low':
+      return 'low';
+    default:
+      return 'info';
+  }
+}
+
+function normalizeState(raw: unknown): AlarmLifecycleState {
+  const value = String(raw ?? '').toLowerCase();
+  switch (value) {
+    case 'acknowledged':
+      return 'acknowledged';
+    case 'cleared':
+      return 'cleared';
+    case 'shelved':
+      return 'shelved';
+    case 'suppressed':
+      return 'suppressed';
+    default:
+      return 'active';
+  }
+}
+
+function normalizeTimestamp(raw: unknown): number | null {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    const parsed = new Date(raw).getTime();
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+/**
+ * Resolve an equipment id from a tag following the repo convention
+ * "ASSET.EVENT" (simulator: `${asset.nameOrTag}.${eventType}`). Tags that
+ * do not follow the convention resolve to themselves so same-equipment
+ * grouping still works per tag.
+ */
+export function resolveEquipmentFromTag(tagId: string): string | undefined {
+  if (!tagId) return undefined;
+  const dot = tagId.indexOf('.');
+  return dot > 0 ? tagId.slice(0, dot) : tagId;
+}
+
+/**
+ * Normalize any of the repo's alarm shapes into a CorrelatedAlarm.
+ * Accepts the tag-stream broadcastAlarm shape ({id, name, severity, state,
+ * tagValue, triggeredAt}), the SingularisPrime/GR::LISTEN AlarmPayload
+ * shape ({alarmId, alarmName, sourceTagId, priority, message, ...}), or a
+ * native CorrelatedAlarm. Returns null when no usable timestamp exists.
+ */
+export function normalizeAlarm(raw: Record<string, unknown>): CorrelatedAlarm | null {
+  const timestamp = normalizeTimestamp(
+    raw.timestamp ?? raw.triggeredAt ?? raw.sourceTimestamp
+  );
+  if (timestamp === null) return null;
+
+  const tagId = String(raw.tagId ?? raw.sourceTagId ?? raw.tagName ?? '');
+  const id = String(raw.id ?? raw.alarmId ?? `${tagId || 'alarm'}:${timestamp}`);
+  const equipmentId =
+    typeof raw.equipmentId === 'string' && raw.equipmentId !== ''
+      ? raw.equipmentId
+      : resolveEquipmentFromTag(tagId);
+
+  return {
+    id,
+    name: String(raw.name ?? raw.alarmName ?? id),
+    tagId,
+    equipmentId,
+    siteId: typeof raw.siteId === 'string' ? raw.siteId : undefined,
+    processArea: typeof raw.processArea === 'string' ? raw.processArea : undefined,
+    severity: normalizeSeverity(raw.severity ?? raw.priority),
+    state: normalizeState(raw.state),
+    message: String(raw.message ?? raw.name ?? raw.alarmName ?? ''),
+    timestamp,
+    value: raw.value as number | string | undefined ?? (raw.tagValue as number | undefined) ?? (raw.triggerValue as number | string | undefined),
+    limit: (raw.limit as number | string | undefined) ?? (raw.limitValue as number | string | undefined),
+    source: typeof raw.source === 'string' ? raw.source : undefined,
+  };
+}
+
+export class AlarmCorrelationService extends EventEmitter {
+  readonly engine = new AlarmCorrelationEngine();
+
+  private initialized = false;
+  private sweepTimer: NodeJS.Timeout | null = null;
+  private readonly sweepIntervalMs: number;
+
+  constructor(sweepIntervalMs = 30_000) {
+    super();
+    this.sweepIntervalMs = sweepIntervalMs;
+    for (const event of [
+      'group-created',
+      'group-updated',
+      'group-closed',
+      'root-cause-changed',
+      'alarm-suppressed',
+      'alarms-unsuppressed',
+    ]) {
+      this.engine.on(event, (payload) => this.emit(event, payload));
+    }
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+    this.sweepTimer = setInterval(() => {
+      try {
+        this.engine.sweep(Date.now());
+      } catch {
+        /* sweep failures must never take down the interval */
+      }
+    }, this.sweepIntervalMs);
+    this.sweepTimer.unref?.();
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+    this.initialized = false;
+  }
+
+  /**
+   * Normalize and correlate one alarm in any supported shape.
+   * Returns null when the input has no usable timestamp.
+   */
+  ingest(raw: Record<string, unknown>): { alarm: CorrelatedAlarm; result: IngestResult } | null {
+    const alarm = normalizeAlarm(raw);
+    if (!alarm) return null;
+    const result = this.engine.ingest(alarm);
+    return { alarm, result };
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
+    const metrics = this.engine.getMetrics();
+    return {
+      healthy: this.initialized,
+      message: this.initialized
+        ? `Alarm correlation running: ${metrics.openGroups} open groups, ` +
+          `${(metrics.suppressionRate * 100).toFixed(1)}% suppression rate`
+        : 'Alarm correlation service not initialized',
+    };
+  }
+}
+
+export const alarmCorrelationService = new AlarmCorrelationService();

--- a/server/services/alarm-correlation/index.ts
+++ b/server/services/alarm-correlation/index.ts
@@ -76,14 +76,23 @@ function normalizeState(raw: unknown): AlarmLifecycleState | null {
     case 'shelved':
       return 'shelved';
     case 'suppressed':
-      return 'suppressed';
+      // Suppression is a correlation-engine decision, never caller-owned
+      // state on a newly raised live alarm.
+      return 'active';
     default:
       return null;
   }
 }
 
-function normalizeTimestamp(raw: unknown): number | null {
-  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+/** Normalize only timestamps that JavaScript Date can safely serialize. */
+export function normalizeAlarmTimestamp(raw: unknown): number | null {
+  if (
+    typeof raw === 'number'
+    && Number.isFinite(raw)
+    && Number.isFinite(new Date(raw).getTime())
+  ) {
+    return raw;
+  }
   if (typeof raw === 'string' && raw.trim() !== '') {
     const parsed = new Date(raw).getTime();
     if (Number.isFinite(parsed)) return parsed;
@@ -111,7 +120,7 @@ export function resolveEquipmentFromTag(tagId: string): string | undefined {
  * native CorrelatedAlarm. Returns null when no usable timestamp exists.
  */
 export function normalizeAlarm(raw: Record<string, unknown>): CorrelatedAlarm | null {
-  const timestamp = normalizeTimestamp(
+  const timestamp = normalizeAlarmTimestamp(
     raw.timestamp ?? raw.triggeredAt ?? raw.sourceTimestamp
   );
   if (timestamp === null) return null;
@@ -225,7 +234,17 @@ export class AlarmCorrelationService extends EventEmitter {
     const alarm = normalizeAlarm(raw);
     if (!alarm) return null;
     const result = this.engine.ingest(alarm);
-    return { alarm, result };
+    if (result.action === 'duplicate') {
+      if (alarm.state === 'acknowledged') {
+        this.engine.alarmAcknowledged(alarm.id);
+      } else if (alarm.state === 'cleared') {
+        this.engine.alarmCleared(alarm.id);
+      }
+    }
+    return {
+      alarm: this.engine.getAlarm(alarm.id) ?? alarm,
+      result,
+    };
   }
 
   async healthCheck(): Promise<{

--- a/server/services/alarm-correlation/index.ts
+++ b/server/services/alarm-correlation/index.ts
@@ -16,9 +16,11 @@ export * from './rules';
 export * from './engine';
 
 import type {
+  AlarmGroup,
   AlarmSeverity,
   AlarmLifecycleState,
   CorrelatedAlarm,
+  AlarmWireSnapshot,
   IngestResult,
 } from '@shared/types/alarm-correlation';
 import { AlarmCorrelationEngine } from './engine';
@@ -47,9 +49,26 @@ export function normalizeSeverity(raw: unknown): AlarmSeverity {
   }
 }
 
-function normalizeState(raw: unknown): AlarmLifecycleState {
+function isRecognizedSeverity(raw: unknown): boolean {
+  if (raw === undefined || raw === null || raw === '') return true;
+  return [
+    'critical',
+    'emergency',
+    'high',
+    'alarm',
+    'medium',
+    'warning',
+    'low',
+    'info',
+  ].includes(String(raw).toLowerCase());
+}
+
+function normalizeState(raw: unknown): AlarmLifecycleState | null {
   const value = String(raw ?? '').toLowerCase();
   switch (value) {
+    case '':
+    case 'active':
+      return 'active';
     case 'acknowledged':
       return 'acknowledged';
     case 'cleared':
@@ -59,7 +78,7 @@ function normalizeState(raw: unknown): AlarmLifecycleState {
     case 'suppressed':
       return 'suppressed';
     default:
-      return 'active';
+      return null;
   }
 }
 
@@ -96,6 +115,10 @@ export function normalizeAlarm(raw: Record<string, unknown>): CorrelatedAlarm | 
     raw.timestamp ?? raw.triggeredAt ?? raw.sourceTimestamp
   );
   if (timestamp === null) return null;
+  const rawSeverity = raw.severity ?? raw.priority;
+  if (!isRecognizedSeverity(rawSeverity)) return null;
+  const state = normalizeState(raw.state);
+  if (!state) return null;
 
   const tagId = String(raw.tagId ?? raw.sourceTagId ?? raw.tagName ?? '');
   const id = String(raw.id ?? raw.alarmId ?? `${tagId || 'alarm'}:${timestamp}`);
@@ -111,13 +134,34 @@ export function normalizeAlarm(raw: Record<string, unknown>): CorrelatedAlarm | 
     equipmentId,
     siteId: typeof raw.siteId === 'string' ? raw.siteId : undefined,
     processArea: typeof raw.processArea === 'string' ? raw.processArea : undefined,
-    severity: normalizeSeverity(raw.severity ?? raw.priority),
-    state: normalizeState(raw.state),
+    severity: normalizeSeverity(rawSeverity),
+    state,
     message: String(raw.message ?? raw.name ?? raw.alarmName ?? ''),
     timestamp,
     value: raw.value as number | string | undefined ?? (raw.tagValue as number | undefined) ?? (raw.triggerValue as number | string | undefined),
     limit: (raw.limit as number | string | undefined) ?? (raw.limitValue as number | string | undefined),
     source: typeof raw.source === 'string' ? raw.source : undefined,
+  };
+}
+
+export function toAlarmWireSnapshot(
+  alarm: CorrelatedAlarm,
+  group?: AlarmGroup,
+): AlarmWireSnapshot {
+  return {
+    ...alarm,
+    triggeredAt: new Date(alarm.timestamp).toISOString(),
+    tagValue: alarm.value,
+    correlation: {
+      groupId: group?.id ?? null,
+      groupState: group?.state ?? null,
+      rootCauseAlarmId: group?.rootCauseAlarmId ?? null,
+      suppressed:
+        group?.suppressedAlarmIds.includes(alarm.id)
+        ?? alarm.state === 'suppressed',
+      isRootCause: group?.rootCauseAlarmId === alarm.id,
+      coordinationMode: 'process-local',
+    },
   };
 }
 
@@ -131,16 +175,25 @@ export class AlarmCorrelationService extends EventEmitter {
   constructor(sweepIntervalMs = 30_000) {
     super();
     this.sweepIntervalMs = sweepIntervalMs;
+    for (const event of ['group-created', 'group-updated', 'group-closed']) {
+      this.engine.on(event, (group: AlarmGroup) => {
+        this.emit(event, group);
+        for (const alarm of group.alarms) {
+          this.emit('alarm-snapshot', toAlarmWireSnapshot(alarm, group));
+        }
+      });
+    }
     for (const event of [
-      'group-created',
-      'group-updated',
-      'group-closed',
       'root-cause-changed',
       'alarm-suppressed',
       'alarms-unsuppressed',
     ]) {
       this.engine.on(event, (payload) => this.emit(event, payload));
     }
+    this.engine.on('alarm-updated', (alarm: CorrelatedAlarm) => {
+      this.emit('alarm-updated', alarm);
+      this.emit('alarm-snapshot', toAlarmWireSnapshot(alarm));
+    });
   }
 
   async initialize(): Promise<void> {
@@ -175,7 +228,13 @@ export class AlarmCorrelationService extends EventEmitter {
     return { alarm, result };
   }
 
-  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
+  async healthCheck(): Promise<{
+    healthy: boolean;
+    message: string;
+    coordinationMode: 'process-local';
+    suppressionEnabled: boolean;
+    ephemeralSuppressionAllowed: boolean;
+  }> {
     const metrics = this.engine.getMetrics();
     return {
       healthy: this.initialized,
@@ -183,6 +242,10 @@ export class AlarmCorrelationService extends EventEmitter {
         ? `Alarm correlation running: ${metrics.openGroups} open groups, ` +
           `${(metrics.suppressionRate * 100).toFixed(1)}% suppression rate`
         : 'Alarm correlation service not initialized',
+      coordinationMode: 'process-local',
+      suppressionEnabled: this.engine.getSuppressionPolicy().enabled,
+      ephemeralSuppressionAllowed:
+        process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION === 'true',
     };
   }
 }

--- a/server/services/alarm-correlation/rules.ts
+++ b/server/services/alarm-correlation/rules.ts
@@ -175,6 +175,13 @@ export class CorrelationRulesEngine {
     group: AlarmGroup,
     topology: EquipmentTopology
   ): CorrelationRule | null {
+    if (
+      group.alarms.some(
+        (member) => !this.areSitesCompatible(alarm, member, topology),
+      )
+    ) {
+      return null;
+    }
     for (const rule of this.enabledRules()) {
       if (
         group.alarms.some((member) =>
@@ -208,7 +215,7 @@ export class CorrelationRulesEngine {
     other: CorrelatedAlarm,
     topology: EquipmentTopology,
   ): boolean {
-    if (!this.siteCompatible(alarm, other)) return false;
+    if (!this.areSitesCompatible(alarm, other, topology)) return false;
     const windowMs = (rule.config as { windowMs: number }).windowMs;
     if (Math.abs(alarm.timestamp - other.timestamp) > windowMs) return false;
 
@@ -254,12 +261,36 @@ export class CorrelationRulesEngine {
   }
 
   /**
-   * Never correlate across explicit site boundaries. Missing site metadata
-   * is compatible only with another unscoped alarm; it must not silently
-   * inherit a named site's topology or process-area namespace.
+   * Never correlate or suppress across effective site boundaries. An alarm
+   * inherits its equipment node's site when the alarm omits one. Explicit
+   * alarm and topology sites that disagree fail closed, while wholly
+   * unscoped alarms remain compatible only with other wholly unscoped alarms.
    */
-  private siteCompatible(a: CorrelatedAlarm, b: CorrelatedAlarm): boolean {
-    return a.siteId === b.siteId;
+  areSitesCompatible(
+    a: CorrelatedAlarm,
+    b: CorrelatedAlarm,
+    topology: EquipmentTopology,
+  ): boolean {
+    const siteA = this.effectiveSite(a, topology);
+    const siteB = this.effectiveSite(b, topology);
+    if (siteA.conflict || siteB.conflict) return false;
+    return siteA.siteId === siteB.siteId;
+  }
+
+  private effectiveSite(
+    alarm: CorrelatedAlarm,
+    topology: EquipmentTopology,
+  ): { siteId?: string; conflict: boolean } {
+    const alarmSite = alarm.siteId || undefined;
+    const topologySite =
+      (alarm.equipmentId && topology.get(alarm.equipmentId)?.siteId) || undefined;
+    if (alarmSite && topologySite && alarmSite !== topologySite) {
+      return { conflict: true };
+    }
+    return {
+      siteId: alarmSite ?? topologySite,
+      conflict: false,
+    };
   }
 
   private cloneRule(rule: CorrelationRule): CorrelationRule {

--- a/server/services/alarm-correlation/rules.ts
+++ b/server/services/alarm-correlation/rules.ts
@@ -23,6 +23,10 @@ import type {
 } from '@shared/types/alarm-correlation';
 import type { EquipmentTopology } from './topology';
 
+const MAX_RULE_WINDOW_MS = 24 * 60 * 60 * 1000;
+const MAX_TOPOLOGY_DISTANCE = 64;
+const DEFAULT_MAX_RULES = 1000;
+
 export const DEFAULT_RULES: CorrelationRule[] = [
   {
     id: 'default-causal',
@@ -60,18 +64,42 @@ export const DEFAULT_RULES: CorrelationRule[] = [
 
 export function validateRule(rule: CorrelationRule): string | null {
   const cfg = rule.config as unknown as Record<string, unknown>;
-  if (typeof cfg.windowMs !== 'number' || cfg.windowMs <= 0) {
-    return 'config.windowMs must be a positive number';
+  if (!rule.id || rule.id.length > 128) {
+    return 'id must contain 1..128 characters';
+  }
+  if (!rule.name || rule.name.length > 256) {
+    return 'name must contain 1..256 characters';
+  }
+  if (typeof rule.enabled !== 'boolean') {
+    return 'enabled must be a boolean';
+  }
+  if (!Number.isSafeInteger(rule.priority) || rule.priority < 0 || rule.priority > 10_000) {
+    return 'priority must be an integer between 0 and 10000';
+  }
+  if (
+    !Number.isSafeInteger(cfg.windowMs)
+    || (cfg.windowMs as number) < 1
+    || (cfg.windowMs as number) > MAX_RULE_WINDOW_MS
+  ) {
+    return `config.windowMs must be an integer between 1 and ${MAX_RULE_WINDOW_MS}`;
   }
   switch (rule.type) {
     case 'causal':
-      if (typeof cfg.maxHops !== 'number' || cfg.maxHops < 1) {
-        return 'causal rule requires config.maxHops >= 1';
+      if (
+        !Number.isSafeInteger(cfg.maxHops)
+        || (cfg.maxHops as number) < 1
+        || (cfg.maxHops as number) > MAX_TOPOLOGY_DISTANCE
+      ) {
+        return `causal rule requires integer config.maxHops between 1 and ${MAX_TOPOLOGY_DISTANCE}`;
       }
       return null;
     case 'hierarchy':
-      if (typeof cfg.maxDistance !== 'number' || cfg.maxDistance < 1) {
-        return 'hierarchy rule requires config.maxDistance >= 1';
+      if (
+        !Number.isSafeInteger(cfg.maxDistance)
+        || (cfg.maxDistance as number) < 1
+        || (cfg.maxDistance as number) > MAX_TOPOLOGY_DISTANCE
+      ) {
+        return `hierarchy rule requires integer config.maxDistance between 1 and ${MAX_TOPOLOGY_DISTANCE}`;
       }
       return null;
     case 'temporal':
@@ -86,24 +114,39 @@ export function validateRule(rule: CorrelationRule): string | null {
 
 export class CorrelationRulesEngine {
   private rules: Map<string, CorrelationRule> = new Map();
+  private readonly maxRules: number;
 
-  constructor(initial: CorrelationRule[] = DEFAULT_RULES) {
-    for (const rule of initial) this.rules.set(rule.id, { ...rule });
+  constructor(initial: CorrelationRule[] = DEFAULT_RULES, maxRules = DEFAULT_MAX_RULES) {
+    if (!Number.isSafeInteger(maxRules) || maxRules < initial.length) {
+      throw new Error('maxRules must be an integer at least as large as the initial rule set');
+    }
+    this.maxRules = maxRules;
+    for (const rule of initial) {
+      const error = validateRule(rule);
+      if (error) throw new Error(`Invalid rule "${rule.id}": ${error}`);
+      this.rules.set(rule.id, this.cloneRule(rule));
+    }
   }
 
   list(): CorrelationRule[] {
-    return Array.from(this.rules.values()).sort((a, b) => a.priority - b.priority);
+    return Array.from(this.rules.values(), (rule) => this.cloneRule(rule))
+      .sort((a, b) => a.priority - b.priority);
   }
 
   get(id: string): CorrelationRule | undefined {
-    return this.rules.get(id);
+    const rule = this.rules.get(id);
+    return rule ? this.cloneRule(rule) : undefined;
   }
 
   upsert(rule: CorrelationRule): CorrelationRule {
     const error = validateRule(rule);
     if (error) throw new Error(`Invalid rule "${rule.id}": ${error}`);
-    this.rules.set(rule.id, { ...rule });
-    return rule;
+    if (!this.rules.has(rule.id) && this.rules.size >= this.maxRules) {
+      throw new Error(`Rule limit of ${this.maxRules} reached`);
+    }
+    const stored = this.cloneRule(rule);
+    this.rules.set(rule.id, stored);
+    return this.cloneRule(stored);
   }
 
   remove(id: string): boolean {
@@ -114,7 +157,7 @@ export class CorrelationRulesEngine {
     const rule = this.rules.get(id);
     if (!rule) return undefined;
     rule.enabled = enabled;
-    return rule;
+    return this.cloneRule(rule);
   }
 
   private enabledRules(): CorrelationRule[] {
@@ -123,47 +166,22 @@ export class CorrelationRulesEngine {
 
   /**
    * First enabled rule (by priority) under which `alarm` belongs in `group`.
-   * The temporal window anchors to the group's latest alarm; relatedness
-   * anchors to the root cause (hierarchy/temporal scopes) or any member
-   * (causal — chains propagate through intermediate members, and checking
-   * both directions admits an upstream cause that arrives late).
+   * A group has connected-component semantics: matching any member is enough
+   * to join. Every rule window is evaluated pairwise, which permits a bounded
+   * causal/chatter chain without making its endpoints directly related.
    */
   evaluateJoin(
     alarm: CorrelatedAlarm,
     group: AlarmGroup,
     topology: EquipmentTopology
   ): CorrelationRule | null {
-    const root = group.alarms.find((a) => a.id === group.rootCauseAlarmId);
     for (const rule of this.enabledRules()) {
-      const windowMs = (rule.config as { windowMs: number }).windowMs;
-      if (Math.abs(alarm.timestamp - group.lastAlarmAt) > windowMs) continue;
-
-      switch (rule.type) {
-        case 'causal': {
-          const { maxHops } = rule.config as CausalRuleConfig;
-          if (!alarm.equipmentId) break;
-          const related = group.alarms.some(
-            (member) =>
-              member.equipmentId &&
-              topology.isCausallyRelated(alarm.equipmentId!, member.equipmentId, maxHops)
-          );
-          if (related) return rule;
-          break;
-        }
-        case 'hierarchy': {
-          const { maxDistance } = rule.config as HierarchyRuleConfig;
-          if (!alarm.equipmentId || !root?.equipmentId) break;
-          if (topology.isHierarchyRelated(alarm.equipmentId, root.equipmentId, maxDistance)) {
-            return rule;
-          }
-          break;
-        }
-        case 'temporal': {
-          if (root && this.temporalScopeMatches(rule.config as TemporalRuleConfig, alarm, root)) {
-            return rule;
-          }
-          break;
-        }
+      if (
+        group.alarms.some((member) =>
+          this.matchesRulePair(rule, alarm, member, topology)
+        )
+      ) {
+        return rule;
       }
     }
     return null;
@@ -179,41 +197,45 @@ export class CorrelationRulesEngine {
     topology: EquipmentTopology
   ): CorrelationRule | null {
     for (const rule of this.enabledRules()) {
-      const windowMs = (rule.config as { windowMs: number }).windowMs;
-      if (Math.abs(alarm.timestamp - other.timestamp) > windowMs) continue;
-
-      switch (rule.type) {
-        case 'causal': {
-          const { maxHops } = rule.config as CausalRuleConfig;
-          if (
-            alarm.equipmentId &&
-            other.equipmentId &&
-            topology.isCausallyRelated(alarm.equipmentId, other.equipmentId, maxHops)
-          ) {
-            return rule;
-          }
-          break;
-        }
-        case 'hierarchy': {
-          const { maxDistance } = rule.config as HierarchyRuleConfig;
-          if (
-            alarm.equipmentId &&
-            other.equipmentId &&
-            topology.isHierarchyRelated(alarm.equipmentId, other.equipmentId, maxDistance)
-          ) {
-            return rule;
-          }
-          break;
-        }
-        case 'temporal': {
-          if (this.temporalScopeMatches(rule.config as TemporalRuleConfig, alarm, other)) {
-            return rule;
-          }
-          break;
-        }
-      }
+      if (this.matchesRulePair(rule, alarm, other, topology)) return rule;
     }
     return null;
+  }
+
+  private matchesRulePair(
+    rule: CorrelationRule,
+    alarm: CorrelatedAlarm,
+    other: CorrelatedAlarm,
+    topology: EquipmentTopology,
+  ): boolean {
+    if (!this.siteCompatible(alarm, other)) return false;
+    const windowMs = (rule.config as { windowMs: number }).windowMs;
+    if (Math.abs(alarm.timestamp - other.timestamp) > windowMs) return false;
+
+    switch (rule.type) {
+      case 'causal': {
+        const { maxHops } = rule.config as CausalRuleConfig;
+        return !!(
+          alarm.equipmentId
+          && other.equipmentId
+          && topology.isCausallyRelated(alarm.equipmentId, other.equipmentId, maxHops)
+        );
+      }
+      case 'hierarchy': {
+        const { maxDistance } = rule.config as HierarchyRuleConfig;
+        return !!(
+          alarm.equipmentId
+          && other.equipmentId
+          && topology.isHierarchyRelated(alarm.equipmentId, other.equipmentId, maxDistance)
+        );
+      }
+      case 'temporal':
+        return this.temporalScopeMatches(
+          rule.config as TemporalRuleConfig,
+          alarm,
+          other,
+        );
+    }
   }
 
   private temporalScopeMatches(
@@ -229,5 +251,21 @@ export class CorrelationRulesEngine {
       case 'process-area':
         return !!a.processArea && a.processArea === b.processArea;
     }
+  }
+
+  /**
+   * Never correlate across explicit site boundaries. Missing site metadata
+   * is compatible only with another unscoped alarm; it must not silently
+   * inherit a named site's topology or process-area namespace.
+   */
+  private siteCompatible(a: CorrelatedAlarm, b: CorrelatedAlarm): boolean {
+    return a.siteId === b.siteId;
+  }
+
+  private cloneRule(rule: CorrelationRule): CorrelationRule {
+    return {
+      ...rule,
+      config: { ...rule.config },
+    };
   }
 }

--- a/server/services/alarm-correlation/rules.ts
+++ b/server/services/alarm-correlation/rules.ts
@@ -1,0 +1,233 @@
+/**
+ * Correlation Rules Engine
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * Rules are evaluated in priority order (lower first) to decide whether an
+ * alarm joins an existing group or pairs with another alarm to form one.
+ * Every stored rule is actually evaluated — a rule that matches nothing is
+ * an authoring problem, not dead machinery.
+ *
+ * Bare temporal proximity across unrelated equipment never correlates:
+ * temporal rules require an explicit scope (same tag, same equipment, or
+ * shared process area); cross-equipment grouping requires causal or
+ * hierarchy evidence from the topology.
+ */
+
+import type {
+  AlarmGroup,
+  CausalRuleConfig,
+  CorrelatedAlarm,
+  CorrelationRule,
+  HierarchyRuleConfig,
+  TemporalRuleConfig,
+} from '@shared/types/alarm-correlation';
+import type { EquipmentTopology } from './topology';
+
+export const DEFAULT_RULES: CorrelationRule[] = [
+  {
+    id: 'default-causal',
+    name: 'Causal chain (topology causalDownstream, transitive)',
+    type: 'causal',
+    enabled: true,
+    priority: 10,
+    config: { windowMs: 30_000, maxHops: 5 } satisfies CausalRuleConfig,
+  },
+  {
+    id: 'default-hierarchy',
+    name: 'Equipment hierarchy (common ancestor)',
+    type: 'hierarchy',
+    enabled: true,
+    priority: 20,
+    config: { windowMs: 10_000, maxDistance: 2 } satisfies HierarchyRuleConfig,
+  },
+  {
+    id: 'default-tag-chatter',
+    name: 'Same-tag chatter',
+    type: 'temporal',
+    enabled: true,
+    priority: 30,
+    config: { windowMs: 5_000, scope: 'same-tag' } satisfies TemporalRuleConfig,
+  },
+  {
+    id: 'default-equipment-burst',
+    name: 'Same-equipment burst',
+    type: 'temporal',
+    enabled: true,
+    priority: 40,
+    config: { windowMs: 5_000, scope: 'same-equipment' } satisfies TemporalRuleConfig,
+  },
+];
+
+export function validateRule(rule: CorrelationRule): string | null {
+  const cfg = rule.config as unknown as Record<string, unknown>;
+  if (typeof cfg.windowMs !== 'number' || cfg.windowMs <= 0) {
+    return 'config.windowMs must be a positive number';
+  }
+  switch (rule.type) {
+    case 'causal':
+      if (typeof cfg.maxHops !== 'number' || cfg.maxHops < 1) {
+        return 'causal rule requires config.maxHops >= 1';
+      }
+      return null;
+    case 'hierarchy':
+      if (typeof cfg.maxDistance !== 'number' || cfg.maxDistance < 1) {
+        return 'hierarchy rule requires config.maxDistance >= 1';
+      }
+      return null;
+    case 'temporal':
+      if (!['same-tag', 'same-equipment', 'process-area'].includes(cfg.scope as string)) {
+        return "temporal rule requires config.scope of 'same-tag' | 'same-equipment' | 'process-area'";
+      }
+      return null;
+    default:
+      return `unknown rule type "${(rule as CorrelationRule).type}"`;
+  }
+}
+
+export class CorrelationRulesEngine {
+  private rules: Map<string, CorrelationRule> = new Map();
+
+  constructor(initial: CorrelationRule[] = DEFAULT_RULES) {
+    for (const rule of initial) this.rules.set(rule.id, { ...rule });
+  }
+
+  list(): CorrelationRule[] {
+    return Array.from(this.rules.values()).sort((a, b) => a.priority - b.priority);
+  }
+
+  get(id: string): CorrelationRule | undefined {
+    return this.rules.get(id);
+  }
+
+  upsert(rule: CorrelationRule): CorrelationRule {
+    const error = validateRule(rule);
+    if (error) throw new Error(`Invalid rule "${rule.id}": ${error}`);
+    this.rules.set(rule.id, { ...rule });
+    return rule;
+  }
+
+  remove(id: string): boolean {
+    return this.rules.delete(id);
+  }
+
+  setEnabled(id: string, enabled: boolean): CorrelationRule | undefined {
+    const rule = this.rules.get(id);
+    if (!rule) return undefined;
+    rule.enabled = enabled;
+    return rule;
+  }
+
+  private enabledRules(): CorrelationRule[] {
+    return this.list().filter((r) => r.enabled);
+  }
+
+  /**
+   * First enabled rule (by priority) under which `alarm` belongs in `group`.
+   * The temporal window anchors to the group's latest alarm; relatedness
+   * anchors to the root cause (hierarchy/temporal scopes) or any member
+   * (causal — chains propagate through intermediate members, and checking
+   * both directions admits an upstream cause that arrives late).
+   */
+  evaluateJoin(
+    alarm: CorrelatedAlarm,
+    group: AlarmGroup,
+    topology: EquipmentTopology
+  ): CorrelationRule | null {
+    const root = group.alarms.find((a) => a.id === group.rootCauseAlarmId);
+    for (const rule of this.enabledRules()) {
+      const windowMs = (rule.config as { windowMs: number }).windowMs;
+      if (Math.abs(alarm.timestamp - group.lastAlarmAt) > windowMs) continue;
+
+      switch (rule.type) {
+        case 'causal': {
+          const { maxHops } = rule.config as CausalRuleConfig;
+          if (!alarm.equipmentId) break;
+          const related = group.alarms.some(
+            (member) =>
+              member.equipmentId &&
+              topology.isCausallyRelated(alarm.equipmentId!, member.equipmentId, maxHops)
+          );
+          if (related) return rule;
+          break;
+        }
+        case 'hierarchy': {
+          const { maxDistance } = rule.config as HierarchyRuleConfig;
+          if (!alarm.equipmentId || !root?.equipmentId) break;
+          if (topology.isHierarchyRelated(alarm.equipmentId, root.equipmentId, maxDistance)) {
+            return rule;
+          }
+          break;
+        }
+        case 'temporal': {
+          if (root && this.temporalScopeMatches(rule.config as TemporalRuleConfig, alarm, root)) {
+            return rule;
+          }
+          break;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * First enabled rule under which two ungrouped alarms belong together —
+   * used to form a new group.
+   */
+  evaluatePair(
+    alarm: CorrelatedAlarm,
+    other: CorrelatedAlarm,
+    topology: EquipmentTopology
+  ): CorrelationRule | null {
+    for (const rule of this.enabledRules()) {
+      const windowMs = (rule.config as { windowMs: number }).windowMs;
+      if (Math.abs(alarm.timestamp - other.timestamp) > windowMs) continue;
+
+      switch (rule.type) {
+        case 'causal': {
+          const { maxHops } = rule.config as CausalRuleConfig;
+          if (
+            alarm.equipmentId &&
+            other.equipmentId &&
+            topology.isCausallyRelated(alarm.equipmentId, other.equipmentId, maxHops)
+          ) {
+            return rule;
+          }
+          break;
+        }
+        case 'hierarchy': {
+          const { maxDistance } = rule.config as HierarchyRuleConfig;
+          if (
+            alarm.equipmentId &&
+            other.equipmentId &&
+            topology.isHierarchyRelated(alarm.equipmentId, other.equipmentId, maxDistance)
+          ) {
+            return rule;
+          }
+          break;
+        }
+        case 'temporal': {
+          if (this.temporalScopeMatches(rule.config as TemporalRuleConfig, alarm, other)) {
+            return rule;
+          }
+          break;
+        }
+      }
+    }
+    return null;
+  }
+
+  private temporalScopeMatches(
+    config: TemporalRuleConfig,
+    a: CorrelatedAlarm,
+    b: CorrelatedAlarm
+  ): boolean {
+    switch (config.scope) {
+      case 'same-tag':
+        return a.tagId !== '' && a.tagId === b.tagId;
+      case 'same-equipment':
+        return !!a.equipmentId && a.equipmentId === b.equipmentId;
+      case 'process-area':
+        return !!a.processArea && a.processArea === b.processArea;
+    }
+  }
+}

--- a/server/services/alarm-correlation/topology.ts
+++ b/server/services/alarm-correlation/topology.ts
@@ -11,9 +11,25 @@
 import type { EquipmentNode } from '@shared/types/alarm-correlation';
 
 const MAX_TRAVERSAL_DEPTH = 64;
+const DEFAULT_MAX_NODES = 5000;
 
 export class EquipmentTopology {
   private nodes: Map<string, EquipmentNode> = new Map();
+  private readonly maxNodes: number;
+
+  constructor(maxNodes = DEFAULT_MAX_NODES) {
+    if (!Number.isSafeInteger(maxNodes) || maxNodes < 1) {
+      throw new Error('maxNodes must be a positive integer');
+    }
+    this.maxNodes = maxNodes;
+  }
+
+  private cloneNode(node: EquipmentNode): EquipmentNode {
+    return {
+      ...node,
+      causalDownstream: [...node.causalDownstream],
+    };
+  }
 
   /**
    * Insert or replace a node. Throws if the parent chain would form a
@@ -22,6 +38,9 @@ export class EquipmentTopology {
    */
   upsert(node: EquipmentNode): EquipmentNode {
     const previous = this.nodes.get(node.equipmentId);
+    if (!previous && this.nodes.size >= this.maxNodes) {
+      throw new Error(`Equipment topology limit of ${this.maxNodes} nodes reached`);
+    }
     const stored: EquipmentNode = {
       ...node,
       causalDownstream: [...new Set(node.causalDownstream)].filter(
@@ -40,19 +59,28 @@ export class EquipmentTopology {
         `Equipment "${node.equipmentId}": parentId "${node.parentId}" would create a hierarchy cycle`
       );
     }
-    return stored;
+    return this.cloneNode(stored);
   }
 
   upsertMany(nodes: EquipmentNode[]): EquipmentNode[] {
-    return nodes.map((n) => this.upsert(n));
+    const before = new Map(
+      Array.from(this.nodes, ([id, node]) => [id, this.cloneNode(node)]),
+    );
+    try {
+      return nodes.map((node) => this.upsert(node));
+    } catch (error) {
+      this.nodes = before;
+      throw error;
+    }
   }
 
   get(equipmentId: string): EquipmentNode | undefined {
-    return this.nodes.get(equipmentId);
+    const node = this.nodes.get(equipmentId);
+    return node ? this.cloneNode(node) : undefined;
   }
 
   list(): EquipmentNode[] {
-    return Array.from(this.nodes.values());
+    return Array.from(this.nodes.values(), (node) => this.cloneNode(node));
   }
 
   remove(equipmentId: string): boolean {

--- a/server/services/alarm-correlation/topology.ts
+++ b/server/services/alarm-correlation/topology.ts
@@ -1,0 +1,177 @@
+/**
+ * Equipment Topology Graph
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * Two edge sets per node: an acyclic containment hierarchy (parentId) and
+ * directed causal edges (causalDownstream). Hierarchy cycles are rejected
+ * at registration; causal traversal is cycle-safe because recirculation
+ * loops legitimately exist in real processes.
+ */
+
+import type { EquipmentNode } from '@shared/types/alarm-correlation';
+
+const MAX_TRAVERSAL_DEPTH = 64;
+
+export class EquipmentTopology {
+  private nodes: Map<string, EquipmentNode> = new Map();
+
+  /**
+   * Insert or replace a node. Throws if the parent chain would form a
+   * cycle. Parents and causal targets need not exist yet — topology can
+   * be registered incrementally.
+   */
+  upsert(node: EquipmentNode): EquipmentNode {
+    const previous = this.nodes.get(node.equipmentId);
+    const stored: EquipmentNode = {
+      ...node,
+      causalDownstream: [...new Set(node.causalDownstream)].filter(
+        (id) => id !== node.equipmentId
+      ),
+    };
+    this.nodes.set(node.equipmentId, stored);
+
+    if (this.hasParentCycle(node.equipmentId)) {
+      if (previous) {
+        this.nodes.set(node.equipmentId, previous);
+      } else {
+        this.nodes.delete(node.equipmentId);
+      }
+      throw new Error(
+        `Equipment "${node.equipmentId}": parentId "${node.parentId}" would create a hierarchy cycle`
+      );
+    }
+    return stored;
+  }
+
+  upsertMany(nodes: EquipmentNode[]): EquipmentNode[] {
+    return nodes.map((n) => this.upsert(n));
+  }
+
+  get(equipmentId: string): EquipmentNode | undefined {
+    return this.nodes.get(equipmentId);
+  }
+
+  list(): EquipmentNode[] {
+    return Array.from(this.nodes.values());
+  }
+
+  remove(equipmentId: string): boolean {
+    return this.nodes.delete(equipmentId);
+  }
+
+  size(): number {
+    return this.nodes.size;
+  }
+
+  /** Depth from the hierarchy root (root = 0). Unknown nodes are depth 0. */
+  depth(equipmentId: string): number {
+    let depth = 0;
+    let current = this.nodes.get(equipmentId);
+    const visited = new Set<string>([equipmentId]);
+    while (current?.parentId && depth < MAX_TRAVERSAL_DEPTH) {
+      if (visited.has(current.parentId)) break;
+      visited.add(current.parentId);
+      depth++;
+      current = this.nodes.get(current.parentId);
+    }
+    return depth;
+  }
+
+  /**
+   * Hierarchy relatedness: steps to the nearest common ancestor, counted
+   * from the deeper side (so parent↔child = 1, siblings = 1, cousins = 2).
+   * Returns null when the nodes share no ancestor.
+   */
+  hierarchyDistance(a: string, b: string): number | null {
+    if (a === b) return 0;
+    const ancestorsA = this.ancestorDepths(a);
+    const ancestorsB = this.ancestorDepths(b);
+    let best: number | null = null;
+    for (const [ancestor, da] of ancestorsA) {
+      const db = ancestorsB.get(ancestor);
+      if (db !== undefined) {
+        const distance = Math.max(da, db);
+        if (best === null || distance < best) best = distance;
+      }
+    }
+    return best;
+  }
+
+  isHierarchyRelated(a: string, b: string, maxDistance: number): boolean {
+    const distance = this.hierarchyDistance(a, b);
+    return distance !== null && distance <= maxDistance;
+  }
+
+  /**
+   * Transitive causal reachability over causalDownstream edges (BFS with
+   * visited-set cycle guard, bounded hops).
+   */
+  isCausallyReachable(from: string, to: string, maxHops: number): boolean {
+    if (from === to) return false;
+    if (!this.nodes.has(from)) return false;
+
+    let frontier = [from];
+    const visited = new Set<string>([from]);
+    for (let hop = 0; hop < maxHops && frontier.length > 0; hop++) {
+      const next: string[] = [];
+      for (const id of frontier) {
+        for (const target of this.nodes.get(id)?.causalDownstream ?? []) {
+          if (target === to) return true;
+          if (!visited.has(target)) {
+            visited.add(target);
+            next.push(target);
+          }
+        }
+      }
+      frontier = next;
+    }
+    return false;
+  }
+
+  /** Causal relatedness in either direction — handles out-of-order arrival */
+  isCausallyRelated(a: string, b: string, maxHops: number): boolean {
+    return (
+      this.isCausallyReachable(a, b, maxHops) || this.isCausallyReachable(b, a, maxHops)
+    );
+  }
+
+  /** How many of `others` this node causally reaches — root-cause dominance */
+  causalDominance(candidate: string, others: string[], maxHops: number): number {
+    let count = 0;
+    for (const other of others) {
+      if (other !== candidate && this.isCausallyReachable(candidate, other, maxHops)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────
+
+  /** Map of ancestor id → steps up from the given node (self = 0) */
+  private ancestorDepths(equipmentId: string): Map<string, number> {
+    const result = new Map<string, number>();
+    let current = this.nodes.get(equipmentId);
+    let steps = 0;
+    result.set(equipmentId, 0);
+    while (current?.parentId && steps < MAX_TRAVERSAL_DEPTH) {
+      if (result.has(current.parentId)) break;
+      steps++;
+      result.set(current.parentId, steps);
+      current = this.nodes.get(current.parentId);
+    }
+    return result;
+  }
+
+  private hasParentCycle(startId: string): boolean {
+    const visited = new Set<string>();
+    let current = this.nodes.get(startId);
+    while (current?.parentId) {
+      if (visited.has(current.equipmentId)) return true;
+      visited.add(current.equipmentId);
+      if (current.parentId === startId) return true;
+      current = this.nodes.get(current.parentId);
+    }
+    return false;
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -84,8 +84,7 @@ export async function initializeServices(): Promise<void> {
     { name: 'Ubiquity', service: () => import('./ubiquity').then(m => m.ubiquityService.initialize()) },
     { name: 'Layer 2 Rollup', service: () => import('./l2-rollup').then(m => m.l2RollupService.initialize()) },
     { name: 'Optimization', service: () => import('./optimization').then(m => m.optimizationService.initialize()) },
-    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) },
-    { name: 'Alarm Correlation', service: () => import('./alarm-correlation').then(m => m.alarmCorrelationService.initialize()) }
+    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) }
   ];
 
   for (const { name, service } of services) {
@@ -176,14 +175,6 @@ export async function getServicesHealthStatus(): Promise<{
         return await spcService.healthCheck();
       } catch {
         return { healthy: false, message: 'SPC service not available' };
-      }
-    },
-    alarmCorrelation: async () => {
-      try {
-        const { alarmCorrelationService } = await import('./alarm-correlation');
-        return await alarmCorrelationService.healthCheck();
-      } catch {
-        return { healthy: false, message: 'Alarm correlation service not available' };
       }
     }
   };

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -66,6 +66,10 @@ export { spcService } from './spc';
 export * from './l2-rollup';
 export { l2RollupService } from './l2-rollup';
 
+// ── Alarm Correlation Service (ADR-0013 [13.2], #213) ────────────────────────
+export * from './alarm-correlation';
+export { alarmCorrelationService } from './alarm-correlation';
+
 /**
  * Initialize all services
  * 
@@ -80,7 +84,8 @@ export async function initializeServices(): Promise<void> {
     { name: 'Ubiquity', service: () => import('./ubiquity').then(m => m.ubiquityService.initialize()) },
     { name: 'Layer 2 Rollup', service: () => import('./l2-rollup').then(m => m.l2RollupService.initialize()) },
     { name: 'Optimization', service: () => import('./optimization').then(m => m.optimizationService.initialize()) },
-    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) }
+    { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) },
+    { name: 'Alarm Correlation', service: () => import('./alarm-correlation').then(m => m.alarmCorrelationService.initialize()) }
   ];
 
   for (const { name, service } of services) {
@@ -171,6 +176,14 @@ export async function getServicesHealthStatus(): Promise<{
         return await spcService.healthCheck();
       } catch {
         return { healthy: false, message: 'SPC service not available' };
+      }
+    },
+    alarmCorrelation: async () => {
+      try {
+        const { alarmCorrelationService } = await import('./alarm-correlation');
+        return await alarmCorrelationService.healthCheck();
+      } catch {
+        return { healthy: false, message: 'Alarm correlation service not available' };
       }
     }
   };

--- a/server/simulator.ts
+++ b/server/simulator.ts
@@ -1,5 +1,6 @@
 import { log, logError, logWarn } from "./logger";
 import { tagStreamServer } from "./websocket/tag-stream";
+import { cachedEventBridge } from "./websocket/cached-event-bridge";
 import { getFluxPublisher } from "./services/flux";
 import { natsPublisher } from "./services/nats";
 import { getAnchorPipeline } from "./bridge";
@@ -115,6 +116,27 @@ class FieldSimulator {
           timestamp: new Date().toISOString(),
         });
       } catch { /* WebSocket not connected — that's fine */ }
+
+      // Raise a real alarm for trip events — feeds the correlation engine
+      // and the alarm WebSocket channel, which had no producer (#213)
+      if (eventType === "BREAKER_TRIP") {
+        try {
+          void cachedEventBridge.publishAlarm({
+            id: `ALM-${asset.nameOrTag}-${Date.now()}`,
+            name: `${asset.nameOrTag} ${eventType}`,
+            tagId: `${asset.nameOrTag}.${eventType}`,
+            equipmentId: asset.nameOrTag,
+            siteId: asset.siteId,
+            severity: asset.critical ? "critical" : "high",
+            state: "active",
+            message: details,
+            timestamp: new Date().toISOString(),
+            triggeredAt: new Date().toISOString(),
+            value: (payload as any).current,
+            source: "simulator",
+          });
+        } catch { /* alarm fan-out failure must not break event generation */ }
+      }
 
       // Publish to NATS for blockchain anchoring (canonical wire schema, #440)
       try {

--- a/server/websocket/__tests__/alarm-correlation-fanout.test.ts
+++ b/server/websocket/__tests__/alarm-correlation-fanout.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { AlarmCorrelationService } from '../../services/alarm-correlation';
+import type { AlarmWireSnapshot } from '@shared/types/alarm-correlation';
+import { CachedEventBridge } from '../cached-event-bridge';
+
+interface CapturingSink {
+  snapshots: AlarmWireSnapshot[];
+  broadcastAlarm(alarm: AlarmWireSnapshot): void;
+}
+
+function capturingSink(): CapturingSink {
+  return {
+    snapshots: [],
+    broadcastAlarm(alarm) {
+      this.snapshots.push(alarm);
+    },
+  };
+}
+
+function latest(sink: CapturingSink, alarmId: string): AlarmWireSnapshot {
+  const matches = sink.snapshots.filter((snapshot) => snapshot.id === alarmId);
+  const snapshot = matches.at(-1);
+  if (!snapshot) throw new Error(`No snapshot for ${alarmId}`);
+  return snapshot;
+}
+
+const bridges: CachedEventBridge[] = [];
+
+function setup() {
+  const service = new AlarmCorrelationService();
+  const tagSink = capturingSink();
+  const unifiedSink = capturingSink();
+  const bridge = new CachedEventBridge(service, tagSink, unifiedSink);
+  bridges.push(bridge);
+  return { service, tagSink, unifiedSink, bridge };
+}
+
+afterEach(async () => {
+  await Promise.all(bridges.splice(0).map((bridge) => bridge.destroy()));
+});
+
+describe('alarm correlation local fanout', () => {
+  it('emits corrected snapshots for every member when a group forms', () => {
+    const { service, tagSink, unifiedSink, bridge } = setup();
+    service.engine.setSuppressionPolicy({ enabled: true });
+    bridge.initializeLocalAlarmFanout();
+
+    service.ingest({
+      id: 'root',
+      tagId: 'VALVE-1.CHATTER',
+      severity: 'high',
+      state: 'active',
+      timestamp: 1000,
+    });
+    service.ingest({
+      id: 'member',
+      tagId: 'VALVE-1.CHATTER',
+      severity: 'medium',
+      state: 'active',
+      timestamp: 1100,
+    });
+
+    expect(latest(tagSink, 'root')).toMatchObject({
+      state: 'active',
+      correlation: {
+        groupState: 'open',
+        rootCauseAlarmId: 'root',
+        suppressed: false,
+        isRootCause: true,
+        coordinationMode: 'process-local',
+      },
+    });
+    expect(latest(tagSink, 'member')).toMatchObject({
+      state: 'suppressed',
+      correlation: {
+        groupState: 'open',
+        rootCauseAlarmId: 'root',
+        suppressed: true,
+        isRootCause: false,
+      },
+    });
+    expect(unifiedSink.snapshots).toEqual(tagSink.snapshots);
+  });
+
+  it('rebroadcasts every member after an out-of-order root change', () => {
+    const { service, tagSink, bridge } = setup();
+    bridge.initializeLocalAlarmFanout();
+
+    service.ingest({
+      id: 'late-event',
+      tagId: 'PUMP-1.TRIP',
+      timestamp: 5000,
+    });
+    service.ingest({
+      id: 'later-event',
+      tagId: 'PUMP-1.TRIP',
+      timestamp: 5200,
+    });
+    service.ingest({
+      id: 'earliest-event',
+      tagId: 'PUMP-1.TRIP',
+      timestamp: 4800,
+    });
+
+    for (const id of ['late-event', 'later-event', 'earliest-event']) {
+      expect(latest(tagSink, id).correlation.rootCauseAlarmId).toBe('earliest-event');
+    }
+    expect(latest(tagSink, 'earliest-event').correlation.isRootCause).toBe(true);
+  });
+
+  it('fans out acknowledgement, clear, policy, and idle-close lifecycle changes', () => {
+    const { service, tagSink, bridge } = setup();
+    service.engine.setSuppressionPolicy({ enabled: true });
+    bridge.initializeLocalAlarmFanout();
+
+    service.ingest({ id: 'root', tagId: 'LOOP-1.ALARM', timestamp: 1000 });
+    service.ingest({ id: 'member', tagId: 'LOOP-1.ALARM', timestamp: 1100 });
+
+    expect(service.engine.alarmAcknowledged('member', 'operator-a')).toBe(true);
+    expect(latest(tagSink, 'member')).toMatchObject({
+      state: 'acknowledged',
+      acknowledgedBy: 'operator-a',
+      correlation: { suppressed: false },
+    });
+
+    service.engine.setSuppressionPolicy({ enabled: false });
+    expect(latest(tagSink, 'root').correlation.groupState).toBe('open');
+    service.engine.setSuppressionPolicy({ enabled: true });
+
+    expect(service.engine.alarmCleared('root', 'operator-b')).toMatchObject({
+      cleared: true,
+      clearedBy: 'operator-b',
+    });
+    expect(latest(tagSink, 'root')).toMatchObject({
+      state: 'cleared',
+      clearedBy: 'operator-b',
+      correlation: { groupState: 'closed' },
+    });
+
+    const idle = setup();
+    idle.service.engine.setSuppressionPolicy({ enabled: true });
+    idle.bridge.initializeLocalAlarmFanout();
+    idle.service.ingest({ id: 'idle-root', tagId: 'IDLE.ALARM', timestamp: 1000 });
+    idle.service.ingest({ id: 'idle-member', tagId: 'IDLE.ALARM', timestamp: 1100 });
+    idle.service.engine.sweep(Date.now() + 11 * 60 * 1000);
+    expect(latest(idle.tagSink, 'idle-member')).toMatchObject({
+      state: 'active',
+      correlation: {
+        groupState: 'closed',
+        suppressed: false,
+      },
+    });
+  });
+
+  it('initializes idempotently and isolates sink failures', async () => {
+    const service = new AlarmCorrelationService();
+    const delivered = capturingSink();
+    const failingSink = {
+      broadcastAlarm() {
+        throw new Error('socket unavailable');
+      },
+    };
+    const bridge = new CachedEventBridge(service, failingSink, delivered);
+    bridges.push(bridge);
+
+    bridge.initializeLocalAlarmFanout();
+    bridge.initializeLocalAlarmFanout();
+    await expect(bridge.publishAlarm({
+      id: 'one',
+      tagId: 'ONE.ALARM',
+      timestamp: 1000,
+    })).resolves.toBeUndefined();
+
+    expect(delivered.snapshots).toHaveLength(1);
+    expect(delivered.snapshots[0]).toMatchObject({
+      id: 'one',
+      triggeredAt: new Date(1000).toISOString(),
+      correlation: {
+        groupId: null,
+        coordinationMode: 'process-local',
+      },
+    });
+  });
+});

--- a/server/websocket/__tests__/alarm-correlation-fanout.test.ts
+++ b/server/websocket/__tests__/alarm-correlation-fanout.test.ts
@@ -153,6 +153,38 @@ describe('alarm correlation local fanout', () => {
     });
   });
 
+  it('keeps missing live severity unsuppressed while preserving explicit info', async () => {
+    for (const [label, severity, expectedSeverity, suppressed] of [
+      ['missing', undefined, 'critical', false],
+      ['blank', '', 'critical', false],
+      ['explicit-info', 'info', 'info', true],
+    ] as const) {
+      const { service, tagSink, bridge } = setup();
+      service.engine.setSuppressionPolicy({ enabled: true });
+
+      await bridge.publishAlarm({
+        id: `${label}-root`,
+        tagId: `${label}.ALARM`,
+        state: 'active',
+        severity: 'high',
+        timestamp: 1000,
+      });
+      await bridge.publishAlarm({
+        id: `${label}-member`,
+        tagId: `${label}.ALARM`,
+        state: 'active',
+        timestamp: 1100,
+        ...(severity === undefined ? {} : { severity }),
+      });
+
+      expect(latest(tagSink, `${label}-member`)).toMatchObject({
+        severity: expectedSeverity,
+        state: suppressed ? 'suppressed' : 'active',
+        correlation: { suppressed },
+      });
+    }
+  });
+
   it('processes and broadcasts a same-id cleared lifecycle update once', async () => {
     const { service, tagSink, unifiedSink, bridge } = setup();
 

--- a/server/websocket/__tests__/alarm-correlation-fanout.test.ts
+++ b/server/websocket/__tests__/alarm-correlation-fanout.test.ts
@@ -153,6 +153,50 @@ describe('alarm correlation local fanout', () => {
     });
   });
 
+  it('processes and broadcasts a same-id cleared lifecycle update once', async () => {
+    const { service, tagSink, unifiedSink, bridge } = setup();
+
+    await bridge.publishAlarm({
+      id: 'same-id',
+      tagId: 'SAME.ALARM',
+      state: 'active',
+      severity: 'high',
+      timestamp: 1000,
+    });
+    expect(latest(tagSink, 'same-id').state).toBe('active');
+
+    await bridge.publishAlarm({
+      id: 'same-id',
+      tagId: 'SAME.ALARM',
+      state: 'cleared',
+      severity: 'high',
+      timestamp: 1100,
+    });
+    expect(latest(tagSink, 'same-id')).toMatchObject({
+      state: 'cleared',
+      correlation: {
+        groupId: null,
+        suppressed: false,
+      },
+    });
+    expect(unifiedSink.snapshots).toEqual(tagSink.snapshots);
+
+    const snapshotCount = tagSink.snapshots.length;
+    await bridge.publishAlarm({
+      id: 'same-id',
+      tagId: 'SAME.ALARM',
+      state: 'cleared',
+      severity: 'high',
+      timestamp: 1200,
+    });
+    expect(tagSink.snapshots).toHaveLength(snapshotCount);
+    expect(latest(tagSink, 'same-id').clearedBy).toBeUndefined();
+    expect(service.engine.getMetrics()).toMatchObject({
+      alarmsIngested: 1,
+      trackedAlarms: 1,
+    });
+  });
+
   it('initializes idempotently and isolates sink failures', async () => {
     const service = new AlarmCorrelationService();
     const delivered = capturingSink();

--- a/server/websocket/cached-event-bridge.ts
+++ b/server/websocket/cached-event-bridge.ts
@@ -11,6 +11,7 @@ import { getRedisClient, isRedisHealthy } from '../services/cache/redis-client.j
 import { eventCache, type CachedEvent } from '../services/cache/event-cache.js';
 import { unifiedStreamServer } from './unified-stream.js';
 import { tagStreamServer, type TagUpdate } from './tag-stream.js';
+import { alarmCorrelationService } from '../services/alarm-correlation';
 import type Redis from 'ioredis';
 
 const CHANNEL_EVENTS = '0xscada:ws:events';
@@ -124,14 +125,37 @@ class CachedEventBridge {
 
   /**
    * Publish an alarm — fans out to all instances.
+   *
+   * Every alarm passes through the correlation engine first (#213); the
+   * broadcast payload is enriched with a `correlation` field carrying
+   * group membership, root-cause, and suppression info so consumers can
+   * de-clutter without any alarm being silently dropped.
    */
   async publishAlarm(alarm: Record<string, unknown>): Promise<void> {
-    tagStreamServer.broadcastAlarm(alarm as any);
-    unifiedStreamServer.broadcastAlarm(alarm);
+    let enriched = alarm;
+    try {
+      const outcome = alarmCorrelationService.ingest(alarm);
+      if (outcome) {
+        enriched = {
+          ...alarm,
+          correlation: {
+            action: outcome.result.action,
+            groupId: outcome.result.groupId ?? null,
+            suppressed: outcome.result.suppressed,
+            isRootCause: outcome.result.isRootCause,
+          },
+        };
+      }
+    } catch {
+      // Correlation must never block alarm fan-out
+    }
+
+    tagStreamServer.broadcastAlarm(enriched as any);
+    unifiedStreamServer.broadcastAlarm(enriched);
 
     if (!this.publisher) return;
     try {
-      await this.publisher.publish(CHANNEL_ALARMS, JSON.stringify(alarm));
+      await this.publisher.publish(CHANNEL_ALARMS, JSON.stringify(enriched));
     } catch {
       // Non-fatal
     }

--- a/server/websocket/cached-event-bridge.ts
+++ b/server/websocket/cached-event-bridge.ts
@@ -11,8 +11,13 @@ import { getRedisClient, isRedisHealthy } from '../services/cache/redis-client.j
 import { eventCache, type CachedEvent } from '../services/cache/event-cache.js';
 import { unifiedStreamServer } from './unified-stream.js';
 import { tagStreamServer, type TagUpdate } from './tag-stream.js';
-import { alarmCorrelationService } from '../services/alarm-correlation';
+import {
+  alarmCorrelationService,
+  type AlarmCorrelationService,
+} from '../services/alarm-correlation';
+import type { AlarmWireSnapshot } from '@shared/types/alarm-correlation';
 import type Redis from 'ioredis';
+import { randomUUID } from 'node:crypto';
 
 const CHANNEL_EVENTS = '0xscada:ws:events';
 const CHANNEL_TAGS = '0xscada:ws:tags';
@@ -20,6 +25,15 @@ const CHANNEL_ALARMS = '0xscada:ws:alarms';
 const RECENT_TAG_CACHE_KEY = '0xscada:ws:recent-tags';
 const MAX_CACHED_TAG_VALUES = 5000;
 const TAG_CACHE_TTL = 60; // seconds
+
+type CorrelationSource = Pick<
+  AlarmCorrelationService,
+  'on' | 'off' | 'ingest'
+>;
+
+interface AlarmSink {
+  broadcastAlarm(alarm: any): void;
+}
 
 /**
  * Cached Event Bridge wires Redis pub/sub into the WebSocket layer:
@@ -31,16 +45,38 @@ const TAG_CACHE_TTL = 60; // seconds
  * 3. **Catch-up** — caches recent events in Redis sorted sets so new
  *    subscribers receive a backlog on connect.
  */
-class CachedEventBridge {
+export class CachedEventBridge {
   private publisher: Redis | null = null;
   private subscriber: Redis | null = null;
   private isInitialized = false;
+  private isLocalAlarmFanoutInitialized = false;
+  private readonly instanceId = randomUUID();
+  private readonly alarmSnapshotHandler = (snapshot: AlarmWireSnapshot): void => {
+    this.broadcastAlarmSnapshot(snapshot);
+  };
+
+  constructor(
+    private readonly correlationService: CorrelationSource = alarmCorrelationService,
+    private readonly tagAlarmSink: AlarmSink = tagStreamServer,
+    private readonly unifiedAlarmSink: AlarmSink = unifiedStreamServer,
+  ) {}
+
+  /**
+   * Wire process-local correlation snapshots to both WebSocket servers.
+   * This is independent of Redis health and safe to call repeatedly.
+   */
+  initializeLocalAlarmFanout(): void {
+    if (this.isLocalAlarmFanoutInitialized) return;
+    this.correlationService.on('alarm-snapshot', this.alarmSnapshotHandler);
+    this.isLocalAlarmFanoutInitialized = true;
+  }
 
   /**
    * Initialize pub/sub connections and start listening.
    * Safe to call multiple times — only initializes once.
    */
   async initialize(): Promise<void> {
+    this.initializeLocalAlarmFanout();
     if (this.isInitialized || !isRedisHealthy()) return;
 
     try {
@@ -132,33 +168,17 @@ class CachedEventBridge {
    * de-clutter without any alarm being silently dropped.
    */
   async publishAlarm(alarm: Record<string, unknown>): Promise<void> {
-    let enriched = alarm;
+    this.initializeLocalAlarmFanout();
     try {
-      const outcome = alarmCorrelationService.ingest(alarm);
-      if (outcome) {
-        enriched = {
-          ...alarm,
-          correlation: {
-            action: outcome.result.action,
-            groupId: outcome.result.groupId ?? null,
-            suppressed: outcome.result.suppressed,
-            isRootCause: outcome.result.isRootCause,
-          },
-        };
-      }
+      const outcome = this.correlationService.ingest(alarm);
+      if (outcome) return;
     } catch {
       // Correlation must never block alarm fan-out
     }
 
-    tagStreamServer.broadcastAlarm(enriched as any);
-    unifiedStreamServer.broadcastAlarm(enriched);
-
-    if (!this.publisher) return;
-    try {
-      await this.publisher.publish(CHANNEL_ALARMS, JSON.stringify(enriched));
-    } catch {
-      // Non-fatal
-    }
+    // Inputs without a normalizable timestamp still retain the bridge's
+    // historical best-effort delivery behavior.
+    this.broadcastRawAlarm(alarm);
   }
 
   /**
@@ -193,10 +213,16 @@ class CachedEventBridge {
    * Graceful shutdown.
    */
   async destroy(): Promise<void> {
+    if (this.isLocalAlarmFanoutInitialized) {
+      this.correlationService.off('alarm-snapshot', this.alarmSnapshotHandler);
+      this.isLocalAlarmFanoutInitialized = false;
+    }
     if (this.subscriber) {
       await this.subscriber.unsubscribe();
       this.subscriber.disconnect();
+      this.subscriber = null;
     }
+    this.publisher = null;
     this.isInitialized = false;
   }
 
@@ -212,9 +238,50 @@ class CachedEventBridge {
         unifiedStreamServer.broadcastEvent(data);
         break;
       case CHANNEL_ALARMS:
-        unifiedStreamServer.broadcastAlarm(data);
+        if (data?._bridgeOrigin === this.instanceId) break;
+        if (data && typeof data === 'object') delete data._bridgeOrigin;
+        try {
+          this.tagAlarmSink.broadcastAlarm(data);
+        } catch {
+          // One local sink must not block the other.
+        }
+        try {
+          this.unifiedAlarmSink.broadcastAlarm(data);
+        } catch {
+          // WebSocket delivery is best effort.
+        }
         break;
     }
+  }
+
+  private broadcastAlarmSnapshot(snapshot: AlarmWireSnapshot): void {
+    this.broadcastRawAlarm(snapshot);
+  }
+
+  private broadcastRawAlarm(
+    alarm: Record<string, unknown> | AlarmWireSnapshot,
+  ): void {
+    try {
+      this.tagAlarmSink.broadcastAlarm(alarm as any);
+    } catch {
+      // One local sink must not block the other.
+    }
+    try {
+      this.unifiedAlarmSink.broadcastAlarm(alarm);
+    } catch {
+      // Correlation state changes must survive delivery failures.
+    }
+
+    if (!this.publisher) return;
+    const remotePayload = {
+      ...alarm,
+      _bridgeOrigin: this.instanceId,
+    };
+    void this.publisher
+      .publish(CHANNEL_ALARMS, JSON.stringify(remotePayload))
+      .catch(() => {
+        // Redis fan-out is optional and process-local delivery already ran.
+      });
   }
 }
 

--- a/shared/types/alarm-correlation.ts
+++ b/shared/types/alarm-correlation.ts
@@ -40,6 +40,10 @@ export interface CorrelatedAlarm {
   limit?: number | string;
   /** Where the alarm came from (simulator, phi, spc, api, ...) */
   source?: string;
+  /** Server-owned control-plane principal that acknowledged this alarm. */
+  acknowledgedBy?: string;
+  /** Server-owned control-plane principal that cleared this alarm. */
+  clearedBy?: string;
 }
 
 // ── Equipment topology ────────────────────────────────────────────────────
@@ -64,7 +68,7 @@ export interface EquipmentNode {
 export type CorrelationRuleType = 'causal' | 'hierarchy' | 'temporal';
 
 export interface CausalRuleConfig {
-  /** Max event-time gap between an alarm and the group's latest alarm */
+  /** Max event-time gap between a candidate alarm and a connected member */
   windowMs: number;
   /** Max causal-edge hops for reachability */
   maxHops: number;
@@ -131,7 +135,7 @@ export interface AlarmGroup {
   closeReason?: 'root-cause-cleared' | 'idle-timeout' | 'evicted';
 }
 
-export type IngestAction = 'joined-group' | 'formed-group' | 'standalone';
+export type IngestAction = 'joined-group' | 'formed-group' | 'standalone' | 'duplicate';
 
 export interface IngestResult {
   alarmId: string;
@@ -162,4 +166,22 @@ export interface CorrelationMetrics {
   suppressionRate: number;
   openGroups: number;
   trackedAlarms: number;
+}
+
+/** Stable correlation metadata attached to each live alarm snapshot. */
+export interface AlarmCorrelationSnapshot {
+  groupId: string | null;
+  groupState: AlarmGroupState | null;
+  rootCauseAlarmId: string | null;
+  suppressed: boolean;
+  isRootCause: boolean;
+  /** Correlation state is process-local until the durable coordination issue lands. */
+  coordinationMode: 'process-local';
+}
+
+/** Canonical alarm payload emitted to live WebSocket consumers. */
+export interface AlarmWireSnapshot extends CorrelatedAlarm {
+  triggeredAt: string;
+  tagValue?: number | string;
+  correlation: AlarmCorrelationSnapshot;
 }

--- a/shared/types/alarm-correlation.ts
+++ b/shared/types/alarm-correlation.ts
@@ -160,9 +160,10 @@ export interface CorrelationMetrics {
   alarmsIngested: number;
   groupsCreated: number;
   groupsClosed: number;
+  /** Unique alarm ids that have entered engine-owned suppression. */
   alarmsSuppressed: number;
   alarmsUnsuppressed: number;
-  /** suppressed / ingested — the alarm-fatigue KPI */
+  /** unique suppressed alarm ids / ingested alarms — the alarm-fatigue KPI */
   suppressionRate: number;
   openGroups: number;
   trackedAlarms: number;

--- a/shared/types/alarm-correlation.ts
+++ b/shared/types/alarm-correlation.ts
@@ -160,10 +160,10 @@ export interface CorrelationMetrics {
   alarmsIngested: number;
   groupsCreated: number;
   groupsClosed: number;
-  /** Unique alarm ids that have entered engine-owned suppression. */
+  /** Unique ingested alarm instances that entered engine-owned suppression. */
   alarmsSuppressed: number;
   alarmsUnsuppressed: number;
-  /** unique suppressed alarm ids / ingested alarms — the alarm-fatigue KPI */
+  /** unique suppressed alarm instances / ingested alarms — the alarm-fatigue KPI */
   suppressionRate: number;
   openGroups: number;
   trackedAlarms: number;

--- a/shared/types/alarm-correlation.ts
+++ b/shared/types/alarm-correlation.ts
@@ -1,0 +1,165 @@
+/**
+ * Alarm Correlation Types
+ * ADR-0013 [13.2] — Issue #213
+ *
+ * Types for grouping related alarms by temporal proximity, causal chains,
+ * and equipment hierarchy; root-cause identification; and suppression of
+ * downstream/consequential alarms.
+ *
+ * Severity aligns with the live runtime vocabulary (SingularisPrime
+ * Severity / GR::LISTEN priority). Lifecycle state extends the client's
+ * active|acknowledged|cleared vocabulary with 'shelved' (DB enum) and
+ * 'suppressed' (ScadaAlarmBlock), which correlation introduces.
+ */
+
+export type AlarmSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+export type AlarmLifecycleState =
+  | 'active'
+  | 'acknowledged'
+  | 'cleared'
+  | 'shelved'
+  | 'suppressed';
+
+/** Normalized alarm instance flowing through the correlation engine */
+export interface CorrelatedAlarm {
+  id: string;
+  name: string;
+  /** Tag that triggered the alarm (free-string, convention "ASSET.EVENT") */
+  tagId: string;
+  /** Resolved equipment id — enables hierarchy/causal correlation */
+  equipmentId?: string;
+  siteId?: string;
+  processArea?: string;
+  severity: AlarmSeverity;
+  state: AlarmLifecycleState;
+  message: string;
+  /** Event time in epoch ms — all correlation logic is event-time driven */
+  timestamp: number;
+  value?: number | string;
+  limit?: number | string;
+  /** Where the alarm came from (simulator, phi, spc, api, ...) */
+  source?: string;
+}
+
+// ── Equipment topology ────────────────────────────────────────────────────
+
+/**
+ * A node in the equipment graph. Two edge sets:
+ * - parentId: physical/functional containment hierarchy (must be acyclic)
+ * - causalDownstream: directed process-causality edges (cycles tolerated
+ *   by traversal guards — recirculation loops exist in real plants)
+ */
+export interface EquipmentNode {
+  equipmentId: string;
+  name?: string;
+  parentId?: string;
+  causalDownstream: string[];
+  siteId?: string;
+  processArea?: string;
+}
+
+// ── Correlation rules ─────────────────────────────────────────────────────
+
+export type CorrelationRuleType = 'causal' | 'hierarchy' | 'temporal';
+
+export interface CausalRuleConfig {
+  /** Max event-time gap between an alarm and the group's latest alarm */
+  windowMs: number;
+  /** Max causal-edge hops for reachability */
+  maxHops: number;
+}
+
+export interface HierarchyRuleConfig {
+  windowMs: number;
+  /** Max steps to a common ancestor for two nodes to count as related */
+  maxDistance: number;
+}
+
+export interface TemporalRuleConfig {
+  windowMs: number;
+  /**
+   * Bare temporal proximity never merges unrelated equipment. Scope
+   * restricts which alarms a temporal rule may group:
+   * - 'same-tag': repeats/chatter of one tag
+   * - 'same-equipment': alarms of one equipment id
+   * - 'process-area': alarms sharing a processArea value
+   */
+  scope: 'same-tag' | 'same-equipment' | 'process-area';
+}
+
+export interface CorrelationRule {
+  id: string;
+  name: string;
+  type: CorrelationRuleType;
+  enabled: boolean;
+  /** Lower runs first */
+  priority: number;
+  config: CausalRuleConfig | HierarchyRuleConfig | TemporalRuleConfig;
+}
+
+/** Policy governing suppression of consequential alarms within groups */
+export interface SuppressionPolicy {
+  enabled: boolean;
+  /** Alarms at or above this severity are never suppressed */
+  neverSuppressAtOrAbove: AlarmSeverity;
+  /** Re-emit suppressed members when the root cause clears */
+  unsuppressOnRootClear: boolean;
+}
+
+// ── Groups & results ──────────────────────────────────────────────────────
+
+export type AlarmGroupState = 'open' | 'closed';
+
+export interface AlarmGroup {
+  id: string;
+  state: AlarmGroupState;
+  /** Snapshots of member alarms, in ingestion order */
+  alarms: CorrelatedAlarm[];
+  /** Membership is tracked by id, never object identity */
+  alarmIds: string[];
+  rootCauseAlarmId: string;
+  /** Rule that formed the group */
+  formedByRuleId: string;
+  /** Rule that admitted each member, keyed by alarm id */
+  joinedVia: Record<string, string>;
+  suppressedAlarmIds: string[];
+  maxSeverity: AlarmSeverity;
+  createdAt: number;
+  lastAlarmAt: number;
+  closedAt?: number;
+  closeReason?: 'root-cause-cleared' | 'idle-timeout' | 'evicted';
+}
+
+export type IngestAction = 'joined-group' | 'formed-group' | 'standalone';
+
+export interface IngestResult {
+  alarmId: string;
+  action: IngestAction;
+  groupId?: string;
+  ruleId?: string;
+  suppressed: boolean;
+  isRootCause: boolean;
+  reason: string;
+}
+
+export interface RootCauseResult {
+  groupId: string;
+  alarm: CorrelatedAlarm;
+  /** How many other members this alarm causally reaches */
+  causalDominance: number;
+  hierarchyDepth: number;
+  electedBy: string;
+}
+
+export interface CorrelationMetrics {
+  alarmsIngested: number;
+  groupsCreated: number;
+  groupsClosed: number;
+  alarmsSuppressed: number;
+  alarmsUnsuppressed: number;
+  /** suppressed / ingested — the alarm-fatigue KPI */
+  suppressionRate: number;
+  openGroups: number;
+  trackedAlarms: number;
+}


### PR DESCRIPTION
Closes #213. Supersedes #497 while preserving its owner-authored correlation core as the first commit.

## Why this replacement

The engine in #497 is substantively strong, but the maintainer review correctly found an unlocked suppression surface, a stale dependency baseline, and untracked process-local state. Rebuilding it on current main also exposed lifecycle, bounded-work, arrival-order, site-boundary, fanout, duplicate-ID, and metric defects that could make production suppression unsafe.

#520 is now merged. This branch is rebased onto the merged gateway at `672dbeeee`, preserving authenticated WebSocket upgrades and the central alarm action-scope floor. It remains a **draft** only while exact-head CI and one final post-composition audit complete.

## Review order

The branch is intentionally organized into five reviewable commits:

1. `db3aa219b` — NickFlach's original correlation engine.
2. `b171cf43a` — bounded state/work, atomic topology, strict validation, exact authorization, authenticated attribution, lifecycle corrections, and fail-safe suppression defaults.
3. `1c36b4de7` — canonical same-process lifecycle snapshots, local WebSocket fanout, and client consumption.
4. `8905bc58d` — independent-review fixes for topology site safety, caller-owned suppression state, duplicate-ID lifecycle fanout, invalid dates, actor attribution, severity handling, and suppression-rate semantics.
5. `786b45820` — fail-safe live severity, immediate topology PUT/DELETE reconciliation, and bounded suppression accounting under retention churn.

## Safety and correctness

- Hard caps cover groups, group membership, pending alarms, topology nodes/traversal, rule count/windows, batch size, input lengths, and retained suppression bookkeeping.
- Pairwise connected-component rule semantics plus deterministic pending reconciliation cover all six `0s/4s/8s` arrival permutations when the component fits one bounded group.
- Group-span checks cover formation, forward joins, and backward/out-of-order joins.
- Cross-site suppression is rejected. Runtime topology PUT/DELETE immediately re-elects roots, restores newly unsafe members, reapplies valid suppression, and fans out corrected canonical snapshots.
- Missing, null, blank, or whitespace severity from live/service ingestion is conservatively normalized to `critical`; explicit recognized `info` remains valid and suppressible.
- Cleared pending alarms cannot become roots. Acknowledge/clear updates preserve canonical severity and server-derived actors and do not duplicate lifecycle fanout.
- Invalid dates fail before state mutation. Duplicate IDs are explicit conflicts except idempotent lifecycle updates.
- Policy changes reconcile existing groups; idle close, eviction, root clear, and topology changes cannot leave unsafe suppressed alarms.
- Suppression metrics are numeric, clamped to `[0,1]`, stable across policy toggles, and bounded by retained group state. Evicted alarm IDs can be reused as new ingested instances.
- Processing-time housekeeping never compares wall clock directly with historical event timestamps.
- Group IDs use UUIDs rather than a process-local counter.

## Authorization evidence

All 18 REST routes are individually guarded and tested for anonymous, invalid-header, query-only, cross-scope, and exact-scope access:

- `alarms.read`
- `alarms.ingest`
- `alarms.acknowledge`
- `alarms.clear`
- `alarms.configure`

API callers cannot supply `source`, acknowledgement actor, or clear actor; those are server-derived from the header-bound control-plane principal merged in #552.

## Suppression and fanout

Suppression defaults **off**. Enabling it requires both `alarms.configure` and `ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION=true`. Closed groups can never retain suppressed alarms.

Every local lifecycle change emits a canonical snapshot for every affected member, including group/root/suppression state. Formation, root re-election, acknowledge, clear, policy/topology reconciliation, and idle close therefore update prior alarms instead of broadcasting only the newest alarm. The dashboard consumes suppressed state while retaining each alarm in its ID-indexed snapshot set.

## Independent review

Two adversarial correction passes found and closed ten concrete gaps. A final read-only correction audit at pre-rebase head `ab9f48d94` reproduced the live/service, HTTP topology, lifecycle, metric, bounded-retention, and reused-ID paths and returned **GO** with no remaining concrete blocker. The current rebased head is `786b45820`; its post-#520 composition audit is pending.

## Verification

- `npm ci`: 0 vulnerabilities
- focused alarm engine/auth/fanout suites: 112/112 passed
- composed gateway/alarm/WebSocket/startup matrix on merged #520: 166/166 passed
- full suite on merged main: 1,531 passed, 4 skipped
- integration: 5/5 passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm audit --audit-level=high`: 0 vulnerabilities
- pre-rebase correction CI, OpenAPI, and GitGuardian: passed  
  https://github.com/NickFlach/0xSCADA/actions/runs/30060444165
- rebased exact-head CI is running  
  https://github.com/NickFlach/0xSCADA/actions/runs/30061407044

## Explicit deferrals

Durable and replica-coordinated state is tracked in #573 with restart, two-replica, idempotency, reconnect, and fail-safe acceptance criteria. Until that lands, status and wire snapshots say `coordinationMode: process-local`, and production suppression stays disabled.

This patch does not claim universal partition invariance after safety caps split a component or when a later event bridges two already-open groups. It also does not claim shared Redis correlation state.