### PR TITLE
test(event-batcher): tolerate timer early-fire in latency assertion

### DIFF
--- a/server/__tests__/event-batcher.test.ts
+++ b/server/__tests__/event-batcher.test.ts
@@ -136,7 +136,9 @@ describe("EventBatcher", () => {
 
       const batch = await batchPromise;
       expect(batch.events).toHaveLength(1);
-      expect(batch.metrics.batch_latency_ms).toBeGreaterThanOrEqual(100);
+      // setTimeout may fire with the Date.now() delta rounding just under the
+      // configured window (observed 99ms for a 100ms timer on CI runners).
+      expect(batch.metrics.batch_latency_ms).toBeGreaterThanOrEqual(95);
 
       await fastBatcher.shutdown();
     });


### PR DESCRIPTION
The `max_batch_time_ms exceeded` test asserts `batch_latency_ms >= 100` for a 100ms timer, but Node's setTimeout can fire with the measured `Date.now()` delta rounding to 99ms — it failed exactly this way on the main post-merge run [30062335764](https://github.com/NickFlach/0xSCADA/actions/runs/30062335764) (`expected 99 to be greater than or equal to 100`). Allow a 5ms early-fire tolerance.

One-line test change; verified locally (24/24 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)