### PR TITLE
Sync from flaukowski/0xSCADA: agent contributor onboarding docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+Every PR is reviewed with the Build → Gate → Hunt → Fix QE cycle — see
+CONTRIBUTING.md and docs/QE-METHODOLOGY.md. PRs missing the City-Agent
+attribution line are returned before review.
+-->
+
+## Summary
+
+<!-- What does this PR do, and which issue does it close? -->
+
+Closes #
+
+## Attribution
+
+City-Agent: <!-- your agent name (required for agent / agent-assisted PRs) -->
+
+## Verification
+
+<!-- The exact commands you ran and their results. The issue's "prove it"
+     section is the minimum bar. -->
+
+```bash
+npx tsc --noEmit
+npm test
+```
+
+## Gate self-check
+
+- [ ] `npx tsc --noEmit` is clean
+- [ ] No new `any` types
+- [ ] Barrel exports updated where new modules were added
+- [ ] Tests added/updated for every claim in the summary
+- [ ] PR is scoped to a single issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to 0xSCADA
+
+0xSCADA accepts contributions from humans and from autonomous agents. The
+process below applies to both; agent-specific requirements are called out
+explicitly. Agent contributors coordinating through OpenClawCity: welcome —
+this document plus [`docs/agent-quickstart.md`](docs/agent-quickstart.md) is
+everything you need.
+
+## Finding work
+
+- Issues labeled **`agent ready`** are scoped so a single agent can complete
+  them solo. Each one states **what done looks like** and **exactly how to
+  run the tests that prove it**. Start there.
+- The bounty program is described in
+  [`docs/ai-agent-bounty-guide.md`](docs/ai-agent-bounty-guide.md).
+- Project conventions live in [`CLAUDE.md`](CLAUDE.md) and
+  [`AGENTS.md`](AGENTS.md) — read both before your first PR.
+
+## Ground rules
+
+- **TypeScript strict, no `any`**, zod on all API inputs, tests for
+  everything you claim (`CLAUDE.md` has the full list).
+- **Integrity rule**: no shortcuts, no fake data, no false claims. If a test
+  fails, say so. If something is mocked, label it as mocked. Verify before
+  claiming success.
+- Keep PRs scoped to one issue. `npx tsc --noEmit` and `npm test` must pass
+  before you open the PR.
+
+## How a PR gets reviewed: Build → Gate → Hunt → Fix
+
+Every PR goes through the four-phase QE cycle documented in
+[`docs/QE-METHODOLOGY.md`](docs/QE-METHODOLOGY.md) (the process 0xSCADA-QE
+describes on OpenClawCity). Knowing the phases in advance tells you exactly
+what your PR will be judged against:
+
+1. **Build** — you implement from a well-specified issue. Keep
+   `npx tsc --noEmit` clean throughout, and write the tests the issue's
+   "prove it" section names. For designs that are hard to reverse (drivers,
+   wire/on-disk formats, concurrency, protocols), attack the design *before*
+   writing code using
+   [NickFlach/adversarial-design-review](https://github.com/NickFlach/adversarial-design-review) —
+   a paragraph-level design attack costs minutes; the same flaw found after
+   merge costs a debugging session.
+
+2. **Gate** — a formal go/no-go check against the thresholds in
+   [`docs/QE-METHODOLOGY.md#phase-2-quality-gate`](docs/QE-METHODOLOGY.md):
+   zero TypeScript errors, zero new `any`, barrel exports updated, ADR
+   compliance, function-length limits. A PR that fails the gate is returned
+   before deeper review begins.
+
+3. **Hunt** — an adversarial (devil's-advocate) reviewer attacks the diff
+   with the explicit goal of finding problems: correctness vs. spec, unsafe
+   types, unbounded memory, races, missing error handling, edge cases,
+   scaling, integration wiring, security, naming. The full checklist is in
+   [`docs/QE-METHODOLOGY.md#phase-3-devils-advocate`](docs/QE-METHODOLOGY.md).
+   Expect findings — they are the point, not a rejection.
+
+4. **Fix** — findings come back triaged by severity. **Critical** and
+   **High** must be fixed before merge; **Medium** is fixed in-PR or filed
+   as a follow-up issue; **Low** is batched into cleanup PRs. After fixes,
+   the gate re-runs. Clean gate → merge.
+
+## PR requirements
+
+Every PR description **must** include:
+
+1. **The attribution line** (agents and agent-assisted work):
+
+   ```
+   City-Agent: <agent-name>
+   ```
+
+   `<agent-name>` is the name your agent is registered under (your
+   OpenClawCity agent name, or the profile name in `.github/agents/` if you
+   registered one). This is how completed work is attributed to the right
+   agent for bounties, reputation, and recruiting. PRs from agents without
+   this line will be sent back before review.
+
+2. **Which issue it closes** (`Closes #NNN`).
+
+3. **How you verified it** — the exact commands you ran and their results.
+   The issue's "prove it" section is the minimum bar.
+
+## Running the tests
+
+```bash
+npm install
+npx tsc --noEmit            # typecheck — must be clean
+npm test                    # full unit suite (vitest)
+npx vitest run <path>       # a single suite, e.g. npx vitest run server/services/predictive
+npm run test:integration    # integration suite (needs a live DB; optional locally)
+```
+
+Each `agent ready` issue names the specific suites that prove its
+acceptance criteria.
+
+## Session completion (agents)
+
+Follow the "Landing the Plane" checklist in [`AGENTS.md`](AGENTS.md): file
+issues for remaining work, run the quality gates, and push — work is not
+complete until the push succeeds and the PR is open.

--- a/README.md
+++ b/README.md
@@ -329,6 +329,24 @@ Prometheus metrics exposed at `/metrics` on all services.
 - **Webhook events** — real-time event system for agent integration
 - **Bounty system** — Gitcoin-powered contributor incentives
 
+### ► Contribute as an agent
+
+0xSCADA recruits autonomous agent contributors (including through
+[OpenClawCity](https://www.producthunt.com/products/openclawcity)). The short version:
+
+- Pick an issue labeled **`agent ready`** — each states what done looks like
+  and the exact test commands that prove it.
+- Every PR is reviewed with the **Build → Gate → Hunt → Fix** QE cycle
+  ([docs/QE-METHODOLOGY.md](docs/QE-METHODOLOGY.md)); risky designs get attacked
+  *before* implementation with
+  [adversarial-design-review](https://github.com/NickFlach/adversarial-design-review).
+- Every PR description must include the line `City-Agent: <agent-name>` so the
+  work is attributed to the right agent.
+
+Full details: [CONTRIBUTING.md](CONTRIBUTING.md) ·
+[docs/agent-quickstart.md](docs/agent-quickstart.md) ·
+[docs/ai-agent-bounty-guide.md](docs/ai-agent-bounty-guide.md)
+
 <br/>
 
 ---

--- a/docs/agent-ready-issues/01-port-pid-autotuning.md
+++ b/docs/agent-ready-issues/01-port-pid-autotuning.md
@@ -1,0 +1,57 @@
+# [13.4] Port PID auto-tuning (safety envelopes + approval gate + RL) onto current main
+
+## Summary
+
+ADR-0013 [13.4] was implemented upstream as
+[NickFlach/0xSCADA#499](https://github.com/NickFlach/0xSCADA/pull/499) but has
+not been ported to this repo (the sibling modules 13.1–13.3 already were, in
+#547, #576, #551). Port it onto current `main`, following the same
+rebase-and-harden pattern those PRs used.
+
+## Context
+
+- Reference implementation: upstream PR #499 (branch `feat/215-pid-autotuning`)
+- The classical stack it composes already exists here:
+  `server/services/optimization/` (PIDController, relay feedback,
+  Ziegler-Nichols, Cohen-Coon) and `server/services/governance/gate-manager.ts`
+  (approval state machine)
+- Mount point conventions: `server/routes.ts`; note `/api/pid` is claimed by
+  P&ID diagrams — use `/api/tuning`
+
+## What done looks like
+
+- [ ] `server/services/tuning/` exists: absolute gain envelopes (ADR-0009),
+      FOPDT process simulation, sim-time relay identification, tabular
+      Q-learning tuner with seeded RNG, and a GateManager-backed proposal flow
+- [ ] Every gain change becomes a pending `TuningProposal`; nothing
+      auto-applies. The existing autotuner's `automatic`-mode self-apply paths
+      are removed (they contradict ADR-0013's human-in-the-loop mandate)
+- [ ] Approved changes apply envelope-clamped AND rate-limited (partial
+      application reported when the 25%-per-step limit truncates a move);
+      `forceGains` is not exposed over HTTP
+- [ ] `/api/tuning` mounted: loops + envelopes, relay/cohen-coon/rl tuning,
+      proposals with approve/reject, status — zod-validated
+- [ ] Service registered in the services barrel and actually initialized at
+      startup
+- [ ] Unit tests cover: envelope validation/clamping, rate-limit stepping,
+      FOPDT physics, relay identification producing stabilizing gains, RL
+      improvement + determinism + envelope containment, approval lifecycle,
+      and a regression pinning that `automatic` mode never self-applies
+
+## Prove it
+
+```bash
+npx tsc --noEmit                                        # clean
+npx vitest run server/services/tuning --project node    # new suite passes
+npx vitest run server/services/optimization             # existing behavior intact
+npm test                                                # no regressions
+```
+
+## Size
+
+Large (the upstream PR is a complete reference — porting + conflict
+resolution, not design work).
+
+---
+Review process: Build → Gate → Hunt → Fix (see CONTRIBUTING.md).
+Your PR description must include `City-Agent: <agent-name>` and `Closes #<this issue>`.

--- a/docs/agent-ready-issues/02-port-nl-query.md
+++ b/docs/agent-ready-issues/02-port-nl-query.md
@@ -1,0 +1,54 @@
+# [13.5] Port the natural-language process query engine onto current main
+
+## Summary
+
+ADR-0013 [13.5] was implemented upstream as
+[NickFlach/0xSCADA#501](https://github.com/NickFlach/0xSCADA/pull/501) but not
+ported here — `POST /api/intelligence/nlquery` is still the placeholder that
+echoes the query back. Port the real engine following the rebase-and-harden
+pattern of #547/#576/#551.
+
+## Context
+
+- Reference implementation: upstream PR #501 (branch `feat/216-nl-query`)
+- Mock endpoints to replace: `server/routes/intelligence.ts` (`/nlquery`,
+  `/nlquery/history`)
+- Live tag data: `server/websocket/tag-stream.ts` (the `onTagUpdate` hook
+  already exists on current main)
+
+## What done looks like
+
+- [ ] `server/services/nlquery/` exists: ordered intent grammar (specific
+      intents before the `read_tag` catch-all), token-scoring tag resolver
+      (numeric tokens must match exactly; ambiguity returns candidates, never a
+      guess), and an engine where every intent has a real execution path
+- [ ] Comparisons report missing data explicitly — a null reading is never
+      coerced to 0
+- [ ] Pluggable `LLMBackend` contract (async `parseQuery`/`formatAnswer`,
+      `null` = decline): output validated before use, errors emitted as
+      `backend-error` events with regex fallback — no LLM dependency ships
+- [ ] `/api/intelligence/nlquery` + `/nlquery/history` serve real results
+      (same response shape as the mock, extended with
+      `answer`/`intent`/`success`), backed by an in-memory rolling tag store
+      fed from the tag stream
+- [ ] Service registered in the barrel and initialized at startup
+
+## Prove it
+
+```bash
+npx tsc --noEmit
+npx vitest run server/services/nlquery --project node
+npm test
+# Manual smoke (dev server running with the simulator):
+curl -s -X POST localhost:5000/api/intelligence/nlquery \
+  -H 'content-type: application/json' \
+  -d '{"query":"What tags are available?"}'   # answer lists live simulator tags
+```
+
+## Size
+
+Medium-large (complete upstream reference exists).
+
+---
+Review process: Build → Gate → Hunt → Fix (see CONTRIBUTING.md).
+Your PR description must include `City-Agent: <agent-name>` and `Closes #<this issue>`.

--- a/docs/agent-ready-issues/03-port-agent-marketplace.md
+++ b/docs/agent-ready-issues/03-port-agent-marketplace.md
@@ -1,0 +1,53 @@
+# [13.6] Port the agent marketplace (plugin registry + capability-scoped execution) onto current main
+
+## Summary
+
+ADR-0013 [13.6] was implemented upstream as
+[NickFlach/0xSCADA#502](https://github.com/NickFlach/0xSCADA/pull/502) but not
+ported here. Port it onto current `main` — it is also the natural home for the
+agent-contributor plugins this repo is recruiting for.
+
+## Context
+
+- Reference implementation: upstream PR #502 (branch `feat/217-agent-marketplace`)
+- `server/agents/runtime.ts` exports `agentRuntime` consumed by
+  `server/health/` — that export shape must survive
+- `/api/agents` and the `/api/agent-outputs` / `/api/agent-proposals`
+  redirects in `server/routes.ts` must remain untouched — mount at
+  `/api/marketplace`
+
+## What done looks like
+
+- [ ] `server/services/marketplace/` exists: registry with real semver
+      (republish requires strictly newer; dependency ranges `^`/`~`/exact/`*`
+      enforced at install), full lifecycle
+      (install/configure/start/stop/enable/disable/update/uninstall), and
+      capability-scoped execution — handlers receive ONLY the host APIs
+      matching granted capabilities, with a wall-clock timeout and windowed
+      failure tracking that auto-disables failing plugins
+- [ ] The isolation model is documented honestly (capability scoping + fault
+      containment, not memory isolation) per the repo integrity rule
+- [ ] `agentRuntime.getHealth()` reports real marketplace stats instead of
+      hardcoded zeros, keeping its export shape
+- [ ] `/api/marketplace` mounted with zod-validated registry, lifecycle,
+      invoke, and health endpoints
+- [ ] Unit tests cover semver, versioned republish/update, dependency ranges,
+      config-validation regressions, capability gating, timeout, auto-disable
+      + recovery, and lifecycle transitions
+
+## Prove it
+
+```bash
+npx tsc --noEmit
+npx vitest run server/services/marketplace --project node
+npx vitest run server/routes/__tests__          # route mounts still intact
+npm test
+```
+
+## Size
+
+Medium-large (complete upstream reference exists).
+
+---
+Review process: Build → Gate → Hunt → Fix (see CONTRIBUTING.md).
+Your PR description must include `City-Agent: <agent-name>` and `Closes #<this issue>`.

--- a/docs/agent-ready-issues/04-simulator-analog-tags.md
+++ b/docs/agent-ready-issues/04-simulator-analog-tags.md
@@ -1,0 +1,54 @@
+# Simulator: emit continuous analog process tags (real numeric time series)
+
+## Summary
+
+The field simulator only emits discrete random events every ~10s, and
+non-numeric payloads are broadcast as JSON-stringified blobs
+(`server/simulator.ts` — see the `JSON.stringify(payload)` fallback in the tag
+broadcast). The analytics services shipped on this repo — predictive
+maintenance (`/api/predictive`), the digital twin (`/api/twin`), and SPC —
+consume numeric time series and currently have almost nothing realistic to
+chew on in dev. Add continuous analog channels.
+
+## Context
+
+- `server/simulator.ts` — `FieldSimulator`, asset list, `generateEvent()`,
+  `tagStreamServer.broadcastTagUpdate(...)`
+- Consumers: `server/services/predictive`, `server/services/twin`,
+  `server/services/spc`
+- Tag naming convention: `${asset.nameOrTag}.${CHANNEL}` (e.g.
+  `TR-MAIN-01.TEMPERATURE`)
+
+## What done looks like
+
+- [ ] Each simulated asset broadcasts 1–3 analog channels (e.g. TRANSFORMER:
+      `TEMPERATURE`, `LOAD_PERCENT`; BREAKER: `CURRENT`) on a steady cadence
+      (default 2s, configurable via `SIMULATOR_ANALOG_INTERVAL_MS`)
+- [ ] Values are plausible process signals: baseline + slow drift + bounded
+      noise (e.g. sine + seeded noise) — always finite numbers, never
+      stringified JSON, `quality: "good"`
+- [ ] The generator is a pure, exported function driven by a seeded RNG so
+      tests are deterministic (no `Math.random` in the signal path)
+- [ ] Existing discrete event behavior is unchanged; analog emission respects
+      `SIMULATOR_ENABLED`
+- [ ] Unit tests: determinism for a fixed seed, bounds (values stay within
+      the configured band), cadence wiring, and that broadcast values are
+      numeric
+
+## Prove it
+
+```bash
+npx tsc --noEmit
+npx vitest run server/__tests__/simulator-analog.test.ts   # new suite (name yours accordingly)
+npm test
+# Manual smoke: npm run dev, then watch /ws/tags — numeric TEMPERATURE/CURRENT
+# updates every ~2s alongside the existing discrete events.
+```
+
+## Size
+
+Small-medium.
+
+---
+Review process: Build → Gate → Hunt → Fix (see CONTRIBUTING.md).
+Your PR description must include `City-Agent: <agent-name>` and `Closes #<this issue>`.

--- a/docs/agent-ready-issues/05-wire-gr-listen.md
+++ b/docs/agent-ready-issues/05-wire-gr-listen.md
@@ -1,0 +1,54 @@
+# Wire GR::LISTEN as the notification-fatigue filter behind alarm correlation
+
+## Summary
+
+`server/services/gr-listen/` (issue #350, ADR-0022) implements alert
+filtering — attention budgets, time-of-day rules, fatigue
+suppress/escalate/group decisions — but has **zero call sites**: the singleton
+is exported from the services barrel and never invoked. Meanwhile the alarm
+correlation engine (#576) now enriches every published alarm with
+group/root-cause/suppression info. Chain them: correlation does structural
+grouping, GR::LISTEN decides notification worthiness.
+
+## Context
+
+- `server/services/gr-listen/index.ts` — `AlertInput`, `FilterDecision`
+  (`pass|suppress|escalate|group`), `getGrListenFilter()`
+- `server/websocket/cached-event-bridge.ts` — `publishAlarm()` already runs
+  alarms through `alarmCorrelationService` and attaches a `correlation` field
+- `server/services/alarm-correlation/` — severity vocabulary
+  (`critical|high|medium|low|info`) matches gr-listen's `Severity`
+
+## What done looks like
+
+- [ ] A small bridge maps the correlation-enriched alarm to gr-listen's
+      `AlertInput` and attaches the `FilterDecision` to the broadcast payload
+      as a `notification` field (e.g.
+      `{ decision, effectivePriority, incidentId?, reason }`)
+- [ ] Alarms are never dropped: a `suppress` decision still broadcasts, with
+      the decision attached so consumers can de-clutter (same non-destructive
+      posture the `correlation` field uses)
+- [ ] Alarms already suppressed by correlation skip gr-listen (no
+      double-processing); root-cause alarms always reach it
+- [ ] The wiring is behind `GR_LISTEN_ENABLED` (default off) so behavior only
+      changes deliberately; a gr-listen failure never blocks alarm fan-out
+- [ ] Unit tests for the bridge mapping (severity passthrough, correlation-
+      suppressed skip, decision attachment, disabled-flag no-op) and at least
+      one test exercising a real `GrListenFilter` end to end
+
+## Prove it
+
+```bash
+npx tsc --noEmit
+npx vitest run server/services/gr-listen --project node    # new bridge tests
+npx vitest run server/services/alarm-correlation           # existing suite intact
+npm test
+```
+
+## Size
+
+Small-medium.
+
+---
+Review process: Build → Gate → Hunt → Fix (see CONTRIBUTING.md).
+Your PR description must include `City-Agent: <agent-name>` and `Closes #<this issue>`.

--- a/docs/agent-ready-issues/06-sqlite-alarm-parity.md
+++ b/docs/agent-ready-issues/06-sqlite-alarm-parity.md
@@ -1,0 +1,46 @@
+# SQLite dev schema: add the alarm tables (parity with Postgres)
+
+## Summary
+
+`shared/schema.ts` defines `alarms` and `alarm_history` (with the
+`alarm_severity` and `alarm_state` enums), but `shared/schema-sqlite.ts` —
+the dev-mode fallback — has **no alarm tables at all** (`grep -c alarm
+shared/schema-sqlite.ts` → 0). Any code path that persists or queries alarms
+works in production Postgres and silently has nothing to talk to in dev.
+Bring the SQLite schema to parity.
+
+## Context
+
+- Postgres source of truth: `shared/schema.ts` (alarms ~lines 193–210,
+  alarm_history ~212–227, enums ~43–44)
+- SQLite schema: `shared/schema-sqlite.ts` (follow its existing conventions —
+  enums become text columns, timestamps follow the file's existing pattern)
+- DB init / fallback selection: `server/storage.ts`
+
+## What done looks like
+
+- [ ] `shared/schema-sqlite.ts` defines `alarms` and `alarm_history` with the
+      same table names, column names, and column intent as the Postgres
+      schema (enum columns as text; document the mapping in a comment)
+- [ ] Insert schemas / inferred types exported following the file's existing
+      pattern
+- [ ] A parity test asserts the two schema modules define the same alarm
+      tables and column-name sets, so future drift fails CI instead of
+      passing silently
+- [ ] `npx tsc --noEmit` stays clean; nothing else in dev-mode startup breaks
+
+## Prove it
+
+```bash
+npx tsc --noEmit
+npx vitest run shared/__tests__/schema-parity.test.ts   # new parity suite (name yours accordingly)
+npm test
+```
+
+## Size
+
+Small.
+
+---
+Review process: Build → Gate → Hunt → Fix (see CONTRIBUTING.md).
+Your PR description must include `City-Agent: <agent-name>` and `Closes #<this issue>`.

--- a/docs/agent-ready-issues/07-retire-intelligence-mocks.md
+++ b/docs/agent-ready-issues/07-retire-intelligence-mocks.md
@@ -1,0 +1,50 @@
+# Retire the mock maintenance/digitaltwin endpoints in /api/intelligence
+
+## Summary
+
+`server/routes/intelligence.ts` still serves `Math.random()` mock data on
+`/maintenance/analyze`, `/maintenance/insights/:assetId`,
+`/digitaltwin/operate`, and `/digitaltwin/status/:assetId` — while the real
+implementations now exist at `/api/predictive` (#547) and `/api/twin` (#551).
+Two competing surfaces where one is fake violates the repo integrity rule
+("no fake data"). Retire the mocks.
+
+## Context
+
+- Mocks: `server/routes/intelligence.ts` (maintenance + digitaltwin handlers)
+- Real services: `server/services/predictive` (engine, alerts, predictions),
+  `server/services/twin` (models, scenarios, compare)
+- Out of scope: the `/nlquery` mock (that's ADR-0013 [13.5], tracked
+  separately) and the `/ml/*` mock endpoints
+
+## What done looks like
+
+- [ ] `/maintenance/insights/:assetId` delegates to the predictive service:
+      real assessment/alerts for tags belonging to the asset (tag convention
+      `ASSET.CHANNEL`), or an honest empty result — no random numbers
+- [ ] `/maintenance/analyze` either delegates to
+      `predictiveMaintenanceService` (mapping its response into the existing
+      shape where feasible) or returns `410 Gone` with a JSON pointer to
+      `/api/predictive` — pick one, document it in the PR
+- [ ] `/digitaltwin/operate` and `/digitaltwin/status/:assetId` same
+      treatment, pointing at `/api/twin`
+- [ ] No `Math.random()` remains in `server/routes/intelligence.ts` outside
+      the explicitly out-of-scope `/ml/*` handlers
+- [ ] Route tests cover the new behavior (delegation output or 410 + pointer)
+
+## Prove it
+
+```bash
+npx tsc --noEmit
+grep -n "Math.random" server/routes/intelligence.ts   # only /ml/* handlers remain
+npx vitest run server/routes/__tests__ --project node
+npm test
+```
+
+## Size
+
+Small-medium.
+
+---
+Review process: Build → Gate → Hunt → Fix (see CONTRIBUTING.md).
+Your PR description must include `City-Agent: <agent-name>` and `Closes #<this issue>`.

--- a/docs/agent-ready-issues/08-type-storage-layer.md
+++ b/docs/agent-ready-issues/08-type-storage-layer.md
@@ -1,0 +1,49 @@
+# Type the storage layer: eliminate every `(storage as any)` cast
+
+## Summary
+
+Routes reach the storage layer through untyped casts — currently **38
+occurrences** of `(storage as any)` across `server/routes/assets.ts` (3),
+`server/routes/blueprints.ts` (18), `server/routes/codegen.ts` (5), and
+`server/routes/vendors.ts` (12). Each cast hides whether the method actually
+exists on `storage`; missing methods surface as runtime 500s instead of
+compile errors. This directly violates the repo's "no `any`" rule.
+
+## Context
+
+- `server/storage.ts` — the exported `storage` object (~line 599+); some
+  accessors already exist (e.g. `getControlModuleTypes`)
+- Call sites: `grep -rn "storage as any" server/routes/`
+
+## What done looks like
+
+- [ ] `server/storage.ts` exports a typed interface (e.g. `Storage`) that the
+      `storage` object satisfies, covering every method the routes call
+- [ ] Methods that exist get real signatures. Methods the routes call that do
+      NOT exist get one of: a real Drizzle implementation (preferred where the
+      table exists in `shared/schema.ts`), or an explicit typed
+      implementation that returns a clear `501`-style error object — never a
+      silent `undefined` call through `any`
+- [ ] `grep -rn "storage as any" server/` returns nothing
+- [ ] No route that worked before regresses: existing route tests pass, and
+      each newly-typed 501 path has a test asserting the explicit error (not
+      a crash)
+- [ ] Zero new `any` anywhere (gate rule)
+
+## Prove it
+
+```bash
+npx tsc --noEmit
+grep -rn "storage as any" server/ | wc -l    # must print 0
+npx vitest run server/routes/__tests__ --project node
+npm test
+```
+
+## Size
+
+Medium (mechanical but wide; the type surface is discoverable from the call
+sites).
+
+---
+Review process: Build → Gate → Hunt → Fix (see CONTRIBUTING.md).
+Your PR description must include `City-Agent: <agent-name>` and `Closes #<this issue>`.

--- a/docs/agent-ready-issues/09-consolidate-service-startup.md
+++ b/docs/agent-ready-issues/09-consolidate-service-startup.md
@@ -1,0 +1,54 @@
+# Consolidate service startup: make initializeServices() real (or remove it)
+
+## Summary
+
+`server/services/index.ts` exports `initializeServices()` and
+`getServicesHealthStatus()` — and nothing calls them. Actual service startup
+is scattered: `server/routes.ts` contains at least three ad-hoc
+`void <service>.initialize()` calls, each with a comment explaining that
+"services/initializeServices() has no callers at startup" (routes.ts ~lines
+114, 136, 140). Every new service PR has had to rediscover this trap. Pick
+one startup path and make it the only one.
+
+## Context
+
+- Dead machinery: `server/services/index.ts` (`initializeServices`,
+  `getServicesHealthStatus`, `serviceRegistry`)
+- Ad-hoc wiring: `grep -n "has no callers at startup" server/routes.ts`
+- Boot sequence: `server/index.ts` (see also the startup-singletons work in
+  #544); liveness registration: `server/health/index.ts`
+
+## What done looks like
+
+- [ ] One documented startup path. Recommended: `server/index.ts` (or the
+      startup-singletons module) calls `initializeServices()` once during
+      boot, and the ad-hoc `void x.initialize()` calls plus their workaround
+      comments are removed from `registerRoutes`
+- [ ] Every service currently initialized ad-hoc is in the
+      `initializeServices()` list (verify none are silently dropped)
+- [ ] Order-sensitive wiring that must happen in `registerRoutes` (e.g.
+      `tagStreamServer.onTagUpdate(...)` hooks that need the HTTP server)
+      stays there — but plain `initialize()` calls move
+- [ ] `getServicesHealthStatus()` is either wired into `server/health/` or
+      deleted — no half-alive machinery remains
+- [ ] A startup test boots the service layer and asserts each registered
+      service reports `healthy: true` from its `healthCheck()`
+- [ ] `grep -rn "has no callers at startup" server/` returns nothing
+
+## Prove it
+
+```bash
+npx tsc --noEmit
+grep -rn "has no callers at startup" server/ | wc -l   # must print 0
+npx vitest run server/services/__tests__/startup.test.ts   # new suite (name yours accordingly)
+npm test
+```
+
+## Size
+
+Small-medium (wiring + one test; the risk is missing a service, which the
+startup test catches).
+
+---
+Review process: Build → Gate → Hunt → Fix (see CONTRIBUTING.md).
+Your PR description must include `City-Agent: <agent-name>` and `Closes #<this issue>`.

--- a/docs/agent-ready-issues/10-route-contract-tests.md
+++ b/docs/agent-ready-issues/10-route-contract-tests.md
@@ -1,0 +1,53 @@
+# Route contract tests for /api/predictive and /api/alarm-correlation
+
+## Summary
+
+The predictive-maintenance and alarm-correlation services have solid unit
+suites, but their HTTP surfaces have almost no contract coverage — a broken
+zod schema, a renamed field, or a wrong status code would ship silently. The
+repo already has the harness pattern: `server/routes/__tests__/` (see
+`route-mounts.test.ts` and `twin-auth.test.ts` — port-0 express with mocked
+storage/blockchain, no new dependencies). Extend it to per-endpoint contract
+tests for these two routers.
+
+## Context
+
+- Harness pattern to copy: `server/routes/__tests__/route-mounts.test.ts`,
+  `server/routes/__tests__/twin-auth.test.ts`
+- Routers under test: `server/routes/predictive.ts`,
+  `server/routes/alarm-correlation.ts`
+- The engines behind them are deterministic and in-memory — tests can seed
+  them directly (ingest points/alarms, then hit the HTTP surface)
+
+## What done looks like
+
+- [ ] For **every** endpoint on both routers, at least: one happy-path test
+      asserting status code and response shape (field names and types, not
+      exact values), and one validation-failure test asserting a 400 with an
+      error message
+- [ ] 404 paths covered where they exist (unknown tag/group/alert/rule ids)
+- [ ] Behavioral contracts pinned where they matter: `GET
+      /api/predictive/analyze/:tagId` must NOT create alerts (read-only GET);
+      future-dated ingest points are rejected; alarm ingest returns per-alarm
+      results including `rejected` entries
+- [ ] Tests run in the default unit suite (no live DB, no network) and are
+      deterministic
+- [ ] No production code changes needed — if a test reveals a real contract
+      bug, file it as a separate issue and mark the test `.todo` with a link
+      (don't silently change the contract in this PR)
+
+## Prove it
+
+```bash
+npx tsc --noEmit
+npx vitest run server/routes/__tests__ --project node   # new suites included
+npm test
+```
+
+## Size
+
+Medium (mechanical once the first endpoint's pattern is set).
+
+---
+Review process: Build → Gate → Hunt → Fix (see CONTRIBUTING.md).
+Your PR description must include `City-Agent: <agent-name>` and `Closes #<this issue>`.

--- a/docs/agent-ready-issues/README.md
+++ b/docs/agent-ready-issues/README.md
@@ -1,0 +1,36 @@
+# Agent-ready issue drafts
+
+Ten issues scoped so a single agent can complete each one solo. Every draft
+states **what done looks like** (acceptance checklist) and **how to prove it**
+(exact test commands). They are grounded in the current state of `main` —
+file pointers and grep counts were verified at drafting time.
+
+These live as files because GitHub issues are not yet enabled on this fork.
+Once they are, a maintainer (or an agent with triage access) files all ten
+with one command:
+
+```bash
+./scripts/file-agent-ready-issues.sh flaukowski/0xSCADA
+```
+
+The script creates the `agent ready` label and opens one issue per
+`NN-*.md` file (first line = title, rest = body). After filing, this
+directory can be deleted or kept as the drafting record.
+
+| # | Draft | Size |
+|---|---|---|
+| 01 | [13.4] Port PID auto-tuning (envelopes + approval gate + RL) | Large |
+| 02 | [13.5] Port the NL process query engine | Medium-large |
+| 03 | [13.6] Port the agent marketplace | Medium-large |
+| 04 | Simulator: continuous analog process tags | Small-medium |
+| 05 | Wire GR::LISTEN behind alarm correlation | Small-medium |
+| 06 | SQLite dev schema: alarm-table parity | Small |
+| 07 | Retire mock maintenance/digitaltwin endpoints | Small-medium |
+| 08 | Type the storage layer (remove `storage as any`) | Medium |
+| 09 | Consolidate service startup | Small-medium |
+| 10 | Route contract tests (predictive + alarm-correlation) | Medium |
+
+Review process for all of them: **Build → Gate → Hunt → Fix** — see
+[CONTRIBUTING.md](../../CONTRIBUTING.md) and
+[QE-METHODOLOGY.md](../QE-METHODOLOGY.md). PRs must carry the
+`City-Agent: <agent-name>` attribution line.

--- a/scripts/file-agent-ready-issues.sh
+++ b/scripts/file-agent-ready-issues.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# File the agent-ready issue drafts as GitHub issues.
+#
+# Usage: ./scripts/file-agent-ready-issues.sh [owner/repo]
+#
+# Requirements:
+#   - gh CLI authenticated as an account with triage (label) + issue access
+#   - Issues enabled on the target repo (Settings → General → Features)
+#
+# Idempotence: the label create uses --force; issue creation is NOT
+# deduplicated — run once, or delete duplicates afterwards.
+
+set -euo pipefail
+
+REPO="${1:-flaukowski/0xSCADA}"
+LABEL="agent ready"
+DIR="$(cd "$(dirname "$0")/.." && pwd)/docs/agent-ready-issues"
+
+if ! gh repo view "$REPO" --json hasIssuesEnabled --jq .hasIssuesEnabled | grep -q true; then
+  echo "error: issues are disabled on $REPO — enable them first (Settings → General → Features)" >&2
+  exit 1
+fi
+
+echo "Creating label '$LABEL' on $REPO..."
+gh label create "$LABEL" --repo "$REPO" --force \
+  --description "Scoped for a single agent to complete solo — states what done looks like and how to prove it" \
+  --color 00FF9C
+
+for file in "$DIR"/[0-9][0-9]-*.md; do
+  title="$(head -1 "$file" | sed 's/^# //')"
+  echo "Filing: $title"
+  tail -n +2 "$file" | gh issue create --repo "$REPO" \
+    --title "$title" \
+    --label "$LABEL" \
+    --body-file -
+done
+
+echo "Done. Verify: gh issue list --repo $REPO --label '$LABEL'"


### PR DESCRIPTION
Brings the parent level with the fork (a clean fast-forward — 2 commits, no divergence): the agent-contributor onboarding merged as flaukowski/0xSCADA#1.

Contents: CONTRIBUTING.md (Build → Gate → Hunt → Fix review process + mandatory `City-Agent:` attribution line), README agent-contribution note, PR template, ten agent-ready issue drafts (now filed as flaukowski/0xSCADA#2–#11), and the label/issue filing script.

Direct push to `main` is blocked by this repo's changes-via-PR rule, hence this sync PR. A follow-up PR proposes automating these.

Merge with a **merge commit** (not squash/rebase) so the fork's commit SHAs are preserved and the two histories stay convergent.

City-Agent: claude-fable-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)