### PR TITLE
CI: automated sync PRs from the flaukowski fork

### DIFF
--- a/.github/workflows/sync-from-fork.yml
+++ b/.github/workflows/sync-from-fork.yml
@@ -1,0 +1,73 @@
+name: Sync from flaukowski fork
+
+# Keeps this repo level with flaukowski/0xSCADA (the community/agent-facing
+# repo where OpenClawCity contributions land). Direct pushes to main are
+# blocked by repo rules, so this opens/refreshes a sync PR instead.
+#
+# Auto-merge is OFF by default. To enable: set the repository variable
+# AUTO_MERGE_FORK_SYNC to "true" (Settings -> Secrets and variables ->
+# Actions -> Variables). Note: PRs created with GITHUB_TOKEN do not trigger
+# other workflows, so if main gains required status checks, auto-merge will
+# wait forever unless CI is dispatched another way (or a PAT/GitHub App
+# token is used instead).
+
+on:
+  schedule:
+    - cron: "23 */6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  sync:
+    # Inert if this file ever syncs down into the fork itself
+    if: github.repository == 'NickFlach/0xSCADA'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      FORK: https://github.com/flaukowski/0xSCADA.git
+      SYNC_BRANCH: sync/from-fork
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch fork main
+        run: git fetch "$FORK" main:refs/remotes/fork/main
+
+      - name: Compare histories
+        id: compare
+        run: |
+          AHEAD=$(git rev-list --count origin/main..fork/main)
+          BEHIND=$(git rev-list --count fork/main..origin/main)
+          echo "ahead=$AHEAD" >> "$GITHUB_OUTPUT"
+          echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
+          echo "Fork is $AHEAD ahead, $BEHIND behind"
+
+      - name: Open/refresh sync PR (fast-forwardable)
+        if: steps.compare.outputs.ahead != '0' && steps.compare.outputs.behind == '0'
+        run: |
+          git push --force origin fork/main:refs/heads/$SYNC_BRANCH
+          if ! gh pr list --head "$SYNC_BRANCH" --state open --json number --jq '.[0].number' | grep -q .; then
+            gh pr create --base main --head "$SYNC_BRANCH" \
+              --title "Sync from flaukowski/0xSCADA ($(git rev-parse --short fork/main))" \
+              --body "$(printf 'Automated fork sync: %s commit(s) from flaukowski/0xSCADA main.\n\nFast-forward — no divergence. Merge with a merge commit (not squash/rebase) so commit SHAs stay convergent across the two repos.\n\nCity-Agent: sync-from-fork-workflow' "$(git rev-list --count origin/main..fork/main)")"
+          fi
+
+      - name: Enable auto-merge (opt-in)
+        if: steps.compare.outputs.ahead != '0' && steps.compare.outputs.behind == '0' && vars.AUTO_MERGE_FORK_SYNC == 'true'
+        run: |
+          PR=$(gh pr list --head "$SYNC_BRANCH" --state open --json number --jq '.[0].number')
+          [ -n "$PR" ] && gh pr merge "$PR" --auto --merge
+
+      - name: Alert on divergence
+        if: steps.compare.outputs.ahead != '0' && steps.compare.outputs.behind != '0'
+        run: |
+          TITLE="Fork sync blocked: histories diverged"
+          if ! gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number' | grep -q .; then
+            gh issue create --title "$TITLE" \
+              --body "flaukowski/0xSCADA main and this repo's main have both moved independently (fork ahead ${{ steps.compare.outputs.ahead }}, parent ahead ${{ steps.compare.outputs.behind }}). Automated fast-forward sync is not possible — reconcile manually, then close this issue."
+          fi


### PR DESCRIPTION
Answers "can we automerge the fork into this repo?" — direct pushes to `main` are blocked by the changes-via-PR rule, so the automation opens **sync PRs** instead.

## What it does

Every 6 hours (and on manual dispatch):

- **Fork ahead, no divergence** → pushes `flaukowski/0xSCADA@main` to a `sync/from-fork` branch and opens/refreshes a sync PR. Merge with a **merge commit** so SHAs stay convergent between the repos.
- **Both repos moved independently** → files a divergence-alert issue instead of guessing.
- **Auto-merge is opt-in**: set repository variable `AUTO_MERGE_FORK_SYNC=true` to have the workflow flag its sync PRs for auto-merge. Caveat stated in the file: PRs created with `GITHUB_TOKEN` don't trigger other workflows, so if `main` ever gains required status checks, auto-merge will wait unless CI is dispatched another way (or the workflow is given a PAT/App token).

The job is guarded with `if: github.repository == 'NickFlach/0xSCADA'` so the file is inert if it syncs down into the fork.

## Recommendation

Keep exactly one merge target for feature PRs (the fork, where OpenClawCity agent contributions and the `agent ready` issues live), and let this workflow carry changes up. If a change ever lands here first, the divergence alert fires and a human reconciles.

Verification: YAML validated with js-yaml; first live run should be triggered manually via *Actions → Sync from flaukowski fork → Run workflow* after merge (it will find 0 ahead once #586 merges, which is the expected no-op).

City-Agent: claude-fable-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)