### PR TITLE
fix(helm): reject dangling optional component references

### DIFF
--- a/docs/deploy/full-stack-helm.md
+++ b/docs/deploy/full-stack-helm.md
@@ -63,6 +63,22 @@ helm upgrade --install oxscada ./helm/oxscada-full \
   --set-string server.apiKeys.existingSecret=oxscada-api-keys
 ```
 
+### Optional-component dependency checks
+
+The chart rejects combinations that would render references to Services that
+do not exist:
+
+- an enabled gateway needs either the in-chart server or an explicit
+  `gateway.serverUrl`
+- the built-in Prometheus job needs the in-chart server
+- the built-in Grafana datasource needs the in-chart Prometheus instance
+- every configured ingress path must name an enabled chart component
+
+When disabling a component, also remove any ingress path that targets it.
+These checks fail during `helm lint` and `helm template`, before Kubernetes can
+accept a deployment with a dangling upstream, scrape target, datasource, or
+Ingress backend.
+
 Global authentication is on by default; rendering fails until the existing
 Secret name is supplied. The chart never ships a default credential.
 See [Control-Plane API Keys](../security/control-plane-api-keys.md) for secure

--- a/gateway/full-stack-helm-chart.test.ts
+++ b/gateway/full-stack-helm-chart.test.ts
@@ -434,6 +434,74 @@ describe("oxscada-full Helm packaging", () => {
         absent(disabled, `minimal-${component}`);
       }
 
+      expect(() => render(
+        "missing-server",
+        chartPath,
+        [
+          "--set",
+          "server.enabled=false",
+          "--set",
+          "observability.enabled=false",
+        ],
+      )).toThrow(/gateway\.serverUrl is required/);
+
+      const externalGateway = render(
+        "external",
+        chartPath,
+        [
+          "--set",
+          "server.enabled=false",
+          "--set",
+          "observability.enabled=false",
+          "--set-string",
+          "gateway.serverUrl=https://scada.example.test",
+        ],
+      );
+      absent(externalGateway, "external-server");
+      expect(env(
+        workloadContainer(
+          externalGateway,
+          "Deployment",
+          "external-gateway",
+          "gateway",
+        ).container,
+        "SERVER_URL",
+      )?.value).toBe("https://scada.example.test");
+
+      expect(() => render(
+        "missing-scrape-target",
+        chartPath,
+        [
+          "--set",
+          "server.enabled=false",
+          "--set",
+          "gateway.enabled=false",
+          "--set",
+          "observability.grafana.enabled=false",
+        ],
+      )).toThrow(/server\.enabled must be true/);
+
+      expect(() => render(
+        "missing-datasource",
+        chartPath,
+        [
+          ...authSecretArgs,
+          "--set",
+          "observability.prometheus.enabled=false",
+        ],
+      )).toThrow(/observability\.prometheus\.enabled must be true/);
+
+      expect(() => render(
+        "disabled-ingress-backend",
+        chartPath,
+        [
+          "--values",
+          productionValues,
+          "--set",
+          "client.enabled=false",
+        ],
+      )).toThrow(/ingress service "client" is disabled/);
+
       const packageDirectory = join(scratchRoot, "packages");
       mkdirSync(packageDirectory);
       execFileSync(

--- a/helm/oxscada-full/templates/gateway-deployment.yaml
+++ b/helm/oxscada-full/templates/gateway-deployment.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.gateway.enabled }}
+{{- if and (not .Values.server.enabled) (empty .Values.gateway.serverUrl) }}
+{{- fail "gateway.serverUrl is required when gateway.enabled=true and server.enabled=false" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/oxscada-full/templates/grafana.yaml
+++ b/helm/oxscada-full/templates/grafana.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.observability.enabled .Values.observability.grafana.enabled }}
+{{- if not .Values.observability.prometheus.enabled }}
+{{- fail "observability.prometheus.enabled must be true when the built-in Grafana datasource is enabled" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/oxscada-full/templates/ingress.yaml
+++ b/helm/oxscada-full/templates/ingress.yaml
@@ -7,6 +7,14 @@
   "prometheus" .Values.observability.prometheus.port
   "grafana" .Values.observability.grafana.port
 -}}
+{{- $serviceEnabled := dict
+  "server" .Values.server.enabled
+  "client" .Values.client.enabled
+  "gateway" .Values.gateway.enabled
+  "blockchain" .Values.blockchain.enabled
+  "prometheus" (and .Values.observability.enabled .Values.observability.prometheus.enabled)
+  "grafana" (and .Values.observability.enabled .Values.observability.grafana.enabled)
+-}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -34,6 +42,9 @@ spec:
           {{- $port := index $servicePorts .service }}
           {{- if not $port }}
           {{- fail (printf "ingress service %q is not a chart component" .service) }}
+          {{- end }}
+          {{- if not (index $serviceEnabled .service) }}
+          {{- fail (printf "ingress service %q is disabled; remove its path or enable the component" .service) }}
           {{- end }}
           - path: {{ .path }}
             pathType: Prefix

--- a/helm/oxscada-full/templates/prometheus.yaml
+++ b/helm/oxscada-full/templates/prometheus.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.observability.enabled .Values.observability.prometheus.enabled }}
+{{- if not .Values.server.enabled }}
+{{- fail "server.enabled must be true when the built-in Prometheus scrape target is enabled" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Follow-up to #582. This PR addresses one independently reviewable chart concern only: optional components could be disabled while rendered workloads, datasources, scrape targets, or Ingress paths still referenced their missing Services.

## Change

- require `gateway.serverUrl` when the in-chart server is disabled
- reject the built-in Prometheus job when its in-chart server target is disabled
- reject the built-in Grafana datasource when in-chart Prometheus is disabled
- reject Ingress paths whose selected chart component is disabled
- document these dependency rules and add positive/negative render regressions

The external-gateway case remains supported and is tested. The chart fails during lint/template instead of allowing Kubernetes to accept dangling references.

## Verification at exact head `311f79653` on main `e1509e2cc`

- Helm 3.17.3 strict lint with fail-closed API-key Secret: passed
- default render: passed
- external gateway + disabled server render: passed and contains the configured external URL
- missing gateway upstream: rejected for the intended reason
- missing Prometheus target: rejected for the intended reason
- missing Grafana datasource: rejected for the intended reason
- disabled Ingress backend: rejected for the intended reason
- `npm run typecheck`: passed
- `npm run build`: passed
- `git diff --check`: passed

This intentionally does not address Prometheus scrape authentication or validator runtime topology; those remain separate follow-ups so this review stays narrow.

The branch was rebased after the repository-sync and predictive contract-test merges; exact-head CI is the remaining gate before marking this draft ready.