### PR TITLE
Sync from flaukowski/0xSCADA — PAT wiring + contract tests

### DIFF
--- a/.github/workflows/sync-from-fork.yml
+++ b/.github/workflows/sync-from-fork.yml
@@ -9,10 +9,17 @@ name: Sync from flaukowski fork
 # merge commit each sync PR leaves behind is never mistaken for new
 # divergent work — the reverse workflow ignores it and the two converge.
 #
+# Token: set repo secret SYNC_PAT to a PAT with `repo` + `workflow` scope
+# (classic) or Contents+Pull-requests+Workflows: write (fine-grained). It's
+# required to sync commits that touch `.github/workflows/*` — the default
+# GITHUB_TOKEN is forbidden from pushing workflow files. Without the secret
+# it falls back to GITHUB_TOKEN, which still syncs everything EXCEPT
+# workflow-file changes (those must then be pushed manually). A PAT also
+# lets sync PRs trigger CI (GITHUB_TOKEN-created PRs don't), which real
+# auto-merge needs.
+#
 # Auto-merge is OFF by default. Set repo variable AUTO_MERGE_FORK_SYNC=true
-# to enable. (PRs created with GITHUB_TOKEN don't trigger other workflows,
-# so a required status check would hold auto-merge unless CI is dispatched
-# another way.) Merge sync PRs with a MERGE COMMIT, never squash/rebase —
+# to enable. Merge sync PRs with a MERGE COMMIT, never squash/rebase —
 # squashing re-authors commits and forces a divergence reconciliation.
 
 on:
@@ -29,7 +36,7 @@ jobs:
     if: github.repository == 'NickFlach/0xSCADA'
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.SYNC_PAT || github.token }}
       OTHER: https://github.com/flaukowski/0xSCADA.git
       OTHER_NAME: flaukowski/0xSCADA
       SYNC_BRANCH: sync/from-fork
@@ -37,6 +44,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # Persisted git credential for `git push` — the PAT (or the
+          # default token as a fallback that can't push workflow files).
+          token: ${{ secrets.SYNC_PAT || github.token }}
 
       - name: Fetch the other repo's main
         run: git fetch "$OTHER" main:refs/remotes/other/main

--- a/.github/workflows/sync-from-parent.yml
+++ b/.github/workflows/sync-from-parent.yml
@@ -13,6 +13,13 @@ name: Sync from NickFlach parent
 # (see dco.yml), so upstream commits that predate the sign-off convention
 # don't block integration.
 #
+# Token: set repo secret SYNC_PAT to a PAT with `repo` + `workflow` scope
+# (classic) or Contents+Pull-requests+Workflows: write (fine-grained) —
+# required to sync commits that touch `.github/workflows/*`, which the
+# default GITHUB_TOKEN cannot push. Falls back to GITHUB_TOKEN (syncs
+# everything except workflow-file changes). A PAT also lets sync PRs
+# trigger CI, which auto-merge needs.
+#
 # Requires the fork setting: Settings → Actions → General → "Allow GitHub
 # Actions to create and approve pull requests". Auto-merge is OFF by
 # default — set repo variable AUTO_MERGE_PARENT_SYNC=true to enable. Merge
@@ -32,7 +39,7 @@ jobs:
     if: github.repository == 'flaukowski/0xSCADA'
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.SYNC_PAT || github.token }}
       OTHER: https://github.com/NickFlach/0xSCADA.git
       OTHER_NAME: NickFlach/0xSCADA
       SYNC_BRANCH: sync/from-parent
@@ -40,6 +47,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # Persisted git credential for `git push` — the PAT (or the
+          # default token as a fallback that can't push workflow files).
+          token: ${{ secrets.SYNC_PAT || github.token }}
 
       - name: Fetch the other repo's main
         run: git fetch "$OTHER" main:refs/remotes/other/main

--- a/server/routes/__tests__/alarm-correlation-contract.test.ts
+++ b/server/routes/__tests__/alarm-correlation-contract.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Contract tests for the alarm-correlation HTTP surface
+ * (server/routes/alarm-correlation.ts). Issue #11.
+ *
+ * The correlation engine is deterministic and in-memory. Every endpoint is
+ * exercised against a port-0 express server (no DB, no network). Assertions
+ * pin status codes and response shapes, the 404 paths for unknown
+ * ids, and the behavioural contract that alarm ingest returns per-alarm
+ * results including `rejected` entries (e.g. future-dated alarms). Unique
+ * ids per test keep the shared engine singleton from leaking state.
+ *
+ * Harness pattern copied from twin-auth.test.ts. No new dependencies, no
+ * production code changes.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import { createServer, type Server } from "node:http";
+
+import { _resetControlPlaneAuthCache } from "../../middleware/control-plane-auth";
+import { alarmCorrelationRoutes } from "../alarm-correlation";
+
+const KEY = "contract-key";
+let server: Server;
+let base: string;
+let seq = 0;
+const uid = (p: string) => `${p}-${seq++}`;
+
+function startServer(): Promise<{ server: Server; base: string }> {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/alarms", alarmCorrelationRoutes);
+  return new Promise((resolve) => {
+    const s = createServer(app);
+    s.listen(0, "127.0.0.1", () => {
+      const addr = s.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ server: s, base: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+async function api(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; json: any }> {
+  const headers: Record<string, string> = { "x-api-key": KEY };
+  if (method !== "GET") headers["content-type"] = "application/json";
+  const res = await fetch(`${base}/api/alarms${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : undefined };
+}
+
+beforeAll(async () => {
+  process.env.API_KEYS = `${KEY}:contract-tester:*`;
+  _resetControlPlaneAuthCache();
+  ({ server, base } = await startServer());
+});
+
+afterAll(async () => {
+  delete process.env.API_KEYS;
+  _resetControlPlaneAuthCache();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function alarm(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { id: uid("alarm"), tagId: uid("tag"), severity: "high", timestamp: Date.now(), ...overrides };
+}
+
+function causalRule(id: string): Record<string, unknown> {
+  return { name: "contract-rule", enabled: true, priority: 1, type: "causal", config: { windowMs: 60_000, maxHops: 3 } };
+}
+
+// ── Ingestion & lifecycle ───────────────────────────────────────────────────
+
+describe("POST /api/alarms/alarms", () => {
+  it("ingests alarms and returns {ingested, results, rejected}", async () => {
+    const { status, json } = await api("POST", "/alarms", { alarms: [alarm()] });
+    expect(status).toBe(200);
+    expect(typeof json.ingested).toBe("number");
+    expect(Array.isArray(json.results)).toBe(true);
+    expect(Array.isArray(json.rejected)).toBe(true);
+    expect(json.results[0]).toHaveProperty("action");
+  });
+
+  it("rejects a malformed body with 400 + error message", async () => {
+    const { status, json } = await api("POST", "/alarms", { alarms: [] });
+    expect(status).toBe(400);
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("returns per-alarm rejected entries for future-dated alarms", async () => {
+    const future = Date.now() + 2 * 60 * 60 * 1000;
+    const { status, json } = await api("POST", "/alarms", {
+      alarms: [alarm(), alarm({ timestamp: future })],
+    });
+    expect(status).toBe(200);
+    expect(json.rejected.length).toBeGreaterThanOrEqual(1);
+    expect(json.rejected[0]).toHaveProperty("reason");
+  });
+});
+
+describe("alarm lifecycle 404s", () => {
+  it("POST /alarms/:id/clear returns 404 for an untracked alarm", async () => {
+    const { status, json } = await api("POST", "/alarms/missing/clear");
+    expect(status).toBe(404);
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("POST /alarms/:id/acknowledge returns 404 for an untracked alarm", async () => {
+    const { status, json } = await api("POST", "/alarms/missing/acknowledge");
+    expect(status).toBe(404);
+    expect(typeof json.error).toBe("string");
+  });
+});
+
+// ── Groups & root cause ─────────────────────────────────────────────────────
+
+describe("GET /api/alarms/groups", () => {
+  it("returns the groups array", async () => {
+    const { status, json } = await api("GET", "/groups");
+    expect(status).toBe(200);
+    expect(Array.isArray(json.groups)).toBe(true);
+  });
+
+  it("rejects an invalid state filter with 400", async () => {
+    const { status, json } = await api("GET", "/groups?state=bogus");
+    expect(status).toBe(400);
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("GET /groups/:id returns 404 for an unknown group", async () => {
+    const { status, json } = await api("GET", "/groups/missing");
+    expect(status).toBe(404);
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("GET /groups/:id/root-cause returns 404 for an unknown group", async () => {
+    const { status, json } = await api("GET", "/groups/missing/root-cause");
+    expect(status).toBe(404);
+    expect(typeof json.error).toBe("string");
+  });
+});
+
+// ── Rules engine ────────────────────────────────────────────────────────────
+
+describe("rules engine", () => {
+  it("GET /rules returns the rules array", async () => {
+    const { status, json } = await api("GET", "/rules");
+    expect(status).toBe(200);
+    expect(Array.isArray(json.rules)).toBe(true);
+  });
+
+  it("PUT /rules/:id upserts a valid rule", async () => {
+    const id = uid("rule");
+    const { status, json } = await api("PUT", `/rules/${id}`, causalRule(id));
+    expect(status).toBe(200);
+    expect(json.id).toBe(id);
+    expect(json.type).toBe("causal");
+  });
+
+  it("PUT /rules/:id rejects a malformed rule with 400", async () => {
+    const { status, json } = await api("PUT", `/rules/${uid("rule")}`, { type: "causal", config: {} });
+    expect(status).toBe(400);
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("DELETE /rules/:id returns 404 for an unknown rule", async () => {
+    const { status, json } = await api("DELETE", "/rules/missing");
+    expect(status).toBe(404);
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("POST /rules/:id/enable and /disable return 404 for an unknown rule", async () => {
+    expect((await api("POST", "/rules/missing/enable")).status).toBe(404);
+    expect((await api("POST", "/rules/missing/disable")).status).toBe(404);
+  });
+
+  it("enable/disable toggle an existing rule", async () => {
+    const id = uid("rule");
+    await api("PUT", `/rules/${id}`, causalRule(id));
+    expect((await api("POST", `/rules/${id}/disable`)).json.enabled).toBe(false);
+    expect((await api("POST", `/rules/${id}/enable`)).json.enabled).toBe(true);
+  });
+});
+
+// ── Topology ────────────────────────────────────────────────────────────────
+
+describe("equipment topology", () => {
+  it("GET /topology returns the nodes array", async () => {
+    const { status, json } = await api("GET", "/topology");
+    expect(status).toBe(200);
+    expect(Array.isArray(json.nodes)).toBe(true);
+  });
+
+  it("PUT /topology upserts nodes and returns a count", async () => {
+    const { status, json } = await api("PUT", "/topology", {
+      nodes: [{ equipmentId: uid("eq"), causalDownstream: [] }],
+    });
+    expect(status).toBe(200);
+    expect(typeof json.upserted).toBe("number");
+    expect(Array.isArray(json.nodes)).toBe(true);
+  });
+
+  it("PUT /topology rejects a malformed body with 400", async () => {
+    const { status, json } = await api("PUT", "/topology", { nodes: [] });
+    expect(status).toBe(400);
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("DELETE /topology/:id returns 404 for unknown equipment", async () => {
+    const { status, json } = await api("DELETE", "/topology/missing");
+    expect(status).toBe(404);
+    expect(typeof json.error).toBe("string");
+  });
+});
+
+// ── Suppression policy ──────────────────────────────────────────────────────
+
+describe("suppression policy", () => {
+  it("GET /suppression-policy returns the policy object", async () => {
+    const { status, json } = await api("GET", "/suppression-policy");
+    expect(status).toBe(200);
+    expect(json).toBeTypeOf("object");
+  });
+
+  it("PUT /suppression-policy rejects an empty body with 400", async () => {
+    const { status, json } = await api("PUT", "/suppression-policy", {});
+    expect(status).toBe(400);
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("PUT /suppression-policy enabling without the env opt-in returns 409", async () => {
+    const { status, json } = await api("PUT", "/suppression-policy", { enabled: true });
+    expect(status).toBe(409);
+    expect(json.coordinationMode).toBe("process-local");
+  });
+});
+
+// ── Metrics & status ────────────────────────────────────────────────────────
+
+describe("metrics & status", () => {
+  it("GET /metrics returns a metrics object", async () => {
+    const { status, json } = await api("GET", "/metrics");
+    expect(status).toBe(200);
+    expect(json).toBeTypeOf("object");
+  });
+
+  it("GET /status returns the engine status envelope", async () => {
+    const { status, json } = await api("GET", "/status");
+    expect(status).toBe(200);
+    expect(json).toBeTypeOf("object");
+  });
+});

--- a/server/routes/__tests__/predictive-contract.test.ts
+++ b/server/routes/__tests__/predictive-contract.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Contract tests for the predictive-maintenance HTTP surface
+ * (server/routes/predictive.ts). Issue #11.
+ *
+ * The engine is deterministic and in-memory, so each endpoint is exercised
+ * against a port-0 express server with no DB and no network. Assertions pin
+ * status codes and response SHAPES (field names and types), plus the two
+ * behavioural contracts that matter: GET /analyze is read-only (never creates
+ * alerts) and future-dated ingest points are rejected. Unique tag ids per
+ * test keep the shared engine singleton from leaking state between cases.
+ *
+ * Harness pattern copied from twin-auth.test.ts (port-0 express, API_KEYS env,
+ * x-api-key header). No new dependencies, no production code changes.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import { createServer, type Server } from "node:http";
+
+import { _resetControlPlaneAuthCache } from "../../middleware/control-plane-auth";
+import { predictiveRoutes } from "../predictive";
+
+const KEY = "contract-key";
+let server: Server;
+let base: string;
+let tagSeq = 0;
+const nextTag = () => `contract-tag-${tagSeq++}`;
+
+function startServer(): Promise<{ server: Server; base: string }> {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/predictive", predictiveRoutes);
+  return new Promise((resolve) => {
+    const s = createServer(app);
+    s.listen(0, "127.0.0.1", () => {
+      const addr = s.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ server: s, base: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+async function api(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; json: any }> {
+  const headers: Record<string, string> = { "x-api-key": KEY };
+  if (method !== "GET") headers["content-type"] = "application/json";
+  const res = await fetch(`${base}/api/predictive${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : undefined };
+}
+
+beforeAll(async () => {
+  // A single privileged key (scope "*") satisfies every guard on the router;
+  // scope enforcement itself is covered elsewhere. Contract tests focus on the
+  // request/response contract, not authorization.
+  process.env.API_KEYS = `${KEY}:contract-tester:*`;
+  _resetControlPlaneAuthCache();
+  ({ server, base } = await startServer());
+});
+
+afterAll(async () => {
+  delete process.env.API_KEYS;
+  _resetControlPlaneAuthCache();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function series(count: number, at = Date.now()): Array<{ timestamp: number; value: number }> {
+  return Array.from({ length: count }, (_, i) => ({ timestamp: at - (count - i) * 1000, value: 10 + Math.sin(i) }));
+}
+
+describe("POST /api/predictive/ingest", () => {
+  it("ingests a series and returns the assessment envelope", async () => {
+    const { status, json } = await api("POST", "/ingest", { tagId: nextTag(), points: series(5) });
+    expect(status).toBe(200);
+    expect(typeof json.ingested).toBe("number");
+    expect(typeof json.rejectedFuturePoints).toBe("number");
+    expect(json).toHaveProperty("assessment"); // object or null, but present
+  });
+
+  it("rejects a malformed body with 400 + error message", async () => {
+    const { status, json } = await api("POST", "/ingest", { tagId: "", points: [] });
+    expect(status).toBe(400);
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("rejects future-dated points (rejectedFuturePoints > 0)", async () => {
+    const future = Date.now() + 2 * 60 * 60 * 1000; // 2h ahead, beyond the 1h skew
+    const { status, json } = await api("POST", "/ingest", {
+      tagId: nextTag(),
+      points: [{ timestamp: future, value: 1 }, { timestamp: Date.now(), value: 2 }],
+    });
+    expect(status).toBe(200);
+    expect(json.rejectedFuturePoints).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("GET /api/predictive/analyze/:tagId", () => {
+  it("returns 404 with required/available for an unknown tag", async () => {
+    const { status, json } = await api("GET", `/analyze/${nextTag()}`);
+    expect(status).toBe(404);
+    expect(typeof json.error).toBe("string");
+    expect(typeof json.required).toBe("number");
+    expect(typeof json.available).toBe("number");
+  });
+
+  it("is read-only: calling analyze never changes the alert count", async () => {
+    const tag = nextTag();
+    await api("POST", "/ingest", { tagId: tag, points: series(40) });
+    const before = (await api("GET", "/alerts")).json.alerts.length;
+    for (let i = 0; i < 3; i++) await api("GET", `/analyze/${tag}`);
+    const after = (await api("GET", "/alerts")).json.alerts.length;
+    expect(after).toBe(before);
+  });
+});
+
+describe("GET /api/predictive/prediction/:tagId", () => {
+  it("returns 404 for a tag with insufficient data", async () => {
+    const { status, json } = await api("GET", `/prediction/${nextTag()}`);
+    expect(status).toBe(404);
+    expect(typeof json.error).toBe("string");
+  });
+});
+
+describe("GET /api/predictive/tags", () => {
+  it("returns the tracked-tags array", async () => {
+    const { status, json } = await api("GET", "/tags");
+    expect(status).toBe(200);
+    expect(Array.isArray(json.tags)).toBe(true);
+  });
+});
+
+describe("GET/PUT /api/predictive/thresholds/:tagId", () => {
+  it("GET returns a thresholds object with minSamples", async () => {
+    const { status, json } = await api("GET", `/thresholds/${nextTag()}`);
+    expect(status).toBe(200);
+    expect(typeof json.minSamples).toBe("number");
+  });
+
+  it("PUT rejects an out-of-range field with 400", async () => {
+    const { status, json } = await api("PUT", `/thresholds/${nextTag()}`, { minSamples: 1 });
+    expect(status).toBe(400);
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("PUT rejects an inconsistent severity ordering with 400", async () => {
+    const { status, json } = await api("PUT", `/thresholds/${nextTag()}`, {
+      severityThresholds: { warning: 0.9, critical: 0.5, emergency: 0.1 },
+    });
+    expect(status).toBe(400);
+    expect(json.error).toContain("warning <= critical <= emergency");
+  });
+
+  it("PUT accepts a valid partial override and returns the merged config", async () => {
+    const { status, json } = await api("PUT", `/thresholds/${nextTag()}`, { zScoreThreshold: 4 });
+    expect(status).toBe(200);
+    expect(typeof json.minSamples).toBe("number");
+  });
+});
+
+describe("GET /api/predictive/alerts", () => {
+  it("returns the alerts array", async () => {
+    const { status, json } = await api("GET", "/alerts");
+    expect(status).toBe(200);
+    expect(Array.isArray(json.alerts)).toBe(true);
+  });
+
+  it("rejects an invalid severity filter with 400", async () => {
+    const { status, json } = await api("GET", "/alerts?severity=bogus");
+    expect(status).toBe(400);
+    expect(typeof json.error).toBe("string");
+  });
+});
+
+describe("POST /api/predictive/alerts/:alertId/acknowledge", () => {
+  it("returns 404 for an unknown alert id", async () => {
+    const { status, json } = await api("POST", "/alerts/missing-alert/acknowledge");
+    expect(status).toBe(404);
+    expect(typeof json.error).toBe("string");
+  });
+});
+
+describe("GET /api/predictive/status", () => {
+  it("returns the engine status envelope", async () => {
+    const { status, json } = await api("GET", "/status");
+    expect(status).toBe(200);
+    expect(typeof json.trackedTags).toBe("number");
+    expect(typeof json.totalAlerts).toBe("number");
+    expect(Array.isArray(json.detectors)).toBe(true);
+  });
+});


### PR DESCRIPTION
Manual sync (workflow-scoped token) to break the bootstrap: carries the PAT edit to the parent's own sync workflows (#21) plus the /api/predictive + /api/alarm-correlation contract tests (#20). After this merges, the parent side also authenticates with SYNC_PAT and the loop is self-sustaining.

Merge with a **merge commit**. DCO exempt (sync/* branch).

City-Agent: sync-from-fork-workflow