### PR TITLE
ci: bump CI Node pins from 20 to 22 so dependabot lockfiles verify natively

### DIFF
--- a/.github/workflows/anchor-pipeline-anvil.yml
+++ b/.github/workflows/anchor-pipeline-anvil.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
 
       - uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/bounty-contract-smoke.yml
+++ b/.github/workflows/bounty-contract-smoke.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/bounty-management.yml
+++ b/.github/workflows/bounty-management.yml
@@ -189,7 +189,7 @@ jobs:
         if: steps.validate.outputs.valid == 'true'
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install transaction runtime
         if: steps.validate.outputs.valid == 'true'
@@ -501,7 +501,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install transaction runtime
         run: npm ci --ignore-scripts
@@ -654,7 +654,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install transaction runtime
         run: npm ci --ignore-scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,14 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '20'
+  # Node 22 ships npm 10.9+, which accepts the package-lock.json format that
+  # current npm (and therefore Dependabot) generates. Node 20's bundled npm
+  # 10.8.2 rejected those lockfiles with EUSAGE "package.json and
+  # package-lock.json are in sync", so every Dependabot PR failed at `npm ci`
+  # and needed a manual `npx npm@10.8.2 install --package-lock-only` rebase.
+  # Keep every CI setup-node pin in this repo on the same major (see
+  # test/ci/workflow-node-version.test.ts).
+  NODE_VERSION: '22'
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/0xscada
 

--- a/.github/workflows/hsm-pkcs11.yml
+++ b/.github/workflows/hsm-pkcs11.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install SoftHSMv2 + OpenSC

--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/test/ci/workflow-node-version.test.ts
+++ b/test/ci/workflow-node-version.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Guards the Node major that CI installs.
+ *
+ * Node 20 bundles npm 10.8.2. Dependabot regenerates package-lock.json with a
+ * newer npm, and npm 10.8.2 rejects those lockfiles with EUSAGE
+ * ("can only install packages when your package.json and package-lock.json are
+ * in sync"), so every Dependabot npm PR failed at `npm ci` until someone
+ * hand-rebased the lockfile with `npx npm@10.8.2 install --package-lock-only`.
+ * Node 22 ships npm 10.9+, which reads them natively.
+ *
+ * This test fails if any workflow reintroduces a setup-node pin below Node 22,
+ * which is the exact regression that brings the toil back.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { JSON_SCHEMA, load } from "js-yaml";
+import { describe, expect, test } from "vitest";
+
+/** Lowest Node major whose bundled npm accepts current Dependabot lockfiles. */
+const MINIMUM_NODE_MAJOR = 22;
+
+type WorkflowStep = {
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type WorkflowJob = {
+  env?: Record<string, unknown>;
+  steps?: WorkflowStep[];
+};
+
+type Workflow = {
+  env?: Record<string, unknown>;
+  jobs?: Record<string, WorkflowJob>;
+};
+
+type NodePin = {
+  workflow: string;
+  job: string;
+  /** The literal written in YAML, e.g. `22` or `${{ env.NODE_VERSION }}`. */
+  raw: string;
+  /** `raw` after substituting workflow/job-level `env`. */
+  resolved: string;
+};
+
+const workflowsDir = resolve(process.cwd(), ".github/workflows");
+
+const workflowFiles = readdirSync(workflowsDir)
+  .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+  .sort();
+
+/**
+ * Substitutes `${{ env.NAME }}` from the job-level then workflow-level `env`
+ * maps. GitHub Actions supports several other expression contexts; anything we
+ * cannot resolve is returned unchanged so the assertions below reject it rather
+ * than silently passing an unknown pin.
+ */
+function resolveEnvExpression(
+  value: string,
+  scopes: ReadonlyArray<Record<string, unknown> | undefined>,
+): string {
+  return value.replace(
+    /\$\{\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g,
+    (unresolved, name: string) => {
+      for (const scope of scopes) {
+        const candidate = scope?.[name];
+        if (typeof candidate === "string" || typeof candidate === "number") {
+          return String(candidate);
+        }
+      }
+      return unresolved;
+    },
+  );
+}
+
+function collectNodePins(fileName: string): NodePin[] {
+  const source = readFileSync(join(workflowsDir, fileName), "utf8");
+  // JSON_SCHEMA keeps `node-version: 22` (unquoted) a string rather than
+  // coercing it to a number, so quoted and unquoted pins compare identically.
+  const workflow = load(source, { schema: JSON_SCHEMA }) as Workflow | undefined;
+  const pins: NodePin[] = [];
+
+  for (const [jobName, job] of Object.entries(workflow?.jobs ?? {})) {
+    for (const step of job.steps ?? []) {
+      if (!step.uses?.startsWith("actions/setup-node@")) {
+        continue;
+      }
+      const pin = step.with?.["node-version"];
+      // A setup-node step with no scalar `node-version` (omitted entirely, or
+      // swapped for `node-version-file`) must NOT be skipped: skipping it would
+      // let someone reintroduce Node 20 in a form this collector cannot see.
+      // Record it with an unresolvable marker so the assertions flag it.
+      const raw =
+        typeof pin === "string" || typeof pin === "number"
+          ? String(pin)
+          : `<no scalar node-version: ${JSON.stringify(step.with ?? null)}>`;
+      pins.push({
+        workflow: fileName,
+        job: jobName,
+        raw,
+        resolved: resolveEnvExpression(raw, [job.env, workflow?.env]),
+      });
+    }
+  }
+
+  return pins;
+}
+
+const nodePins = workflowFiles.flatMap(collectNodePins);
+
+describe("CI workflow Node version pins", () => {
+  test("every workflow file is parseable YAML", () => {
+    expect(workflowFiles.length).toBeGreaterThan(0);
+    for (const fileName of workflowFiles) {
+      const source = readFileSync(join(workflowsDir, fileName), "utf8");
+      expect(() => load(source, { schema: JSON_SCHEMA })).not.toThrow();
+    }
+  });
+
+  test("at least one setup-node pin is discovered", () => {
+    // Sanity check: if the collector silently stopped matching (renamed action,
+    // restructured steps), the version assertion below would vacuously pass.
+    expect(nodePins.length).toBeGreaterThan(0);
+  });
+
+  test("no setup-node pin resolves below Node 22", () => {
+    const offenders = nodePins.filter((pin) => {
+      const major = Number.parseInt(pin.resolved, 10);
+      return !Number.isFinite(major) || major < MINIMUM_NODE_MAJOR;
+    });
+
+    expect(
+      offenders.map(
+        (pin) =>
+          `${pin.workflow} job "${pin.job}": ${pin.raw} -> ${pin.resolved}`,
+      ),
+    ).toEqual([]);
+  });
+
+  test("ci.yml drives every setup-node step from the shared NODE_VERSION", () => {
+    const source = readFileSync(join(workflowsDir, "ci.yml"), "utf8");
+    const workflow = load(source, { schema: JSON_SCHEMA }) as Workflow;
+
+    expect(String(workflow.env?.NODE_VERSION)).toBe("22");
+
+    const ciPins = nodePins.filter((pin) => pin.workflow === "ci.yml");
+    expect(ciPins.length).toBeGreaterThan(0);
+    for (const pin of ciPins) {
+      expect(pin.raw).toBe("${{ env.NODE_VERSION }}");
+      expect(pin.resolved).toBe("22");
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Every dependabot npm PR failed CI at `npm ci` with:

```
EUSAGE  can only install packages when your package.json and package-lock.json are in sync
```

The dependency changes were never the issue — this is **npm-version skew**. Dependabot regenerates `package-lock.json` with a current npm, while CI pinned Node 20, which bundles npm 10.8.2 and rejects that lockfile format. The standing workaround on every single dependabot PR was a manual `npx npm@10.8.2 install --package-lock-only` plus a force-push. Pure toil.

## Fix

Bump every `setup-node` pin under `.github/workflows/` from 20 to 22 (npm 10.9+), which reads current lockfiles natively. This is triage option 1 — it avoids option 3's `pull_request_target` / write-token surface on dependabot branches.

9 edited literals covering all 15 `actions/setup-node@v7` steps in the repo:

| Workflow | setup-node steps | Edited sites |
|---|---|---|
| `ci.yml` | 7 | 1 (`env.NODE_VERSION`, referenced by all 7) |
| `bounty-management.yml` | 3 | 3 |
| `openapi-validation.yml` | 2 | 2 |
| `anchor-pipeline-anvil.yml` | 1 | 1 |
| `bounty-contract-smoke.yml` | 1 | 1 |
| `hsm-pkcs11.yml` | 1 | 1 |

`dco.yml`, `sync-from-fork.yml` and `sync-from-parent.yml` have no `setup-node` step. Per-file quoting style is preserved (`'22'` vs `"22"`). A short rationale comment sits above `NODE_VERSION` in `ci.yml` so the next person doesn't re-pin it to 20.

### Verifying "the Node 20 pin is historical, not load-bearing"

Checked rather than assumed. Nothing in the repo asserts Node 20 as a floor:

- `package.json` and `cli/package.json` both declare `engines.node` `">=18.0.0"` — Node 22 satisfies it, so `engines` is left untouched (no contradiction to resolve).
- No `.nvmrc`, no `.node-version`.
- `helm/` and `k8s/` contain no Node image references.
- `docker/validator/Dockerfile` is already `node:22-alpine` as of #577.

### Regression guard

Adds `test/ci/workflow-node-version.test.ts` (4 tests): parses every workflow with `js-yaml` (`JSON_SCHEMA`, so unquoted `22` stays a string), resolves `${{ env.NODE_VERSION }}` against job- then workflow-level `env`, and fails if any pin resolves below Node 22 — the exact regression that brings the manual lockfile rebasing back.

Two anti-vacuity properties, both deliberate:
- it asserts at least one pin was discovered, so a renamed action or restructured steps can't make the version check pass on an empty set;
- a `setup-node` step with no scalar `node-version` (omitted, or swapped for `node-version-file`) is recorded as an unresolvable offender rather than skipped, so Node 20 cannot be reintroduced in a shape the collector doesn't read.

## Verification

```
npx tsc --noEmit          -> exit 0

npx vitest run
 Test Files  96 passed | 2 skipped (98)
      Tests  2028 passed | 5 skipped (2033)
```

Baseline on `main` is 95 files / 2024 passing, 2 files + 5 tests skipped. The delta is exactly +1 file / +4 tests — the new test. No regressions.

All nine workflows parse cleanly under `js-yaml`, an independent parse confirms all 15 `setup-node` steps resolve to `22`, and `grep -rn "node-version: *['\"]\?20" .github/` returns no matches.

The guard is not ceremonial — negative controls:
- reverting `ci.yml`'s `NODE_VERSION` to `'20'` plus one hardcoded pin fails 2 of 4 tests, naming each offender (`ci.yml job "build": ${{ env.NODE_VERSION }} -> 20`, `openapi-validation.yml job "validate-openapi": 20 -> 20`);
- replacing a pin with `node-version-file: '.nvmrc'` fails with `<no scalar node-version: {...}>`.

Restoring the files makes both pass again.

## Caveats

- **This is not proven end-to-end.** The change alters which npm generates and validates lockfiles in CI, so **the next dependabot PR is the real proof**. No Actions run was triggered here. Please don't read the green local suite as more than it is; local runs were on Windows, not Node 22 / ubuntu-latest. What they do establish is that the repo is not Node-20-bound, which is the load-bearing claim.
- **The failure may relocate to post-merge `main`, and a reviewer should decide whether that's acceptable.** `ci.yml`'s `docker` job builds `docker/{server,client,gateway,validator}/Dockerfile`; `server`, `client` and `gateway` are still `FROM node:20-alpine` and `RUN npm ci` against this same root `package-lock.json`. That job is gated `if: github.event_name == 'push'` and push only fires on `[main, 'feat/**', 'feature/**']`, so a dependabot `pull_request` never reaches it — the PR path this issue is about is genuinely fixed. But today it's the blocked PR that forces the `npm@10.8.2` lockfile rebase, which is also what keeps those node:20 images buildable. Once an un-rebased lockfile merges, the `docker` job runs npm 10.8.2 against it and can hit the identical EUSAGE, with `deploy-staging` (`needs: [docker, integration-test]`) downstream. This PR is deliberately scoped to CI and does **not** move runtime images — that's a separate decision with its own risk surface — but moving `docker/server`, `docker/client` and `docker/gateway` to `node:22-alpine` is the obvious follow-up, and it should land before or with the first un-rebased dependabot merge. Same scoping leaves the root `Dockerfile` (`node:18-alpine`, not built by CI) and `cli/src/commands/deploy.ts:85` (`image: node:20-alpine` in generated output) alone.
- `engines.node` stays `">=18.0.0"`. Node 22 satisfies it, so there was nothing to reconcile. Raising the floor to match CI would be a deliberate follow-up, not something to smuggle in here.
- `npx tsc --noEmit` does **not** cover the new file — `tsconfig.json` excludes `**/*.test.ts` and doesn't include `test/`, and vitest transpiles without typechecking. The green tsc means the rest of the repo still typechecks, nothing more.
- `ci.yml`'s security job runs `npm audit --audit-level=high`; npm 10.9's audit output can differ from 10.8.2's, so that job's result could shift independently of any dependency change (not observed, just possible).
- **Pre-existing doc drift, neither introduced nor fixed here:** `docs/k8s/container-images.md` still lists the validator as `node:20-alpine` (stale since #577) and references `services/modbus-driver/Dockerfile` and `services/opcua-driver/Dockerfile` — there is no `services/` directory. Worth its own docs issue.
- The guard asserts a floor (`>= 22`), so a future bump to Node 24 won't fail it — but it does hard-assert `ci.yml`'s `NODE_VERSION` is exactly `"22"`, which keeps `ci.yml` single-sourced at the cost of one line to update on a future major bump. It resolves only the `${{ env.NAME }}` context; a matrix/inputs-based pin would be flagged as unresolvable rather than silently passing.

Refs #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)