### PR TITLE
fix(intelligence): retire the fabricated /api/intelligence mock endpoints

### DIFF
--- a/client/src/pages/intelligence.tsx
+++ b/client/src/pages/intelligence.tsx
@@ -1,40 +1,125 @@
 /**
  * Intelligence Page
- * 
- * Wave feature for natural language query, predictive maintenance,
- * and digital twin capabilities within the 0xSCADA ecosystem.
- * Part of issue #277 - wave features implementation.
+ *
+ * Issue #216 (ADR-0013 [13.5]) review: this page previously rendered a fully
+ * fabricated dashboard — invented asset risk ratings ("Pump P-101: Medium
+ * Risk"), an invented maintenance schedule, and invented twin metrics
+ * ("Simulation Accuracy 97.3%", "Optimization Gains +8.2%"). None of it came
+ * from an API call; the values were literals in this file, and the query box
+ * and simulation buttons had no handlers. On an operator-facing SCADA screen
+ * that reads as live plant state, which is exactly what the repository
+ * integrity rule forbids.
+ *
+ * The fabricated panels are gone. Each tab now states plainly what is and is
+ * not implemented, and names the API that actually serves the capability, so
+ * this page cannot be mistaken for a working readout. It renders no numbers
+ * because it has none to render.
  */
 
 import React, { useState } from 'react';
 
-const Intelligence: React.FC = () => {
-  const [query, setQuery] = useState('');
-  const [selectedTab, setSelectedTab] = useState<'nl-query' | 'predictive' | 'digital-twin'>('nl-query');
+type TabKey = 'nl-query' | 'predictive' | 'digital-twin';
 
-  const handleTabChange = (tab: 'nl-query' | 'predictive' | 'digital-twin') => {
-    setSelectedTab(tab);
-  };
+interface TabDefinition {
+  key: TabKey;
+  label: string;
+  icon: string;
+}
+
+interface TabContent {
+  heading: string;
+  /** Server contract for this capability: 501 unbuilt, 410 moved. */
+  status: 'not-implemented' | 'moved';
+  /** What the legacy /api/intelligence path now returns. */
+  legacyPath: string;
+  summary: string;
+  /** Endpoints that actually serve this capability; empty when unbuilt. */
+  endpoints: readonly string[];
+}
+
+const TABS: readonly TabDefinition[] = [
+  { key: 'nl-query', label: 'Natural Language', icon: '🔍' },
+  { key: 'predictive', label: 'Predictive Maintenance', icon: '📈' },
+  { key: 'digital-twin', label: 'Digital Twin', icon: '🔗' },
+];
+
+const CONTENT: Record<TabKey, TabContent> = {
+  'nl-query': {
+    heading: 'Natural language query',
+    status: 'not-implemented',
+    legacyPath: 'POST /api/intelligence/nlquery',
+    summary:
+      'Not implemented. No natural-language query engine is wired to this '
+      + 'service, so there is nothing to display here. The endpoint returns '
+      + '501 with { error: "not_implemented" } rather than a placeholder '
+      + 'answer.',
+    endpoints: [],
+  },
+  predictive: {
+    heading: 'Predictive maintenance',
+    status: 'moved',
+    legacyPath: 'POST /api/intelligence/maintenance/analyze',
+    summary:
+      'Implemented, but not on this page and not on the legacy '
+      + '/api/intelligence path, which now returns 410. The predictive '
+      + 'maintenance engine is tag-scoped: ingest a tag series, then read its '
+      + 'assessment, failure prediction, or alerts. Access requires '
+      + 'predictive.* control-plane scopes.',
+    endpoints: [
+      'POST /api/predictive/ingest',
+      'GET /api/predictive/analyze/:tagId',
+      'GET /api/predictive/prediction/:tagId',
+      'GET /api/predictive/alerts',
+    ],
+  },
+  'digital-twin': {
+    heading: 'Digital twin',
+    status: 'moved',
+    legacyPath: 'POST /api/intelligence/digitaltwin/operate',
+    summary:
+      'Implemented, but not on this page and not on the legacy '
+      + '/api/intelligence path, which now returns 410. The twin runtime holds '
+      + 'the model registry, simulation stepping, live-state compare, and '
+      + 'what-if scenarios. Access requires twin.* control-plane scopes.',
+    endpoints: [
+      'POST /api/twin/models',
+      'POST /api/twin/models/:modelId/step',
+      'GET /api/twin/models/:modelId/state',
+      'POST /api/twin/scenarios',
+    ],
+  },
+};
+
+const STATUS_LABEL: Record<TabContent['status'], string> = {
+  'not-implemented': 'Not implemented',
+  moved: 'Moved — this path returns 410',
+};
+
+const STATUS_COLOR: Record<TabContent['status'], string> = {
+  'not-implemented': '#ef4444',
+  moved: '#f59e0b',
+};
+
+const Intelligence: React.FC = () => {
+  const [selectedTab, setSelectedTab] = useState<TabKey>('nl-query');
+  const content = CONTENT[selectedTab];
 
   return (
     <div style={{ padding: 24, backgroundColor: '#0a0a0a', color: '#e5e5e5', minHeight: '100vh' }}>
       <div style={{ marginBottom: 24 }}>
-        <h1 style={{ margin: 0, fontSize: 28, marginBottom: 8 }}>🧠 Intelligence Hub</h1>
+        <h1 style={{ margin: 0, fontSize: 28, marginBottom: 8 }}>Intelligence Hub</h1>
         <p style={{ color: '#888', fontSize: 16, margin: 0 }}>
-          Natural language queries, predictive analytics, and digital twin visualization
+          Status of the natural language, predictive maintenance, and digital twin surfaces.
+          This page reports what exists; it does not display plant data.
         </p>
       </div>
 
       {/* Tab Navigation */}
       <div style={{ display: 'flex', marginBottom: 24, borderBottom: '2px solid #333' }}>
-        {[
-          { key: 'nl-query', label: '💬 Natural Language', icon: '🔍' },
-          { key: 'predictive', label: '📈 Predictive Maintenance', icon: '⚡' },
-          { key: 'digital-twin', label: '🔗 Digital Twin', icon: '🌐' }
-        ].map(tab => (
+        {TABS.map(tab => (
           <button
             key={tab.key}
-            onClick={() => handleTabChange(tab.key as any)}
+            onClick={() => setSelectedTab(tab.key)}
             style={{
               padding: '12px 24px',
               backgroundColor: selectedTab === tab.key ? '#1f2937' : 'transparent',
@@ -43,7 +128,7 @@ const Intelligence: React.FC = () => {
               color: selectedTab === tab.key ? '#e5e5e5' : '#888',
               cursor: 'pointer',
               fontSize: 14,
-              fontWeight: selectedTab === tab.key ? 'bold' : 'normal'
+              fontWeight: selectedTab === tab.key ? 'bold' : 'normal',
             }}
           >
             {tab.icon} {tab.label}
@@ -51,166 +136,65 @@ const Intelligence: React.FC = () => {
         ))}
       </div>
 
-      {/* Natural Language Query Tab */}
-      {selectedTab === 'nl-query' && (
-        <div style={{ backgroundColor: '#111827', borderRadius: 8, padding: 24 }}>
-          <h2 style={{ fontSize: 20, marginTop: 0, marginBottom: 16 }}>🔍 Ask Anything About Your System</h2>
-          <div style={{ marginBottom: 20 }}>
-            <textarea
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="e.g., 'Show me all pumps with efficiency below 80%' or 'What caused the temperature spike in reactor R-301?'"
-              style={{
-                width: '100%',
-                minHeight: 100,
-                padding: 16,
-                backgroundColor: '#0a0a0a',
-                border: '1px solid #374151',
-                borderRadius: 6,
-                color: '#e5e5e5',
-                fontSize: 14,
-                resize: 'vertical'
-              }}
-            />
-            <button style={{
-              marginTop: 12,
-              padding: '12px 32px',
-              backgroundColor: '#3b82f6',
-              border: 'none',
+      <div style={{ backgroundColor: '#111827', borderRadius: 8, padding: 24 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+          <h2 style={{ fontSize: 20, margin: 0 }}>{content.heading}</h2>
+          <span
+            style={{
+              fontSize: 12,
+              fontWeight: 'bold',
+              padding: '4px 10px',
+              borderRadius: 4,
+              border: `1px solid ${STATUS_COLOR[content.status]}`,
+              color: STATUS_COLOR[content.status],
+            }}
+          >
+            {STATUS_LABEL[content.status]}
+          </span>
+        </div>
+
+        <p style={{ fontSize: 14, lineHeight: 1.6, color: '#d1d5db', marginTop: 0 }}>
+          {content.summary}
+        </p>
+
+        <div
+          style={{
+            backgroundColor: '#0a0a0a',
+            padding: 16,
+            borderRadius: 6,
+            border: '1px solid #333',
+            marginTop: 20,
+          }}
+        >
+          <h3 style={{ fontSize: 14, marginTop: 0, marginBottom: 8, color: '#888' }}>
+            Legacy path
+          </h3>
+          <code style={{ fontSize: 13, color: '#f87171' }}>{content.legacyPath}</code>
+        </div>
+
+        {content.endpoints.length > 0 && (
+          <div
+            style={{
+              backgroundColor: '#0a0a0a',
+              padding: 16,
               borderRadius: 6,
-              color: 'white',
-              cursor: 'pointer',
-              fontSize: 14,
-              fontWeight: 'bold'
-            }}>
-              ⚡ Analyze Query
-            </button>
+              border: '1px solid #333',
+              marginTop: 16,
+            }}
+          >
+            <h3 style={{ fontSize: 14, marginTop: 0, marginBottom: 8, color: '#888' }}>
+              Implemented endpoints
+            </h3>
+            <ul style={{ margin: 0, paddingLeft: 20, fontSize: 13, lineHeight: 1.9 }}>
+              {content.endpoints.map(endpoint => (
+                <li key={endpoint}>
+                  <code style={{ color: '#86efac' }}>{endpoint}</code>
+                </li>
+              ))}
+            </ul>
           </div>
-          <div style={{ backgroundColor: '#0a0a0a', padding: 16, borderRadius: 6, border: '1px solid #333' }}>
-            <h3 style={{ fontSize: 16, marginTop: 0, marginBottom: 12 }}>💡 Recent Insights</h3>
-            <div style={{ fontSize: 14, lineHeight: 1.6 }}>
-              <p>• Tank TK-101 level trending downward - recommend inspection</p>
-              <p>• Pump P-205 showing increased vibration patterns</p>
-              <p>• Energy efficiency up 12% this quarter vs last</p>
-              <p>• 3 valves due for calibration next week</p>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Predictive Maintenance Tab */}
-      {selectedTab === 'predictive' && (
-        <div style={{ backgroundColor: '#111827', borderRadius: 8, padding: 24 }}>
-          <h2 style={{ fontSize: 20, marginTop: 0, marginBottom: 16 }}>📈 Predictive Analytics</h2>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24, marginBottom: 24 }}>
-            <div style={{ backgroundColor: '#0a0a0a', padding: 16, borderRadius: 6, border: '1px solid #333' }}>
-              <h3 style={{ fontSize: 16, marginTop: 0, marginBottom: 12 }}>⚠️ Risk Assessment</h3>
-              <div style={{ fontSize: 14 }}>
-                <div style={{ marginBottom: 8, display: 'flex', justifyContent: 'space-between' }}>
-                  <span>Pump P-101</span>
-                  <span style={{ color: '#f59e0b' }}>Medium Risk</span>
-                </div>
-                <div style={{ marginBottom: 8, display: 'flex', justifyContent: 'space-between' }}>
-                  <span>Heat Exchanger E-201</span>
-                  <span style={{ color: '#ef4444' }}>High Risk</span>
-                </div>
-                <div style={{ marginBottom: 8, display: 'flex', justifyContent: 'space-between' }}>
-                  <span>Compressor C-301</span>
-                  <span style={{ color: '#22c55e' }}>Low Risk</span>
-                </div>
-              </div>
-            </div>
-            <div style={{ backgroundColor: '#0a0a0a', padding: 16, borderRadius: 6, border: '1px solid #333' }}>
-              <h3 style={{ fontSize: 16, marginTop: 0, marginBottom: 12 }}>🗓️ Maintenance Schedule</h3>
-              <div style={{ fontSize: 14 }}>
-                <p>• P-101 Bearing replacement: 14 days</p>
-                <p>• E-201 Tube cleaning: 7 days</p>
-                <p>• V-105 Calibration: 21 days</p>
-                <p>• TK-203 Inspection: 30 days</p>
-              </div>
-            </div>
-          </div>
-          <div style={{ backgroundColor: '#0a0a0a', padding: 16, borderRadius: 6, border: '1px solid #333' }}>
-            <h3 style={{ fontSize: 16, marginTop: 0, marginBottom: 12 }}>🤖 ML Model Status</h3>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16, fontSize: 14 }}>
-              <div>Vibration Analysis: <span style={{ color: '#22c55e' }}>Active</span></div>
-              <div>Temperature Trends: <span style={{ color: '#22c55e' }}>Active</span></div>
-              <div>Flow Pattern Recognition: <span style={{ color: '#f59e0b' }}>Training</span></div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Digital Twin Tab */}
-      {selectedTab === 'digital-twin' && (
-        <div style={{ backgroundColor: '#111827', borderRadius: 8, padding: 24 }}>
-          <h2 style={{ fontSize: 20, marginTop: 0, marginBottom: 16 }}>🌐 Digital Twin Mirror</h2>
-          <div style={{ marginBottom: 24 }}>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 16 }}>
-              <div style={{ padding: 16, backgroundColor: '#0a0a0a', borderRadius: 6, textAlign: 'center' }}>
-                <div style={{ fontSize: 12, color: '#888', marginBottom: 4 }}>Simulation Accuracy</div>
-                <div style={{ fontSize: 24, fontWeight: 'bold', color: '#22c55e' }}>97.3%</div>
-              </div>
-              <div style={{ padding: 16, backgroundColor: '#0a0a0a', borderRadius: 6, textAlign: 'center' }}>
-                <div style={{ fontSize: 12, color: '#888', marginBottom: 4 }}>Twin Sync Status</div>
-                <div style={{ fontSize: 24, fontWeight: 'bold', color: '#22c55e' }}>Real-time</div>
-              </div>
-              <div style={{ padding: 16, backgroundColor: '#0a0a0a', borderRadius: 6, textAlign: 'center' }}>
-                <div style={{ fontSize: 12, color: '#888', marginBottom: 4 }}>Active Scenarios</div>
-                <div style={{ fontSize: 24, fontWeight: 'bold', color: '#60a5fa' }}>5</div>
-              </div>
-              <div style={{ padding: 16, backgroundColor: '#0a0a0a', borderRadius: 6, textAlign: 'center' }}>
-                <div style={{ fontSize: 12, color: '#888', marginBottom: 4 }}>Optimization Gains</div>
-                <div style={{ fontSize: 24, fontWeight: 'bold', color: '#f59e0b' }}>+8.2%</div>
-              </div>
-            </div>
-          </div>
-          <div style={{ backgroundColor: '#0a0a0a', padding: 16, borderRadius: 6, border: '1px solid #333', marginBottom: 16 }}>
-            <h3 style={{ fontSize: 16, marginTop: 0, marginBottom: 12 }}>🎮 Simulation Controls</h3>
-            <div style={{ display: 'flex', gap: 12, marginBottom: 16 }}>
-              <button style={{
-                padding: '8px 16px',
-                backgroundColor: '#22c55e',
-                border: 'none',
-                borderRadius: 4,
-                color: 'white',
-                cursor: 'pointer',
-                fontSize: 12
-              }}>
-                ▶️ Run Simulation
-              </button>
-              <button style={{
-                padding: '8px 16px',
-                backgroundColor: '#f59e0b',
-                border: 'none',
-                borderRadius: 4,
-                color: 'white',
-                cursor: 'pointer',
-                fontSize: 12
-              }}>
-                ⏸️ Pause
-              </button>
-              <button style={{
-                padding: '8px 16px',
-                backgroundColor: '#ef4444',
-                border: 'none',
-                borderRadius: 4,
-                color: 'white',
-                cursor: 'pointer',
-                fontSize: 12
-              }}>
-                🔄 Reset
-              </button>
-            </div>
-            <div style={{ fontSize: 14, color: '#888' }}>
-              Current scenario: Normal operation + 15% throughput increase
-            </div>
-          </div>
-          <p style={{ fontSize: 14, color: '#666', fontStyle: 'italic' }}>
-            3D visualization and advanced twin modeling features coming soon...
-          </p>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/server/middleware/control-route-policy.ts
+++ b/server/middleware/control-route-policy.ts
@@ -101,7 +101,11 @@ export const CONTROL_ROUTE_POLICIES: readonly ControlRoutePolicy[] = Object.free
     id: "digital-twin-control",
     pathPrefix: "/api/intelligence/digitaltwin/operate",
     scopes: Object.freeze(["control.write"]),
-    description: "Operate a digital twin against control inputs.",
+    description:
+      "Retired legacy path (#216): the handler now returns 410 with a pointer "
+      + "to /api/twin, which enforces its own twin.* scopes. The policy is kept "
+      + "so the prefix cannot silently fall back to broad `write` if a handler "
+      + "is ever remounted here.",
   },
   {
     id: "hsm-control",

--- a/server/routes/__tests__/intelligence-contract.test.ts
+++ b/server/routes/__tests__/intelligence-contract.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Contract tests for the legacy /api/intelligence surface (issue #216).
+ *
+ * Every handler on this router used to fabricate its payload: PRNG-generated
+ * risk and health scores, hardcoded recommendations, invented timestamps. These
+ * tests pin the replacement contract — an explicit, machine-readable refusal —
+ * and, just as importantly, assert the *absence* of fabricated measurements:
+ * no score fields, and byte-identical bodies across repeated calls, which a
+ * pseudo-random payload cannot satisfy.
+ *
+ * The real routers (/api/predictive #212, /api/twin #214) are mounted on the
+ * same test server so the "the working APIs still work" half of the contract is
+ * exercised rather than assumed.
+ *
+ * Harness pattern follows predictive-contract.test.ts: port-0 express server,
+ * API_KEYS env, x-api-key header. No DB, no network, no new dependencies.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import { createServer, type Server } from "node:http";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { _resetControlPlaneAuthCache } from "../../middleware/control-plane-auth";
+import { intelligenceRoutes } from "../intelligence";
+import { predictiveRoutes } from "../predictive";
+import { twinRoutes } from "../twin";
+
+const KEY = "intelligence-contract-key";
+let server: Server;
+let base: string;
+
+interface ApiResponse {
+  status: number;
+  json: Record<string, unknown>;
+  /** Raw body text, so byte-level equality can be compared across calls. */
+  text: string;
+}
+
+async function api(method: string, path: string, body?: unknown): Promise<ApiResponse> {
+  const headers: Record<string, string> = { "x-api-key": KEY };
+  if (body !== undefined) headers["content-type"] = "application/json";
+  const res = await fetch(`${base}${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  return {
+    status: res.status,
+    json: text ? (JSON.parse(text) as Record<string, unknown>) : {},
+    text,
+  };
+}
+
+beforeAll(async () => {
+  // A single privileged key satisfies the guards on the real routers. The
+  // intelligence router carries no per-route control-plane guard of its own,
+  // which is precisely why its handlers must not serve engine data (see the
+  // module comment there).
+  process.env.API_KEYS = `${KEY}:intelligence-contract-tester:*`;
+  _resetControlPlaneAuthCache();
+
+  const app = express();
+  app.use(express.json());
+  // Mirror the mounts in server/routes.ts registerRoutes.
+  app.use("/api/intelligence", intelligenceRoutes);
+  app.use("/api/predictive", predictiveRoutes);
+  app.use("/api/twin", twinRoutes);
+
+  await new Promise<void>((resolve) => {
+    server = createServer(app);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  base = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  delete process.env.API_KEYS;
+  _resetControlPlaneAuthCache();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+/** Field names the removed handlers used to fabricate. */
+const FABRICATED_FIELDS = [
+  "riskScore",
+  "healthScore",
+  "predictions",
+  "accuracy",
+  "confidence",
+  "recommendations",
+  "trends",
+  "alerts",
+  "insights",
+  "models",
+  "history",
+  "results",
+] as const;
+
+function expectNoFabricatedMeasurements(body: Record<string, unknown>): void {
+  for (const field of FABRICATED_FIELDS) {
+    expect(body).not.toHaveProperty(field);
+  }
+  // Belt and braces: a refusal body carries strings only. Any bare number in
+  // the payload would be a measurement-shaped value that a caller could plot.
+  for (const value of Object.values(body)) {
+    expect(typeof value).not.toBe("number");
+  }
+}
+
+// ── Endpoints with no implementation anywhere on main → 501 ────────────────
+
+const NOT_IMPLEMENTED: ReadonlyArray<readonly [string, string, unknown]> = [
+  ["POST", "/api/intelligence/nlquery", { query: "Show me pump efficiency trends" }],
+  ["GET", "/api/intelligence/nlquery/history", undefined],
+  [
+    "POST",
+    "/api/intelligence/ml/pipeline",
+    { modelId: "pump-efficiency-v1", operation: "predict", data: [{ vibration: 1 }] },
+  ],
+  ["GET", "/api/intelligence/ml/models", undefined],
+  ["GET", "/api/intelligence/ml/pipeline/status/job-1", undefined],
+];
+
+describe("unimplemented intelligence endpoints return 501, never fabricated data", () => {
+  it.each(NOT_IMPLEMENTED)("%s %s", async (method, path, body) => {
+    const res = await api(method, path, body);
+
+    expect(res.status).toBe(501);
+    expect(res.json.error).toBe("not_implemented");
+    expect(typeof res.json.detail).toBe("string");
+    expect((res.json.detail as string).length).toBeGreaterThan(0);
+    expect(res.json.reference).toContain("216");
+    // 501 means "nothing implements this" — there is no endpoint to point at.
+    expect(res.json).not.toHaveProperty("replacement");
+    expectNoFabricatedMeasurements(res.json);
+  });
+
+  it("refuses a request that the removed Zod schema would have accepted", async () => {
+    // The old handler validated this exact body and answered 200 with
+    // pseudo-random predictions. A well-formed request must still be refused.
+    const res = await api("POST", "/api/intelligence/ml/pipeline", {
+      modelId: "pump-efficiency-v1",
+      operation: "predict",
+      data: [{ vibration: 0.4 }, { vibration: 0.6 }],
+    });
+    expect(res.status).toBe(501);
+    expect(res.json).not.toHaveProperty("results");
+  });
+});
+
+// ── Endpoints superseded by a real, guarded router → 410 + pointer ─────────
+
+const RETIRED: ReadonlyArray<readonly [string, string, unknown, string]> = [
+  [
+    "POST",
+    "/api/intelligence/maintenance/analyze",
+    {
+      assetId: "PUMP-101",
+      timeRange: { start: "2026-01-01T00:00:00.000Z", end: "2026-01-02T00:00:00.000Z" },
+      analysisType: "predictive",
+    },
+    "/api/predictive",
+  ],
+  ["GET", "/api/intelligence/maintenance/insights/PUMP-101", undefined, "/api/predictive"],
+  [
+    "POST",
+    "/api/intelligence/digitaltwin/operate",
+    { assetId: "PUMP-101", operation: "simulate", parameters: {} },
+    "/api/twin",
+  ],
+  ["GET", "/api/intelligence/digitaltwin/status/PUMP-101", undefined, "/api/twin"],
+];
+
+describe("superseded intelligence endpoints return 410 with a migration pointer", () => {
+  it.each(RETIRED)("%s %s", async (method, path, body, expectedApi) => {
+    const res = await api(method, path, body);
+
+    expect(res.status).toBe(410);
+    expect(res.json.error).toBe("endpoint_retired");
+    expect(typeof res.json.detail).toBe("string");
+    expect(res.json.reference).toContain("216");
+    expectNoFabricatedMeasurements(res.json);
+
+    const replacement = res.json.replacement as {
+      endpoints: string[];
+      scopes: string[];
+    };
+    expect(Array.isArray(replacement.endpoints)).toBe(true);
+    expect(replacement.endpoints.length).toBeGreaterThan(0);
+    // Every pointer names the real router, so a caller can act on the 410.
+    for (const endpoint of replacement.endpoints) {
+      expect(endpoint).toContain(expectedApi);
+    }
+    expect(replacement.scopes.length).toBeGreaterThan(0);
+  });
+});
+
+// ── The anti-fabrication assertion ─────────────────────────────────────────
+
+describe("no intelligence endpoint returns a value that varies between calls", () => {
+  const ALL_PATHS: ReadonlyArray<readonly [string, string, unknown]> = [
+    ...NOT_IMPLEMENTED,
+    ...RETIRED.map(([method, path, body]) => [method, path, body] as const),
+  ];
+
+  it.each(ALL_PATHS)("%s %s is byte-identical across repeated calls", async (method, path, body) => {
+    const [first, second, third] = await Promise.all([
+      api(method, path, body),
+      api(method, path, body),
+      api(method, path, body),
+    ]);
+    // Pseudo-random payloads cannot pass this; fixed refusal bodies always do.
+    expect(second.text).toBe(first.text);
+    expect(third.text).toBe(first.text);
+  });
+
+  it("gives every asset id the same answer (the mocks varied per call, not per asset)", async () => {
+    const a = await api("GET", "/api/intelligence/maintenance/insights/PUMP-101");
+    const b = await api("GET", "/api/intelligence/maintenance/insights/TANK-203");
+    expect(b.text).toBe(a.text);
+    expect(a.status).toBe(410);
+  });
+});
+
+// ── The real routers are untouched ─────────────────────────────────────────
+
+describe("the implemented APIs still serve real data", () => {
+  it("GET /api/predictive/tags returns the engine's tracked tags", async () => {
+    const res = await api("GET", "/api/predictive/tags");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.json.tags)).toBe(true);
+  });
+
+  it("POST /api/predictive/ingest then GET /analyze/:tagId returns a real assessment", async () => {
+    const tagId = "intelligence-contract-tag";
+    const now = Date.now();
+    // A flat baseline with a terminal spike: enough samples for the engine's
+    // default minSamples, and a value the ensemble can actually score.
+    const points = Array.from({ length: 40 }, (_, i) => ({
+      timestamp: now - (40 - i) * 1000,
+      value: i === 39 ? 500 : 10,
+    }));
+
+    const ingest = await api("POST", "/api/predictive/ingest", { tagId, points });
+    expect(ingest.status).toBe(200);
+    expect(ingest.json.ingested).toBe(points.length);
+
+    const analyze = await api("GET", `/api/predictive/analyze/${tagId}`);
+    expect(analyze.status).toBe(200);
+    // The assessment is computed from the ingested series, so it is tied to the
+    // data — unlike the removed mock, which ignored its input entirely.
+    expect(analyze.json.tagId).toBe(tagId);
+    expect(typeof analyze.json.ensembleScore).toBe("number");
+    expect(Array.isArray(analyze.json.detectorResults)).toBe(true);
+    // The spike is the last ingested point, so the assessment must reflect it.
+    expect(analyze.json.value).toBe(500);
+  });
+
+  it("GET /api/twin/models and /api/twin/step-functions respond from the runtime", async () => {
+    const models = await api("GET", "/api/twin/models");
+    expect(models.status).toBe(200);
+    expect(Array.isArray(models.json.models)).toBe(true);
+
+    const stepFunctions = await api("GET", "/api/twin/step-functions");
+    expect(stepFunctions.status).toBe(200);
+    expect(Array.isArray(stepFunctions.json.stepFunctions)).toBe(true);
+  });
+
+  it("the real routers still enforce their control-plane scopes", async () => {
+    // Proves the 410 pointer sends callers somewhere that is actually guarded,
+    // which is why /api/intelligence must not proxy to these engines.
+    const res = await fetch(`${base}/api/predictive/tags`);
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── Source-level regression guard ──────────────────────────────────────────
+
+describe("server/routes contains no fabricated-measurement source", () => {
+  it("no route module calls Math.random()", () => {
+    const routesDir = dirname(dirname(fileURLToPath(import.meta.url)));
+    // Top-level route modules only; __tests__ is excluded because test
+    // fixtures may legitimately generate values.
+    const modules = readdirSync(routesDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+      .map((entry) => entry.name);
+
+    expect(modules.length).toBeGreaterThan(0);
+    const offenders = modules.filter((name) =>
+      /Math\s*\.\s*random\s*\(/.test(readFileSync(join(routesDir, name), "utf8"))
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/server/routes/intelligence.ts
+++ b/server/routes/intelligence.ts
@@ -1,263 +1,225 @@
+/**
+ * Legacy /api/intelligence surface.
+ *
+ * Issue #216 (ADR-0013 [13.5]) review: this router shipped as a demo scaffold
+ * and every handler fabricated its payload — PRNG-generated risk and health
+ * "scores" on a 0..100 scale, hardcoded maintenance recommendations, invented
+ * 2024 failure dates, canned ML accuracy figures. It was mounted next to the real
+ * APIs at `/api/predictive` (#212) and `/api/twin` (#214) with nothing in the
+ * response to tell a caller which surface they had reached. On an
+ * operator-facing SCADA system a synthetic "risk score" that reads like a
+ * measurement is a safety hazard, and it violates the repository integrity
+ * rule ("NO shortcuts, fake data, or false claims").
+ *
+ * No handler here produces data any more. Each returns an explicit,
+ * machine-readable refusal:
+ *
+ *   410 Gone             `error: "endpoint_retired"` — the capability is
+ *                        implemented, on another router. The body carries the
+ *                        replacement endpoints and the scopes they require.
+ *   501 Not Implemented  `error: "not_implemented"` — nothing on `main`
+ *                        implements this capability at all.
+ *
+ * Why refuse rather than proxy to the real engines: every handler on
+ * `/api/predictive` and `/api/twin` carries a per-route
+ * `requireControlPlaneAccess` check for a specific scope (`predictive.read`,
+ * `twin.read`, ...), while this router carries none. The API gateway does sit
+ * in front of both — `apiKeyMiddleware` covers all of `/api/` when
+ * `ENABLE_API_KEYS` is on (fail-closed in production), and mutations also pass
+ * `mutationAuthorizationMiddleware` — but the gateway only proves a caller
+ * holds *some* valid key. Delegating from here would therefore hand predictive
+ * assessments and twin state to any key holder, bypassing the fine-grained
+ * scopes the real routers require; with API-key auth disabled (the default
+ * outside production) it would be an outright unauthenticated read path, since
+ * `requireControlPlaneAccess` is what rejects an unkeyed request today. Adding
+ * a duplicate guarded copy would just rebuild the two-competing-surfaces
+ * problem that this change exists to remove.
+ *
+ * Why keep the routes rather than delete them: `client/src/pages/intelligence`
+ * and the `digital-twin-control` entry in `server/middleware/control-route-policy`
+ * still reference these paths. A 410/501 with a pointer is diagnosable; a bare
+ * 404 from an unmounted router is not.
+ */
+
 import { Router } from "express";
-import { z } from "zod";
+import type { Response } from "express";
 
 const router = Router();
 
-// Schema definitions for intelligence modules
-const NLQuerySchema = z.object({
-  query: z.string().min(1),
-  context: z.string().optional(),
-  filters: z.record(z.any()).optional(),
+/** Where the decision is recorded, echoed to operators reading logs. */
+const ISSUE_REFERENCE = "https://github.com/NickFlach/0xSCADA/issues/216";
+
+/** The implemented surface that supersedes a retired path. */
+interface Replacement {
+  /** Concrete endpoints a caller should migrate to. */
+  endpoints: readonly string[];
+  /** Control-plane scopes those endpoints require. */
+  scopes: readonly string[];
+}
+
+/** Single response envelope for every refusal this router emits. */
+interface RefusalBody {
+  error: "endpoint_retired" | "not_implemented";
+  detail: string;
+  reference: string;
+  replacement?: Replacement;
+}
+
+/**
+ * The capability exists — on a different, authenticated router.
+ * 410 rather than 501: the server implements the function, this URL is gone.
+ */
+function retired(res: Response, detail: string, replacement: Replacement): void {
+  const body: RefusalBody = {
+    error: "endpoint_retired",
+    detail,
+    reference: ISSUE_REFERENCE,
+    replacement,
+  };
+  res.status(410).json(body);
+}
+
+/** Nothing on `main` implements this capability, here or anywhere else. */
+function notImplemented(res: Response, detail: string): void {
+  const body: RefusalBody = {
+    error: "not_implemented",
+    detail,
+    reference: ISSUE_REFERENCE,
+  };
+  res.status(501).json(body);
+}
+
+const PREDICTIVE_REPLACEMENT: Replacement = {
+  endpoints: [
+    "POST /api/predictive/ingest",
+    "GET /api/predictive/analyze/:tagId",
+    "GET /api/predictive/prediction/:tagId",
+    "GET /api/predictive/alerts",
+  ],
+  scopes: ["predictive.ingest", "predictive.read", "predictive.recommend"],
+};
+
+const TWIN_REPLACEMENT: Replacement = {
+  endpoints: [
+    "POST /api/twin/models",
+    "POST /api/twin/models/:modelId/step",
+    "GET /api/twin/models/:modelId/state",
+    "POST /api/twin/scenarios",
+  ],
+  scopes: ["twin.read", "twin.configure", "twin.operate", "twin.simulate"],
+};
+
+// ── Natural-language query (ADR-0013 [13.5], #216) ─────────────────────────
+// Not implemented on main. The former handler echoed the request back as an
+// "interpretation", returned `results: []`, and appended two fixed
+// "suggestions" — it never reached a data source.
+
+router.post("/nlquery", (_req, res) => {
+  notImplemented(
+    res,
+    "Natural-language process query is not implemented. The previous handler "
+      + "echoed the submitted query back as an interpretation with an empty "
+      + "result set; it queried no tags, events, or historian data. Query the "
+      + "typed APIs directly (for example GET /api/predictive/alerts or "
+      + "GET /api/v2/events) until this is built.",
+  );
 });
 
-const MaintenanceAnalysisSchema = z.object({
-  assetId: z.string(),
-  timeRange: z.object({
-    start: z.string().datetime(),
-    end: z.string().datetime(),
-  }),
-  analysisType: z.enum(["predictive", "diagnostic", "prescriptive"]),
+router.get("/nlquery/history", (_req, res) => {
+  notImplemented(
+    res,
+    "Natural-language query history is not implemented. No query history is "
+      + "recorded anywhere in this service; the previous handler returned one "
+      + "hardcoded example row stamped with the current time.",
+  );
 });
 
-const DigitalTwinSchema = z.object({
-  assetId: z.string(),
-  operation: z.enum(["simulate", "predict", "optimize"]),
-  parameters: z.record(z.any()),
+// ── Predictive maintenance — superseded by /api/predictive (#212) ──────────
+// The former handlers returned a PRNG draw scaled to 0..100 as `riskScore` and
+// `healthScore`, plus fixed recommendations and a fixed `nextFailure` date.
+
+router.post("/maintenance/analyze", (_req, res) => {
+  retired(
+    res,
+    "Mock endpoint removed. It returned a pseudo-random 0..100 draw as a risk "
+      + "score with hardcoded recommendations and a fixed failure date, none of "
+      + "which were derived from asset data. Real analysis runs on the predictive "
+      + "maintenance engine, which is tag-scoped rather than asset-scoped: "
+      + "ingest the asset's tag series, then request its assessment or failure "
+      + "prediction.",
+    PREDICTIVE_REPLACEMENT,
+  );
 });
 
-const MLPipelineSchema = z.object({
-  modelId: z.string(),
-  operation: z.enum(["train", "predict", "evaluate"]),
-  data: z.array(z.record(z.any())),
+router.get("/maintenance/insights/:assetId", (_req, res) => {
+  retired(
+    res,
+    "Mock endpoint removed. It returned a pseudo-random 0..100 draw as a health "
+      + "score with fixed performance trends and a fixed vibration alert. Real "
+      + "detector output and alerts come from the predictive maintenance "
+      + "engine, keyed by tag id.",
+    PREDICTIVE_REPLACEMENT,
+  );
 });
 
-// NL Query Engine endpoints
-router.post("/nlquery", async (req, res) => {
-  try {
-    const { query, context, filters } = NLQuerySchema.parse(req.body);
-    
-    // Basic NL query processing (placeholder implementation)
-    const results = {
-      query,
-      interpretation: `Processed query: ${query}`,
-      results: [],
-      suggestions: [
-        "Try refining your query with more specific terms",
-        "Consider adding time filters",
-      ],
-    };
-    
-    res.json(results);
-  } catch (error) {
-    res.status(400).json({ error: "Invalid NL query request" });
-  }
+// ── Digital twin — superseded by /api/twin (#214) ──────────────────────────
+// The former handlers reported `status: "completed"` for every operation and
+// returned fixed strings ("Expected performance: 95%", "12% efficiency
+// improvement", accuracy 94.5) without running a simulation.
+
+router.post("/digitaltwin/operate", (_req, res) => {
+  retired(
+    res,
+    "Mock endpoint removed. It reported every operation as completed and "
+      + "returned fixed simulation, prediction, and optimization strings "
+      + "without stepping a model. Real simulation, what-if scenarios, and "
+      + "rollback analysis run on the digital twin runtime.",
+    TWIN_REPLACEMENT,
+  );
 });
 
-router.get("/nlquery/history", async (req, res) => {
-  try {
-    // Mock query history
-    const history = [
-      {
-        id: "1",
-        query: "Show me pump efficiency trends",
-        timestamp: new Date().toISOString(),
-        results: 15,
-      },
-    ];
-    
-    res.json({ history });
-  } catch (error) {
-    res.status(500).json({ error: "Failed to fetch query history" });
-  }
+router.get("/digitaltwin/status/:assetId", (_req, res) => {
+  retired(
+    res,
+    "Mock endpoint removed. It reported a fixed 'synchronized' status, a fixed "
+      + "94.5 accuracy figure, and a fixed session count for any asset id, "
+      + "including ids with no twin. Real model state and runtime status come "
+      + "from the digital twin runtime.",
+    TWIN_REPLACEMENT,
+  );
 });
 
-// Predictive Maintenance endpoints
-router.post("/maintenance/analyze", async (req, res) => {
-  try {
-    const { assetId, timeRange, analysisType } = MaintenanceAnalysisSchema.parse(req.body);
-    
-    // Mock predictive maintenance analysis
-    const analysis = {
-      assetId,
-      analysisType,
-      riskScore: Math.random() * 100,
-      recommendations: [
-        {
-          priority: "HIGH",
-          action: "Inspect bearing lubrication",
-          confidence: 0.85,
-          timeframe: "1-2 weeks",
-        },
-      ],
-      predictions: {
-        nextFailure: "2024-04-15T10:00:00Z",
-        confidence: 0.78,
-        factors: ["vibration increase", "temperature anomaly"],
-      },
-    };
-    
-    res.json(analysis);
-  } catch (error) {
-    res.status(400).json({ error: "Invalid maintenance analysis request" });
-  }
+// ── ML pipeline ────────────────────────────────────────────────────────────
+// Not implemented on main. `server/services/ml` exists but is a simulation
+// harness — its inference path returns PRNG draws and "training" is a
+// setTimeout — so wiring these routes to it would relabel the same fabricated
+// numbers rather than remove them. It is deliberately left unexposed over HTTP.
+
+router.post("/ml/pipeline", (_req, res) => {
+  notImplemented(
+    res,
+    "ML pipeline execution is not implemented. The previous handler returned "
+      + "pseudo-random values as predictions and fixed accuracy/loss/F1 figures "
+      + "for train and evaluate. No model runtime is wired to this service; "
+      + "server/services/ml is a simulation harness, not an inference backend.",
+  );
 });
 
-router.get("/maintenance/insights/:assetId", async (req, res) => {
-  try {
-    const { assetId } = req.params;
-    
-    // Mock maintenance insights
-    const insights = {
-      assetId,
-      healthScore: Math.random() * 100,
-      trends: {
-        performance: "declining",
-        efficiency: "stable",
-        reliability: "improving",
-      },
-      alerts: [
-        {
-          type: "warning",
-          message: "Unusual vibration pattern detected",
-          severity: "medium",
-        },
-      ],
-    };
-    
-    res.json(insights);
-  } catch (error) {
-    res.status(500).json({ error: "Failed to fetch maintenance insights" });
-  }
+router.get("/ml/models", (_req, res) => {
+  notImplemented(
+    res,
+    "There is no model registry. The previous handler returned two invented "
+      + "models with fixed accuracy figures and 2024 training dates.",
+  );
 });
 
-// Digital Twin endpoints
-router.post("/digitaltwin/operate", async (req, res) => {
-  try {
-    const { assetId, operation, parameters } = DigitalTwinSchema.parse(req.body);
-    
-    // Mock digital twin operations
-    const result = {
-      assetId,
-      operation,
-      status: "completed",
-      results: {
-        simulation: operation === "simulate" ? "Simulation completed successfully" : undefined,
-        prediction: operation === "predict" ? {
-          outcome: "Expected performance: 95%",
-          confidence: 0.82,
-        } : undefined,
-        optimization: operation === "optimize" ? {
-          recommendations: ["Adjust flow rate to 85%", "Reduce pressure by 5%"],
-          expectedGain: "12% efficiency improvement",
-        } : undefined,
-      },
-    };
-    
-    res.json(result);
-  } catch (error) {
-    res.status(400).json({ error: "Invalid digital twin operation request" });
-  }
-});
-
-router.get("/digitaltwin/status/:assetId", async (req, res) => {
-  try {
-    const { assetId } = req.params;
-    
-    // Mock digital twin status
-    const status = {
-      assetId,
-      twinStatus: "synchronized",
-      lastSync: new Date().toISOString(),
-      accuracy: 94.5,
-      activeSessions: 2,
-    };
-    
-    res.json(status);
-  } catch (error) {
-    res.status(500).json({ error: "Failed to fetch digital twin status" });
-  }
-});
-
-// ML Pipeline endpoints
-router.post("/ml/pipeline", async (req, res) => {
-  try {
-    const { modelId, operation, data } = MLPipelineSchema.parse(req.body);
-    
-    // Mock ML pipeline operations
-    const result = {
-      modelId,
-      operation,
-      status: "completed",
-      jobId: `job-${Date.now()}`,
-      results: {
-        train: operation === "train" ? {
-          accuracy: 0.92,
-          loss: 0.08,
-          epochs: 100,
-        } : undefined,
-        predict: operation === "predict" ? {
-          predictions: data.map((_, i) => ({ index: i, value: Math.random() })),
-        } : undefined,
-        evaluate: operation === "evaluate" ? {
-          metrics: {
-            accuracy: 0.91,
-            precision: 0.88,
-            recall: 0.94,
-            f1Score: 0.91,
-          },
-        } : undefined,
-      },
-    };
-    
-    res.json(result);
-  } catch (error) {
-    res.status(400).json({ error: "Invalid ML pipeline request" });
-  }
-});
-
-router.get("/ml/models", async (req, res) => {
-  try {
-    // Mock ML models list
-    const models = [
-      {
-        id: "pump-efficiency-v1",
-        name: "Pump Efficiency Predictor",
-        status: "trained",
-        accuracy: 0.92,
-        lastTrained: "2024-01-15T10:00:00Z",
-      },
-      {
-        id: "failure-prediction-v2",
-        name: "Failure Prediction Model",
-        status: "training",
-        accuracy: 0.87,
-        lastTrained: "2024-01-10T15:30:00Z",
-      },
-    ];
-    
-    res.json({ models });
-  } catch (error) {
-    res.status(500).json({ error: "Failed to fetch ML models" });
-  }
-});
-
-router.get("/ml/pipeline/status/:jobId", async (req, res) => {
-  try {
-    const { jobId } = req.params;
-    
-    // Mock pipeline status
-    const status = {
-      jobId,
-      status: "completed",
-      progress: 100,
-      startTime: "2024-01-15T10:00:00Z",
-      endTime: "2024-01-15T10:15:00Z",
-    };
-    
-    res.json(status);
-  } catch (error) {
-    res.status(500).json({ error: "Failed to fetch pipeline status" });
-  }
+router.get("/ml/pipeline/status/:jobId", (_req, res) => {
+  notImplemented(
+    res,
+    "There is no pipeline job store. The previous handler reported any job id "
+      + "as completed at 100% with fixed 2024 start and end timestamps, "
+      + "including ids that were never submitted.",
+  );
 });
 
 export { router as intelligenceRoutes };


### PR DESCRIPTION
## Problem

Review on #216 flagged that "the neighbouring `Math.random()` mock endpoints (`/maintenance/analyze`, `/ml/*`) were left alive next to the real APIs."

Reading `server/routes/intelligence.ts` in full, the problem covered **all nine handlers** — every one fabricated its entire response:

| Endpoint | What it returned |
| --- | --- |
| `POST /nlquery` | echoed the query as an "interpretation", `results: []`, two canned suggestions |
| `GET /nlquery/history` | one hardcoded row |
| `POST /maintenance/analyze` | pseudo-random 0..100 `riskScore`, fixed recommendations, fixed `nextFailure: "2024-04-15"` |
| `GET /maintenance/insights/:assetId` | pseudo-random 0..100 `healthScore`, fixed trends, fixed vibration alert |
| `POST /digitaltwin/operate` | `status: "completed"` for everything, fixed "Expected performance: 95%" / "12% efficiency improvement" |
| `GET /digitaltwin/status/:assetId` | fixed `"synchronized"`, `accuracy: 94.5`, `activeSessions: 2` for *any* asset id |
| `POST /ml/pipeline` | pseudo-random `predictions`, fixed accuracy/loss/F1 |
| `GET /ml/models` | two invented models, fixed 2024 training dates |
| `GET /ml/pipeline/status/:jobId` | any job id reported complete at 100%, fixed 2024 timestamps |

The router is mounted at `/api/intelligence` (`server/routes.ts:68`), immediately beside the real `/api/predictive` (#212) and `/api/twin` (#214), and nothing in the response distinguished the two. An operator-facing SCADA surface handing out random "risk" and "health" scores that read as measurements is a safety problem and violates the integrity rule in `CLAUDE.md`.

`client/src/pages/intelligence.tsx` had the same defect independently. It is routed at `client/src/App.tsx:89` but never called an API at all — invented asset risk ratings ("Pump P-101: Medium Risk"), an invented maintenance schedule, and invented twin metrics ("Simulation Accuracy 97.3%", "Optimization Gains +8.2%") were literals in the file, behind a query box and simulation buttons with no handlers.

## Fix

No handler produces data any more. Each returns an explicit, machine-readable refusal on one shared envelope `{ error, detail, reference, replacement? }`:

- **`410 Gone` / `"endpoint_retired"`** — `/maintenance/*` and `/digitaltwin/*`. The capability is implemented, on another router; the body carries the replacement endpoints and the control-plane scopes they require.
- **`501 Not Implemented` / `"not_implemented"`** — `/nlquery`, `/nlquery/history`, `/ml/*`. Nothing on `main` implements these.

**Why refuse rather than delegate.** Every handler on `/api/predictive` and `/api/twin` carries a per-route `requireControlPlaneAccess` check for a specific scope (`predictive.read`, `twin.read`, …); this router carries none. The API gateway does front both — `apiKeyMiddleware` covers all of `/api/` when `ENABLE_API_KEYS` is on (fail-closed in production), and mutations additionally pass `mutationAuthorizationMiddleware` — but the gateway only proves a caller holds *some* valid key. Delegating from here would therefore hand predictive assessments and twin state to any key holder, bypassing the fine-grained scopes the real routers enforce; with API-key auth disabled (the default outside production) it would be an outright unauthenticated read path, since `requireControlPlaneAccess` is what rejects an unkeyed request today. Standing up a second guarded copy would rebuild the two-competing-surfaces problem this change removes.

**Why keep the routes.** `client/src/pages/intelligence.tsx` and the `digital-twin-control` entry in `server/middleware/control-route-policy.ts` still reference these paths. A 410/501 with a pointer is diagnosable; a bare 404 from an unmounted router is not.

**Why `/ml/*` is not wired to `server/services/ml`.** That service is itself a simulation harness — PRNG inference, `setTimeout` "training". Wiring it would relabel the same fabricated numbers rather than remove them, so it stays unexposed over HTTP.

The UI now reports, per capability, what is and is not implemented and names the API that serves it; it renders no numbers because it has none. `control-route-policy.ts` keeps the `digital-twin-control` prefix and `control.write` scope (so the retired path cannot fall back to the broad default `write` policy if a handler is ever remounted); only its description changed, since it claimed the route operates a twin.

## Verification

```
npx tsc --noEmit
  -> exit 0

npx vitest run
  -> Test Files  96 passed | 2 skipped (98)
     Tests  2049 passed | 5 skipped (2054)
  (baseline on main: 95 files / 2024 passing, 2 files + 5 tests skipped
   -> +1 file, +25 tests, no regression, skips unchanged)

grep -rn "Math\.random" server/routes/
  -> one hit: server/routes/__tests__/intelligence-contract.test.ts:284,
     the title of the guard test asserting no route module calls it
```

New: `server/routes/__tests__/intelligence-contract.test.ts` (25 tests). It pins the refusal contract for all nine endpoints, asserts the fabricated field names are absent and that no top-level value is a bare number, and asserts responses are **byte-identical across repeated calls and across different asset ids** — an assertion a pseudo-random payload cannot pass. It mounts `/api/predictive` and `/api/twin` on the same server to prove the real APIs still serve real data (ingest a 40-point series with a terminal spike, get back an assessment whose `value` is that spike) and still return `401` unauthenticated. A source-level guard fails if any module in `server/routes/` reintroduces a PRNG call.

The tests were confirmed to bind the defect: reverting only `server/routes/intelligence.ts` to `origin/main` and re-running the file gives `Tests  16 failed | 9 passed (25)`.

## Caveats

- **Status codes, please confirm.** The issue text asked for 501 everywhere. 501 is used only where nothing is implemented; 410 for `/maintenance/*` and `/digitaltwin/*` where the capability exists elsewhere, following `docs/agent-ready-issues/07-retire-intelligence-mocks.md` ("returns `410 Gone` with a JSON pointer to `/api/predictive` — pick one, document it in the PR"). Both share one envelope, so uniform 501 is a two-line change.
- That doc also lists *delegation* as the first option for `/maintenance/insights/:assetId`. This PR takes the 410 branch instead, for the scope reason above. Delegating safely needs control-plane guards on this router first — its own PR. That checklist item is therefore only partially satisfied.
- **Still fabricating, out of scope:** `server/services/ml/index.ts` is unchanged and still simulates — `Math.random()` at lines 164, 331, 335, 342, 347-348, 352, 355 and `setTimeout` "training" at 161. It is still initialized at boot and health-checked. This PR removes its only HTTP exposure; the service itself needs a follow-up issue.
- `docs/agent-ready-issues/07-retire-intelligence-mocks.md` is now partly stale (it describes these mocks as live). Left unedited for scope discipline.
- The rewritten client page is static — it states the documented contract rather than probing the endpoints, so its copy could drift from the server if the status codes change. The previous page made no API calls either, so this is not a regression.
- Verified on Windows; the 2 skipped files / 5 skipped tests are the pre-existing platform-gated ones (e.g. GOOSE AF_PACKET needs Linux) and are unchanged from baseline.

Refs #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)