### PR TITLE
feat(dnp3): serialise Class 1/2/3 events and execute SELECT/OPERATE controls

### DIFF
--- a/docs/protocols/dnp3-outstation.md
+++ b/docs/protocols/dnp3-outstation.md
@@ -5,28 +5,31 @@ front-end processors running [opendnp3](https://github.com/dnp3/opendnp3)) poll
 0xSCADA over DNP3 (IEEE 1815-2012) as if it were a conventional RTU/outstation.
 Required for the utility-consortium pilots.
 
-> **Status: scaffold-core (substantial-but-partial).** The protocol's testable
-> cores — point mapping, status flags, Class 0/1/2/3 event buffering, the
-> unsolicited trigger, Secure Authentication v5 HMAC, link CRC, and transport
-> segmentation — are **fully implemented and unit-tested**. The full
-> link/transport/application framing on a live socket is wired but several
-> framing details are explicit TODOs (see "Implemented vs TODO" below). This is
-> intentional for the tier: the network glue is hardware/conformance-gated and
-> verified centrally, not faked here.
+> **Status: working outstation for reads, events and controls.** A master can
+> run an integrity poll (Class 0), poll Class 1/2/3 and receive **real
+> timestamped event objects**, confirm them, and issue **SELECT/OPERATE or
+> DIRECT-OPERATE** controls that reach live tag state — provided controls are
+> explicitly enabled (they are off by default; see
+> [Controls](#controls-select--operate--direct-operate)). Some framing details
+> remain explicit TODOs (see "Implemented vs TODO" below), and the outstation is
+> **not started by server startup** — see
+> [Not wired into startup](#not-wired-into-server-startup).
 
 ## Module layout
 
 ```
 server/protocols/dnp3-outstation/
   index.ts          TCP outstation server (default port 20000) + pure request handler
-  app-objects.ts    DNP3 object groups/variations, status-flag (quality) octets, IIN, encoders
+  app-objects.ts    DNP3 object groups/variations, status-flag (quality) octets, IIN, encoders, DNP3 time
   point-map.ts      tag -> DNP3 point mapping for all 5 static groups (+ flags, scaling, deadband)
   event-buffer.ts   Class 0/1/2/3 event buffering, overflow, unsolicited-trigger evaluation
+  event-objects.ts  event object serialisation: g2/g11/g22/g32/g42 (+ g51 CTO), qualifiers 0x17/0x28
+  controls.ts       g12v1 CROB + g41v1..v4 analog output: codecs and the select-before-operate machine
   secure-auth.ts    Secure Authentication v5 — HMAC challenge/response state machine
   link-layer.ts     DNP3 data-link framing + CRC-DNP (poly 0x3D65)
   transport.ts      transport function segmentation / reassembly (FIR/FIN/SEQ)
-  app-layer.ts      APDU parse + response/object-header assembly + Class-0 reader
-  __tests__/        unit tests for every core above
+  app-layer.ts      APDU parse (incl. index-prefixed qualifiers) + object-header assembly + Class-0 reader
+  __tests__/        unit tests for every core above, incl. golden byte vectors
 ```
 
 ## DNP3 layer model — Implemented vs TODO
@@ -42,13 +45,17 @@ DNP3 is a four-layer stack. Here is exactly what is real today.
 | **Transport** | FIR/FIN/SEQ segmentation + reassembly | **fully implemented + tested** |
 | **Application** | request header parse (FIR/FIN/CON/UNS/SEQ + func) | implemented |
 | | object-header scan (qualifiers 0x00/0x01/0x06/0x07/0x08) | implemented |
-| | prefixed-index qualifiers (0x17/0x28) length decode | **TODO** |
+| | prefixed-index qualifiers (0x17/0x28) length decode | **implemented + tested** (for objects of known fixed size, which covers all control objects) |
+| | free-format qualifier 0x5B (group-120 objects) | **TODO** — SAv5 objects use the simple count-1 header this module also emits |
 | | response header + IIN | **fully implemented + tested** |
-| | Class 0 static read (BI/AI/Counter/BO/AO + flags) | **fully implemented + tested** |
-| | Class 1/2/3 event read | buffer + IIN/report-state implemented; per-variation **timestamped event object encoder is a TODO** (g2v2 / g22v1 / g32v1) |
-| | SELECT/OPERATE CROB execution + arm/disarm timing | **TODO** |
+| | Class 0 static read (BI/AI/Counter/BO/AO + flags) | **fully implemented + tested**, split into fragment-sized object blocks, non-contiguous indices and 16-bit ranges handled |
+| | Class 1/2/3 event read | **fully implemented + tested** — g2v1/v2/v3, g11v1/v2, g22v1/v5, g32v1/v3/v5/v7, g42, with g51v1 CTO for relative time |
+| | multi-fragment responses (FIR/FIN/CON + per-fragment CONFIRM) | **implemented + tested** |
+| | SELECT/OPERATE/DIRECT-OPERATE (g12v1, g41v1..v4) | **implemented + tested**, fail-closed and off by default |
 | | WRITE g80v1 (clear DEVICE_RESTART IIN) | **TODO** |
+| | per-variation read selection (master asks for a variation, not a class) | **TODO** |
 | **Secure Auth v5** | HMAC over critical ASDU (challenge/response) | **fully implemented + tested** |
+| | dispatch of the ASDU once its reply verifies | **implemented + tested** |
 | | session-key wrap (g120v6), aggressive mode, key-change | **TODO** (Update Key used directly today) |
 
 ## Point mapping
@@ -116,6 +123,142 @@ outstation.updateTag('tank.level', { value: 12.4, quality: 'good', timestamp: Da
   (or `unsolicitedEnabled: true` at construction). The decision logic is pure
   and unit-tested (`event-buffer.test.ts`).
 
+### Event object encoding
+
+Events are serialised by `event-objects.ts` into index-prefixed object headers —
+qualifier `0x17` (1-octet index prefix + 1-octet count) while every index in the
+run is ≤ 255, otherwise `0x28` (2-octet prefix + 2-octet count). Consecutive
+events sharing a group/variation share one header; a change of group starts a
+new one, so chronological order is preserved across headers.
+
+| Point type | Group | No time | Absolute time | Relative time |
+|-----------|-------|---------|---------------|---------------|
+| Binary Input | 2 | v1 | v2 | v3 (+ g51v1 CTO) |
+| Binary Output | 11 | v1 | v2 | — |
+| Counter | 22 | v1 | v5 | — |
+| Analog Input (int32) | 32 | v1 | v3 | — |
+| Analog Input (float32) | 32 | v5 | v7 | — |
+| Analog Output | 42 | v1 / v5 | v3 / v7 | — |
+
+The numeric width is **not** configurable: it follows the point's own
+`encoding`, so an event never truncates a value the static read reports at full
+precision. The time representation is chosen per event type with
+`eventVariations` (default: absolute time everywhere):
+
+```ts
+createDnp3Outstation({
+  eventVariations: { binary: 'absolute-time', counter: 'absolute-time', analog: 'absolute-time' },
+});
+```
+
+Absolute timestamps are the 6-octet little-endian DNP3 Time (48-bit ms since the
+Unix epoch). Relative-time binary events (`g2v3`) are only legal after a Common
+Time Of Occurrence object, so a `g51v1` CTO is emitted immediately before each
+relative run and a fresh CTO is started whenever the 16-bit offset would
+overflow. Group 11 (Binary Output Event) has no relative-time variation in IEEE
+1815 — only `v1` and `v2` — so a `relative-time` policy degrades to `g11v2` for
+binary *output* events while binary *inputs* still use `g2v3`.
+
+### Fragmentation and confirmation
+
+Responses respect `maxTxFragmentSize` (default 2048, the IEEE 1815 maximum).
+Static object blocks are emitted first, then events; when they do not fit, the
+response is split. Non-final fragments and any fragment carrying events set the
+`CON` bit, and the outstation holds the remaining fragments until the master's
+application `CONFIRM` arrives.
+
+**Events are removed from the buffer only on CONFIRM**, never on send. A
+reported-but-unconfirmed event stays buffered, stops driving the unsolicited
+trigger (so a master that never confirms cannot cause an unsolicited storm), and
+is re-sent on the next Class poll.
+
+## Controls (SELECT / OPERATE / DIRECT-OPERATE)
+
+Supported command objects: **g12v1** Control Relay Output Block (→
+`binaryOutput` points) and **g41v1..v4** Analog Output Block (→ `analogOutput`
+points, 32/16-bit integer and single/double float).
+
+> ### The write path is fail-closed and OFF by default
+>
+> A DNP3 control is the highest-privilege operation this codebase exposes. Two
+> independent things must **both** be true before an octet reaches tag state:
+>
+> 1. `controls.enabled` is explicitly `true` (default `false`), **and**
+> 2. a control sink has been installed with `setControlSink()`.
+>
+> If either is missing the outstation is read-only and echoes every control
+> object with CommandStatus `NOT_SUPPORTED` (4). It never silently accepts, and
+> never reports `SUCCESS` for something it did not perform.
+
+```ts
+const outstation = createDnp3Outstation({
+  controls: { enabled: true, selectTimeoutMs: 5000 },
+  pointMap: { points: [{ tagId: 'valve.cmd', type: 'binaryOutput', index: 0 }] },
+});
+
+// The sink is the seam to the tag store. It is synchronous because DNP3 needs a
+// CommandStatus in the response: a sink talking to slow hardware must enqueue
+// the write and answer for the enqueue.
+outstation.setControlSink((command) => {
+  // `command.tagId` was resolved through the point map — e.g. 'valve.cmd'.
+  // `yourTagWriter` stands in for whatever the deployment uses; this module
+  // deliberately ships no default sink, so there is nothing to write through
+  // until one is supplied.
+  return yourTagWriter.enqueue(command.tagId, command.value)
+    ? { ok: true }
+    : { ok: false, status: DNP3_COMMAND_STATUS.HARDWARE_ERROR };
+});
+```
+
+The outstation deliberately does **not** update its own Binary/Analog Output
+Status points when a control succeeds. Doing so would report a state it has not
+observed. The real value must come back through `updateTag()` from the tag
+layer, exactly like any other measurement.
+
+### Select-before-operate
+
+A `SELECT` validates and arms a specific point+value set for
+`selectTimeoutMs`; it never touches the process. The following `OPERATE` must
+reproduce the armed objects exactly **and** carry an application sequence number
+one greater than the SELECT's (IEEE 1815 §4.4.2.1). The arm is single-use: it is
+consumed whatever the outcome, so a rejected OPERATE cannot be replayed.
+
+| Situation | CommandStatus |
+|-----------|---------------|
+| Control executed | `SUCCESS` (0) |
+| Armed selection expired (matching objects) | `TIMEOUT` (1) |
+| No arm, wrong objects, or wrong sequence number | `NO_SELECT` (2) |
+| Malformed object body | `FORMAT_ERROR` (3) |
+| Controls disabled / no sink / unmapped point / unsupported op type | `NOT_SUPPORTED` (4) |
+| Pulse still running on that output | `ALREADY_ACTIVE` (5) |
+| Sink threw, or refused without a status | `HARDWARE_ERROR` (6) |
+
+A CROB `count` of 0 is a spec-defined no-op: the outstation answers `SUCCESS`
+and does **not** call the sink. The deprecated queue bit and the clear bit are
+refused with `NOT_SUPPORTED` rather than being silently ignored.
+
+## Not wired into server startup
+
+`createDnp3Outstation()` does not listen; only an explicit `start()` does, and
+nothing in `server/` calls it. Exposing the outstation on a network interface is
+deliberately a separate change: it needs its own network-policy review because
+any master that can reach the port can drive the control path. Until then this
+module is a library that a deployment must opt into.
+
+## Known limitations
+
+- **One master association.** Application-confirm state is per connection, but
+  the event buffer is shared, so with two masters connected at once the first
+  CONFIRM drains events for both. DNP3 outstations conventionally serve a single
+  master.
+- Unconfirmed events are re-sent on the next Class poll, but there is no
+  independent retry timer.
+- The secondary link-confirm / frame-count-bit (FCB) state machine is not
+  implemented.
+- `WRITE g80v1` (the master clearing `DEVICE_RESTART`) is not handled, so that
+  IIN bit stays set for the lifetime of the process.
+- TCP only; DNP3 serial is a separate task.
+
 ## Secure Authentication v5
 
 Critical function codes (SELECT, OPERATE, DIRECT_OPERATE, WRITE, restarts,
@@ -161,16 +304,19 @@ opendnp3 available; do not treat it as executed.
 4. **Integrity poll (Class 0):** master issues `READ g60v1` → expect a RESPONSE
    (func 0x81) carrying g1/g30/g20/g10/g40 static objects with flags.
 5. **Event poll (Class 1/2/3):** push a tag change via `updateTag`, then have
-   the master `READ g60v2/v3/v4`. (Per-variation timestamped event objects are
-   the TODO above; the IIN class-event bits + buffer drain are verifiable now.)
+   the master `READ g60v2/v3/v4` → expect timestamped g2/g22/g32 objects and the
+   matching class-event IIN bit, cleared after the master's CONFIRM.
 6. **Unsolicited:** enable unsolicited on the master, breach a class threshold,
    confirm the master receives a func-0x82 fragment.
 7. **Secure auth:** provision a matching Update Key on both ends, send an
    OPERATE, confirm the g120v1 challenge / g120v2 reply handshake succeeds.
+8. **Controls:** with `controls.enabled` and a sink installed, SELECT then
+   OPERATE a CROB and confirm the echoed status octet is 0 (SUCCESS); repeat
+   with controls disabled and confirm it is 4 (NOT_SUPPORTED).
 
 ### Local equivalent (no opendnp3)
 
-The pure cores are exhaustively covered by `npm run test:unit`:
+The protocol logic is covered by `npm run test:unit`:
 
 ```bash
 npx vitest run server/protocols/dnp3-outstation
@@ -180,6 +326,23 @@ These verify CRC against the canonical DNP3 vector, link frame round-trips,
 transport segmentation, Class 0/1/2/3 buffering + unsolicited triggers, point
 serialisation with flags, and the full SAv5 HMAC challenge/response including
 adversarial rejection paths.
+
+Added for the event/control work, with **golden byte vectors derived by hand
+from IEEE 1815** and annotated octet by octet:
+
+- `event-objects.test.ts` — exact octets for g2v1/v2/v3 (incl. the g51v1 CTO and
+  16-bit offset roll), g22v1/v5, g32v1/v3/v7, qualifier 0x17 vs 0x28, and the
+  byte-budget cut-off.
+- `class-read.test.ts` — full response fragments for empty, populated and
+  mixed-class polls; the three-fragment split with FIR/FIN/CON and sequence
+  numbering; and the rule that events leave the buffer only on CONFIRM.
+- `controls.test.ts` — decode of real master CROB/analog-output requests, the
+  select→operate happy path, and the rejection paths (no select, select
+  timeout, mismatched operate, wrong sequence number, controls disabled, no
+  sink, unmapped point, truncated object).
+- `outstation.test.ts` — fail-closed defaults, the SAv5 challenge→verify→execute
+  round trip, and a **live localhost TCP round trip** in which a real master
+  frame produces real g2v2 event octets on the wire.
 
 ## References
 

--- a/server/protocols/dnp3-outstation/__tests__/app-layer.test.ts
+++ b/server/protocols/dnp3-outstation/__tests__/app-layer.test.ts
@@ -14,7 +14,7 @@ import {
 import { Dnp3PointMap } from '../point-map';
 import { Dnp3EventBuffer, DEFAULT_EVENT_BUFFER_CONFIG } from '../event-buffer';
 import { Sav5Outstation } from '../secure-auth';
-import { handleApplicationRequest, type OutstationContext } from '../index';
+import { createOutstationContext, handleApplicationRequest, type OutstationContext } from '../index';
 import { DNP3_FUNCTION, DNP3_GROUP, DNP3_VARIATION, DNP3_IIN } from '../app-objects';
 
 function readClass0Fragment(): Buffer {
@@ -112,13 +112,13 @@ describe('handleApplicationRequest (pure)', () => {
     pointMap.applyTagUpdate('ai0', { value: 42, quality: 'good', timestamp: 1 });
     const secureAuth = new Sav5Outstation();
     if (withKey) secureAuth.setUpdateKey(1, Buffer.alloc(16, 0x11));
-    return {
+    return createOutstationContext({
       pointMap,
       eventBuffer: new Dnp3EventBuffer(DEFAULT_EVENT_BUFFER_CONFIG),
       secureAuth,
       restartPending: false,
       unsolicitedEnabled: false,
-    };
+    });
   }
 
   test('class 0 read returns a response with static data', () => {

--- a/server/protocols/dnp3-outstation/__tests__/class-read.test.ts
+++ b/server/protocols/dnp3-outstation/__tests__/class-read.test.ts
@@ -1,0 +1,357 @@
+/**
+ * End-to-end Class 0/1/2/3 read tests through the pure application handler (#464).
+ *
+ * These assert the bytes a master would actually receive: the application
+ * header (FIR/FIN/CON/sequence + IIN) plus the serialised event objects, the
+ * multi-fragment split, and the rule that events only leave the buffer on an
+ * application CONFIRM.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  createOutstationContext,
+  handleApplicationRequest,
+  type OutstationContext,
+} from '../index';
+import { parseRequest, APP_CTRL_CON, APP_CTRL_FIR, APP_CTRL_FIN } from '../app-layer';
+import { Dnp3PointMap } from '../point-map';
+import { Dnp3EventBuffer, type EventClass } from '../event-buffer';
+import { DNP3_FUNCTION, DNP3_GROUP, DNP3_IIN, DNP3_VARIATION, DNP3_FLAG } from '../app-objects';
+
+const T0 = 0xabcdef;
+
+/** READ g60 for the given classes, with qualifier 0x06 (all objects). */
+function readClasses(seq: number, ...classes: (0 | 1 | 2 | 3)[]): ReturnType<typeof parseRequest> {
+  const variationOf = { 0: DNP3_VARIATION.CLASS0, 1: DNP3_VARIATION.CLASS1, 2: DNP3_VARIATION.CLASS2, 3: DNP3_VARIATION.CLASS3 };
+  const bytes = [0xc0 | (seq & 0x0f), DNP3_FUNCTION.READ];
+  for (const cls of classes) bytes.push(DNP3_GROUP.CLASS_DATA, variationOf[cls], 0x06);
+  return parseRequest(Buffer.from(bytes));
+}
+
+/** An application CONFIRM (function 0x00) for a given sequence number. */
+function confirm(seq: number): ReturnType<typeof parseRequest> {
+  return parseRequest(Buffer.from([0xc0 | (seq & 0x0f), DNP3_FUNCTION.CONFIRM]));
+}
+
+function makeCtx(opts?: { maxTxFragmentSize?: number }): OutstationContext {
+  const pointMap = new Dnp3PointMap({
+    points: [
+      { tagId: 'bi3', type: 'binaryInput', index: 3, eventClass: 1 },
+      { tagId: 'bi7', type: 'binaryInput', index: 7, eventClass: 1 },
+      { tagId: 'c0', type: 'counter', index: 0, eventClass: 2 },
+      { tagId: 'ai1', type: 'analogInput', index: 1, eventClass: 3, encoding: 'int32' },
+    ],
+  });
+  return createOutstationContext({
+    pointMap,
+    eventBuffer: new Dnp3EventBuffer(),
+    maxTxFragmentSize: opts?.maxTxFragmentSize,
+  });
+}
+
+function pushBinaryEvent(ctx: OutstationContext, index: number, on: boolean, timestamp: number, cls: EventClass = 1): number {
+  return ctx.eventBuffer.enqueue({
+    pointType: 'binaryInput',
+    index,
+    eventClass: cls,
+    value: on,
+    flags: on ? DNP3_FLAG.ONLINE | DNP3_FLAG.STATE : DNP3_FLAG.ONLINE,
+    timestamp,
+  });
+}
+
+describe('Class 1/2/3 read with an empty buffer', () => {
+  test('returns a bare 4-octet header with no class-event IIN bits and no CON', () => {
+    const ctx = makeCtx();
+    const { response, fragments } = handleApplicationRequest(ctx, readClasses(1, 1, 2, 3));
+    expect(fragments).toHaveLength(1);
+    expect([...response]).toEqual([
+      0xc1, // FIR|FIN, no CON, sequence 1
+      0x81, // RESPONSE
+      0x00, 0x00, // IIN: nothing pending
+    ]);
+    expect(fragments[0].con).toBe(false);
+    expect(fragments[0].eventSeqs).toEqual([]);
+  });
+});
+
+describe('Class 1 read with buffered events — golden vector', () => {
+  test('serialises g2v2 objects into the response and sets CON + the class-1 IIN bit', () => {
+    const ctx = makeCtx();
+    pushBinaryEvent(ctx, 3, true, T0);
+    pushBinaryEvent(ctx, 7, false, T0 + 6);
+
+    const { response, fragments } = handleApplicationRequest(ctx, readClasses(0, 1));
+    expect([...response]).toEqual([
+      // ── application header ──
+      0xe0, // FIR|FIN|CON, sequence 0
+      0x81, // RESPONSE
+      0x00, 0x02, // IIN little-endian: 0x0200 = CLASS1_EVENTS
+      // ── g2v2 events, qualifier 0x17, count 2 ──
+      0x02, 0x02, 0x17, 0x02,
+      0x03, 0x81, 0xef, 0xcd, 0xab, 0x00, 0x00, 0x00,
+      0x07, 0x01, 0xf5, 0xcd, 0xab, 0x00, 0x00, 0x00,
+    ]);
+    expect(response.readUInt16LE(2) & DNP3_IIN.CLASS1_EVENTS).toBe(DNP3_IIN.CLASS1_EVENTS);
+    expect(fragments[0].con).toBe(true);
+    expect(fragments[0].eventSeqs).toEqual([1, 2]);
+  });
+
+  test('reading class 1 does not drain class 2 or 3', () => {
+    const ctx = makeCtx();
+    pushBinaryEvent(ctx, 3, true, T0, 1);
+    ctx.eventBuffer.enqueue({ pointType: 'counter', index: 0, eventClass: 2, value: 5, flags: 0x01, timestamp: T0 });
+
+    const { fragments } = handleApplicationRequest(ctx, readClasses(0, 1));
+    expect(fragments[0].eventSeqs).toEqual([1]);
+    expect(ctx.eventBuffer.classSize(2)).toBe(1);
+  });
+});
+
+describe('mixed-class reads', () => {
+  test('a class 1+2+3 read returns all three groups in chronological order', () => {
+    const ctx = makeCtx();
+    pushBinaryEvent(ctx, 3, true, T0, 1);
+    ctx.eventBuffer.enqueue({ pointType: 'counter', index: 0, eventClass: 2, value: 0x12345678, flags: 0x01, timestamp: T0 });
+    ctx.eventBuffer.enqueue({ pointType: 'analogInput', index: 1, eventClass: 3, value: -2, flags: 0x01, timestamp: T0 });
+
+    const { response, fragments } = handleApplicationRequest(ctx, readClasses(2, 1, 2, 3));
+    expect(fragments[0].eventSeqs).toEqual([1, 2, 3]);
+    expect([...response]).toEqual([
+      0xe2, 0x81, 0x00, 0x0e, // FIR|FIN|CON seq 2; IIN 0x0E00 = CLASS1|CLASS2|CLASS3
+      0x02, 0x02, 0x17, 0x01, 0x03, 0x81, 0xef, 0xcd, 0xab, 0x00, 0x00, 0x00, // g2v2
+      0x16, 0x05, 0x17, 0x01, 0x00, 0x01, 0x78, 0x56, 0x34, 0x12, 0xef, 0xcd, 0xab, 0x00, 0x00, 0x00, // g22v5
+      0x20, 0x03, 0x17, 0x01, 0x01, 0x01, 0xfe, 0xff, 0xff, 0xff, 0xef, 0xcd, 0xab, 0x00, 0x00, 0x00, // g32v3
+    ]);
+  });
+
+  test('a class 0+1 read puts static objects first, then events', () => {
+    const ctx = makeCtx();
+    ctx.pointMap.applyTagUpdate('bi3', { value: true, quality: 'good', timestamp: T0 });
+    pushBinaryEvent(ctx, 3, true, T0);
+
+    const { response } = handleApplicationRequest(ctx, readClasses(0, 0, 1));
+    // Static block for the binary inputs (group 1) comes before the g2 events.
+    const staticStart = 4;
+    expect(response[staticStart]).toBe(DNP3_GROUP.BINARY_INPUT_STATIC);
+    expect(response.indexOf(Buffer.from([0x02, 0x02, 0x17]))).toBeGreaterThan(staticStart);
+  });
+
+  test('a read with no recognised class object falls back to all static data', () => {
+    const ctx = makeCtx();
+    ctx.pointMap.applyTagUpdate('bi3', { value: true, quality: 'good', timestamp: T0 });
+    const { response } = handleApplicationRequest(ctx, parseRequest(Buffer.from([0xc0, DNP3_FUNCTION.READ])));
+    expect(response[4]).toBe(DNP3_GROUP.BINARY_INPUT_STATIC);
+  });
+});
+
+describe('response fragmentation', () => {
+  /**
+   * g2v2 costs 4 header octets + 8 per event, and the application header is 4,
+   * so a 24-octet fragment budget leaves 20 octets of objects = exactly two
+   * events per fragment.
+   */
+  test('five events split into three fragments with correct FIR/FIN/CON and sequences', () => {
+    const ctx = makeCtx({ maxTxFragmentSize: 24 });
+    for (let i = 0; i < 5; i++) pushBinaryEvent(ctx, 3, true, T0 + i);
+
+    const { fragments, response } = handleApplicationRequest(ctx, readClasses(5, 1));
+    expect(fragments).toHaveLength(3);
+    expect(fragments.map((f) => f.eventSeqs)).toEqual([[1, 2], [3, 4], [5]]);
+    expect(fragments.map((f) => f.seq)).toEqual([5, 6, 7]);
+    expect(fragments.every((f) => f.bytes.length <= 24)).toBe(true);
+
+    // First: FIR set, FIN clear, CON set. Middle: neither FIR nor FIN. Last: FIN.
+    expect(fragments[0].bytes[0] & APP_CTRL_FIR).toBe(APP_CTRL_FIR);
+    expect(fragments[0].bytes[0] & APP_CTRL_FIN).toBe(0);
+    expect(fragments[1].bytes[0] & APP_CTRL_FIR).toBe(0);
+    expect(fragments[1].bytes[0] & APP_CTRL_FIN).toBe(0);
+    expect(fragments[2].bytes[0] & APP_CTRL_FIN).toBe(APP_CTRL_FIN);
+    expect(fragments.every((f) => (f.bytes[0] & APP_CTRL_CON) === APP_CTRL_CON)).toBe(true);
+
+    // Only the first fragment is transmitted immediately.
+    expect(response.equals(fragments[0].bytes)).toBe(true);
+  });
+
+  test('the master walks the fragments with CONFIRMs, and each confirm drains its own events', () => {
+    const ctx = makeCtx({ maxTxFragmentSize: 24 });
+    for (let i = 0; i < 5; i++) pushBinaryEvent(ctx, 3, true, T0 + i);
+    const { fragments } = handleApplicationRequest(ctx, readClasses(5, 1));
+    expect(ctx.eventBuffer.classSize(1)).toBe(5);
+
+    const second = handleApplicationRequest(ctx, confirm(5));
+    expect(second.response.equals(fragments[1].bytes)).toBe(true);
+    expect(ctx.eventBuffer.classSize(1)).toBe(3); // first two confirmed
+
+    const third = handleApplicationRequest(ctx, confirm(6));
+    expect(third.response.equals(fragments[2].bytes)).toBe(true);
+    expect(ctx.eventBuffer.classSize(1)).toBe(1);
+
+    const done = handleApplicationRequest(ctx, confirm(7));
+    expect(done.response.length).toBe(0);
+    expect(ctx.eventBuffer.classSize(1)).toBe(0);
+  });
+
+  test('a fragment budget too small for one event object withholds events instead of looping', () => {
+    // 4 header + 4 object header + 8 per event = 16 minimum; 12 cannot fit one.
+    const ctx = makeCtx({ maxTxFragmentSize: 12 });
+    pushBinaryEvent(ctx, 3, true, T0);
+    const { fragments } = handleApplicationRequest(ctx, readClasses(0, 1));
+    expect(fragments).toHaveLength(1);
+    expect(fragments[0].eventSeqs).toEqual([]);
+    expect(fragments[0].bytes.length).toBe(4);
+    expect(ctx.eventBuffer.classSize(1)).toBe(1); // still buffered, nothing lost
+  });
+});
+
+describe('confirm semantics', () => {
+  test('events survive the read and are removed only by a matching CONFIRM', () => {
+    const ctx = makeCtx();
+    pushBinaryEvent(ctx, 3, true, T0);
+    pushBinaryEvent(ctx, 7, false, T0 + 6);
+
+    handleApplicationRequest(ctx, readClasses(4, 1));
+    expect(ctx.eventBuffer.classSize(1)).toBe(2); // sent, not yet confirmed
+
+    handleApplicationRequest(ctx, confirm(4));
+    expect(ctx.eventBuffer.classSize(1)).toBe(0);
+  });
+
+  test('a CONFIRM with the wrong sequence number drops nothing', () => {
+    const ctx = makeCtx();
+    pushBinaryEvent(ctx, 3, true, T0);
+    handleApplicationRequest(ctx, readClasses(4, 1));
+    const stray = handleApplicationRequest(ctx, confirm(9));
+    expect(stray.response.length).toBe(0);
+    expect(ctx.eventBuffer.classSize(1)).toBe(1); // the event is still buffered
+  });
+
+  test('an unconfirmed event is re-sent on the next poll', () => {
+    const ctx = makeCtx();
+    pushBinaryEvent(ctx, 3, true, T0);
+    const first = handleApplicationRequest(ctx, readClasses(1, 1));
+    const second = handleApplicationRequest(ctx, readClasses(2, 1));
+    // Same objects, different sequence number in the header.
+    expect([...first.response.subarray(4)]).toEqual([...second.response.subarray(4)]);
+    expect(second.fragments[0].eventSeqs).toEqual([1]);
+  });
+
+  test('a new request abandons an outstanding unconfirmed response', () => {
+    const ctx = makeCtx({ maxTxFragmentSize: 24 });
+    for (let i = 0; i < 5; i++) pushBinaryEvent(ctx, 3, true, T0 + i);
+    handleApplicationRequest(ctx, readClasses(5, 1));
+    expect(ctx.session.pendingFragments.length).toBe(2);
+
+    // Any new request cancels it — here an (empty) class 2 poll.
+    handleApplicationRequest(ctx, readClasses(8, 2));
+    expect(ctx.session.pendingFragments.length).toBe(0);
+    expect(ctx.session.awaitingConfirm).toBeNull();
+    // A now-stale CONFIRM must not drop anything.
+    handleApplicationRequest(ctx, confirm(5));
+    expect(ctx.eventBuffer.classSize(1)).toBe(5);
+  });
+
+  test('a CONFIRM with nothing outstanding is silently ignored', () => {
+    const ctx = makeCtx();
+    const result = handleApplicationRequest(ctx, confirm(3));
+    expect(result.response.length).toBe(0);
+    expect(result.fragments).toEqual([]);
+  });
+});
+
+describe('IIN reporting', () => {
+  test('event-buffer overflow raises the EVENT_BUFFER_OVERFLOW bit', () => {
+    const ctx = createOutstationContext({
+      pointMap: new Dnp3PointMap({ points: [{ tagId: 'bi3', type: 'binaryInput', index: 3, eventClass: 1 }] }),
+      eventBuffer: new Dnp3EventBuffer({
+        class1: { maxEvents: 2, unsolicitedThreshold: 0 },
+        class2: { maxEvents: 2, unsolicitedThreshold: 0 },
+        class3: { maxEvents: 2, unsolicitedThreshold: 0 },
+        unsolicitedMaxDelayMs: 0,
+      }),
+    });
+    for (let i = 0; i < 3; i++) pushBinaryEvent(ctx, 3, true, T0 + i);
+
+    const { response } = handleApplicationRequest(ctx, readClasses(0, 1));
+    const iin = response.readUInt16LE(2);
+    expect(iin & DNP3_IIN.EVENT_BUFFER_OVERFLOW).toBe(DNP3_IIN.EVENT_BUFFER_OVERFLOW);
+    expect(iin & DNP3_IIN.CLASS1_EVENTS).toBe(DNP3_IIN.CLASS1_EVENTS);
+  });
+
+  test('the class-event bit stays set until the events are confirmed', () => {
+    const ctx = makeCtx();
+    pushBinaryEvent(ctx, 3, true, T0);
+    const first = handleApplicationRequest(ctx, readClasses(0, 1));
+    expect(first.response.readUInt16LE(2) & DNP3_IIN.CLASS1_EVENTS).toBe(DNP3_IIN.CLASS1_EVENTS);
+
+    handleApplicationRequest(ctx, confirm(0));
+    const after = handleApplicationRequest(ctx, readClasses(1, 1));
+    expect(after.response.readUInt16LE(2) & DNP3_IIN.CLASS1_EVENTS).toBe(0);
+  });
+});
+
+describe('static reads split into fragment-sized blocks', () => {
+  test('a large point map produces multiple object headers and fragments', () => {
+    const points = Array.from({ length: 40 }, (_, i) => ({
+      tagId: `ai${i}`,
+      type: 'analogInput' as const,
+      index: i,
+      encoding: 'int32' as const,
+    }));
+    const ctx = createOutstationContext({
+      pointMap: new Dnp3PointMap({ points }),
+      maxTxFragmentSize: 64,
+    });
+    const { fragments } = handleApplicationRequest(ctx, readClasses(0, 0));
+    expect(fragments.length).toBeGreaterThan(1);
+    expect(fragments.every((f) => f.bytes.length <= 64)).toBe(true);
+    // Each fragment starts with a well-formed g30v1 object header.
+    for (const f of fragments) {
+      expect(f.bytes[4]).toBe(DNP3_GROUP.ANALOG_INPUT_STATIC);
+      expect(f.bytes[5]).toBe(DNP3_VARIATION.AI_32_WITH_FLAG);
+      expect(f.bytes[6]).toBe(0x00); // qualifier: 8-bit start/stop range
+    }
+    // Every point appears exactly once across the fragments.
+    const totalPoints = fragments.reduce((sum, f) => {
+      let n = 0;
+      for (let off = 4; off + 5 <= f.bytes.length; ) {
+        const start = f.bytes[off + 3];
+        const stop = f.bytes[off + 4];
+        n += stop - start + 1;
+        off += 5 + (stop - start + 1) * 5;
+      }
+      return sum + n;
+    }, 0);
+    expect(totalPoints).toBe(40);
+  });
+
+  test('non-contiguous indices get their own object header instead of a bogus range', () => {
+    const ctx = createOutstationContext({
+      pointMap: new Dnp3PointMap({
+        points: [
+          { tagId: 'a', type: 'binaryInput', index: 0 },
+          { tagId: 'b', type: 'binaryInput', index: 1 },
+          { tagId: 'c', type: 'binaryInput', index: 9 },
+        ],
+      }),
+    });
+    const { response } = handleApplicationRequest(ctx, readClasses(0, 0));
+    expect([...response.subarray(4)]).toEqual([
+      0x01, 0x02, 0x00, 0x00, 0x01, // g1v2 range 0..1
+      0x04, 0x04, // two points, quality bad until first sample (COMM_LOST)
+      0x01, 0x02, 0x00, 0x09, 0x09, // g1v2 range 9..9
+      0x04,
+    ]);
+  });
+
+  test('an index above 255 uses the 16-bit range qualifier 0x01', () => {
+    const ctx = createOutstationContext({
+      pointMap: new Dnp3PointMap({ points: [{ tagId: 'far', type: 'binaryInput', index: 300 }] }),
+    });
+    const { response } = handleApplicationRequest(ctx, readClasses(0, 0));
+    expect([...response.subarray(4)]).toEqual([
+      0x01, 0x02, 0x01, // g1v2, qualifier 0x01 (16-bit start/stop)
+      0x2c, 0x01, 0x2c, 0x01, // start 300, stop 300
+      0x04,
+    ]);
+  });
+});

--- a/server/protocols/dnp3-outstation/__tests__/controls.test.ts
+++ b/server/protocols/dnp3-outstation/__tests__/controls.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Tests for DNP3 SELECT / OPERATE / DIRECT-OPERATE (#464).
+ *
+ * Covers the g12v1 CROB and g41 Analog Output Block codecs against hand-derived
+ * byte vectors, the select-before-operate state machine, and — most importantly
+ * — that the write path stays fail-closed unless it is explicitly turned on.
+ */
+import { describe, test, expect, vi } from 'vitest';
+import {
+  Dnp3ControlProcessor,
+  decodeCrob,
+  encodeCrob,
+  decodeAnalogOutput,
+  encodeAnalogOutput,
+  commandObjectSize,
+  crobValue,
+  pulseDurationMs,
+  type CrobFields,
+  type Dnp3ControlCommand,
+  type Dnp3ControlSink,
+} from '../controls';
+import { parseRequest } from '../app-layer';
+import { Dnp3PointMap } from '../point-map';
+import {
+  DNP3_COMMAND_STATUS,
+  DNP3_CONTROL_OP_TYPE,
+  DNP3_CONTROL_TCC,
+  DNP3_FUNCTION,
+  DNP3_IIN,
+} from '../app-objects';
+
+/**
+ * A real master's OPERATE of a CROB, octet by octet:
+ *   C1                FIR|FIN, sequence 1
+ *   04                OPERATE
+ *   0C 01             group 12 variation 1 (CROB)
+ *   17                qualifier: 1-octet index prefix + 1-octet count
+ *   01                count = 1
+ *   00                index prefix = point 0
+ *   41                control code 0b0100_0001 = TCC CLOSE(1), op type PULSE_ON(1)
+ *   01                count = 1 execution
+ *   E8 03 00 00       on-time  = 1000 ms
+ *   D0 07 00 00       off-time = 2000 ms
+ *   00                status octet (always 0 in a request)
+ */
+const OPERATE_CROB = Buffer.from([
+  0xc1, 0x04, 0x0c, 0x01, 0x17, 0x01, 0x00,
+  0x41, 0x01, 0xe8, 0x03, 0x00, 0x00, 0xd0, 0x07, 0x00, 0x00, 0x00,
+]);
+
+/** The same objects under function code 0x03 SELECT, sequence 0. */
+const SELECT_CROB = Buffer.from([
+  0xc0, 0x03, 0x0c, 0x01, 0x17, 0x01, 0x00,
+  0x41, 0x01, 0xe8, 0x03, 0x00, 0x00, 0xd0, 0x07, 0x00, 0x00, 0x00,
+]);
+
+/**
+ * DIRECT_OPERATE of a g41v1 Analog Output Block:
+ *   C2 05          FIR|FIN seq 2, DIRECT_OPERATE
+ *   29 01          group 41 (0x29) variation 1 (32-bit signed)
+ *   17 01 02       qualifier 0x17, count 1, index 2
+ *   E8 03 00 00    value = 1000
+ *   00             status octet
+ */
+const DIRECT_OPERATE_AO = Buffer.from([
+  0xc2, 0x05, 0x29, 0x01, 0x17, 0x01, 0x02, 0xe8, 0x03, 0x00, 0x00, 0x00,
+]);
+
+function makeMap(): Dnp3PointMap {
+  return new Dnp3PointMap({
+    points: [
+      { tagId: 'valve.cmd', type: 'binaryOutput', index: 0 },
+      { tagId: 'pump.cmd', type: 'binaryOutput', index: 1 },
+      { tagId: 'setpoint', type: 'analogOutput', index: 2, encoding: 'int32' },
+    ],
+  });
+}
+
+interface Harness {
+  processor: Dnp3ControlProcessor;
+  calls: Dnp3ControlCommand[];
+}
+
+function harness(opts?: { enabled?: boolean; sink?: Dnp3ControlSink | null; selectTimeoutMs?: number }): Harness {
+  const calls: Dnp3ControlCommand[] = [];
+  const defaultSink: Dnp3ControlSink = (cmd) => {
+    calls.push(cmd);
+    return { ok: true };
+  };
+  const sink = opts?.sink === undefined ? defaultSink : opts.sink;
+  const processor = new Dnp3ControlProcessor(
+    makeMap(),
+    { enabled: opts?.enabled ?? true, selectTimeoutMs: opts?.selectTimeoutMs ?? 5000 },
+    sink,
+  );
+  return { processor, calls };
+}
+
+describe('g12v1 CROB codec', () => {
+  test('decodes the golden OPERATE request', () => {
+    const req = parseRequest(OPERATE_CROB);
+    expect(req.func).toBe(DNP3_FUNCTION.OPERATE);
+    expect(req.seq).toBe(1);
+    expect(req.objects).toHaveLength(1);
+    const header = req.objects[0];
+    expect(header.group).toBe(12);
+    expect(header.variation).toBe(1);
+    expect(header.qualifier).toBe(0x17);
+    expect(header.count).toBe(1);
+    expect(header.items).toHaveLength(1);
+    expect(header.items![0].index).toBe(0);
+
+    const crob = decodeCrob(header.items![0].data);
+    expect(crob).toEqual<CrobFields>({
+      opType: DNP3_CONTROL_OP_TYPE.PULSE_ON,
+      tcc: DNP3_CONTROL_TCC.CLOSE,
+      clear: false,
+      queue: false,
+      count: 1,
+      onTimeMs: 1000,
+      offTimeMs: 2000,
+    });
+  });
+
+  test('re-encodes to the same octets with the status field replaced', () => {
+    const crob = decodeCrob(OPERATE_CROB.subarray(7))!;
+    expect([...encodeCrob(crob, DNP3_COMMAND_STATUS.SUCCESS)]).toEqual([
+      0x41, 0x01, 0xe8, 0x03, 0x00, 0x00, 0xd0, 0x07, 0x00, 0x00, 0x00,
+    ]);
+    expect(encodeCrob(crob, DNP3_COMMAND_STATUS.NOT_SUPPORTED)[10]).toBe(4);
+  });
+
+  test('rejects a body that is not exactly 11 octets', () => {
+    expect(decodeCrob(Buffer.alloc(10))).toBeNull();
+    expect(decodeCrob(Buffer.alloc(12))).toBeNull();
+  });
+
+  test('control code maps to a coil state, with TCC overriding polarity', () => {
+    const base: CrobFields = { opType: 0, tcc: 0, clear: false, queue: false, count: 1, onTimeMs: 0, offTimeMs: 0 };
+    expect(crobValue({ ...base, opType: DNP3_CONTROL_OP_TYPE.LATCH_ON })).toBe(true);
+    expect(crobValue({ ...base, opType: DNP3_CONTROL_OP_TYPE.LATCH_OFF })).toBe(false);
+    expect(crobValue({ ...base, opType: DNP3_CONTROL_OP_TYPE.PULSE_ON })).toBe(true);
+    expect(crobValue({ ...base, opType: DNP3_CONTROL_OP_TYPE.PULSE_OFF })).toBe(false);
+    // TCC selects the physical coil on a paired trip/close output.
+    expect(crobValue({ ...base, opType: DNP3_CONTROL_OP_TYPE.PULSE_ON, tcc: DNP3_CONTROL_TCC.TRIP })).toBe(false);
+    expect(crobValue({ ...base, opType: DNP3_CONTROL_OP_TYPE.PULSE_OFF, tcc: DNP3_CONTROL_TCC.CLOSE })).toBe(true);
+    // NUL and reserved operation types are not executed at all.
+    expect(crobValue({ ...base, opType: DNP3_CONTROL_OP_TYPE.NUL })).toBeNull();
+    expect(crobValue({ ...base, opType: 9 })).toBeNull();
+  });
+
+  test('pulse duration covers the whole train; latches finish immediately', () => {
+    const pulse: CrobFields = {
+      opType: DNP3_CONTROL_OP_TYPE.PULSE_ON, tcc: 0, clear: false, queue: false,
+      count: 3, onTimeMs: 100, offTimeMs: 50,
+    };
+    // 3 on-periods + 2 intervening off-periods.
+    expect(pulseDurationMs(pulse)).toBe(3 * 100 + 2 * 50);
+    expect(pulseDurationMs({ ...pulse, count: 1 })).toBe(100);
+    expect(pulseDurationMs({ ...pulse, count: 0 })).toBe(0);
+    expect(pulseDurationMs({ ...pulse, opType: DNP3_CONTROL_OP_TYPE.LATCH_ON })).toBe(0);
+  });
+});
+
+describe('g41 Analog Output Block codec', () => {
+  test('object sizes per variation', () => {
+    expect(commandObjectSize(12, 1)).toBe(11); // CROB
+    expect(commandObjectSize(41, 1)).toBe(5); // int32 + status
+    expect(commandObjectSize(41, 2)).toBe(3); // int16 + status
+    expect(commandObjectSize(41, 3)).toBe(5); // float32 + status
+    expect(commandObjectSize(41, 4)).toBe(9); // float64 + status
+    expect(commandObjectSize(41, 9)).toBeNull();
+    expect(commandObjectSize(30, 1)).toBeNull();
+  });
+
+  test('decodes the golden DIRECT_OPERATE request', () => {
+    const req = parseRequest(DIRECT_OPERATE_AO);
+    expect(req.func).toBe(DNP3_FUNCTION.DIRECT_OPERATE);
+    const header = req.objects[0];
+    expect([header.group, header.variation, header.qualifier]).toEqual([41, 1, 0x17]);
+    expect(header.items![0].index).toBe(2);
+    expect(decodeAnalogOutput(1, header.items![0].data)).toBe(1000);
+  });
+
+  test('round-trips every supported variation', () => {
+    expect(decodeAnalogOutput(1, encodeAnalogOutput(1, -70000, 0))).toBe(-70000);
+    expect(decodeAnalogOutput(2, encodeAnalogOutput(2, -1234, 0))).toBe(-1234);
+    expect(decodeAnalogOutput(3, encodeAnalogOutput(3, 1.5, 0))).toBeCloseTo(1.5);
+    expect(decodeAnalogOutput(4, encodeAnalogOutput(4, 1e300, 0))).toBe(1e300);
+    expect([...encodeAnalogOutput(1, 1000, DNP3_COMMAND_STATUS.SUCCESS)]).toEqual([0xe8, 0x03, 0x00, 0x00, 0x00]);
+  });
+
+  test('rejects a wrong-length body and an unknown variation', () => {
+    expect(decodeAnalogOutput(1, Buffer.alloc(4))).toBeNull();
+    expect(decodeAnalogOutput(9, Buffer.alloc(5))).toBeNull();
+  });
+});
+
+describe('fail-closed write path', () => {
+  test('controls disabled: every object is rejected with NOT_SUPPORTED and nothing executes', () => {
+    const { processor, calls } = harness({ enabled: false });
+    const result = processor.process(parseRequest(DIRECT_OPERATE_AO), 1000);
+    expect(result.statuses).toEqual([DNP3_COMMAND_STATUS.NOT_SUPPORTED]);
+    expect(calls).toEqual([]);
+    expect(result.executed).toEqual([]);
+    expect(processor.writable).toBe(false);
+    // The echoed object carries the rejection in its status octet.
+    expect([...result.objects]).toEqual([
+      0x29, 0x01, 0x17, 0x01, // g41 v1, qualifier 0x17, count 1
+      0x02, // index 2
+      0xe8, 0x03, 0x00, 0x00, // the value the master asked for, echoed back
+      0x04, // CommandStatus NOT_SUPPORTED
+    ]);
+  });
+
+  test('controls enabled but no sink installed still rejects', () => {
+    const { processor } = harness({ enabled: true, sink: null });
+    expect(processor.writable).toBe(false);
+    const result = processor.process(parseRequest(DIRECT_OPERATE_AO), 1000);
+    expect(result.statuses).toEqual([DNP3_COMMAND_STATUS.NOT_SUPPORTED]);
+  });
+
+  test('a disabled outstation never arms a SELECT', () => {
+    const { processor } = harness({ enabled: false });
+    processor.process(parseRequest(SELECT_CROB), 1000);
+    expect(processor.armedSelect).toBeNull();
+  });
+
+  test('installing a sink later makes the path writable', () => {
+    const { processor } = harness({ enabled: true, sink: null });
+    expect(processor.writable).toBe(false);
+    processor.setSink(() => ({ ok: true }));
+    expect(processor.writable).toBe(true);
+  });
+});
+
+describe('select-before-operate', () => {
+  test('happy path: SELECT arms without executing, OPERATE executes', () => {
+    const { processor, calls } = harness();
+
+    const select = processor.process(parseRequest(SELECT_CROB), 1000);
+    expect(select.statuses).toEqual([DNP3_COMMAND_STATUS.SUCCESS]);
+    expect(calls).toEqual([]); // a SELECT must never touch plant state
+    expect(processor.armedSelect).not.toBeNull();
+
+    const operate = processor.process(parseRequest(OPERATE_CROB), 1500);
+    expect(operate.statuses).toEqual([DNP3_COMMAND_STATUS.SUCCESS]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      kind: 'binaryOutput',
+      index: 0,
+      tagId: 'valve.cmd', // resolved through the point map, not invented
+      value: true,
+    });
+    // The arm is consumed by the OPERATE.
+    expect(processor.armedSelect).toBeNull();
+
+    // Response echoes the request objects with SUCCESS in the status octet.
+    expect([...operate.objects]).toEqual([
+      0x0c, 0x01, 0x17, 0x01, 0x00,
+      0x41, 0x01, 0xe8, 0x03, 0x00, 0x00, 0xd0, 0x07, 0x00, 0x00, 0x00,
+    ]);
+  });
+
+  test('OPERATE without a SELECT is rejected with NO_SELECT', () => {
+    const { processor, calls } = harness();
+    const operate = processor.process(parseRequest(OPERATE_CROB), 1000);
+    expect(operate.statuses).toEqual([DNP3_COMMAND_STATUS.NO_SELECT]);
+    expect(calls).toEqual([]);
+    expect(operate.objects[operate.objects.length - 1]).toBe(DNP3_COMMAND_STATUS.NO_SELECT);
+  });
+
+  test('OPERATE after the select timeout is rejected with TIMEOUT', () => {
+    const { processor, calls } = harness({ selectTimeoutMs: 5000 });
+    processor.process(parseRequest(SELECT_CROB), 1000);
+    const operate = processor.process(parseRequest(OPERATE_CROB), 1000 + 5001);
+    expect(operate.statuses).toEqual([DNP3_COMMAND_STATUS.TIMEOUT]);
+    expect(calls).toEqual([]);
+    // Expiry consumes the arm: a prompt retry must not succeed either.
+    expect(processor.armedSelect).toBeNull();
+    expect(processor.process(parseRequest(OPERATE_CROB), 1000 + 5002).statuses)
+      .toEqual([DNP3_COMMAND_STATUS.NO_SELECT]);
+  });
+
+  test('an OPERATE whose value differs from the SELECT is rejected', () => {
+    const { processor, calls } = harness();
+    processor.process(parseRequest(SELECT_CROB), 1000);
+    // Same point, but LATCH_OFF (0x04) instead of the selected pulse-on/close.
+    const tampered = Buffer.from(OPERATE_CROB);
+    tampered[7] = 0x04;
+    const operate = processor.process(parseRequest(tampered), 1100);
+    expect(operate.statuses).toEqual([DNP3_COMMAND_STATUS.NO_SELECT]);
+    expect(calls).toEqual([]);
+  });
+
+  test('an OPERATE for a different point than the SELECT is rejected', () => {
+    const { processor, calls } = harness();
+    processor.process(parseRequest(SELECT_CROB), 1000);
+    const otherPoint = Buffer.from(OPERATE_CROB);
+    otherPoint[6] = 0x01; // index 1 instead of 0
+    expect(processor.process(parseRequest(otherPoint), 1100).statuses)
+      .toEqual([DNP3_COMMAND_STATUS.NO_SELECT]);
+    expect(calls).toEqual([]);
+  });
+
+  test('an OPERATE whose sequence number is not SELECT+1 is rejected', () => {
+    const { processor, calls } = harness();
+    processor.process(parseRequest(SELECT_CROB), 1000); // seq 0
+    const wrongSeq = Buffer.from(OPERATE_CROB);
+    wrongSeq[0] = 0xc5; // FIR|FIN, sequence 5 instead of 1
+    expect(processor.process(parseRequest(wrongSeq), 1100).statuses)
+      .toEqual([DNP3_COMMAND_STATUS.NO_SELECT]);
+    expect(calls).toEqual([]);
+  });
+
+  test('sequence numbers wrap: SELECT at 15 is matched by OPERATE at 0', () => {
+    const { processor, calls } = harness();
+    const select = Buffer.from(SELECT_CROB);
+    select[0] = 0xcf; // FIR|FIN, sequence 15
+    const operate = Buffer.from(OPERATE_CROB);
+    operate[0] = 0xc0; // FIR|FIN, sequence 0
+    processor.process(parseRequest(select), 1000);
+    expect(processor.process(parseRequest(operate), 1100).statuses)
+      .toEqual([DNP3_COMMAND_STATUS.SUCCESS]);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('DIRECT_OPERATE needs no SELECT and invalidates any armed one', () => {
+    const { processor, calls } = harness();
+    processor.process(parseRequest(SELECT_CROB), 1000);
+    const direct = processor.process(parseRequest(DIRECT_OPERATE_AO), 1100);
+    expect(direct.statuses).toEqual([DNP3_COMMAND_STATUS.SUCCESS]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ kind: 'analogOutput', index: 2, tagId: 'setpoint', value: 1000 });
+    expect(processor.armedSelect).toBeNull();
+  });
+});
+
+describe('control execution outcomes', () => {
+  test('a pulse still running rejects the next OPERATE with ALREADY_ACTIVE', () => {
+    const { processor, calls } = harness();
+    // on-time 1000 ms, count 1 -> busy until t=2000.
+    processor.process(parseRequest(SELECT_CROB), 1000);
+    expect(processor.process(parseRequest(OPERATE_CROB), 1000).statuses)
+      .toEqual([DNP3_COMMAND_STATUS.SUCCESS]);
+
+    processor.process(parseRequest(SELECT_CROB), 1500);
+    expect(processor.process(parseRequest(OPERATE_CROB), 1500).statuses)
+      .toEqual([DNP3_COMMAND_STATUS.ALREADY_ACTIVE]);
+    expect(calls).toHaveLength(1); // the second one never reached the sink
+
+    // Once the pulse has finished the point accepts commands again.
+    processor.process(parseRequest(SELECT_CROB), 2100);
+    expect(processor.process(parseRequest(OPERATE_CROB), 2100).statuses)
+      .toEqual([DNP3_COMMAND_STATUS.SUCCESS]);
+    expect(calls).toHaveLength(2);
+  });
+
+  test('an unmapped point is rejected and sets the OBJECT_UNKNOWN IIN bit', () => {
+    const { processor, calls } = harness();
+    const unmapped = Buffer.from(OPERATE_CROB);
+    unmapped[1] = DNP3_FUNCTION.DIRECT_OPERATE;
+    unmapped[6] = 0x7f; // point 127 is not in the map
+    const result = processor.process(parseRequest(unmapped), 1000);
+    expect(result.statuses).toEqual([DNP3_COMMAND_STATUS.NOT_SUPPORTED]);
+    expect(result.iin & DNP3_IIN.OBJECT_UNKNOWN).toBe(DNP3_IIN.OBJECT_UNKNOWN);
+    expect(calls).toEqual([]);
+  });
+
+  test('a CROB count of 0 is a spec no-op: SUCCESS without touching the sink', () => {
+    const { processor, calls } = harness();
+    const noop = Buffer.from(OPERATE_CROB);
+    noop[1] = DNP3_FUNCTION.DIRECT_OPERATE;
+    noop[8] = 0x00; // count field = 0
+    expect(processor.process(parseRequest(noop), 1000).statuses).toEqual([DNP3_COMMAND_STATUS.SUCCESS]);
+    expect(calls).toEqual([]);
+  });
+
+  test('the deprecated queue bit and the clear bit are refused, not silently ignored', () => {
+    const { processor, calls } = harness();
+    for (const bit of [0x10, 0x20]) {
+      const req = Buffer.from(OPERATE_CROB);
+      req[1] = DNP3_FUNCTION.DIRECT_OPERATE;
+      req[7] = 0x41 | bit;
+      expect(processor.process(parseRequest(req), 1000).statuses)
+        .toEqual([DNP3_COMMAND_STATUS.NOT_SUPPORTED]);
+    }
+    expect(calls).toEqual([]);
+  });
+
+  test('a NUL operation type is refused', () => {
+    const { processor } = harness();
+    const req = Buffer.from(OPERATE_CROB);
+    req[1] = DNP3_FUNCTION.DIRECT_OPERATE;
+    req[7] = 0x00;
+    expect(processor.process(parseRequest(req), 1000).statuses)
+      .toEqual([DNP3_COMMAND_STATUS.NOT_SUPPORTED]);
+  });
+
+  test('a sink refusal is reported verbatim; a throwing sink becomes HARDWARE_ERROR', () => {
+    const refusing = new Dnp3ControlProcessor(makeMap(), { enabled: true, selectTimeoutMs: 5000 }, () => ({
+      ok: false,
+      status: DNP3_COMMAND_STATUS.LOCAL,
+    }));
+    expect(refusing.process(parseRequest(DIRECT_OPERATE_AO), 1000).statuses)
+      .toEqual([DNP3_COMMAND_STATUS.LOCAL]);
+
+    const throwing = new Dnp3ControlProcessor(makeMap(), { enabled: true, selectTimeoutMs: 5000 }, () => {
+      throw new Error('field device unreachable');
+    });
+    expect(throwing.process(parseRequest(DIRECT_OPERATE_AO), 1000).statuses)
+      .toEqual([DNP3_COMMAND_STATUS.HARDWARE_ERROR]);
+  });
+
+  test('truncated control objects yield a parameter error and never execute', () => {
+    const { processor, calls } = harness();
+    // Claims one CROB but only supplies 3 of its 11 octets.
+    const truncated = Buffer.from([0xc0, 0x05, 0x0c, 0x01, 0x17, 0x01, 0x00, 0x41, 0x01, 0xe8]);
+    const req = parseRequest(truncated);
+    expect(req.objects[0].items).toBeUndefined();
+    const result = processor.process(req, 1000);
+    expect(result.iin & DNP3_IIN.PARAMETER_ERROR).toBe(DNP3_IIN.PARAMETER_ERROR);
+    expect(result.statuses).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  test('a control function code with no control objects is a parameter error', () => {
+    const { processor } = harness();
+    const result = processor.process(parseRequest(Buffer.from([0xc0, 0x05])), 1000);
+    expect(result.iin & DNP3_IIN.PARAMETER_ERROR).toBe(DNP3_IIN.PARAMETER_ERROR);
+    expect(result.objects.length).toBe(0);
+  });
+
+  test('multiple objects in one request each get their own status', () => {
+    const { processor, calls } = harness();
+    // Two CROBs: point 1 (mapped) and point 9 (not mapped).
+    const req = Buffer.from([
+      0xc0, DNP3_FUNCTION.DIRECT_OPERATE, 0x0c, 0x01, 0x17, 0x02,
+      0x01, 0x03, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x09, 0x03, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    const result = processor.process(parseRequest(req), 1000);
+    expect(result.statuses).toEqual([DNP3_COMMAND_STATUS.SUCCESS, DNP3_COMMAND_STATUS.NOT_SUPPORTED]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ index: 1, tagId: 'pump.cmd', value: true });
+    // Echo keeps the master's header and both index prefixes.
+    expect([...result.objects.subarray(0, 6)]).toEqual([0x0c, 0x01, 0x17, 0x02, 0x01, 0x03]);
+    // 4-octet header, then two 12-octet blocks (1 index prefix + 11 CROB octets);
+    // each block's status octet is its last one.
+    expect(result.objects.length).toBe(4 + 12 + 12);
+    expect(result.objects[15]).toBe(DNP3_COMMAND_STATUS.SUCCESS);
+    expect(result.objects[27]).toBe(DNP3_COMMAND_STATUS.NOT_SUPPORTED);
+  });
+
+  test('a SELECT containing an invalid object arms nothing', () => {
+    const { processor } = harness();
+    const req = Buffer.from([
+      0xc0, DNP3_FUNCTION.SELECT, 0x0c, 0x01, 0x17, 0x02,
+      0x01, 0x03, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x09, 0x03, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    const result = processor.process(parseRequest(req), 1000);
+    expect(result.statuses).toEqual([DNP3_COMMAND_STATUS.SUCCESS, DNP3_COMMAND_STATUS.NOT_SUPPORTED]);
+    expect(processor.armedSelect).toBeNull();
+  });
+
+  test('disarm() drops an armed selection', () => {
+    const { processor } = harness();
+    processor.process(parseRequest(SELECT_CROB), 1000);
+    expect(processor.armedSelect).not.toBeNull();
+    processor.disarm();
+    expect(processor.process(parseRequest(OPERATE_CROB), 1100).statuses)
+      .toEqual([DNP3_COMMAND_STATUS.NO_SELECT]);
+  });
+
+  test('qualifier 0x28 (2-octet prefix/count) control objects are handled', () => {
+    const map = new Dnp3PointMap({ points: [{ tagId: 'far.cmd', type: 'binaryOutput', index: 300 }] });
+    const calls: Dnp3ControlCommand[] = [];
+    const processor = new Dnp3ControlProcessor(map, { enabled: true, selectTimeoutMs: 5000 }, (cmd) => {
+      calls.push(cmd);
+      return { ok: true };
+    });
+    const req = Buffer.from([
+      0xc0, DNP3_FUNCTION.DIRECT_OPERATE, 0x0c, 0x01, 0x28,
+      0x01, 0x00, // count 1 (2 octets)
+      0x2c, 0x01, // index 300 (2 octets)
+      0x03, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // LATCH_ON
+    ]);
+    const parsed = parseRequest(req);
+    expect(parsed.objects[0].items![0].index).toBe(300);
+    const result = processor.process(parsed, 1000);
+    expect(result.statuses).toEqual([DNP3_COMMAND_STATUS.SUCCESS]);
+    expect(calls[0]).toMatchObject({ index: 300, tagId: 'far.cmd', value: true });
+    // Echo preserves the 0x28 qualifier and the 2-octet count/prefix.
+    expect([...result.objects.subarray(0, 7)]).toEqual([0x0c, 0x01, 0x28, 0x01, 0x00, 0x2c, 0x01]);
+  });
+
+  test('the sink receives exactly one call per executed object', () => {
+    const sink = vi.fn<Dnp3ControlSink>(() => ({ ok: true }));
+    const processor = new Dnp3ControlProcessor(makeMap(), { enabled: true, selectTimeoutMs: 5000 }, sink);
+    processor.process(parseRequest(SELECT_CROB), 1000);
+    expect(sink).not.toHaveBeenCalled();
+    processor.process(parseRequest(OPERATE_CROB), 1000);
+    expect(sink).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/protocols/dnp3-outstation/__tests__/event-objects.test.ts
+++ b/server/protocols/dnp3-outstation/__tests__/event-objects.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Golden-byte-vector tests for DNP3 event object serialisation (#464).
+ *
+ * Every expected buffer below is derived by hand from IEEE 1815-2012 and is
+ * annotated octet by octet, so a failure points at the exact field that drifted
+ * rather than at an opaque hex blob.
+ *
+ * Shared conventions used by these vectors:
+ *   - Object header = GROUP(1) VARIATION(1) QUALIFIER(1) then the range field.
+ *   - Qualifier 0x17 = index-prefix code 1 (1-octet prefix) + range code 7
+ *     (1-octet count). Qualifier 0x28 = prefix code 2 (2-octet prefix) + range
+ *     code 8 (2-octet count).
+ *   - Flag octet bit 0 = ONLINE, bit 7 = binary STATE.
+ *   - DNP3 Time is a 48-bit unsigned little-endian millisecond count.
+ *
+ * The timestamps are chosen so their little-endian octets are readable:
+ *   T0 = 0x0000_00AB_CDEF ms -> EF CD AB 00 00 00
+ *   T1 = T0 + 6             -> F5 CD AB 00 00 00
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  buildEventObjects,
+  buildCtoObject,
+  DEFAULT_EVENT_VARIATIONS,
+  type EventVariationPolicy,
+} from '../event-objects';
+import { Dnp3EventBuffer, type Dnp3Event } from '../event-buffer';
+import { Dnp3PointMap } from '../point-map';
+import { encodeDnp3Time, decodeDnp3Time, DNP3_FLAG } from '../app-objects';
+
+const T0 = 0xabcdef; // 11_259_375 ms
+const T1 = T0 + 6;
+
+/** ONLINE + STATE(on) */
+const FLAGS_ON = DNP3_FLAG.ONLINE | DNP3_FLAG.STATE; // 0x81
+/** ONLINE, binary state off */
+const FLAGS_OFF = DNP3_FLAG.ONLINE; // 0x01
+
+function ev(partial: Partial<Dnp3Event> & Pick<Dnp3Event, 'seq' | 'pointType' | 'index'>): Dnp3Event {
+  return {
+    eventClass: 1,
+    value: true,
+    flags: FLAGS_ON,
+    timestamp: T0,
+    ...partial,
+  } as Dnp3Event;
+}
+
+const binaryMap = new Dnp3PointMap({
+  points: [
+    { tagId: 'bi3', type: 'binaryInput', index: 3, eventClass: 1 },
+    { tagId: 'bi7', type: 'binaryInput', index: 7, eventClass: 1 },
+  ],
+});
+
+const twoBinaryEvents: Dnp3Event[] = [
+  ev({ seq: 1, pointType: 'binaryInput', index: 3, value: true, flags: FLAGS_ON, timestamp: T0 }),
+  ev({ seq: 2, pointType: 'binaryInput', index: 7, value: false, flags: FLAGS_OFF, timestamp: T1 }),
+];
+
+describe('DNP3 time field', () => {
+  test('is a 48-bit little-endian millisecond count', () => {
+    expect([...encodeDnp3Time(T0)]).toEqual([0xef, 0xcd, 0xab, 0x00, 0x00, 0x00]);
+    expect(encodeDnp3Time(T0).length).toBe(6);
+    expect(decodeDnp3Time(encodeDnp3Time(1_785_000_000_000))).toBe(1_785_000_000_000);
+  });
+
+  test('saturates at the 48-bit maximum instead of wrapping', () => {
+    // 2^48 - 1 is the largest representable instant; a larger value must clamp,
+    // never silently truncate into a wildly wrong timestamp.
+    expect([...encodeDnp3Time(2 ** 48 + 5)]).toEqual([0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+    expect([...encodeDnp3Time(-1)]).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+});
+
+describe('g2 Binary Input Event — golden vectors', () => {
+  test('g2v2 (absolute time), qualifier 0x17, two events', () => {
+    const { bytes, encodedSeqs, remaining } = buildEventObjects(twoBinaryEvents, { pointMap: binaryMap });
+    expect([...bytes]).toEqual([
+      0x02, 0x02, 0x17, 0x02, // g2 v2, qualifier 0x17, count 2
+      0x03, 0x81, 0xef, 0xcd, 0xab, 0x00, 0x00, 0x00, // index 3, flags ONLINE|STATE, T0
+      0x07, 0x01, 0xf5, 0xcd, 0xab, 0x00, 0x00, 0x00, // index 7, flags ONLINE, T1
+    ]);
+    expect(encodedSeqs).toEqual([1, 2]);
+    expect(remaining).toBe(0);
+    // 4-octet header + 2 * (1 prefix + 1 flag + 6 time)
+    expect(bytes.length).toBe(20);
+  });
+
+  test('g2v1 (no time) drops the time field entirely', () => {
+    const policy: EventVariationPolicy = { ...DEFAULT_EVENT_VARIATIONS, binary: 'no-time' };
+    const { bytes } = buildEventObjects(twoBinaryEvents, { pointMap: binaryMap, policy });
+    expect([...bytes]).toEqual([
+      0x02, 0x01, 0x17, 0x02, // g2 v1, qualifier 0x17, count 2
+      0x03, 0x81, // index 3, flag octet only
+      0x07, 0x01, // index 7, flag octet only
+    ]);
+  });
+
+  test('g2v3 (relative time) is preceded by a g51v1 CTO and uses 16-bit offsets', () => {
+    const policy: EventVariationPolicy = { ...DEFAULT_EVENT_VARIATIONS, binary: 'relative-time' };
+    const { bytes } = buildEventObjects(twoBinaryEvents, { pointMap: binaryMap, policy });
+    expect([...bytes]).toEqual([
+      // g51 (0x33) v1 Common Time Of Occurrence, qualifier 0x07 count 1, T0
+      0x33, 0x01, 0x07, 0x01, 0xef, 0xcd, 0xab, 0x00, 0x00, 0x00,
+      0x02, 0x03, 0x17, 0x02, // g2 v3, qualifier 0x17, count 2
+      0x03, 0x81, 0x00, 0x00, // index 3, flags, offset 0 ms from the CTO
+      0x07, 0x01, 0x06, 0x00, // index 7, flags, offset 6 ms from the CTO
+    ]);
+  });
+
+  test('a relative-time offset beyond 16 bits starts a fresh CTO run', () => {
+    const policy: EventVariationPolicy = { ...DEFAULT_EVENT_VARIATIONS, binary: 'relative-time' };
+    const far = T0 + 0x10000; // one millisecond too far for a uint16 offset
+    const events = [
+      twoBinaryEvents[0],
+      ev({ seq: 2, pointType: 'binaryInput', index: 7, value: false, flags: FLAGS_OFF, timestamp: far }),
+    ];
+    const { bytes, encodedSeqs } = buildEventObjects(events, { pointMap: binaryMap, policy });
+    expect(encodedSeqs).toEqual([1, 2]);
+    // Two CTO objects, each introducing a single-event run.
+    expect([...bytes]).toEqual([
+      0x33, 0x01, 0x07, 0x01, 0xef, 0xcd, 0xab, 0x00, 0x00, 0x00,
+      0x02, 0x03, 0x17, 0x01, 0x03, 0x81, 0x00, 0x00,
+      // second CTO = T0 + 0x10000 = 0xABCDEF + 0x10000 = 0xACCDEF
+      0x33, 0x01, 0x07, 0x01, 0xef, 0xcd, 0xac, 0x00, 0x00, 0x00,
+      0x02, 0x03, 0x17, 0x01, 0x07, 0x01, 0x00, 0x00,
+    ]);
+  });
+
+  test('buildCtoObject is a 10-octet g51v1 object', () => {
+    expect([...buildCtoObject(T0)]).toEqual([0x33, 0x01, 0x07, 0x01, 0xef, 0xcd, 0xab, 0x00, 0x00, 0x00]);
+  });
+});
+
+describe('g11 Binary Output Event — variation availability', () => {
+  const boMap = new Dnp3PointMap({
+    points: [{ tagId: 'bo0', type: 'binaryOutput', index: 0, eventClass: 1 }],
+  });
+  const boEvent = ev({ seq: 1, pointType: 'binaryOutput', index: 0, flags: FLAGS_ON, timestamp: T0 });
+
+  test('absolute time emits g11v2', () => {
+    const { bytes } = buildEventObjects([boEvent], { pointMap: boMap });
+    expect([...bytes]).toEqual([
+      0x0b, 0x02, 0x17, 0x01, // g11 (0x0B) v2, qualifier 0x17, count 1
+      0x00, 0x81, 0xef, 0xcd, 0xab, 0x00, 0x00, 0x00,
+    ]);
+  });
+
+  test('no-time emits g11v1', () => {
+    const policy: EventVariationPolicy = { ...DEFAULT_EVENT_VARIATIONS, binary: 'no-time' };
+    const { bytes } = buildEventObjects([boEvent], { pointMap: boMap, policy });
+    expect([...bytes]).toEqual([0x0b, 0x01, 0x17, 0x01, 0x00, 0x81]);
+  });
+
+  test('a relative-time policy degrades to g11v2 — IEEE 1815 has no g11v3', () => {
+    // Group 11 (Binary Output Event) defines only v0/v1/v2 in IEEE 1815-2012
+    // Table A-1. Emitting a g11v3 (plus a CTO) would put an undecodable object
+    // on the wire for any conformant master, so the relative-time policy must
+    // fall back to the absolute-time variation for binary OUTPUT events only.
+    const policy: EventVariationPolicy = { ...DEFAULT_EVENT_VARIATIONS, binary: 'relative-time' };
+    const { bytes } = buildEventObjects([boEvent], { pointMap: boMap, policy });
+    expect(bytes[0]).toBe(0x0b); // group 11
+    expect(bytes[1]).toBe(0x02); // variation 2, NOT 3
+    // No CTO object is emitted, because there is no relative-time run.
+    expect([...bytes]).toEqual([
+      0x0b, 0x02, 0x17, 0x01, 0x00, 0x81, 0xef, 0xcd, 0xab, 0x00, 0x00, 0x00,
+    ]);
+
+    // Binary INPUTS keep the relative-time behaviour: g2v3 preceded by a CTO.
+    const biOnly = buildEventObjects([twoBinaryEvents[0]], { pointMap: binaryMap, policy });
+    expect(biOnly.bytes[0]).toBe(0x33); // g51 CTO first
+    expect(biOnly.bytes[10]).toBe(0x02); // then group 2
+    expect(biOnly.bytes[11]).toBe(0x03); // variation 3 is legal for group 2
+  });
+});
+
+describe('g22 Counter Event — golden vectors', () => {
+  const map = new Dnp3PointMap({ points: [{ tagId: 'c0', type: 'counter', index: 0, eventClass: 2 }] });
+  const counterEvent = ev({
+    seq: 9,
+    pointType: 'counter',
+    index: 0,
+    eventClass: 2,
+    value: 0x12345678,
+    flags: DNP3_FLAG.ONLINE,
+    timestamp: T0,
+  });
+
+  test('g22v5 (32-bit with flag and time)', () => {
+    const { bytes } = buildEventObjects([counterEvent], { pointMap: map });
+    expect([...bytes]).toEqual([
+      0x16, 0x05, 0x17, 0x01, // g22 (0x16) v5, qualifier 0x17, count 1
+      0x00, // index 0
+      0x01, // flags ONLINE
+      0x78, 0x56, 0x34, 0x12, // counter 0x12345678 little-endian
+      0xef, 0xcd, 0xab, 0x00, 0x00, 0x00, // T0
+    ]);
+  });
+
+  test('g22v1 (32-bit with flag, no time)', () => {
+    const policy: EventVariationPolicy = { ...DEFAULT_EVENT_VARIATIONS, counter: 'no-time' };
+    const { bytes } = buildEventObjects([counterEvent], { pointMap: map, policy });
+    expect([...bytes]).toEqual([0x16, 0x01, 0x17, 0x01, 0x00, 0x01, 0x78, 0x56, 0x34, 0x12]);
+  });
+
+  test('counter values are unsigned and saturate at 2^32-1', () => {
+    const policy: EventVariationPolicy = { ...DEFAULT_EVENT_VARIATIONS, counter: 'no-time' };
+    const { bytes } = buildEventObjects(
+      [{ ...counterEvent, value: 0x1_0000_0000 }],
+      { pointMap: map, policy },
+    );
+    expect([...bytes.subarray(6)]).toEqual([0xff, 0xff, 0xff, 0xff]);
+  });
+});
+
+describe('g32 Analog Input Event — golden vectors', () => {
+  const map = new Dnp3PointMap({
+    points: [
+      { tagId: 'ai1', type: 'analogInput', index: 1, eventClass: 3, encoding: 'int32' },
+      { tagId: 'ai2', type: 'analogInput', index: 2, eventClass: 3, encoding: 'float32' },
+    ],
+  });
+
+  test('g32v3 (32-bit int with time) for an int32 point', () => {
+    const { bytes } = buildEventObjects(
+      [ev({ seq: 4, pointType: 'analogInput', index: 1, eventClass: 3, value: -2, flags: DNP3_FLAG.ONLINE })],
+      { pointMap: map },
+    );
+    expect([...bytes]).toEqual([
+      0x20, 0x03, 0x17, 0x01, // g32 (0x20) v3, qualifier 0x17, count 1
+      0x01, // index 1
+      0x01, // flags ONLINE
+      0xfe, 0xff, 0xff, 0xff, // int32 -2, little-endian two's complement
+      0xef, 0xcd, 0xab, 0x00, 0x00, 0x00, // T0
+    ]);
+  });
+
+  test('g32v1 (32-bit int, no time)', () => {
+    const policy: EventVariationPolicy = { ...DEFAULT_EVENT_VARIATIONS, analog: 'no-time' };
+    const { bytes } = buildEventObjects(
+      [ev({ seq: 4, pointType: 'analogInput', index: 1, eventClass: 3, value: -2, flags: DNP3_FLAG.ONLINE })],
+      { pointMap: map, policy },
+    );
+    expect([...bytes]).toEqual([0x20, 0x01, 0x17, 0x01, 0x01, 0x01, 0xfe, 0xff, 0xff, 0xff]);
+  });
+
+  test('a float32 point uses g32v7, not the int32 variation', () => {
+    // Emitting v1/v3 for a float point would silently truncate the value the
+    // static (g30v5) read reports at full precision.
+    const { bytes } = buildEventObjects(
+      [ev({ seq: 5, pointType: 'analogInput', index: 2, eventClass: 3, value: 1.5, flags: DNP3_FLAG.ONLINE })],
+      { pointMap: map },
+    );
+    expect([...bytes]).toEqual([
+      0x20, 0x07, 0x17, 0x01, // g32 v7 (single-precision float with time)
+      0x02, // index 2
+      0x01, // flags ONLINE
+      0x00, 0x00, 0xc0, 0x3f, // IEEE-754 float32 1.5 little-endian
+      0xef, 0xcd, 0xab, 0x00, 0x00, 0x00,
+    ]);
+  });
+
+  test('analog events for an unmapped point are withheld rather than guessed', () => {
+    const { bytes, encodedSeqs, remaining } = buildEventObjects(
+      [ev({ seq: 6, pointType: 'analogInput', index: 99, eventClass: 3, value: 1, flags: 0x01 })],
+      { pointMap: map },
+    );
+    expect(encodedSeqs).toEqual([]);
+    expect(bytes.length).toBe(0);
+    expect(remaining).toBe(1);
+  });
+});
+
+describe('object-header run splitting', () => {
+  const map = new Dnp3PointMap({
+    points: [
+      { tagId: 'bi0', type: 'binaryInput', index: 0, eventClass: 1 },
+      { tagId: 'c0', type: 'counter', index: 0, eventClass: 1 },
+      { tagId: 'bi1', type: 'binaryInput', index: 1, eventClass: 1 },
+    ],
+  });
+
+  test('a change of group starts a new object header but keeps chronological order', () => {
+    const events: Dnp3Event[] = [
+      ev({ seq: 1, pointType: 'binaryInput', index: 0, flags: FLAGS_ON, timestamp: T0 }),
+      ev({ seq: 2, pointType: 'counter', index: 0, value: 1, flags: 0x01, timestamp: T0 }),
+      ev({ seq: 3, pointType: 'binaryInput', index: 1, flags: FLAGS_ON, timestamp: T0 }),
+    ];
+    const { bytes, encodedSeqs } = buildEventObjects(events, { pointMap: map });
+    expect(encodedSeqs).toEqual([1, 2, 3]);
+    // Three headers: g2 (1 event), g22 (1 event), g2 again (1 event).
+    expect([...bytes.subarray(0, 4)]).toEqual([0x02, 0x02, 0x17, 0x01]);
+    expect([...bytes.subarray(12, 16)]).toEqual([0x16, 0x05, 0x17, 0x01]);
+    expect([...bytes.subarray(28, 32)]).toEqual([0x02, 0x02, 0x17, 0x01]);
+  });
+
+  test('an index above 255 switches to qualifier 0x28 (2-octet prefix and count)', () => {
+    const wideMap = new Dnp3PointMap({
+      points: [{ tagId: 'bi300', type: 'binaryInput', index: 300, eventClass: 1 }],
+    });
+    const { bytes } = buildEventObjects(
+      [ev({ seq: 1, pointType: 'binaryInput', index: 300, flags: FLAGS_ON, timestamp: T0 })],
+      { pointMap: wideMap },
+    );
+    expect([...bytes]).toEqual([
+      0x02, 0x02, 0x28, // g2 v2, qualifier 0x28
+      0x01, 0x00, // count 1, 2-octet little-endian
+      0x2c, 0x01, // index 300 = 0x012C, 2-octet little-endian prefix
+      0x81, 0xef, 0xcd, 0xab, 0x00, 0x00, 0x00,
+    ]);
+  });
+});
+
+describe('byte budget', () => {
+  test('stops on the object that would overflow and reports the remainder', () => {
+    // g2v2 costs 4 octets of header + 8 octets per event, so 12 fits exactly one
+    // event and 19 still fits only one (a second needs 20).
+    const one = buildEventObjects(twoBinaryEvents, { pointMap: binaryMap, maxBytes: 19 });
+    expect(one.encodedSeqs).toEqual([1]);
+    expect(one.remaining).toBe(1);
+    expect(one.bytes.length).toBe(12);
+
+    const both = buildEventObjects(twoBinaryEvents, { pointMap: binaryMap, maxBytes: 20 });
+    expect(both.encodedSeqs).toEqual([1, 2]);
+    expect(both.remaining).toBe(0);
+
+    const none = buildEventObjects(twoBinaryEvents, { pointMap: binaryMap, maxBytes: 11 });
+    expect(none.encodedSeqs).toEqual([]);
+    expect(none.bytes.length).toBe(0);
+  });
+
+  test('encoded sequences are always a prefix of the input, so callers can resume', () => {
+    const buffer = new Dnp3EventBuffer();
+    for (let i = 0; i < 5; i++) {
+      buffer.enqueue({ pointType: 'binaryInput', index: 3, eventClass: 1, value: true, flags: FLAGS_ON, timestamp: T0 + i });
+    }
+    let pending = buffer.peek([1]);
+    const seen: number[] = [];
+    while (pending.length > 0) {
+      const res = buildEventObjects(pending, { pointMap: binaryMap, maxBytes: 20 });
+      expect(res.encodedSeqs.length).toBeGreaterThan(0);
+      seen.push(...res.encodedSeqs);
+      pending = pending.slice(res.encodedSeqs.length);
+    }
+    expect(seen).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/server/protocols/dnp3-outstation/__tests__/outstation.test.ts
+++ b/server/protocols/dnp3-outstation/__tests__/outstation.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Outstation-level tests (#464): fail-closed defaults, the SAv5 -> control
+ * dispatch path, and a real localhost TCP round trip that proves a master's
+ * Class-1 poll comes back with actual event octets.
+ *
+ * The TCP test uses a real socket and real DNP3 framing — no mocks, no stubs.
+ * The outstation binds port 0 so the OS picks a free port.
+ */
+import { describe, test, expect, afterEach } from 'vitest';
+import net from 'net';
+import {
+  createDnp3Outstation,
+  createOutstationContext,
+  handleApplicationRequest,
+  handleSecureAuthReply,
+  Dnp3Outstation,
+} from '../index';
+import { parseRequest } from '../app-layer';
+import { Dnp3PointMap } from '../point-map';
+import { Sav5Outstation, computeMac, decodeChallengeObject, encodeReplyObject } from '../secure-auth';
+import { DNP3_COMMAND_STATUS, DNP3_FUNCTION } from '../app-objects';
+import { buildLinkFrame, extractPayload } from '../link-layer';
+import { segment, TransportReassembler } from '../transport';
+import type { Dnp3ControlCommand } from '../controls';
+
+const T0 = 0xabcdef;
+
+/** OPERATE of a LATCH_ON CROB on binary output 0, application sequence 1. */
+const OPERATE_LATCH_ON = Buffer.from([
+  0xc1, DNP3_FUNCTION.OPERATE, 0x0c, 0x01, 0x17, 0x01, 0x00,
+  0x03, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+]);
+/** The same objects as a SELECT at sequence 0. */
+const SELECT_LATCH_ON = Buffer.from([
+  0xc0, DNP3_FUNCTION.SELECT, 0x0c, 0x01, 0x17, 0x01, 0x00,
+  0x03, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+]);
+
+const POINTS = [
+  { tagId: 'pump.run', type: 'binaryInput' as const, index: 3, eventClass: 1 as const },
+  { tagId: 'valve.cmd', type: 'binaryOutput' as const, index: 0 },
+];
+
+describe('fail-closed defaults', () => {
+  test('a default outstation is read-only and is not listening', () => {
+    const os = createDnp3Outstation({ pointMap: { points: POINTS } });
+    expect(os.config.controls.enabled).toBe(false);
+    expect(os.controlsWritable).toBe(false);
+    expect(os.listeningPort).toBeNull();
+  });
+
+  test('a sink alone does not enable controls', () => {
+    const os = createDnp3Outstation({ pointMap: { points: POINTS } });
+    os.setControlSink(() => ({ ok: true }));
+    expect(os.controlsWritable).toBe(false);
+
+    const result = handleApplicationRequest(os.ctx, parseRequest(OPERATE_LATCH_ON));
+    // Echoed CROB, status octet last: NOT_SUPPORTED.
+    expect(result.response[result.response.length - 1]).toBe(DNP3_COMMAND_STATUS.NOT_SUPPORTED);
+  });
+
+  test('enabling the flag alone does not enable controls either', () => {
+    const os = createDnp3Outstation({ pointMap: { points: POINTS }, controls: { enabled: true } });
+    expect(os.controlsWritable).toBe(false);
+    os.setControlSink(() => ({ ok: true }));
+    expect(os.controlsWritable).toBe(true);
+  });
+
+  test('both together let a SELECT/OPERATE pair reach the sink', () => {
+    const calls: Dnp3ControlCommand[] = [];
+    const os = createDnp3Outstation({ pointMap: { points: POINTS }, controls: { enabled: true } });
+    os.setControlSink((cmd) => {
+      calls.push(cmd);
+      return { ok: true };
+    });
+
+    handleApplicationRequest(os.ctx, parseRequest(SELECT_LATCH_ON), { now: 1000 });
+    expect(calls).toEqual([]);
+    const operate = handleApplicationRequest(os.ctx, parseRequest(OPERATE_LATCH_ON), { now: 1100 });
+    expect(operate.response[operate.response.length - 1]).toBe(DNP3_COMMAND_STATUS.SUCCESS);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ kind: 'binaryOutput', index: 0, tagId: 'valve.cmd', value: true });
+  });
+
+  test('DIRECT_OPERATE_NR executes but transmits nothing', () => {
+    const calls: Dnp3ControlCommand[] = [];
+    const os = createDnp3Outstation({ pointMap: { points: POINTS }, controls: { enabled: true } });
+    os.setControlSink((cmd) => {
+      calls.push(cmd);
+      return { ok: true };
+    });
+    const nr = Buffer.from(OPERATE_LATCH_ON);
+    nr[1] = DNP3_FUNCTION.DIRECT_OPERATE_NR;
+    const result = handleApplicationRequest(os.ctx, parseRequest(nr));
+    expect(result.response.length).toBe(0);
+    expect(result.fragments).toEqual([]);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('a restart disarms any pending SELECT', () => {
+    const os = createDnp3Outstation({ pointMap: { points: POINTS }, controls: { enabled: true } });
+    os.setControlSink(() => ({ ok: true }));
+    handleApplicationRequest(os.ctx, parseRequest(SELECT_LATCH_ON), { now: 1000 });
+    expect(os.ctx.controls.armedSelect).not.toBeNull();
+    handleApplicationRequest(os.ctx, parseRequest(Buffer.from([0xc0, DNP3_FUNCTION.WARM_RESTART])));
+    expect(os.ctx.controls.armedSelect).toBeNull();
+  });
+});
+
+describe('Secure Authentication v5 gates and then dispatches a control', () => {
+  test('an OPERATE is challenged, and the verified ASDU actually executes', () => {
+    const key = Buffer.alloc(16, 0xab);
+    const secureAuth = new Sav5Outstation();
+    secureAuth.setUpdateKey(1, key);
+    const calls: Dnp3ControlCommand[] = [];
+    const ctx = createOutstationContext({
+      pointMap: new Dnp3PointMap({ points: POINTS }),
+      secureAuth,
+      controlConfig: { enabled: true, selectTimeoutMs: 5000 },
+      controlSink: (cmd) => {
+        calls.push(cmd);
+        return { ok: true };
+      },
+    });
+
+    // 1. The master's DIRECT_OPERATE is challenged, not executed.
+    const direct = Buffer.from(OPERATE_LATCH_ON);
+    direct[1] = DNP3_FUNCTION.DIRECT_OPERATE;
+    const req = parseRequest(direct);
+    const challenge = handleApplicationRequest(ctx, req, { userNumber: 1, now: 1000 });
+    expect(challenge.challenged).toBe(true);
+    expect(calls).toEqual([]);
+
+    // 2. The master computes the MAC over the whole critical ASDU.
+    const challengeObject = decodeChallengeObject(challenge.response.subarray(8));
+    const mac = computeMac(key, challengeObject, req.raw);
+    const verify = handleSecureAuthReply(
+      ctx,
+      encodeReplyObject({ challengeSeq: challengeObject.challengeSeq, userNumber: 1, mac }),
+      1200,
+    );
+    expect(verify.ok).toBe(true);
+
+    // 3. The authorised ASDU is re-dispatched and now reaches the sink.
+    if (!verify.ok) throw new Error('unreachable');
+    const authorised = parseRequest(verify.criticalAsdu);
+    const executed = handleApplicationRequest(ctx, authorised, {
+      userNumber: verify.userNumber,
+      now: 1200,
+      skipSecureAuth: true,
+    });
+    expect(executed.response[executed.response.length - 1]).toBe(DNP3_COMMAND_STATUS.SUCCESS);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ tagId: 'valve.cmd', value: true });
+  });
+
+  test('a MAC computed over the wrong ASDU is rejected and nothing executes', () => {
+    const key = Buffer.alloc(16, 0xab);
+    const secureAuth = new Sav5Outstation();
+    secureAuth.setUpdateKey(1, key);
+    const calls: Dnp3ControlCommand[] = [];
+    const ctx = createOutstationContext({
+      pointMap: new Dnp3PointMap({ points: POINTS }),
+      secureAuth,
+      controlConfig: { enabled: true, selectTimeoutMs: 5000 },
+      controlSink: (cmd) => {
+        calls.push(cmd);
+        return { ok: true };
+      },
+    });
+
+    const req = parseRequest(OPERATE_LATCH_ON);
+    const challenge = handleApplicationRequest(ctx, req, { userNumber: 1, now: 1000 });
+    const challengeObject = decodeChallengeObject(challenge.response.subarray(8));
+    // Sign a LATCH_OFF while the challenged ASDU was LATCH_ON.
+    const tampered = Buffer.from(req.raw);
+    tampered[7] = 0x04;
+    const mac = computeMac(key, challengeObject, tampered);
+    const verify = handleSecureAuthReply(
+      ctx,
+      encodeReplyObject({ challengeSeq: challengeObject.challengeSeq, userNumber: 1, mac }),
+      1200,
+    );
+    expect(verify.ok).toBe(false);
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('live TCP round trip', () => {
+  let outstation: Dnp3Outstation | null = null;
+  let client: net.Socket | null = null;
+
+  afterEach(async () => {
+    client?.destroy();
+    client = null;
+    await outstation?.stop();
+    outstation = null;
+  });
+
+  /** Frame an application fragment the way a master would (DIR=1, PRM=1). */
+  function masterFrame(appFragment: Buffer, source: number, destination: number): Buffer {
+    const parts = segment(appFragment).map((seg) =>
+      buildLinkFrame({ control: 0xc4, destination, source, payload: seg }),
+    );
+    return Buffer.concat(parts);
+  }
+
+  /** Resolve with the next complete application fragment the outstation sends. */
+  function nextFragment(socket: net.Socket): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const reassembler = new TransportReassembler();
+      let buffered = Buffer.alloc(0);
+      const timer = setTimeout(() => {
+        socket.off('data', onData);
+        reject(new Error('timed out waiting for a DNP3 response'));
+      }, 5000);
+      function onData(chunk: Buffer): void {
+        buffered = Buffer.concat([buffered, chunk]);
+        while (buffered.length >= 10) {
+          const userDataLen = buffered[2] - 5;
+          const blocks = userDataLen > 0 ? Math.ceil(userDataLen / 16) : 0;
+          const total = 10 + userDataLen + blocks * 2;
+          if (buffered.length < total) return;
+          const frame = buffered.subarray(0, total);
+          buffered = buffered.subarray(total);
+          const extracted = extractPayload(frame);
+          if (!extracted) {
+            clearTimeout(timer);
+            socket.off('data', onData);
+            reject(new Error('response frame failed CRC'));
+            return;
+          }
+          const result = reassembler.accept(extracted.payload);
+          if (result.fragment) {
+            clearTimeout(timer);
+            socket.off('data', onData);
+            resolve(result.fragment);
+            return;
+          }
+        }
+      }
+      socket.on('data', onData);
+    });
+  }
+
+  test('a master polling Class 1 over a real socket receives real g2v2 event octets', async () => {
+    outstation = createDnp3Outstation({
+      port: 0,
+      host: '127.0.0.1',
+      localAddress: 10,
+      pointMap: { points: POINTS },
+    });
+    await outstation.start();
+    const port = outstation.listeningPort;
+    expect(port).not.toBeNull();
+
+    // A real value change on the tag layer becomes a buffered Class-1 event.
+    outstation.updateTag('pump.run', { value: true, quality: 'good', timestamp: T0 });
+    expect(outstation.ctx.eventBuffer.classSize(1)).toBe(1);
+
+    client = net.createConnection({ port: port!, host: '127.0.0.1' });
+    await new Promise<void>((resolve, reject) => {
+      client!.once('connect', resolve);
+      client!.once('error', reject);
+    });
+
+    // READ g60v2 (Class 1), qualifier 0x06, application sequence 0.
+    const pending = nextFragment(client);
+    client.write(masterFrame(Buffer.from([0xc0, DNP3_FUNCTION.READ, 0x3c, 0x02, 0x06]), 1, 10));
+    const fragment = await pending;
+
+    expect([...fragment]).toEqual([
+      0xe0, // FIR|FIN|CON, sequence 0
+      0x81, // RESPONSE
+      // IIN 0x8200 little-endian: CLASS1_EVENTS (0x0200) plus DEVICE_RESTART
+      // (0x8000), which a freshly started outstation must report until the
+      // master clears it.
+      0x00, 0x82,
+      0x02, 0x02, 0x17, 0x01, // g2v2, qualifier 0x17, count 1
+      0x03, // index 3
+      0x81, // flags ONLINE|STATE
+      0xef, 0xcd, 0xab, 0x00, 0x00, 0x00, // DNP3 time T0
+    ]);
+
+    // The event is still buffered until the master confirms.
+    expect(outstation.ctx.eventBuffer.classSize(1)).toBe(1);
+    client.write(masterFrame(Buffer.from([0xc0, DNP3_FUNCTION.CONFIRM]), 1, 10));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(outstation.ctx.eventBuffer.classSize(1)).toBe(0);
+  });
+
+  test('a control over a real socket is refused while the outstation is read-only', async () => {
+    outstation = createDnp3Outstation({ port: 0, host: '127.0.0.1', pointMap: { points: POINTS } });
+    await outstation.start();
+    client = net.createConnection({ port: outstation.listeningPort!, host: '127.0.0.1' });
+    await new Promise<void>((resolve, reject) => {
+      client!.once('connect', resolve);
+      client!.once('error', reject);
+    });
+
+    const direct = Buffer.from(OPERATE_LATCH_ON);
+    direct[1] = DNP3_FUNCTION.DIRECT_OPERATE;
+    const pending = nextFragment(client);
+    client.write(masterFrame(direct, 1, 10));
+    const fragment = await pending;
+
+    expect(fragment[1]).toBe(DNP3_FUNCTION.RESPONSE);
+    // Echoed CROB with CommandStatus NOT_SUPPORTED in its final octet.
+    expect(fragment[fragment.length - 1]).toBe(DNP3_COMMAND_STATUS.NOT_SUPPORTED);
+  });
+});

--- a/server/protocols/dnp3-outstation/app-layer.ts
+++ b/server/protocols/dnp3-outstation/app-layer.ts
@@ -2,11 +2,12 @@
  * DNP3 Application Layer — APDU Assembly
  * Issue #464: DNP3 Outstation Mode
  *
- * PARTIAL (substantial). The request-header parse, response-header build,
- * object-header (qualifier 0x00/0x01 — 1-octet start/stop range) emission, and
- * the Class-0 static-read assembly are implemented + unit tested. Full request
- * parsing for every qualifier code, prefixed object headers, and per-variation
- * read selection are marked TODO inline.
+ * Implemented + unit tested: request-header parse, object-header scan for the
+ * range/count qualifiers AND the index-prefixed qualifiers (0x17/0x28) that
+ * carry control objects, response-header build, and Class-0 static-read
+ * assembly split into fragment-sized object blocks. Per-variation read
+ * selection (a master asking for a specific variation rather than a class) is
+ * still TODO and marked inline.
  *
  * Application request header (master -> outstation):
  *   APP_CONTROL (1) : FIR/FIN/CON/UNS/SEQ
@@ -32,6 +33,7 @@ import {
   type Dnp3PointType,
   type PointGroupVariation,
 } from './point-map';
+import { commandObjectSize } from './controls';
 
 export const APP_CTRL_FIR = 0x80;
 export const APP_CTRL_FIN = 0x40;
@@ -52,19 +54,52 @@ export interface ParsedRequest {
   objects: ParsedObjectHeader[];
   /** raw bytes after the function code (for SAv5 critical-ASDU MAC input) */
   rawObjects: Buffer;
+  /**
+   * The complete application fragment as received. IEEE 1815 defines the
+   * Secure-Authentication "Critical ASDU" as the whole fragment (application
+   * header included), and a verified request has to be re-dispatched from it.
+   */
+  raw: Buffer;
+}
+
+/** One index-prefixed object carried by a request (qualifier 0x17 / 0x28). */
+export interface ParsedPrefixedObject {
+  /** DNP3 point index from the object's index prefix */
+  index: number;
+  /** object body octets, excluding the index prefix */
+  data: Buffer;
 }
 
 export interface ParsedObjectHeader {
   group: number;
   variation: number;
   qualifier: number;
+  /** start/stop range, for qualifiers 0x00 / 0x01 */
+  range?: { start: number; stop: number };
+  /** object count, for the count and index-prefixed qualifiers */
+  count?: number;
+  /**
+   * Decoded index-prefixed objects, for qualifiers 0x17 / 0x28 whose object
+   * length this outstation knows. Absent when the objects could not be
+   * length-decoded — callers must then treat the header as undecodable rather
+   * than guessing at the octets.
+   */
+  items?: ParsedPrefixedObject[];
 }
 
 /**
- * Parse an application request fragment. Implemented: header + object-header
- * group/variation/qualifier scan with range field skipping for the common
- * qualifiers (0x00,0x01,0x06,0x07,0x08). TODO: prefixed counts (0x17/0x28) and
- * object-data length computation for write/operate payloads.
+ * Parse an application request fragment.
+ *
+ * Object-header scanning understands the range qualifiers (0x00/0x01), the
+ * "all objects" qualifier (0x06), the count qualifiers (0x07/0x08) and the
+ * index-prefixed qualifiers 0x17 (1-octet prefix + 1-octet count) and 0x28
+ * (2-octet prefix + 2-octet count). Index-prefixed object bodies are decoded
+ * when the group/variation has a known fixed size — which covers every control
+ * object (g12v1, g41v1..v4). Anything else stops the scan rather than
+ * misinterpreting octets.
+ *
+ * TODO: free-format qualifiers (0x5B) used by the group-120 objects, and
+ * object data following a non-prefixed range header (e.g. WRITE g80v1).
  */
 export function parseRequest(fragment: Buffer): ParsedRequest {
   if (fragment.length < 2) {
@@ -80,44 +115,95 @@ export function parseRequest(fragment: Buffer): ParsedRequest {
     const group = fragment[off];
     const variation = fragment[off + 1];
     const qualifier = fragment[off + 2];
-    objects.push({ group, variation, qualifier });
+    const header: ParsedObjectHeader = { group, variation, qualifier };
+    objects.push(header);
     off += 3;
-    // Skip the range field based on qualifier code (low nibble).
-    const rangeSpecifier = qualifier & 0x0f;
-    switch (rangeSpecifier) {
-      case 0x00: // start/stop 1-octet
+
+    const prefixCode = (qualifier & 0xf0) >>> 4;
+    const rangeCode = qualifier & 0x0f;
+    let count: number | null = null;
+
+    switch (rangeCode) {
+      case 0x00: // start/stop, 1-octet indices
+        if (off + 2 > fragment.length) return finish();
+        header.range = { start: fragment[off], stop: fragment[off + 1] };
+        count = header.range.stop - header.range.start + 1;
         off += 2;
         break;
-      case 0x01: // start/stop 2-octet
+      case 0x01: // start/stop, 2-octet indices
+        if (off + 4 > fragment.length) return finish();
+        header.range = { start: fragment.readUInt16LE(off), stop: fragment.readUInt16LE(off + 2) };
+        count = header.range.stop - header.range.start + 1;
         off += 4;
         break;
-      case 0x06: // all objects, no range
+      case 0x06: // all objects — no range field, no object data
         break;
       case 0x07: // 1-octet count
+        if (off + 1 > fragment.length) return finish();
+        count = fragment[off];
         off += 1;
         break;
       case 0x08: // 2-octet count
+        if (off + 2 > fragment.length) return finish();
+        count = fragment.readUInt16LE(off);
         off += 2;
         break;
       default:
-        // TODO: prefixed-index qualifiers (0x17/0x28) carry object data we do
-        // not yet length-decode; stop scanning to avoid misparsing.
-        off = fragment.length;
-        break;
+        // Unknown range specifier: object data of unknown length follows, so
+        // stop scanning rather than misparsing.
+        return finish();
+    }
+    if (count !== null) header.count = count;
+
+    // Index-prefixed object data (qualifiers 0x17 / 0x28).
+    if (prefixCode === 1 || prefixCode === 2) {
+      const prefixLen = prefixCode === 1 ? 1 : 2;
+      const objectSize = commandObjectSize(group, variation);
+      if (objectSize === null || count === null || count < 0) {
+        // We cannot compute where this header's data ends.
+        return finish();
+      }
+      const items: ParsedPrefixedObject[] = [];
+      let ok = true;
+      for (let n = 0; n < count; n++) {
+        if (off + prefixLen + objectSize > fragment.length) {
+          ok = false;
+          break;
+        }
+        const index = prefixLen === 1 ? fragment[off] : fragment.readUInt16LE(off);
+        const data = Buffer.from(fragment.subarray(off + prefixLen, off + prefixLen + objectSize));
+        items.push({ index, data });
+        off += prefixLen + objectSize;
+      }
+      if (!ok) {
+        // Truncated object data: leave `items` unset so callers reject the
+        // header with a format error instead of acting on a partial command.
+        return finish();
+      }
+      header.items = items;
+    } else if (prefixCode !== 0) {
+      // 4-octet index prefixes and the free-format/object-size prefixes are not
+      // modelled; their object data length is unknown to us.
+      return finish();
     }
   }
 
-  return {
-    appControl,
-    fir: (appControl & APP_CTRL_FIR) !== 0,
-    fin: (appControl & APP_CTRL_FIN) !== 0,
-    con: (appControl & APP_CTRL_CON) !== 0,
-    uns: (appControl & APP_CTRL_UNS) !== 0,
-    seq: appControl & APP_CTRL_SEQ_MASK,
-    func,
-    objects,
-    rawObjects,
-  };
+  return finish();
+
+  function finish(): ParsedRequest {
+    return {
+      appControl,
+      fir: (appControl & APP_CTRL_FIR) !== 0,
+      fin: (appControl & APP_CTRL_FIN) !== 0,
+      con: (appControl & APP_CTRL_CON) !== 0,
+      uns: (appControl & APP_CTRL_UNS) !== 0,
+      seq: appControl & APP_CTRL_SEQ_MASK,
+      func,
+      objects,
+      rawObjects,
+      raw: Buffer.from(fragment),
+    };
+  }
 }
 
 /** Build the 4-octet response header (APP_CONTROL + FUNCTION + IIN). */
@@ -161,6 +247,26 @@ export function buildObjectHeaderRange8(
   return Buffer.concat([header, data]);
 }
 
+/**
+ * Build an object header with qualifier 0x01 (16-bit start/stop index range).
+ * Required once a point index exceeds 255 — the 8-bit form would silently
+ * truncate the index and hand the master the wrong points.
+ */
+export function buildObjectHeaderRange16(
+  gv: PointGroupVariation,
+  start: number,
+  stop: number,
+  data: Buffer,
+): Buffer {
+  const header = Buffer.alloc(7);
+  header.writeUInt8(gv.group, 0);
+  header.writeUInt8(gv.variation, 1);
+  header.writeUInt8(0x01, 2); // qualifier: 16-bit start/stop
+  header.writeUInt16LE(start & 0xffff, 3);
+  header.writeUInt16LE(stop & 0xffff, 5);
+  return Buffer.concat([header, data]);
+}
+
 /** Mapping of the five point types to read order for Class 0. */
 const STATIC_READ_ORDER: Dnp3PointType[] = [
   'binaryInput',
@@ -170,34 +276,88 @@ const STATIC_READ_ORDER: Dnp3PointType[] = [
   'analogOutput',
 ];
 
+/** A contiguous run of same-variation static points being assembled. */
+interface StaticRun {
+  gv: PointGroupVariation;
+  /** true when the run needs the 16-bit start/stop qualifier */
+  wide: boolean;
+  start: number;
+  stop: number;
+  chunks: Buffer[];
+  /** octets of point data accumulated so far (header excluded) */
+  bytes: number;
+}
+
+function encodeStaticRun(run: StaticRun): Buffer {
+  const data = Buffer.concat(run.chunks);
+  return run.wide
+    ? buildObjectHeaderRange16(run.gv, run.start, run.stop, data)
+    : buildObjectHeaderRange8(run.gv, run.start, run.stop, data);
+}
+
 /**
- * Assemble the object portion of a Class-0 (all static data) response from the
- * point map. Groups contiguous points of each type into a single qualifier-0x00
- * object header. Returns the concatenated object bytes (no app header).
+ * Assemble the Class-0 (all static data) response as a list of self-contained
+ * object blocks. Each block is one object header plus its points, so the caller
+ * can pack blocks into response fragments without splitting an object header.
  *
- * NOTE: assumes each type's indices are contiguous from 0; gaps would require
- * multiple range headers — a TODO for sparse maps.
+ * A new block is started whenever the point indices stop being contiguous, the
+ * group/variation changes (e.g. an int32 and a float32 analog input in the same
+ * group), an index crosses 255 (the range qualifier has to widen), or adding
+ * the next point would exceed `maxBlockBytes`.
+ */
+export function buildClass0Blocks(
+  map: Dnp3PointMap,
+  maxBlockBytes: number = Number.MAX_SAFE_INTEGER,
+): Buffer[] {
+  const blocks: Buffer[] = [];
+  for (const type of STATIC_READ_ORDER) {
+    let current: StaticRun | undefined;
+    for (const def of map.pointsOfType(type)) {
+      const resolved = map.resolve(def.type, def.index);
+      if (!resolved) continue;
+      const ser = serializeStaticPoint(resolved);
+      const wide = def.index > 0xff;
+
+      if (current !== undefined) {
+        const headerLen = current.wide ? 7 : 5;
+        const continues =
+          def.index === current.stop + 1 &&
+          wide === current.wide &&
+          ser.groupVariation.group === current.gv.group &&
+          ser.groupVariation.variation === current.gv.variation &&
+          headerLen + current.bytes + ser.data.length <= maxBlockBytes;
+        if (!continues) {
+          blocks.push(encodeStaticRun(current));
+          current = undefined;
+        }
+      }
+
+      if (current === undefined) {
+        current = {
+          gv: ser.groupVariation,
+          wide,
+          start: def.index,
+          stop: def.index,
+          chunks: [ser.data],
+          bytes: ser.data.length,
+        };
+      } else {
+        current.chunks.push(ser.data);
+        current.bytes += ser.data.length;
+        current.stop = def.index;
+      }
+    }
+    if (current !== undefined) blocks.push(encodeStaticRun(current));
+  }
+  return blocks;
+}
+
+/**
+ * Assemble the object portion of a Class-0 response as one buffer. Convenience
+ * wrapper over {@link buildClass0Blocks} for callers with no fragment budget.
  */
 export function buildClass0Objects(map: Dnp3PointMap): Buffer {
-  const parts: Buffer[] = [];
-  for (const type of STATIC_READ_ORDER) {
-    const points = map.pointsOfType(type);
-    if (points.length === 0) continue;
-
-    const dataChunks: Buffer[] = [];
-    let gv: PointGroupVariation | null = null;
-    for (const def of points) {
-      const resolved = map.resolve(def.type, def.index)!;
-      const ser = serializeStaticPoint(resolved);
-      gv = ser.groupVariation;
-      dataChunks.push(ser.data);
-    }
-    if (!gv) continue;
-    const start = points[0].index;
-    const stop = points[points.length - 1].index;
-    parts.push(buildObjectHeaderRange8(gv, start, stop, Buffer.concat(dataChunks)));
-  }
-  return Buffer.concat(parts);
+  return Buffer.concat(buildClass0Blocks(map));
 }
 
 /**

--- a/server/protocols/dnp3-outstation/app-objects.ts
+++ b/server/protocols/dnp3-outstation/app-objects.ts
@@ -11,12 +11,14 @@
  *   - Object group / variation enums for the five static groups + their events
  *   - Status-flag octet construction (IIN-independent point quality flags)
  *   - Internal Indication (IIN) bit constants
- *   - Function codes
+ *   - Function codes and control CommandStatus codes
+ *   - CROB control-code bit layout
+ *   - DNP3 Time (48-bit little-endian epoch ms) codec
  *   - Single-point value encoders for each supported variation
  *
- * NOTE: Object-header (qualifier/range) framing and full APDU assembly live in
- * `index.ts` and are marked there as substantial-but-partial. This file only
- * owns the leaf encoding that opendnp3 conformance most depends on.
+ * NOTE: this file owns only the leaf encoding. Object-header (qualifier/range)
+ * framing lives in `app-layer.ts`, event objects in `event-objects.ts`, and
+ * command objects in `controls.ts`.
  */
 
 /** DNP3 application-layer function codes (subset relevant to an outstation). */
@@ -59,6 +61,8 @@ export const DNP3_GROUP = {
   ANALOG_OUTPUT_STATUS: 40,
   ANALOG_OUTPUT_EVENT: 42,
   ANALOG_OUTPUT_COMMAND: 41,
+  /** Common Time Of Occurrence — the time base for relative-time events (g2v3) */
+  TIME_AND_DATE_CTO: 51,
   CLASS_DATA: 60,
   INTERNAL_INDICATIONS: 80,
   SECURE_AUTH: 120,
@@ -75,23 +79,45 @@ export const DNP3_VARIATION = {
   // Group 2 — Binary Input Event
   BI_EVENT_NO_TIME: 1,
   BI_EVENT_ABS_TIME: 2,
+  BI_EVENT_REL_TIME: 3,
   // Group 10 — Binary Output Status
   BO_STATUS_WITH_FLAGS: 2,
+  // Group 11 — Binary Output Event (same octet layout as group 2 v1/v2)
+  BO_EVENT_NO_TIME: 1,
+  BO_EVENT_ABS_TIME: 2,
+  // Group 12 — Control Relay Output Block
+  CROB: 1,
   // Group 20 — Counter
   CNT_32_WITH_FLAG: 1,
   CNT_16_WITH_FLAG: 2,
   // Group 22 — Counter Event
   CNT_EVENT_32_WITH_FLAG: 1,
+  CNT_EVENT_32_ABS_TIME: 5,
   // Group 30 — Analog Input
   AI_32_WITH_FLAG: 1,
   AI_16_WITH_FLAG: 2,
   AI_FLOAT_WITH_FLAG: 5,
   // Group 32 — Analog Input Event
   AI_EVENT_32_WITH_FLAG: 1,
+  AI_EVENT_32_ABS_TIME: 3,
   AI_EVENT_FLOAT_WITH_FLAG: 5,
+  AI_EVENT_FLOAT_ABS_TIME: 7,
   // Group 40 — Analog Output Status
   AO_STATUS_32_WITH_FLAG: 1,
   AO_STATUS_FLOAT_WITH_FLAG: 3,
+  // Group 41 — Analog Output Block (command)
+  AO_CMD_INT32: 1,
+  AO_CMD_INT16: 2,
+  AO_CMD_FLOAT32: 3,
+  AO_CMD_DOUBLE64: 4,
+  // Group 42 — Analog Output Event (same layout as group 32)
+  AO_EVENT_32_WITH_FLAG: 1,
+  AO_EVENT_32_ABS_TIME: 3,
+  AO_EVENT_FLOAT_WITH_FLAG: 5,
+  AO_EVENT_FLOAT_ABS_TIME: 7,
+  // Group 51 — Common Time Of Occurrence
+  CTO_SYNC: 1,
+  CTO_UNSYNC: 2,
   // Class objects (group 60)
   CLASS0: 1,
   CLASS1: 2,
@@ -139,6 +165,76 @@ export const DNP3_IIN = {
   ALREADY_EXECUTING: 0x0010,
   CONFIG_CORRUPT: 0x0020,
 } as const;
+
+/**
+ * Command status codes returned in the status octet of an echoed control object
+ * (IEEE 1815-2012 Table 11-6 — "Control status codes").
+ */
+export const DNP3_COMMAND_STATUS = {
+  SUCCESS: 0,
+  TIMEOUT: 1,
+  NO_SELECT: 2,
+  FORMAT_ERROR: 3,
+  NOT_SUPPORTED: 4,
+  ALREADY_ACTIVE: 5,
+  HARDWARE_ERROR: 6,
+  LOCAL: 7,
+  TOO_MANY_OBJS: 8,
+  NOT_AUTHORIZED: 9,
+  AUTOMATION_INHIBIT: 10,
+  PROCESSING_LIMITED: 11,
+  OUT_OF_RANGE: 12,
+  UNDEFINED: 127,
+} as const;
+
+export type Dnp3CommandStatus = (typeof DNP3_COMMAND_STATUS)[keyof typeof DNP3_COMMAND_STATUS];
+
+/** g12v1 control-code operation types (low nibble of the control-code octet). */
+export const DNP3_CONTROL_OP_TYPE = {
+  NUL: 0,
+  PULSE_ON: 1,
+  PULSE_OFF: 2,
+  LATCH_ON: 3,
+  LATCH_OFF: 4,
+} as const;
+
+/** g12v1 Trip-Close Code (bits 6-7 of the control-code octet). */
+export const DNP3_CONTROL_TCC = {
+  NUL: 0,
+  CLOSE: 1,
+  TRIP: 2,
+} as const;
+
+/** g12v1 control-code octet bit masks. */
+export const CROB_OP_TYPE_MASK = 0x0f;
+/** Queue bit — deprecated by IEEE 1815-2012; this outstation rejects it. */
+export const CROB_QUEUE_MASK = 0x10;
+/** Clear bit — "cancel the operation currently running on this point". */
+export const CROB_CLEAR_MASK = 0x20;
+export const CROB_TCC_MASK = 0xc0;
+export const CROB_TCC_SHIFT = 6;
+
+/** Largest value representable by the DNP3 48-bit millisecond timestamp. */
+export const DNP3_TIME_MAX = 0xffffffffffff; // 2^48 - 1, below Number.MAX_SAFE_INTEGER
+
+/**
+ * Encode a DNP3 "DNP3 Time" field: 48-bit unsigned count of milliseconds since
+ * 1970-01-01 00:00:00 UTC, little-endian (IEEE 1815-2012 §A.4). Six octets.
+ */
+export function encodeDnp3Time(epochMs: number): Buffer {
+  const buf = Buffer.alloc(6);
+  const ms = Math.trunc(epochMs);
+  buf.writeUIntLE(ms < 0 ? 0 : Math.min(ms, DNP3_TIME_MAX), 0, 6);
+  return buf;
+}
+
+/** Decode a 6-octet little-endian DNP3 Time field into epoch milliseconds. */
+export function decodeDnp3Time(buf: Buffer, offset = 0): number {
+  if (buf.length < offset + 6) {
+    throw new Error('DNP3 time field truncated');
+  }
+  return buf.readUIntLE(offset, 6);
+}
 
 /** Quality of a point as understood by the rest of 0xSCADA. */
 export type PointQuality = 'good' | 'bad' | 'uncertain';

--- a/server/protocols/dnp3-outstation/controls.ts
+++ b/server/protocols/dnp3-outstation/controls.ts
@@ -1,0 +1,640 @@
+/**
+ * DNP3 Controls — SELECT / OPERATE / DIRECT-OPERATE
+ * Issue #464: DNP3 Outstation Mode
+ *
+ * Implements the outstation side of IEEE 1815-2012 §4.4.2 (control operations)
+ * for the two command object groups an RTU must support:
+ *
+ *   - g12v1  Control Relay Output Block (CROB)   -> binaryOutput points
+ *   - g41v1..v4 Analog Output Block              -> analogOutput points
+ *
+ * Before this module existed, SELECT/OPERATE fell through to the "unsupported
+ * function code" branch of the application handler: a master's control request
+ * was answered with IIN2.0 and nothing was ever executed.
+ *
+ * ── SAFETY ───────────────────────────────────────────────────────────────────
+ * A DNP3 control is the highest-privilege operation this codebase exposes: it
+ * moves live plant state. The write path is therefore FAIL-CLOSED and OFF BY
+ * DEFAULT. Two independent things must both be true before a single octet
+ * reaches the tag layer:
+ *
+ *   1. `config.enabled` must be explicitly set true (default false), and
+ *   2. a `Dnp3ControlSink` must be installed by the embedder.
+ *
+ * If either is missing the outstation is read-only: every control object is
+ * echoed with CommandStatus NOT_SUPPORTED (4). It never silently accepts, and
+ * it never reports SUCCESS for an operation it did not perform.
+ *
+ * ── Select-before-operate ────────────────────────────────────────────────────
+ * A SELECT validates and ARMS a specific point+value set for
+ * `selectTimeoutMs`; it does NOT touch the process. The following OPERATE must
+ * match the armed request exactly — same objects, same values, and an
+ * application sequence number exactly one greater than the SELECT's (IEEE 1815
+ * §4.4.2.1) — or it is rejected with NO_SELECT. An expired arm that otherwise
+ * matches is rejected with TIMEOUT. Either way the arm is consumed, so a
+ * rejected OPERATE can never be retried against a stale selection.
+ */
+
+import { logWarn } from '../../logger';
+import {
+  CROB_CLEAR_MASK,
+  CROB_OP_TYPE_MASK,
+  CROB_QUEUE_MASK,
+  CROB_TCC_MASK,
+  CROB_TCC_SHIFT,
+  DNP3_COMMAND_STATUS,
+  DNP3_CONTROL_OP_TYPE,
+  DNP3_CONTROL_TCC,
+  DNP3_FUNCTION,
+  DNP3_GROUP,
+  DNP3_IIN,
+  DNP3_VARIATION,
+  type Dnp3CommandStatus,
+} from './app-objects';
+import type { ParsedObjectHeader, ParsedPrefixedObject, ParsedRequest } from './app-layer';
+import { Dnp3PointMap } from './point-map';
+
+/** Decoded g12v1 control-code + timing fields. */
+export interface CrobFields {
+  /** operation type (low nibble of the control code) */
+  opType: number;
+  /** trip-close code (bits 6-7 of the control code) */
+  tcc: number;
+  /** "clear the operation running on this point" bit */
+  clear: boolean;
+  /** deprecated queue bit */
+  queue: boolean;
+  /** number of times to execute; 0 means "do not execute" */
+  count: number;
+  onTimeMs: number;
+  offTimeMs: number;
+}
+
+/** Size in octets of each supported command object (including its status octet). */
+export const CROB_OBJECT_SIZE = 11;
+
+/** Octet size of a g41 Analog Output Block variation, or null if unsupported. */
+export function analogOutputObjectSize(variation: number): number | null {
+  switch (variation) {
+    case DNP3_VARIATION.AO_CMD_INT32:
+      return 5; // int32 + status
+    case DNP3_VARIATION.AO_CMD_INT16:
+      return 3; // int16 + status
+    case DNP3_VARIATION.AO_CMD_FLOAT32:
+      return 5; // float32 + status
+    case DNP3_VARIATION.AO_CMD_DOUBLE64:
+      return 9; // float64 + status
+    default:
+      return null;
+  }
+}
+
+/**
+ * Octet size of a command object for a group/variation pair, or null when the
+ * outstation does not model it. Used by the request parser to length-decode
+ * index-prefixed control objects.
+ */
+export function commandObjectSize(group: number, variation: number): number | null {
+  if (group === DNP3_GROUP.BINARY_OUTPUT_COMMAND && variation === DNP3_VARIATION.CROB) {
+    return CROB_OBJECT_SIZE;
+  }
+  if (group === DNP3_GROUP.ANALOG_OUTPUT_COMMAND) {
+    return analogOutputObjectSize(variation);
+  }
+  return null;
+}
+
+/** Whether an object group carries control commands. */
+export function isControlGroup(group: number): boolean {
+  return group === DNP3_GROUP.BINARY_OUTPUT_COMMAND || group === DNP3_GROUP.ANALOG_OUTPUT_COMMAND;
+}
+
+/** Decode an 11-octet g12v1 CROB body. Returns null if the length is wrong. */
+export function decodeCrob(data: Buffer): CrobFields | null {
+  if (data.length !== CROB_OBJECT_SIZE) return null;
+  const controlCode = data.readUInt8(0);
+  return {
+    opType: controlCode & CROB_OP_TYPE_MASK,
+    tcc: (controlCode & CROB_TCC_MASK) >>> CROB_TCC_SHIFT,
+    clear: (controlCode & CROB_CLEAR_MASK) !== 0,
+    queue: (controlCode & CROB_QUEUE_MASK) !== 0,
+    count: data.readUInt8(1),
+    onTimeMs: data.readUInt32LE(2),
+    offTimeMs: data.readUInt32LE(6),
+  };
+}
+
+/** Re-encode a CROB body with the given command status in its status octet. */
+export function encodeCrob(fields: CrobFields, status: number): Buffer {
+  const buf = Buffer.alloc(CROB_OBJECT_SIZE);
+  let controlCode = fields.opType & CROB_OP_TYPE_MASK;
+  controlCode |= (fields.tcc << CROB_TCC_SHIFT) & CROB_TCC_MASK;
+  if (fields.clear) controlCode |= CROB_CLEAR_MASK;
+  if (fields.queue) controlCode |= CROB_QUEUE_MASK;
+  buf.writeUInt8(controlCode, 0);
+  buf.writeUInt8(fields.count & 0xff, 1);
+  buf.writeUInt32LE(fields.onTimeMs >>> 0, 2);
+  buf.writeUInt32LE(fields.offTimeMs >>> 0, 6);
+  buf.writeUInt8(status & 0xff, 10);
+  return buf;
+}
+
+/** Decode the commanded value of a g41 Analog Output Block. */
+export function decodeAnalogOutput(variation: number, data: Buffer): number | null {
+  const size = analogOutputObjectSize(variation);
+  if (size === null || data.length !== size) return null;
+  switch (variation) {
+    case DNP3_VARIATION.AO_CMD_INT32:
+      return data.readInt32LE(0);
+    case DNP3_VARIATION.AO_CMD_INT16:
+      return data.readInt16LE(0);
+    case DNP3_VARIATION.AO_CMD_FLOAT32:
+      return data.readFloatLE(0);
+    case DNP3_VARIATION.AO_CMD_DOUBLE64:
+      return data.readDoubleLE(0);
+    default:
+      return null;
+  }
+}
+
+/** Re-encode a g41 Analog Output Block with the given command status. */
+export function encodeAnalogOutput(variation: number, value: number, status: number): Buffer {
+  const size = analogOutputObjectSize(variation);
+  if (size === null) throw new Error(`Unsupported g41 variation ${variation}`);
+  const buf = Buffer.alloc(size);
+  switch (variation) {
+    case DNP3_VARIATION.AO_CMD_INT32:
+      buf.writeInt32LE(clampInt(value, -2147483648, 2147483647), 0);
+      break;
+    case DNP3_VARIATION.AO_CMD_INT16:
+      buf.writeInt16LE(clampInt(value, -32768, 32767), 0);
+      break;
+    case DNP3_VARIATION.AO_CMD_FLOAT32:
+      buf.writeFloatLE(value, 0);
+      break;
+    case DNP3_VARIATION.AO_CMD_DOUBLE64:
+      buf.writeDoubleLE(value, 0);
+      break;
+  }
+  buf.writeUInt8(status & 0xff, size - 1);
+  return buf;
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  const v = Math.trunc(value);
+  if (v < min) return min;
+  if (v > max) return max;
+  return v;
+}
+
+/**
+ * A control the outstation is asking the embedder to perform, already resolved
+ * from a DNP3 point index to the 0xSCADA tag that backs it.
+ */
+export type Dnp3ControlCommand =
+  | {
+      kind: 'binaryOutput';
+      group: number;
+      variation: number;
+      index: number;
+      /** 0xSCADA tag id the DNP3 point maps to */
+      tagId: string;
+      /** commanded coil state */
+      value: boolean;
+      crob: CrobFields;
+    }
+  | {
+      kind: 'analogOutput';
+      group: number;
+      variation: number;
+      index: number;
+      tagId: string;
+      value: number;
+    };
+
+/** Result the embedder returns for one control. */
+export type Dnp3ControlOutcome =
+  | { ok: true }
+  | { ok: false; status?: Dnp3CommandStatus };
+
+/**
+ * The seam through which controls reach live plant state. Synchronous by
+ * design: DNP3 requires a CommandStatus in the OPERATE response, so a sink that
+ * talks to slow hardware must enqueue the write and answer for the enqueue —
+ * it must not report `ok` for something it has not at least durably accepted.
+ */
+export type Dnp3ControlSink = (command: Dnp3ControlCommand) => Dnp3ControlOutcome;
+
+export interface Dnp3ControlConfig {
+  /**
+   * Master switch for the DNP3 write path. FALSE BY DEFAULT: an outstation is
+   * read-only until an operator explicitly opts in.
+   */
+  enabled: boolean;
+  /** How long a SELECT stays armed before an OPERATE is rejected with TIMEOUT. */
+  selectTimeoutMs: number;
+}
+
+export const DEFAULT_CONTROL_CONFIG: Dnp3ControlConfig = {
+  enabled: false,
+  selectTimeoutMs: 5000,
+};
+
+/** An armed SELECT awaiting its matching OPERATE. */
+export interface ArmedSelect {
+  /** application sequence number of the SELECT request */
+  seq: number;
+  /** epoch ms at which the SELECT was accepted */
+  armedAt: number;
+  /** canonical object bytes (status octets zeroed) the OPERATE must reproduce */
+  digest: Buffer;
+  /** commands to run when a matching OPERATE arrives */
+  commands: Dnp3ControlCommand[];
+}
+
+export interface ControlProcessResult {
+  /** echoed control objects, ready to append after the application header */
+  objects: Buffer;
+  /** IIN bits to OR into the response header */
+  iin: number;
+  /** per-object command status, in request order */
+  statuses: number[];
+  /** commands actually handed to the sink */
+  executed: Dnp3ControlCommand[];
+}
+
+/** One control object of a request, decoded as far as it could be. */
+interface DecodedObject {
+  header: ParsedObjectHeader;
+  item: ParsedPrefixedObject;
+  /** null when the object body could not be decoded */
+  command: Dnp3ControlCommand | null;
+  /** status determined during validation, or null when the object is valid */
+  rejection: number | null;
+  /** IIN bits this object contributes */
+  iin: number;
+}
+
+/**
+ * Owns the control state machine: the armed SELECT and the set of outputs with
+ * an operation still running (used for ALREADY_ACTIVE).
+ */
+export class Dnp3ControlProcessor {
+  private armed: ArmedSelect | null = null;
+  /** binaryOutput index -> epoch ms until which its pulse is still running */
+  private activeUntil = new Map<number, number>();
+
+  constructor(
+    private readonly pointMap: Dnp3PointMap,
+    private readonly config: Dnp3ControlConfig = DEFAULT_CONTROL_CONFIG,
+    private sink: Dnp3ControlSink | null = null,
+  ) {}
+
+  /** Install (or remove) the write seam. */
+  setSink(sink: Dnp3ControlSink | null): void {
+    this.sink = sink;
+  }
+
+  /** Whether the write path can actually reach plant state right now. */
+  get writable(): boolean {
+    return this.config.enabled && this.sink !== null;
+  }
+
+  /** Currently armed SELECT (diagnostics/tests). */
+  get armedSelect(): ArmedSelect | null {
+    return this.armed;
+  }
+
+  /** Drop any armed SELECT (e.g. on restart or link loss). */
+  disarm(): void {
+    this.armed = null;
+  }
+
+  /**
+   * Process a SELECT / OPERATE / DIRECT_OPERATE(_NR) request and produce the
+   * echoed objects plus per-object CommandStatus.
+   */
+  process(req: ParsedRequest, now: number): ControlProcessResult {
+    const controlHeaders = req.objects.filter((o) => isControlGroup(o.group));
+    if (controlHeaders.length === 0) {
+      // A control function code with no control objects is a parameter error.
+      return { objects: Buffer.alloc(0), iin: DNP3_IIN.PARAMETER_ERROR, statuses: [], executed: [] };
+    }
+
+    const decoded: DecodedObject[] = [];
+    let iin = 0;
+    for (const header of controlHeaders) {
+      if (!header.items) {
+        // The object header used a qualifier/variation whose object length we
+        // could not decode — we must not guess at control bytes.
+        iin |= DNP3_IIN.PARAMETER_ERROR;
+        continue;
+      }
+      for (const item of header.items) {
+        const d = this.decodeObject(header, item);
+        iin |= d.iin;
+        decoded.push(d);
+      }
+    }
+
+    if (decoded.length === 0) {
+      return { objects: Buffer.alloc(0), iin, statuses: [], executed: [] };
+    }
+
+    const statuses = this.resolveStatuses(req, decoded, now);
+    const executed = decoded
+      .map((d, i) => (statuses[i] === DNP3_COMMAND_STATUS.SUCCESS && d.command ? d.command : null))
+      .filter((c): c is Dnp3ControlCommand => c !== null);
+
+    return {
+      objects: this.echo(controlHeaders, decoded, statuses),
+      iin,
+      statuses,
+      executed: req.func === DNP3_FUNCTION.SELECT ? [] : executed,
+    };
+  }
+
+  /** Decode + statically validate one control object. */
+  private decodeObject(header: ParsedObjectHeader, item: ParsedPrefixedObject): DecodedObject {
+    const base = { header, item };
+
+    if (header.group === DNP3_GROUP.BINARY_OUTPUT_COMMAND) {
+      const crob = decodeCrob(item.data);
+      if (!crob) {
+        return { ...base, command: null, rejection: DNP3_COMMAND_STATUS.FORMAT_ERROR, iin: DNP3_IIN.PARAMETER_ERROR };
+      }
+      // The queue bit is deprecated by IEEE 1815-2012 and the clear bit asks us
+      // to cancel a running operation; neither is modelled, so say so rather
+      // than executing something subtly different from what was asked.
+      if (crob.queue || crob.clear) {
+        return { ...base, command: null, rejection: DNP3_COMMAND_STATUS.NOT_SUPPORTED, iin: 0 };
+      }
+      const value = crobValue(crob);
+      if (value === null) {
+        return { ...base, command: null, rejection: DNP3_COMMAND_STATUS.NOT_SUPPORTED, iin: 0 };
+      }
+      const def = this.pointMap.getPoint('binaryOutput', item.index);
+      if (!def) {
+        return { ...base, command: null, rejection: DNP3_COMMAND_STATUS.NOT_SUPPORTED, iin: DNP3_IIN.OBJECT_UNKNOWN };
+      }
+      return {
+        ...base,
+        command: {
+          kind: 'binaryOutput',
+          group: header.group,
+          variation: header.variation,
+          index: item.index,
+          tagId: def.tagId,
+          value,
+          crob,
+        },
+        rejection: null,
+        iin: 0,
+      };
+    }
+
+    // Analog Output Block (group 41).
+    const value = decodeAnalogOutput(header.variation, item.data);
+    if (value === null) {
+      const known = analogOutputObjectSize(header.variation) !== null;
+      return {
+        ...base,
+        command: null,
+        // A known variation with the wrong length is a format error; an unknown
+        // variation is simply not supported.
+        rejection: known ? DNP3_COMMAND_STATUS.FORMAT_ERROR : DNP3_COMMAND_STATUS.NOT_SUPPORTED,
+        iin: known ? DNP3_IIN.PARAMETER_ERROR : DNP3_IIN.OBJECT_UNKNOWN,
+      };
+    }
+    const def = this.pointMap.getPoint('analogOutput', item.index);
+    if (!def) {
+      return { ...base, command: null, rejection: DNP3_COMMAND_STATUS.NOT_SUPPORTED, iin: DNP3_IIN.OBJECT_UNKNOWN };
+    }
+    return {
+      ...base,
+      command: {
+        kind: 'analogOutput',
+        group: header.group,
+        variation: header.variation,
+        index: item.index,
+        tagId: def.tagId,
+        value,
+      },
+      rejection: null,
+      iin: 0,
+    };
+  }
+
+  /** Apply the function-code semantics and produce one status per object. */
+  private resolveStatuses(req: ParsedRequest, decoded: DecodedObject[], now: number): number[] {
+    // ── Fail-closed gate ─────────────────────────────────────────────────────
+    // Nothing below this point may run unless controls are explicitly enabled
+    // AND a sink exists. A read-only outstation answers NOT_SUPPORTED.
+    if (!this.writable) {
+      logWarn(
+        this.config.enabled
+          ? 'DNP3 outstation: control rejected — controls enabled but no control sink installed'
+          : 'DNP3 outstation: control rejected — controls are disabled (read-only outstation)',
+      );
+      this.armed = null;
+      return decoded.map(() => DNP3_COMMAND_STATUS.NOT_SUPPORTED);
+    }
+
+    const invalid = decoded.map((d) => d.rejection);
+
+    if (req.func === DNP3_FUNCTION.SELECT) {
+      // A SELECT never touches the process. Arm only when every object is valid.
+      if (invalid.some((r) => r !== null)) {
+        this.armed = null;
+        return invalid.map((r) => r ?? DNP3_COMMAND_STATUS.SUCCESS);
+      }
+      const commands = decoded.map((d) => d.command!);
+      this.armed = {
+        seq: req.seq,
+        armedAt: now,
+        digest: canonicalDigest(decoded),
+        commands,
+      };
+      return decoded.map(() => DNP3_COMMAND_STATUS.SUCCESS);
+    }
+
+    if (req.func === DNP3_FUNCTION.OPERATE) {
+      const armed = this.armed;
+      // The arm is single-use: consume it whatever the outcome, so a rejected
+      // OPERATE can never be replayed against a stale selection.
+      this.armed = null;
+      if (!armed) {
+        return decoded.map(() => DNP3_COMMAND_STATUS.NO_SELECT);
+      }
+      const matches =
+        armed.seq === ((req.seq - 1 + 16) & 0x0f) &&
+        armed.digest.equals(canonicalDigest(decoded));
+      if (!matches) {
+        return decoded.map(() => DNP3_COMMAND_STATUS.NO_SELECT);
+      }
+      if (now - armed.armedAt > this.config.selectTimeoutMs) {
+        return decoded.map(() => DNP3_COMMAND_STATUS.TIMEOUT);
+      }
+      return this.execute(decoded, invalid, now);
+    }
+
+    // DIRECT_OPERATE / DIRECT_OPERATE_NR: no prior SELECT required. Any armed
+    // selection is invalidated because the point state may now differ.
+    this.armed = null;
+    return this.execute(decoded, invalid, now);
+  }
+
+  /** Run the valid commands through the sink and collect their statuses. */
+  private execute(decoded: DecodedObject[], invalid: (number | null)[], now: number): number[] {
+    const sink = this.sink;
+    if (!sink) return decoded.map(() => DNP3_COMMAND_STATUS.NOT_SUPPORTED);
+
+    return decoded.map((d, i) => {
+      const rejection = invalid[i];
+      if (rejection !== null) return rejection;
+      const command = d.command!;
+
+      if (command.kind === 'binaryOutput') {
+        // IEEE 1815 g12v1: a count of 0 means the outstation shall NOT execute
+        // the operation. That is a well-formed no-op, not an error.
+        if (command.crob.count === 0) return DNP3_COMMAND_STATUS.SUCCESS;
+        const busyUntil = this.activeUntil.get(command.index);
+        if (busyUntil !== undefined && busyUntil > now) {
+          return DNP3_COMMAND_STATUS.ALREADY_ACTIVE;
+        }
+      }
+
+      let outcome: Dnp3ControlOutcome;
+      try {
+        outcome = sink(command);
+      } catch {
+        // A throwing sink is a hardware/integration failure, not a protocol one.
+        return DNP3_COMMAND_STATUS.HARDWARE_ERROR;
+      }
+      if (!outcome.ok) {
+        return outcome.status ?? DNP3_COMMAND_STATUS.HARDWARE_ERROR;
+      }
+
+      if (command.kind === 'binaryOutput') {
+        const duration = pulseDurationMs(command.crob);
+        if (duration > 0) this.activeUntil.set(command.index, now + duration);
+        else this.activeUntil.delete(command.index);
+      }
+      return DNP3_COMMAND_STATUS.SUCCESS;
+    });
+  }
+
+  /** Rebuild the request's object headers with per-object status octets. */
+  private echo(headers: ParsedObjectHeader[], decoded: DecodedObject[], statuses: number[]): Buffer {
+    const parts: Buffer[] = [];
+    let cursor = 0;
+    for (const header of headers) {
+      if (!header.items || header.items.length === 0) continue;
+      const twoOctet = (header.qualifier & 0xf0) === 0x20;
+      const prefixLen = twoOctet ? 2 : 1;
+      const countLen = twoOctet ? 2 : 1;
+
+      const objHeader = Buffer.alloc(3 + countLen);
+      objHeader.writeUInt8(header.group, 0);
+      objHeader.writeUInt8(header.variation, 1);
+      objHeader.writeUInt8(header.qualifier, 2);
+      if (twoOctet) objHeader.writeUInt16LE(header.items.length, 3);
+      else objHeader.writeUInt8(header.items.length, 3);
+      parts.push(objHeader);
+
+      for (const item of header.items) {
+        const d = decoded[cursor];
+        const status = statuses[cursor] ?? DNP3_COMMAND_STATUS.UNDEFINED;
+        cursor += 1;
+        const prefix = Buffer.alloc(prefixLen);
+        if (twoOctet) prefix.writeUInt16LE(item.index, 0);
+        else prefix.writeUInt8(item.index, 0);
+        parts.push(prefix, echoBody(header, item, d, status));
+      }
+    }
+    return Buffer.concat(parts);
+  }
+}
+
+/**
+ * Echo one command object with its status octet replaced. When the body could
+ * not be decoded we echo the master's own octets back verbatim except for the
+ * final status octet, which is what IEEE 1815 asks for.
+ */
+function echoBody(
+  header: ParsedObjectHeader,
+  item: ParsedPrefixedObject,
+  decoded: DecodedObject | undefined,
+  status: number,
+): Buffer {
+  if (decoded?.command) {
+    if (decoded.command.kind === 'binaryOutput') {
+      return encodeCrob(decoded.command.crob, status);
+    }
+    return encodeAnalogOutput(header.variation, decoded.command.value, status);
+  }
+  if (item.data.length === 0) return Buffer.alloc(0);
+  const copy = Buffer.from(item.data);
+  copy.writeUInt8(status & 0xff, copy.length - 1);
+  return copy;
+}
+
+/**
+ * The commanded coil state of a CROB, or null when the operation type is not
+ * one this outstation performs. The Trip-Close Code selects the physical coil
+ * on a paired output and therefore overrides the operation-type polarity.
+ */
+export function crobValue(crob: CrobFields): boolean | null {
+  let value: boolean;
+  switch (crob.opType) {
+    case DNP3_CONTROL_OP_TYPE.LATCH_ON:
+    case DNP3_CONTROL_OP_TYPE.PULSE_ON:
+      value = true;
+      break;
+    case DNP3_CONTROL_OP_TYPE.LATCH_OFF:
+    case DNP3_CONTROL_OP_TYPE.PULSE_OFF:
+      value = false;
+      break;
+    default:
+      // NUL and reserved operation types are not executed.
+      return null;
+  }
+  if (crob.tcc === DNP3_CONTROL_TCC.TRIP) return false;
+  if (crob.tcc === DNP3_CONTROL_TCC.CLOSE) return true;
+  return value;
+}
+
+/**
+ * How long a CROB keeps the output busy, in ms. Latch operations complete
+ * immediately; pulse trains are busy for `count` on-periods plus the
+ * intervening off-periods. A later OPERATE arriving inside that window is
+ * rejected with ALREADY_ACTIVE.
+ */
+export function pulseDurationMs(crob: CrobFields): number {
+  if (crob.opType !== DNP3_CONTROL_OP_TYPE.PULSE_ON && crob.opType !== DNP3_CONTROL_OP_TYPE.PULSE_OFF) {
+    return 0;
+  }
+  const count = Math.max(0, crob.count);
+  if (count === 0) return 0;
+  return count * crob.onTimeMs + (count - 1) * crob.offTimeMs;
+}
+
+/**
+ * Canonical bytes an OPERATE must reproduce to match its SELECT: group,
+ * variation, index and the full object body with the status octet zeroed (the
+ * master sends status 0 in requests, but zeroing makes the comparison immune to
+ * a master that echoes something else).
+ */
+function canonicalDigest(decoded: DecodedObject[]): Buffer {
+  const parts: Buffer[] = [];
+  for (const d of decoded) {
+    const head = Buffer.alloc(4);
+    head.writeUInt8(d.header.group, 0);
+    head.writeUInt8(d.header.variation, 1);
+    head.writeUInt16LE(d.item.index & 0xffff, 2);
+    const body = Buffer.from(d.item.data);
+    if (body.length > 0) body.writeUInt8(0, body.length - 1);
+    parts.push(head, body);
+  }
+  return Buffer.concat(parts);
+}

--- a/server/protocols/dnp3-outstation/event-objects.ts
+++ b/server/protocols/dnp3-outstation/event-objects.ts
@@ -1,0 +1,364 @@
+/**
+ * DNP3 Event Object Serialisation — g2 / g11 / g22 / g32 / g42 (+ g51 CTO)
+ * Issue #464: DNP3 Outstation Mode
+ *
+ * Turns buffered `Dnp3Event`s into the octets a master expects inside a Class
+ * 1/2/3 response. Before this module existed the event path returned
+ * `Buffer.alloc(0)` — events were counted, reported and IIN-flagged but no data
+ * ever reached the master.
+ *
+ * Wire rules implemented here (IEEE 1815-2012 §5.1.5, §A.2):
+ *
+ *   - Events are NOT contiguous in index space, so every event object header
+ *     uses an INDEX-PREFIXED qualifier: 0x17 (1-octet index prefix, 1-octet
+ *     count) while every index in the run is <= 255, otherwise 0x28 (2-octet
+ *     index prefix, 2-octet count).
+ *   - Consecutive events sharing a group/variation are merged into a single
+ *     object header; a change of group/variation starts a new header. Event
+ *     ordering (chronological, by the buffer's global sequence) is preserved
+ *     across headers, which is what the standard requires.
+ *   - Absolute timestamps are the 6-octet little-endian DNP3 Time.
+ *   - Relative-time binary INPUT events (g2v3) are only legal after a Common
+ *     Time Of Occurrence object, so a g51v1 CTO is emitted immediately before
+ *     each relative-time run and the per-event field is the 16-bit unsigned
+ *     millisecond offset from that CTO. A run is closed and a new CTO started
+ *     whenever the offset would not fit in 16 bits or would go negative.
+ *     Group 11 (Binary Output Event) has NO relative-time variation in IEEE
+ *     1815 — only v1 and v2 — so a relative-time policy degrades to g11v2 for
+ *     binary outputs rather than emitting an object no master can decode.
+ *
+ * Everything here is pure (events in -> octets out) and byte-exact, so it is
+ * covered by golden-vector unit tests rather than a live master.
+ */
+
+import {
+  DNP3_GROUP,
+  DNP3_VARIATION,
+  encodeDnp3Time,
+} from './app-objects';
+import type { Dnp3Event } from './event-buffer';
+import { Dnp3PointMap, type AnalogEncoding, type Dnp3PointType } from './point-map';
+
+/** Time representation to use for binary (g2/g11) events. */
+export type BinaryEventTimeMode = 'no-time' | 'absolute-time' | 'relative-time';
+/** Time representation to use for counter/analog events. */
+export type NumericEventTimeMode = 'no-time' | 'absolute-time';
+
+/**
+ * Which variation family the outstation emits per event type. The numeric WIDTH
+ * (int32 vs float32) is not configurable here — it follows the point's own
+ * `encoding` so an event never silently truncates a value the static read
+ * reports at full precision.
+ */
+export interface EventVariationPolicy {
+  /** g2 (binary input) / g11 (binary output): v1 no time, v2 absolute, v3 relative */
+  binary: BinaryEventTimeMode;
+  /** g22 (counter): v1 no time, v5 with absolute time */
+  counter: NumericEventTimeMode;
+  /** g32 (analog input) / g42 (analog output): v1/v5 no time, v3/v7 with absolute time */
+  analog: NumericEventTimeMode;
+}
+
+/**
+ * Default policy: absolute timestamps everywhere. Timestamped variations are
+ * what utility masters expect from an outstation that buffers events, and they
+ * are self-contained (no CTO ordering dependency).
+ */
+export const DEFAULT_EVENT_VARIATIONS: EventVariationPolicy = {
+  binary: 'absolute-time',
+  counter: 'absolute-time',
+  analog: 'absolute-time',
+};
+
+/** How the time field of one event object is encoded. */
+type TimeMode = 'none' | 'absolute' | 'relative';
+
+/** A single event, resolved to its group/variation and value octets. */
+interface EventDescriptor {
+  /** event-buffer sequence number (for confirm bookkeeping) */
+  seq: number;
+  group: number;
+  variation: number;
+  index: number;
+  timestamp: number;
+  /** flag octet + value octets, WITHOUT any time field */
+  core: Buffer;
+  timeMode: TimeMode;
+}
+
+export interface EventEncodeResult {
+  /** Concatenated object blocks, ready to append after the application header. */
+  bytes: Buffer;
+  /** Event-buffer sequence numbers actually encoded, in emission order. */
+  encodedSeqs: number[];
+  /** Events that did not fit in the byte budget (they remain buffered). */
+  remaining: number;
+}
+
+const EMPTY = Buffer.alloc(0);
+
+/** Number of octets the time field of a descriptor occupies. */
+function timeFieldLength(mode: TimeMode): number {
+  switch (mode) {
+    case 'absolute':
+      return 6;
+    case 'relative':
+      return 2;
+    case 'none':
+      return 0;
+  }
+}
+
+/** Group used for an event of the given point type. */
+function eventGroupFor(pointType: Dnp3PointType): number | null {
+  switch (pointType) {
+    case 'binaryInput':
+      return DNP3_GROUP.BINARY_INPUT_EVENT;
+    case 'binaryOutput':
+      return DNP3_GROUP.BINARY_OUTPUT_EVENT;
+    case 'counter':
+      return DNP3_GROUP.COUNTER_EVENT;
+    case 'analogInput':
+      return DNP3_GROUP.ANALOG_INPUT_EVENT;
+    case 'analogOutput':
+      return DNP3_GROUP.ANALOG_OUTPUT_EVENT;
+    default:
+      return null;
+  }
+}
+
+/** Clamp+truncate to a signed 32-bit range (analog events). */
+function toInt32(value: number): number {
+  const v = Math.trunc(value);
+  if (v < -2147483648) return -2147483648;
+  if (v > 2147483647) return 2147483647;
+  return v;
+}
+
+/** Clamp+truncate to an unsigned 32-bit range (counter events). */
+function toUint32(value: number): number {
+  const v = Math.trunc(value);
+  if (v < 0) return 0;
+  if (v > 0xffffffff) return 0xffffffff;
+  return v;
+}
+
+/**
+ * Resolve one buffered event to its group/variation + value octets. Returns null
+ * for point types that have no event group (never happens for the five mapped
+ * types, but keeps the function total).
+ */
+function describeEvent(
+  event: Dnp3Event,
+  encoding: AnalogEncoding,
+  policy: EventVariationPolicy,
+): EventDescriptor | null {
+  const group = eventGroupFor(event.pointType);
+  if (group === null) return null;
+  const flags = event.flags & 0xff;
+
+  if (event.pointType === 'binaryInput' || event.pointType === 'binaryOutput') {
+    // g2v1/g11v1: flag octet only. The binary STATE is bit 7 of the flag octet,
+    // so no separate value field exists for any binary event variation.
+    const core = Buffer.from([flags]);
+    // IEEE 1815-2012 Table A-1: group 2 (Binary Input Event) defines v1 (no
+    // time), v2 (absolute time) and v3 (relative time), but group 11 (Binary
+    // Output Event) defines ONLY v1 and v2 — there is no g11v3. A relative-time
+    // policy therefore has to degrade to the absolute-time variation for binary
+    // OUTPUT events; emitting a g11v3 would put an object on the wire that no
+    // conformant master can decode.
+    const isInput = event.pointType === 'binaryInput';
+    const noTime = isInput ? DNP3_VARIATION.BI_EVENT_NO_TIME : DNP3_VARIATION.BO_EVENT_NO_TIME;
+    const absTime = isInput ? DNP3_VARIATION.BI_EVENT_ABS_TIME : DNP3_VARIATION.BO_EVENT_ABS_TIME;
+    const mode: BinaryEventTimeMode =
+      policy.binary === 'relative-time' && !isInput ? 'absolute-time' : policy.binary;
+    switch (mode) {
+      case 'no-time':
+        return { seq: event.seq, group, variation: noTime, index: event.index, timestamp: event.timestamp, core, timeMode: 'none' };
+      case 'relative-time':
+        return { seq: event.seq, group, variation: DNP3_VARIATION.BI_EVENT_REL_TIME, index: event.index, timestamp: event.timestamp, core, timeMode: 'relative' };
+      case 'absolute-time':
+      default:
+        return { seq: event.seq, group, variation: absTime, index: event.index, timestamp: event.timestamp, core, timeMode: 'absolute' };
+    }
+  }
+
+  if (event.pointType === 'counter') {
+    // g22v1: flag + 32-bit unsigned. g22v5 appends the 6-octet DNP3 time.
+    const core = Buffer.alloc(5);
+    core.writeUInt8(flags, 0);
+    core.writeUInt32LE(toUint32(Number(event.value)), 1);
+    const withTime = policy.counter === 'absolute-time';
+    return {
+      seq: event.seq,
+      group,
+      variation: withTime ? DNP3_VARIATION.CNT_EVENT_32_ABS_TIME : DNP3_VARIATION.CNT_EVENT_32_WITH_FLAG,
+      index: event.index,
+      timestamp: event.timestamp,
+      core,
+      timeMode: withTime ? 'absolute' : 'none',
+    };
+  }
+
+  // Analog input (g32) / analog output (g42). Width follows the point encoding:
+  //   int32   -> v1 (no time) / v3 (with time)
+  //   float32 -> v5 (no time) / v7 (with time)
+  const withTime = policy.analog === 'absolute-time';
+  const core = Buffer.alloc(5);
+  core.writeUInt8(flags, 0);
+  if (encoding === 'int32') {
+    core.writeInt32LE(toInt32(Number(event.value)), 1);
+  } else {
+    core.writeFloatLE(Number(event.value), 1);
+  }
+  // Groups 32 and 42 share the same variation numbering, but name them
+  // separately so the constant matches the group actually emitted.
+  const isInput = event.pointType === 'analogInput';
+  const variation = encoding === 'int32'
+    ? withTime
+      ? (isInput ? DNP3_VARIATION.AI_EVENT_32_ABS_TIME : DNP3_VARIATION.AO_EVENT_32_ABS_TIME)
+      : (isInput ? DNP3_VARIATION.AI_EVENT_32_WITH_FLAG : DNP3_VARIATION.AO_EVENT_32_WITH_FLAG)
+    : withTime
+      ? (isInput ? DNP3_VARIATION.AI_EVENT_FLOAT_ABS_TIME : DNP3_VARIATION.AO_EVENT_FLOAT_ABS_TIME)
+      : (isInput ? DNP3_VARIATION.AI_EVENT_FLOAT_WITH_FLAG : DNP3_VARIATION.AO_EVENT_FLOAT_WITH_FLAG);
+  return {
+    seq: event.seq,
+    group,
+    variation,
+    index: event.index,
+    timestamp: event.timestamp,
+    core,
+    timeMode: withTime ? 'absolute' : 'none',
+  };
+}
+
+/**
+ * Build a g51v1 Common Time Of Occurrence object: object header with qualifier
+ * 0x07 (1-octet count) count=1, followed by the 6-octet absolute DNP3 time.
+ * Ten octets total.
+ */
+export function buildCtoObject(epochMs: number): Buffer {
+  return Buffer.concat([
+    Buffer.from([DNP3_GROUP.TIME_AND_DATE_CTO, DNP3_VARIATION.CTO_SYNC, 0x07, 0x01]),
+    encodeDnp3Time(epochMs),
+  ]);
+}
+
+/**
+ * Serialise buffered events into DNP3 event objects.
+ *
+ * Encoding stops as soon as the next event would exceed `maxBytes`; the events
+ * that did fit are reported in `encodedSeqs` (always a prefix of `events`, so a
+ * caller can resume with `events.slice(encodedSeqs.length)` on the next
+ * fragment). Nothing is removed from the event buffer here — that is the
+ * caller's confirm bookkeeping.
+ */
+export function buildEventObjects(
+  events: readonly Dnp3Event[],
+  opts: {
+    pointMap: Dnp3PointMap;
+    policy?: EventVariationPolicy;
+    /** octets available for object data (the application header is excluded) */
+    maxBytes?: number;
+  },
+): EventEncodeResult {
+  const policy = opts.policy ?? DEFAULT_EVENT_VARIATIONS;
+  const maxBytes = opts.maxBytes ?? Number.MAX_SAFE_INTEGER;
+
+  const descriptors: EventDescriptor[] = [];
+  for (const event of events) {
+    const def = opts.pointMap.getPoint(event.pointType, event.index);
+    const isAnalog = event.pointType === 'analogInput' || event.pointType === 'analogOutput';
+    // An analog event whose point is no longer mapped has no known value width.
+    // Stop here rather than guess: `encodedSeqs` must stay a prefix of `events`
+    // so the caller can resume, and a wrong width would corrupt the response.
+    if (isAnalog && !def) break;
+    const encoding: AnalogEncoding = def?.encoding ?? 'float32';
+    const descriptor = describeEvent(event, encoding, policy);
+    if (!descriptor) break;
+    descriptors.push(descriptor);
+  }
+
+  const parts: Buffer[] = [];
+  const encodedSeqs: number[] = [];
+  let used = 0;
+  let i = 0;
+
+  while (i < descriptors.length) {
+    const first = descriptors[i];
+    const twoOctet = first.index > 0xff;
+    const prefixLen = twoOctet ? 2 : 1;
+    const countLen = twoOctet ? 2 : 1;
+    const qualifier = twoOctet ? 0x28 : 0x17;
+    const maxCount = twoOctet ? 0xffff : 0xff;
+    const headerLen = 3 + countLen;
+
+    // A relative-time run must be introduced by its own CTO object.
+    const ctoBytes = first.timeMode === 'relative' ? buildCtoObject(first.timestamp) : null;
+    const ctoBase = first.timestamp;
+    const ctoLen = ctoBytes ? ctoBytes.length : 0;
+
+    const firstItemLen = prefixLen + first.core.length + timeFieldLength(first.timeMode);
+    if (used + ctoLen + headerLen + firstItemLen > maxBytes) {
+      // Not even one more object fits in this fragment.
+      break;
+    }
+
+    const items: Buffer[] = [];
+    const runSeqs: number[] = [];
+    let itemsLen = 0;
+    let j = i;
+    while (j < descriptors.length && runSeqs.length < maxCount) {
+      const d = descriptors[j];
+      if (d.group !== first.group || d.variation !== first.variation) break;
+      if ((d.index > 0xff) !== twoOctet) break;
+
+      let timeField: Buffer;
+      if (d.timeMode === 'absolute') {
+        timeField = encodeDnp3Time(d.timestamp);
+      } else if (d.timeMode === 'relative') {
+        const offset = d.timestamp - ctoBase;
+        // Offsets are 16-bit unsigned; anything outside that needs a new CTO.
+        if (offset < 0 || offset > 0xffff) break;
+        timeField = Buffer.alloc(2);
+        timeField.writeUInt16LE(offset, 0);
+      } else {
+        timeField = EMPTY;
+      }
+
+      const itemLen = prefixLen + d.core.length + timeField.length;
+      if (used + ctoLen + headerLen + itemsLen + itemLen > maxBytes) break;
+
+      const prefix = Buffer.alloc(prefixLen);
+      if (twoOctet) prefix.writeUInt16LE(d.index, 0);
+      else prefix.writeUInt8(d.index, 0);
+      items.push(prefix, d.core, timeField);
+      itemsLen += itemLen;
+      runSeqs.push(d.seq);
+      j += 1;
+    }
+
+    // Defensive: the pre-check above guarantees at least one item, but never
+    // loop forever if that ever stops holding.
+    if (runSeqs.length === 0) break;
+
+    const header = Buffer.alloc(headerLen);
+    header.writeUInt8(first.group, 0);
+    header.writeUInt8(first.variation, 1);
+    header.writeUInt8(qualifier, 2);
+    if (twoOctet) header.writeUInt16LE(runSeqs.length, 3);
+    else header.writeUInt8(runSeqs.length, 3);
+
+    if (ctoBytes) parts.push(ctoBytes);
+    parts.push(header, ...items);
+    used += ctoLen + headerLen + itemsLen;
+    encodedSeqs.push(...runSeqs);
+    i = j;
+  }
+
+  return {
+    bytes: Buffer.concat(parts),
+    encodedSeqs,
+    remaining: events.length - encodedSeqs.length,
+  };
+}

--- a/server/protocols/dnp3-outstation/index.ts
+++ b/server/protocols/dnp3-outstation/index.ts
@@ -2,28 +2,45 @@
  * DNP3 Outstation — TCP Server
  * Issue #464: [wave:2c] Build DNP3 Outstation Mode
  *
- * PARTIAL (substantial). This module wires the fully-implemented cores
- * (point-map, event-buffer, secure-auth, link CRC, transport, APDU assembly)
- * into a TCP outstation that DNP3 masters (e.g. opendnp3) can poll. The
- * request-dispatch covers the conformance-critical paths:
- *   - Class 0 read  -> all static data (BI/AI/Counter/BO status/AO status)
- *   - Class 1/2/3 read -> buffered events for the requested class(es)
+ * Wires the protocol cores (point-map, event-buffer, event-object encoder,
+ * controls, secure-auth, link CRC, transport, APDU assembly) into a TCP
+ * outstation that DNP3 masters (e.g. opendnp3) can poll. The request-dispatch
+ * covers the conformance-critical paths:
+ *   - Class 0 read      -> all static data (BI/AI/Counter/BO status/AO status)
+ *   - Class 1/2/3 read  -> buffered events serialised as g2/g11/g22/g32/g42
+ *                          objects with index-prefixed qualifiers, split across
+ *                          response fragments and cleared only on CONFIRM
+ *   - SELECT / OPERATE / DIRECT-OPERATE of g12v1 CROB and g41v1..v4 analog
+ *     output blocks, with real select-before-operate arming (OFF BY DEFAULT —
+ *     see the safety note below)
  *   - Unsolicited responses on Class 1/2/3 buffer thresholds
- *   - SAv5 challenge/verify on critical function codes (SELECT/OPERATE/WRITE…)
+ *   - SAv5 challenge/verify on critical function codes, and dispatch of the
+ *     ASDU once the reply's MAC verifies
  *
- * EXPLICITLY TODO (documented in docs/protocols/dnp3-outstation.md):
- *   - Event object serialisation per group/variation with absolute timestamps
- *     (group 2/22/32/42) — events are currently surfaced via the buffer + a
- *     placeholder object header; the per-variation event encoder is stubbed.
+ * ── SAFETY: the write path is fail-closed ────────────────────────────────────
+ * DNP3 controls move live plant state. They are rejected with CommandStatus
+ * NOT_SUPPORTED unless BOTH `config.controls.enabled` is explicitly true (it
+ * defaults to false) AND the embedder installs a control sink via
+ * `setControlSink()`. A default-constructed outstation is read-only.
+ *
+ * ── NOT WIRED INTO SERVER STARTUP ────────────────────────────────────────────
+ * Nothing here starts a listener on import. `start()` must be called
+ * explicitly. Exposing the outstation on a network interface is deliberately
+ * left to a separate change: it needs its own network-policy review because a
+ * DNP3 master that reaches this port can drive the control path.
+ *
+ * ── Known remaining gaps (honest list) ───────────────────────────────────────
+ *   - One master association. The application-layer confirm state lives in a
+ *     per-connection `OutstationSession`, but the event buffer is shared, so if
+ *     two masters connect at once the first CONFIRM drains events for both.
+ *     DNP3 outstations conventionally serve a single master.
  *   - Full secondary link-confirm + frame-count-bit (FCB) state machine.
- *   - SELECT-before-OPERATE arm/disarm timing and CROB execution side effects.
- *   - Multi-fragment response continuation (CON/sequence) on large reads.
- *   - DNP3 serial transport (this is TCP only; serial is a separate task).
- *
- * The networking layer is isolated so the pure cores remain unit-testable
- * without opening a socket. `Dnp3Outstation` is the network object; the
- * request-handling logic is exposed via `handleApplicationRequest` which is
- * pure (buffer in -> buffer out) and testable.
+ *   - WRITE g80v1 (master clearing the DEVICE_RESTART IIN bit).
+ *   - Group-120 free-format object framing (qualifier 0x5B); the SAv5 objects
+ *     use the simple count-1 header this module also emits.
+ *   - Unconfirmed events are re-sent on the next Class poll (correct), but
+ *     there is no independent retry timer.
+ *   - DNP3 serial transport (this is TCP only).
  */
 
 import net from 'net';
@@ -37,6 +54,16 @@ import {
   type EventClass,
 } from './event-buffer';
 import {
+  buildEventObjects,
+  DEFAULT_EVENT_VARIATIONS,
+  type EventVariationPolicy,
+} from './event-objects';
+import {
+  Dnp3ControlProcessor,
+  type Dnp3ControlConfig,
+  type Dnp3ControlSink,
+} from './controls';
+import {
   Sav5Outstation,
   isCriticalFunction,
   encodeChallengeObject,
@@ -46,9 +73,10 @@ import {
 import {
   parseRequest,
   buildResponseHeader,
-  buildClass0Objects,
+  buildClass0Blocks,
   buildIin,
   classReadTargets,
+  APP_CTRL_SEQ_MASK,
   type ParsedRequest,
 } from './app-layer';
 import { DNP3_FUNCTION, DNP3_GROUP } from './app-objects';
@@ -58,17 +86,44 @@ import {
   extractPayload,
   DNP3_LINK_FUNCTION,
 } from './link-layer';
-import { segment, TransportReassembler } from './transport';
+import { segment, TransportReassembler, TRANSPORT_SEQ_MASK } from './transport';
+
+/** Octets of application header (APP_CONTROL + FUNCTION + IIN) on a response. */
+const APP_HEADER_LEN = 4;
 
 export const Dnp3OutstationConfigSchema = z.object({
-  /** TCP listen port. DNP3 default is 20000. */
-  port: z.number().int().min(1).max(65535).default(20000),
+  /** TCP listen port. DNP3 default is 20000; 0 asks the OS for a free port. */
+  port: z.number().int().min(0).max(65535).default(20000),
   /** Bind host. */
   host: z.string().default('0.0.0.0'),
   /** This outstation's DNP3 link address. */
   localAddress: z.number().int().min(0).max(0xffff).default(10),
   /** Whether unsolicited responses are enabled at startup. */
   unsolicitedEnabled: z.boolean().default(false),
+  /**
+   * Maximum application fragment the outstation will transmit. IEEE 1815 caps
+   * responses at 2048 octets; larger event sets are split across fragments.
+   */
+  maxTxFragmentSize: z.number().int().min(64).max(2048).default(2048),
+  /** Which event variations to emit (time representation per event type). */
+  eventVariations: z
+    .object({
+      binary: z.enum(['no-time', 'absolute-time', 'relative-time']).default('absolute-time'),
+      counter: z.enum(['no-time', 'absolute-time']).default('absolute-time'),
+      analog: z.enum(['no-time', 'absolute-time']).default('absolute-time'),
+    })
+    .default({}),
+  /**
+   * DNP3 control (SELECT/OPERATE/DIRECT-OPERATE) policy. Disabled by default:
+   * the outstation is read-only until an operator opts in AND a control sink is
+   * installed.
+   */
+  controls: z
+    .object({
+      enabled: z.boolean().default(false),
+      selectTimeoutMs: z.number().int().positive().default(5000),
+    })
+    .default({}),
   /** Point map. */
   pointMap: Dnp3PointMapConfigSchema.default({ points: [] }),
 });
@@ -76,14 +131,42 @@ export const Dnp3OutstationConfigSchema = z.object({
 export type Dnp3OutstationConfig = z.input<typeof Dnp3OutstationConfigSchema>;
 type ResolvedConfig = z.infer<typeof Dnp3OutstationConfigSchema>;
 
+/** One fragment of an application response, plus what it commits the outstation to. */
+export interface Dnp3ResponseFragment {
+  /** the application fragment octets (header + objects) */
+  bytes: Buffer;
+  /** application sequence number carried in the fragment header */
+  seq: number;
+  /** CON bit — the master must send an application CONFIRM for this fragment */
+  con: boolean;
+  /** event-buffer sequence numbers carried; removed from the buffer on CONFIRM */
+  eventSeqs: number[];
+}
+
+/**
+ * Per-master-association application-layer state. An outstation may only have
+ * one response outstanding at a time, so this holds the fragment awaiting a
+ * CONFIRM plus any fragments queued behind it.
+ */
+export interface OutstationSession {
+  pendingFragments: Dnp3ResponseFragment[];
+  awaitingConfirm: Dnp3ResponseFragment | null;
+}
+
+export function createSession(): OutstationSession {
+  return { pendingFragments: [], awaitingConfirm: null };
+}
+
 /** Per-connection link/transport state. */
 interface ConnectionState {
   socket: net.Socket;
   reassembler: TransportReassembler;
   /** master's link address learned from the first frame */
   masterAddress: number;
-  /** application response sequence */
-  appSeq: number;
+  /** running transport-function sequence number for transmitted segments */
+  transportSeq: number;
+  /** application-layer response state for this association */
+  session: OutstationSession;
   rxBuffer: Buffer;
 }
 
@@ -95,64 +178,130 @@ export interface OutstationContext {
   pointMap: Dnp3PointMap;
   eventBuffer: Dnp3EventBuffer;
   secureAuth: Sav5Outstation;
+  /** control (write) path — fail-closed unless enabled AND given a sink */
+  controls: Dnp3ControlProcessor;
+  /** which event variations to emit */
+  eventVariations: EventVariationPolicy;
+  /** max application fragment size for responses */
+  maxTxFragmentSize: number;
+  /** default association state, used when no per-connection session is passed */
+  session: OutstationSession;
   /** set false until the master clears it; surfaces DEVICE_RESTART IIN */
   restartPending: boolean;
   unsolicitedEnabled: boolean;
 }
 
+/** Build an `OutstationContext` with the module's defaults applied. */
+export function createOutstationContext(opts?: {
+  pointMap?: Dnp3PointMap;
+  eventBuffer?: Dnp3EventBuffer;
+  secureAuth?: Sav5Outstation;
+  controlConfig?: Dnp3ControlConfig;
+  controlSink?: Dnp3ControlSink | null;
+  eventVariations?: EventVariationPolicy;
+  maxTxFragmentSize?: number;
+  restartPending?: boolean;
+  unsolicitedEnabled?: boolean;
+}): OutstationContext {
+  const pointMap = opts?.pointMap ?? new Dnp3PointMap();
+  return {
+    pointMap,
+    eventBuffer: opts?.eventBuffer ?? new Dnp3EventBuffer(DEFAULT_EVENT_BUFFER_CONFIG),
+    secureAuth: opts?.secureAuth ?? new Sav5Outstation(),
+    controls: new Dnp3ControlProcessor(
+      pointMap,
+      opts?.controlConfig ?? { enabled: false, selectTimeoutMs: 5000 },
+      opts?.controlSink ?? null,
+    ),
+    eventVariations: opts?.eventVariations ?? DEFAULT_EVENT_VARIATIONS,
+    maxTxFragmentSize: opts?.maxTxFragmentSize ?? 2048,
+    session: createSession(),
+    restartPending: opts?.restartPending ?? false,
+    unsolicitedEnabled: opts?.unsolicitedEnabled ?? false,
+  };
+}
+
+/** Outcome of handling one application request. */
+export interface Dnp3RequestResult {
+  /** the fragment to transmit now; empty when there is nothing to send */
+  response: Buffer;
+  /** all fragments produced (the first is `response`); empty for no-response funcs */
+  fragments: Dnp3ResponseFragment[];
+  challenged: boolean;
+}
+
+const NO_RESPONSE: Dnp3RequestResult = { response: Buffer.alloc(0), fragments: [], challenged: false };
+
 /**
  * Handle one parsed application request and return the application response
- * fragment bytes (no link/transport framing). PURE — no I/O. This is the
- * primary unit-test surface for the application layer.
+ * fragment bytes (no link/transport framing). PURE apart from the outstation
+ * state it is given — no I/O. This is the primary unit-test surface for the
+ * application layer.
  *
- * SAv5: when a critical function arrives we do NOT execute it; instead we return
- * a g120v1 challenge fragment. The master's g120v2 reply is handled separately
- * via `handleSecureAuthReply`.
+ * SAv5: when a critical function arrives and a key is provisioned we do NOT
+ * execute it; instead we return a g120v1 challenge fragment. The master's
+ * g120v2 reply is verified via `handleSecureAuthReply`, after which the caller
+ * re-dispatches the authorised ASDU with `skipSecureAuth`.
  */
 export function handleApplicationRequest(
   ctx: OutstationContext,
   req: ParsedRequest,
-  opts?: { userNumber?: number; now?: number },
-): { response: Buffer; challenged: boolean } {
+  opts?: { userNumber?: number; now?: number; session?: OutstationSession; skipSecureAuth?: boolean },
+): Dnp3RequestResult {
   const now = opts?.now ?? Date.now();
   const userNumber = opts?.userNumber ?? 1;
+  const session = opts?.session ?? ctx.session;
 
   // ── Secure Authentication: challenge critical requests ──────────────────
-  if (isCriticalFunction(req.func) && ctx.secureAuth.hasUser(userNumber)) {
-    const challenge = ctx.secureAuth.issueChallenge(userNumber, req.rawObjects, { now });
-    const header = buildResponseHeader({
-      seq: req.seq,
-      iin: currentIin(ctx),
-    });
+  if (!opts?.skipSecureAuth && isCriticalFunction(req.func) && ctx.secureAuth.hasUser(userNumber)) {
+    // The Critical ASDU is the whole application fragment (IEEE 1815 §7.5.2.2),
+    // so the MAC covers the function code and application control octet too.
+    const challenge = ctx.secureAuth.issueChallenge(userNumber, req.raw, { now });
+    const header = buildResponseHeader({ seq: req.seq, iin: currentIin(ctx) });
     // g120v1 object header (qualifier 0x5B free-format is spec; we use a simple
-    // count-1 header here as the integration seam — see TODO in module doc).
+    // count-1 header here as the integration seam — see module doc).
     const objHeader = Buffer.from([DNP3_GROUP.SECURE_AUTH, 0x01, 0x07, 0x01]);
     const body = encodeChallengeObject(challenge);
-    return { response: Buffer.concat([header, objHeader, body]), challenged: true };
+    const bytes = Buffer.concat([header, objHeader, body]);
+    return {
+      response: bytes,
+      fragments: [{ bytes, seq: req.seq, con: false, eventSeqs: [] }],
+      challenged: true,
+    };
   }
+
+  // An application CONFIRM refers to the fragment already in flight; every other
+  // request abandons an unconfirmed response (IEEE 1815 §4.2.2).
+  if (req.func === DNP3_FUNCTION.CONFIRM) {
+    return handleConfirm(ctx, req, session);
+  }
+  session.pendingFragments = [];
+  session.awaitingConfirm = null;
 
   switch (req.func) {
     case DNP3_FUNCTION.READ:
-      return { response: handleRead(ctx, req), challenged: false };
+      return dispatchFragments(handleRead(ctx, req), session);
+
+    case DNP3_FUNCTION.SELECT:
+    case DNP3_FUNCTION.OPERATE:
+    case DNP3_FUNCTION.DIRECT_OPERATE:
+    case DNP3_FUNCTION.DIRECT_OPERATE_NR:
+      return handleControlRequest(ctx, req, now);
 
     case DNP3_FUNCTION.ENABLE_UNSOLICITED:
       ctx.unsolicitedEnabled = true;
-      return { response: emptyResponse(ctx, req.seq), challenged: false };
+      return singleFragment(emptyResponse(ctx, req.seq), req.seq);
 
     case DNP3_FUNCTION.DISABLE_UNSOLICITED:
       ctx.unsolicitedEnabled = false;
-      return { response: emptyResponse(ctx, req.seq), challenged: false };
+      return singleFragment(emptyResponse(ctx, req.seq), req.seq);
 
     case DNP3_FUNCTION.COLD_RESTART:
     case DNP3_FUNCTION.WARM_RESTART:
       ctx.eventBuffer.clear();
+      ctx.controls.disarm();
       ctx.restartPending = true;
-      return { response: emptyResponse(ctx, req.seq), challenged: false };
-
-    case DNP3_FUNCTION.CONFIRM:
-      // Application confirm: clear reported events. TODO: track which seqs were
-      // sent in the last response to confirm precisely; for now we clear all.
-      return { response: Buffer.alloc(0), challenged: false };
+      return singleFragment(emptyResponse(ctx, req.seq), req.seq);
 
     default: {
       // Unknown / unsupported function code — respond with IIN2 bit set.
@@ -161,53 +310,151 @@ export function handleApplicationRequest(
         iin: currentIin(ctx) | buildIin({ noFuncSupport: true }),
       });
       logWarn(`DNP3 outstation: unsupported function code 0x${req.func.toString(16)}`);
-      return { response: header, challenged: false };
+      return singleFragment(header, req.seq);
     }
   }
 }
 
-/** Handle a Class 0/1/2/3 read request. */
-function handleRead(ctx: OutstationContext, req: ParsedRequest): Buffer {
-  const targets = classReadTargets(req);
-  const header = buildResponseHeader({ seq: req.seq, iin: currentIin(ctx) });
+/** Wrap a single already-built fragment (no events, no confirm needed). */
+function singleFragment(bytes: Buffer, seq: number): Dnp3RequestResult {
+  return { response: bytes, fragments: [{ bytes, seq, con: false, eventSeqs: [] }], challenged: false };
+}
 
+/**
+ * Queue a multi-fragment response on the session and return its first fragment.
+ * Fragments that carry events (or that are not final) set CON, so the master's
+ * CONFIRM both releases the next fragment and clears the reported events.
+ */
+function dispatchFragments(fragments: Dnp3ResponseFragment[], session: OutstationSession): Dnp3RequestResult {
+  if (fragments.length === 0) return NO_RESPONSE;
+  const [first, ...rest] = fragments;
+  session.pendingFragments = rest;
+  session.awaitingConfirm = first.con ? first : null;
+  return { response: first.bytes, fragments, challenged: false };
+}
+
+/**
+ * Application CONFIRM from the master: permanently remove the events carried by
+ * the confirmed fragment and release the next fragment, if any.
+ */
+function handleConfirm(ctx: OutstationContext, req: ParsedRequest, session: OutstationSession): Dnp3RequestResult {
+  const awaiting = session.awaitingConfirm;
+  if (!awaiting) return NO_RESPONSE;
+  if (awaiting.seq !== req.seq) {
+    logWarn(`DNP3 outstation: CONFIRM seq ${req.seq} does not match outstanding fragment seq ${awaiting.seq}`);
+    return NO_RESPONSE;
+  }
+  if (awaiting.eventSeqs.length > 0) {
+    ctx.eventBuffer.confirm(awaiting.eventSeqs);
+  }
+  session.awaitingConfirm = null;
+  const next = session.pendingFragments.shift();
+  if (!next) return NO_RESPONSE;
+  session.awaitingConfirm = next.con ? next : null;
+  return { response: next.bytes, fragments: [next], challenged: false };
+}
+
+/** Handle a control function code (SELECT / OPERATE / DIRECT-OPERATE). */
+function handleControlRequest(ctx: OutstationContext, req: ParsedRequest, now: number): Dnp3RequestResult {
+  const result = ctx.controls.process(req, now);
+  if (req.func === DNP3_FUNCTION.DIRECT_OPERATE_NR) {
+    // "No response" variant: the operation runs, nothing is transmitted.
+    return NO_RESPONSE;
+  }
+  const header = buildResponseHeader({ seq: req.seq, iin: currentIin(ctx) | result.iin });
+  return singleFragment(Buffer.concat([header, result.objects]), req.seq);
+}
+
+/**
+ * Handle a Class 0/1/2/3 read request, producing one or more response
+ * fragments. Static (Class 0) object blocks come first, then buffered events in
+ * the event buffer's chronological order; both are packed to respect
+ * `maxTxFragmentSize`.
+ */
+function handleRead(ctx: OutstationContext, req: ParsedRequest): Dnp3ResponseFragment[] {
+  const targets = classReadTargets(req);
   // Default (no recognised class object, or explicit class 0): all static data.
   const wantStatic = targets.class0 || (!targets.class1 && !targets.class2 && !targets.class3);
-  const parts: Buffer[] = [header];
-
-  if (wantStatic) {
-    parts.push(buildClass0Objects(ctx.pointMap));
-  }
 
   const eventClasses: EventClass[] = [];
   if (targets.class1) eventClasses.push(1);
   if (targets.class2) eventClasses.push(2);
   if (targets.class3) eventClasses.push(3);
-  if (eventClasses.length > 0) {
-    parts.push(buildEventObjects(ctx, eventClasses));
+
+  // IIN is sampled before reporting: the class-event bits stay set while events
+  // remain buffered (they are only dropped on CONFIRM), which is what tells the
+  // master more data is pending.
+  const iin = currentIin(ctx);
+  const budget = Math.max(1, ctx.maxTxFragmentSize - APP_HEADER_LEN);
+
+  interface PackedFragment {
+    blocks: Buffer[];
+    eventSeqs: number[];
+    used: number;
+  }
+  const packed: PackedFragment[] = [];
+  let current: PackedFragment = { blocks: [], eventSeqs: [], used: 0 };
+
+  if (wantStatic) {
+    for (const block of buildClass0Blocks(ctx.pointMap, budget)) {
+      if (current.used > 0 && current.used + block.length > budget) {
+        packed.push(current);
+        current = { blocks: [], eventSeqs: [], used: 0 };
+      }
+      current.blocks.push(block);
+      current.used += block.length;
+    }
   }
 
-  return Buffer.concat(parts);
-}
+  let pending = eventClasses.length > 0 ? ctx.eventBuffer.peek(eventClasses) : [];
+  while (pending.length > 0) {
+    const encoded = buildEventObjects(pending, {
+      pointMap: ctx.pointMap,
+      policy: ctx.eventVariations,
+      maxBytes: budget - current.used,
+    });
+    if (encoded.encodedSeqs.length === 0) {
+      if (current.used === 0) {
+        // Nothing fits even in an empty fragment: the configured fragment size
+        // is smaller than a single event object. Say so rather than looping.
+        logWarn(
+          `DNP3 outstation: maxTxFragmentSize=${ctx.maxTxFragmentSize} cannot carry one event object; ` +
+            `${pending.length} event(s) withheld`,
+        );
+        break;
+      }
+      packed.push(current);
+      current = { blocks: [], eventSeqs: [], used: 0 };
+      continue;
+    }
+    current.blocks.push(encoded.bytes);
+    current.eventSeqs.push(...encoded.encodedSeqs);
+    current.used += encoded.bytes.length;
+    pending = pending.slice(encoded.encodedSeqs.length);
+    if (pending.length > 0) {
+      packed.push(current);
+      current = { blocks: [], eventSeqs: [], used: 0 };
+    }
+  }
 
-/**
- * Build event objects for the requested classes. The event buffer ordering is
- * fully implemented; the per-variation event-object serialisation (g2/g22/g32
- * with timestamps) is a documented TODO — here we emit a placeholder object
- * header carrying the count so masters see the event-class IIN clear correctly.
- *
- * INTEGRATION TODO(#464): replace placeholder with real g2v2/g22v1/g32v1
- * timestamped event encoders driven by serializeStaticPoint + 6-octet DNP3 time.
- */
-function buildEventObjects(ctx: OutstationContext, classes: EventClass[]): Buffer {
-  const events = ctx.eventBuffer.peek(classes);
-  if (events.length === 0) return Buffer.alloc(0);
-  // Placeholder: count-qualified header per group; data omitted until the
-  // timestamped encoder lands. Mark the events reported so IIN clears.
-  ctx.eventBuffer.markReported(events.map((e) => e.seq));
-  // TODO: emit real g2/g22/g32 objects. Returning an empty object set keeps the
-  // response well-formed; the event-buffer state transition above is real.
-  return Buffer.alloc(0);
+  if (current.used > 0 || packed.length === 0) packed.push(current);
+
+  const lastIndex = packed.length - 1;
+  const fragments = packed.map((frag, i) => {
+    const seq = (req.seq + i) & APP_CTRL_SEQ_MASK;
+    // Non-final fragments must be confirmed before the next is sent; fragments
+    // carrying events must be confirmed before those events can be dropped.
+    const con = frag.eventSeqs.length > 0 || i < lastIndex;
+    const header = buildResponseHeader({ seq, fir: i === 0, fin: i === lastIndex, con, iin });
+    return { bytes: Buffer.concat([header, ...frag.blocks]), seq, con, eventSeqs: frag.eventSeqs };
+  });
+
+  // Reported-but-unconfirmed events stay buffered (and are re-sent on the next
+  // poll) but must stop driving the unsolicited count/delay triggers.
+  const reported = fragments.flatMap((f) => f.eventSeqs);
+  if (reported.length > 0) ctx.eventBuffer.markReported(reported);
+
+  return fragments;
 }
 
 /** Build an empty (header-only) response carrying current IIN. */
@@ -249,15 +496,22 @@ export class Dnp3Outstation {
   private server: net.Server | null = null;
   private connections = new Set<ConnectionState>();
   private unsolicitedTimer: NodeJS.Timeout | null = null;
+  private unsolicitedSeq = 0;
+  private boundPort: number | null = null;
   readonly config: ResolvedConfig;
   readonly ctx: OutstationContext;
 
   constructor(config: Dnp3OutstationConfig = {}, eventBufferConfig: EventBufferConfig = DEFAULT_EVENT_BUFFER_CONFIG) {
     this.config = Dnp3OutstationConfigSchema.parse(config);
+    const pointMap = new Dnp3PointMap(this.config.pointMap);
     this.ctx = {
-      pointMap: new Dnp3PointMap(this.config.pointMap),
+      pointMap,
       eventBuffer: new Dnp3EventBuffer(eventBufferConfig),
       secureAuth: new Sav5Outstation(),
+      controls: new Dnp3ControlProcessor(pointMap, this.config.controls, null),
+      eventVariations: this.config.eventVariations,
+      maxTxFragmentSize: this.config.maxTxFragmentSize,
+      session: createSession(),
       restartPending: true, // a fresh outstation reports DEVICE_RESTART
       unsolicitedEnabled: this.config.unsolicitedEnabled,
     };
@@ -266,6 +520,31 @@ export class Dnp3Outstation {
   /** Provision an SAv5 Update Key for a user. */
   setUpdateKey(userNumber: number, key: Buffer): void {
     this.ctx.secureAuth.setUpdateKey(userNumber, key);
+  }
+
+  /**
+   * Install the seam through which DNP3 controls reach live tag state. Until
+   * this is called — and unless `controls.enabled` was set — every SELECT /
+   * OPERATE / DIRECT-OPERATE is rejected with CommandStatus NOT_SUPPORTED.
+   */
+  setControlSink(sink: Dnp3ControlSink | null): void {
+    this.ctx.controls.setSink(sink);
+    if (sink && !this.config.controls.enabled) {
+      logWarn('DNP3 outstation: control sink installed but controls.enabled is false — controls stay rejected');
+    }
+  }
+
+  /** Whether controls can currently reach plant state. */
+  get controlsWritable(): boolean {
+    return this.ctx.controls.writable;
+  }
+
+  /**
+   * The port actually bound, or null when not listening. Differs from
+   * `config.port` when the OS assigned an ephemeral port (`port: 0`).
+   */
+  get listeningPort(): number | null {
+    return this.boundPort;
   }
 
   /**
@@ -302,7 +581,12 @@ export class Dnp3Outstation {
       this.server!.once('error', reject);
       this.server!.listen(this.config.port, this.config.host, () => {
         this.server!.off('error', reject);
-        log(`DNP3 outstation listening on ${this.config.host}:${this.config.port} (link addr ${this.config.localAddress})`);
+        const address = this.server!.address();
+        this.boundPort = typeof address === 'object' && address !== null ? address.port : null;
+        log(
+          `DNP3 outstation listening on ${this.config.host}:${this.boundPort ?? this.config.port} ` +
+            `(link addr ${this.config.localAddress}, controls ${this.ctx.controls.writable ? 'ENABLED' : 'disabled'})`,
+        );
         resolve();
       });
     });
@@ -318,9 +602,11 @@ export class Dnp3Outstation {
     }
     for (const conn of this.connections) conn.socket.destroy();
     this.connections.clear();
+    this.ctx.controls.disarm();
     if (this.server) {
       await new Promise<void>((resolve) => this.server!.close(() => resolve()));
       this.server = null;
+      this.boundPort = null;
     }
   }
 
@@ -329,7 +615,8 @@ export class Dnp3Outstation {
       socket,
       reassembler: new TransportReassembler(),
       masterAddress: 1,
-      appSeq: 0,
+      transportSeq: 0,
+      session: createSession(),
       rxBuffer: Buffer.alloc(0),
     };
     this.connections.add(conn);
@@ -342,6 +629,8 @@ export class Dnp3Outstation {
     socket.on('error', (err) => logError(err, 'DNP3 outstation socket error'));
     socket.on('close', () => {
       this.connections.delete(conn);
+      // A dropped link invalidates any armed SELECT.
+      this.ctx.controls.disarm();
       log('DNP3 master disconnected');
     });
   }
@@ -397,33 +686,61 @@ export class Dnp3Outstation {
 
     // SAv5 reply (g120v2) arriving from the master.
     if (req.func === DNP3_FUNCTION.WRITE && req.objects.some((o) => o.group === DNP3_GROUP.SECURE_AUTH)) {
-      // The reply object body follows the object header; integration seam.
-      // TODO: locate the g120v2 object precisely; here we hand the raw objects.
-      try {
-        const verify = handleSecureAuthReply(this.ctx, req.rawObjects.subarray(4));
-        if (verify.ok) {
-          log('DNP3 SAv5: reply verified, dispatching authorised critical ASDU');
-          // TODO: dispatch verify.criticalAsdu now that it is authorised.
-        } else {
-          logWarn(`DNP3 SAv5: reply rejected (${verify.error})`);
-        }
-      } catch (err) {
-        logError(err, 'DNP3 outstation: malformed SAv5 reply');
-      }
+      this.processSecureAuthReply(conn, req);
       return;
     }
 
-    const { response } = handleApplicationRequest(this.ctx, req, { userNumber: 1 });
+    const { response } = handleApplicationRequest(this.ctx, req, {
+      userNumber: 1,
+      session: conn.session,
+    });
     if (response.length > 0) {
-      this.sendResponse(conn, response);
+      this.sendFragment(conn, response);
     }
     // A successful read with the device-restart bit acknowledged clears it once
     // the master writes IIN1.7 = 0 (WRITE g80v1). TODO: handle that write.
   }
 
-  /** Frame + send an application response fragment to the master. */
-  private sendResponse(conn: ConnectionState, appFragment: Buffer): void {
-    const segments = segment(appFragment);
+  /**
+   * Verify a g120v2 reply and, on success, execute the ASDU it authorises.
+   * The reply object body follows the 4-octet object header this module emits
+   * for group 120 (see the free-format TODO in the module doc).
+   */
+  private processSecureAuthReply(conn: ConnectionState, req: ParsedRequest): void {
+    let verify: Sav5VerifyResult;
+    try {
+      verify = handleSecureAuthReply(this.ctx, req.rawObjects.subarray(4));
+    } catch (err) {
+      logError(err, 'DNP3 outstation: malformed SAv5 reply');
+      return;
+    }
+    if (!verify.ok) {
+      logWarn(`DNP3 SAv5: reply rejected (${verify.error})`);
+      return;
+    }
+
+    let authorised: ParsedRequest;
+    try {
+      authorised = parseRequest(verify.criticalAsdu);
+    } catch (err) {
+      logError(err, 'DNP3 outstation: authorised ASDU failed to parse');
+      return;
+    }
+    log(`DNP3 SAv5: reply verified, dispatching authorised function 0x${authorised.func.toString(16)}`);
+    const { response } = handleApplicationRequest(this.ctx, authorised, {
+      userNumber: verify.userNumber,
+      session: conn.session,
+      skipSecureAuth: true,
+    });
+    if (response.length > 0) {
+      this.sendFragment(conn, response);
+    }
+  }
+
+  /** Frame + send one application response fragment to the master. */
+  private sendFragment(conn: ConnectionState, appFragment: Buffer): void {
+    const segments = segment(appFragment, conn.transportSeq);
+    conn.transportSeq = (conn.transportSeq + segments.length) & TRANSPORT_SEQ_MASK;
     for (const seg of segments) {
       const control = buildResponseControl(DNP3_LINK_FUNCTION.UNCONFIRMED_USER_DATA);
       const frame = buildLinkFrame({
@@ -449,25 +766,52 @@ export class Dnp3Outstation {
 
   /**
    * Evaluate the unsolicited trigger and, if due, push an unsolicited response
-   * to every connected master. Honours the enable flag.
+   * to every connected master. Honours the enable flag. Connections with a
+   * response already awaiting confirmation are skipped — an outstation may only
+   * have one outstanding response per association.
    */
   private maybeSendUnsolicited(now: number = Date.now()): void {
     if (!this.ctx.unsolicitedEnabled) return;
     const decision = this.ctx.eventBuffer.evaluateUnsolicited(now);
     if (!decision.shouldSend) return;
 
+    const events = this.ctx.eventBuffer.peek(decision.classes);
+    if (events.length === 0) return;
+    const encoded = buildEventObjects(events, {
+      pointMap: this.ctx.pointMap,
+      policy: this.ctx.eventVariations,
+      maxBytes: Math.max(1, this.ctx.maxTxFragmentSize - APP_HEADER_LEN),
+    });
+    if (encoded.encodedSeqs.length === 0) return;
+
+    const seq = this.unsolicitedSeq & APP_CTRL_SEQ_MASK;
+    this.unsolicitedSeq = (this.unsolicitedSeq + 1) & APP_CTRL_SEQ_MASK;
     const header = buildResponseHeader({
-      seq: 0,
+      seq,
       unsolicited: true,
-      con: true,
+      con: true, // events are only dropped once the master confirms
       iin: currentIin(this.ctx),
     });
-    const objects = buildEventObjects(this.ctx, decision.classes);
-    const fragment = Buffer.concat([header, objects]);
+    const fragment: Dnp3ResponseFragment = {
+      bytes: Buffer.concat([header, encoded.bytes]),
+      seq,
+      con: true,
+      eventSeqs: encoded.encodedSeqs,
+    };
+
+    let sent = 0;
     for (const conn of this.connections) {
-      this.sendResponse(conn, fragment);
+      if (conn.session.awaitingConfirm) continue;
+      conn.session.awaitingConfirm = fragment;
+      this.sendFragment(conn, fragment.bytes);
+      sent += 1;
     }
-    log(`DNP3 outstation: sent unsolicited response (classes ${decision.classes.join(',')}, reason ${decision.reason})`);
+    if (sent === 0) return;
+    this.ctx.eventBuffer.markReported(encoded.encodedSeqs);
+    log(
+      `DNP3 outstation: sent unsolicited response (classes ${decision.classes.join(',')}, ` +
+        `reason ${decision.reason}, ${encoded.encodedSeqs.length} event(s))`,
+    );
   }
 }
 


### PR DESCRIPTION
## Problem

The DNP3 outstation had genuine cores (verified CRC-DNP golden vector, link framing, transport segmentation, SAv5 HMAC) but two dead ends in the request path made it a partial library rather than a working outstation.

**Class 1/2/3 event reads returned no data, ever.** `buildEventObjects` drained the buffer and returned nothing:

```ts
const events = ctx.eventBuffer.peek(classes);
if (events.length === 0) return Buffer.alloc(0);
ctx.eventBuffer.markReported(events.map((e) => e.seq));
// TODO: emit real g2/g22/g32 objects. Returning an empty object set keeps the
// response well-formed; the event-buffer state transition above is real.
return Buffer.alloc(0);
```

A master polling Class 1 got a bare 4-octet header — and the events were marked reported on the way out.

**Controls were never executed.** `SELECT` / `OPERATE` / `DIRECT_OPERATE` / `DIRECT_OPERATE_NR` had no case in the dispatch switch, so they fell through to `default:` and were answered with IIN2.0 "no function code support". The baseline test log shows it plainly: `DNP3 outstation: unsupported function code 0x4`.

## Fix

**Event encoding** (new `event-objects.ts`) — g2v1/v2/v3, g11v1/v2, g22v1/v5, g32v1/v3/v5/v7, g42. Index-prefixed qualifiers (0x17 while indices fit one octet, else 0x28), little-endian values, 48-bit DNP3 time, flag octet captured at event time. Relative-time binary *input* events emit a g51v1 CTO first and use 16-bit offsets, opening a fresh CTO when one would overflow or go negative; group 11 has no relative-time variation in IEEE 1815, so binary *outputs* degrade to g11v2 rather than emitting an object no master can decode. Numeric width follows the point's `encoding`, so a float32 point emits g32v7 rather than truncating into the int32 variation.

**Fragmentation + confirms** — responses honour `maxTxFragmentSize` (default 2048) with correct FIR/FIN/CON and sequence numbering (`req.seq + i`, mod 16); remaining fragments are held in a per-connection `OutstationSession` and released on the master's application CONFIRM. **Events leave the buffer only on CONFIRM, never on send**, and unconfirmed events are re-sent on the next poll.

**Controls** (new `controls.ts`) — g12v1 CROB and g41v1..v4 analog output with real select-before-operate. A SELECT validates and arms without touching the process; the OPERATE must reproduce the armed objects byte-for-byte (status octet zeroed) and carry an application sequence number exactly one greater, or it is rejected. The arm is single-use — consumed whatever the outcome — so a rejected OPERATE cannot be replayed. Responses echo the objects with CommandStatus SUCCESS / TIMEOUT / NO_SELECT / FORMAT_ERROR / NOT_SUPPORTED / ALREADY_ACTIVE / HARDWARE_ERROR. Execution resolves the DNP3 index to a tagId through the existing point map and hands it to an injected sink.

### Safety: the write path is fail-closed and OFF by default

Controls are rejected with `NOT_SUPPORTED` unless **both** `controls.enabled` is explicitly true (default false) **and** a sink is installed via `setControlSink()`. Neither alone is sufficient — there is a test for each half. A read-only outstation rejects with the correct DNP3 status rather than silently accepting.

The outstation deliberately does **not** update its own output-status points when a control succeeds; it has not observed that state. The real value must return through `updateTag()`, like any other measurement.

### Supporting changes

- `parseRequest` length-decodes index-prefixed qualifiers (0x17/0x28) for known-size objects — this is what makes control objects readable at all — and exposes the full fragment as `raw`.
- Class-0 assembly is split into fragment-sized blocks. Previously `buildClass0Objects` emitted a single `range8` header spanning `points[0].index`..`points[last].index` regardless of contiguity, and `& 0xff` silently truncated any index above 255.
- The SAv5 seam now MACs the whole critical ASDU (IEEE 1815 defines it as the full fragment) and dispatches it once the reply verifies. Previously a `// TODO: dispatch verify.criticalAsdu` meant enabling secure auth silently disabled controls forever.

## Verification

Both gates run from the worktree root:

- `npx tsc --noEmit` → exit 0
- `npx vitest run` → `Test Files 99 passed | 2 skipped (101)` / `Tests 2108 passed | 5 skipped (2113)`

Baseline before any edit was `95 passed | 2 skipped` files / `2024 passed | 5 skipped` tests — **+4 files, +84 tests, zero regressions**.

Golden byte vectors derived by hand from IEEE 1815 and annotated octet by octet:

- `event-objects.test.ts` — exact octets for g2v1/v2/v3 (incl. the g51v1 CTO and the 16-bit offset roll), g11v1/v2, g22v1/v5, g32v1/v3/v7, qualifier 0x17 vs 0x28, and the byte-budget cut-off.
- `class-read.test.ts` — empty vs populated vs mixed-class polls, the three-fragment split with FIR/FIN/CON and sequence numbering, and the CONFIRM walk proving events drain only on confirm (`classSize` 5 → 3 → 1 → 0).
- `controls.test.ts` — decode of real master CROB/analog-output requests, select→operate happy path, and every rejection path: no select, select timeout, mismatched operate, wrong sequence number, controls disabled, no sink, unmapped point, truncated object.
- `outstation.test.ts` — fail-closed defaults, the SAv5 challenge→verify→execute round trip (plus a tampered-ASDU rejection), and a **live localhost TCP round trip** where a real master frame produces real g2v2 octets on the wire.

## Caveats

- **Wiring into server startup is out of scope and remains a gap.** Nothing in `server/` references this module at all today, so this PR changes no runtime behaviour on its own. Exposing the outstation on a network interface needs its own network-policy review, since any master reaching the port can drive the control path. Nothing here starts a listener on import; only an explicit `start()` listens.
- **No production control sink exists yet.** The write path is proven by tests but is not connected to the real tag store — by design, that is the wiring change above. Until then every control is answered NOT_SUPPORTED.
- Changed the `port` zod minimum from 1 to 0 (plus a `listeningPort` getter) so the TCP test can bind an OS-assigned port. Small surface change beyond the strict defect, but it is what enabled a real non-mocked socket test.
- Modified one existing test helper (`makeCtx` now uses the new `createOutstationContext()` factory) because `OutstationContext` gained required fields. No existing assertion was weakened or removed.
- **Multi-master is not supported and not fixed here**: confirm state is per connection but the event buffer is shared, so with two masters the first CONFIRM drains events for both. Documented; DNP3 outstations conventionally serve one master.
- Events queued in fragments that have not yet been transmitted are marked reported at read time, so they stop driving the unsolicited count/delay triggers until confirmed or re-polled. They are never lost — an unconfirmed event is always re-sent.
- The IIN class-event bits are sampled before encoding and stay set on the response carrying the last buffered events, because they only clear on CONFIRM. This costs a master one redundant poll per drain; it is pinned by a test rather than accidental.
- Still TODO and documented: g120 free-format qualifier 0x5B framing, `WRITE g80v1` (clearing DEVICE_RESTART), the secondary link-confirm/FCB state machine, and an independent event retry timer.
- **No conformance test against a real opendnp3 master was run** — that toolchain is unavailable in this environment. Evidence here is hand-derived spec vectors plus a localhost round trip, not third-party interop.
- `ALREADY_ACTIVE` is modelled from the CROB's own on/off-time fields rather than device feedback, since there is no device. Deterministic (time is injected), but it reflects what was commanded, not observed hardware.

Refs #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)