### PR TITLE
feat(blueprint): give the deterministic runtime a gated production host (#457)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,41 @@ ANCHOR_CHAIN_ID=31337
 EVENT_ANCHOR_CONTRACT=
 ANCHOR_PRIVATE_KEY=
 ANCHOR_HSM_KEY_PATH=
+
+# Deterministic Blueprint Control Loop (ADR-0026, Issue #457)
+# Drives the compiled blueprint runtime on a fixed scan cadence in-process.
+#
+# SCOPE — READ BEFORE ENABLING: the loop EXECUTES control logic, it does NOT
+# ACTUATE. There is no field-bus/gateway/storage write path anywhere in it, so
+# turning it on cannot drive a plant; computed outputs stay in the runtime's own
+# buffer and are only readable via the health/metrics surfaces. Until a field-IO
+# binding lands, input tags hold their load-time initial values unless an
+# in-process caller writes them.
+#
+# Enabled ONLY when the value is exactly "true" — "1"/"yes"/"on"/"TRUE" leave it
+# off — and a readable definition file is configured. A malformed, oversized or
+# uncompilable blueprint fails closed: the error is logged, the loop stays off
+# and the server still starts.
+BLUEPRINT_CONTROL_LOOP_ENABLED=false
+# Path to a blueprint definition JSON file. Required when enabled. The shape is
+# BlueprintDefinition in server/blueprint/types.ts, Zod-validated at load; a
+# complete worked example is in docs/decisions/ADR-0026-deterministic-blueprint-runtime.md.
+# No definition ships with the repo — this must be operator-authored on purpose.
+BLUEPRINT_CONTROL_LOOP_DEFINITION=
+# Optional scan-period override in ms. Applied to the definition BEFORE
+# compilation so stateful ops (TON) integrate with the cadence actually used.
+# Defaults to the definition's own scanPeriodMs (which itself defaults to 100).
+BLUEPRINT_CONTROL_LOOP_PERIOD_MS=
+# Scan-duration samples backing the exported p50/p99/max gauges.
+BLUEPRINT_CONTROL_LOOP_WINDOW_SAMPLES=1024
+# How often window quantiles are mirrored onto the Prometheus registry.
+BLUEPRINT_CONTROL_LOOP_METRICS_INTERVAL_MS=1000
+# Lateness tolerated before a scan counts as a missed deadline.
+# Defaults to 25% of the scan period, floored at 1 ms.
+BLUEPRINT_CONTROL_LOOP_JITTER_MS=
+# How long a missed deadline keeps the health check in "degraded".
+BLUEPRINT_CONTROL_LOOP_DEGRADED_WINDOW_MS=60000
+# Fail-closed load ceilings.
+BLUEPRINT_CONTROL_LOOP_MAX_BYTES=4194304
+BLUEPRINT_CONTROL_LOOP_MAX_TAGS=50000
+BLUEPRINT_CONTROL_LOOP_MAX_NODES=50000

--- a/docs/decisions/ADR-0026-deterministic-blueprint-runtime.md
+++ b/docs/decisions/ADR-0026-deterministic-blueprint-runtime.md
@@ -142,6 +142,105 @@ or scheduler jitter under a single OCPU), the contingency is:
   smallest samples; percentiles remain meaningful because they aggregate 10⁵
   samples.
 
+## Amendment (2026-07): production control-loop host
+
+**Problem.** The decision above shipped a well-tested interpreter that nothing in
+production ever constructed — `new BlueprintRuntime(...)` appeared only in the
+unit tests and the benchmark. As deployed, the deterministic runtime executed
+nothing, so none of the guarantees above were observable on a running system.
+
+**Decision.** Add `server/blueprint/control-loop.ts`: a host that loads a
+blueprint definition from disk, validates it, compiles it once, and drives
+`tickFast()` from a single `setInterval` at the compiled scan period.
+
+- **Gated OFF by default.** The loop starts only when
+  `BLUEPRINT_CONTROL_LOOP_ENABLED` is exactly the string `"true"` *and*
+  `BLUEPRINT_CONTROL_LOOP_DEFINITION` names a readable definition file. There is
+  no truthy coercion, so `1`/`yes`/`on`/`TRUE` leave it off. This follows the
+  existing opt-in convention (`ENABLE_BLOCKCHAIN`, `SPARKPLUG_BROKER_URL`,
+  `FLUX_URL`) rather than introducing a new one.
+- **Execution, not actuation.** The host contains no field-bus, gateway,
+  OPC-UA/Modbus/DNP3 or storage write. Enabling it creates no plant-output path
+  that did not already exist; computed outputs stay in the runtime's own
+  `Float64Array`. Until a field-IO binding lands (with the safety review such a
+  write path requires), input tags hold their load-time initial values unless an
+  in-process caller uses `writeInputs()`. `status().actuatesOutputs` is a
+  hard-coded `false` so operators can confirm the boundary from `/health`.
+- **Fail closed at load.** The definition is size-checked before it is read,
+  parsed as JSON, validated by a `.strict()` Zod schema derived from the runtime
+  opcode table (`server/blueprint/definition-schema.ts`), bounded by configurable
+  tag/node ceilings, and only then compiled. Every failure raises a
+  `BlueprintControlLoopError` naming the file and the reason; `tryStart()` logs
+  it and leaves the loop off, so a bad blueprint cannot take down server startup.
+- **Hot-path contract preserved.** The measured scan is allocation-free: the
+  timer callback does only numeric work around `tickFast()` — two
+  `performance.now()` reads, counter updates and one store into a pre-allocated
+  `Float64Array` ring buffer. No closure is allocated per arm (the callback is
+  bound once), and there is no `await`/Promise, so the scan still cannot be
+  preempted mid-tick. **One honest exception:** at most once per
+  `BLUEPRINT_CONTROL_LOOP_METRICS_INTERVAL_MS` (default 1 s) the same callback
+  also publishes metrics, and that path *does* allocate — two `subarray` views
+  plus the registry's per-call label key (`labelNames.map(...).join()`). It runs
+  strictly after the scan duration has been recorded, so it cannot inflate a
+  measured tick, but it is real work on the scan timer; any resulting lateness
+  is not hidden, it surfaces as a missed deadline. Moving publication to its own
+  timer would remove even that; it is kept on one timer deliberately.
+
+**Telemetry shape (and why it is not a histogram).** Scan durations go into a
+pre-allocated ring buffer; p50/p99/max over that window are mirrored onto the
+existing `server/metrics` registry on a slow cadence (default 1 s) as gauges
+under `scada_blueprint_control_loop_*`, alongside counters for ticks, missed
+deadlines, overruns and load failures. A histogram would be the idiomatic shape,
+but this registry's `Histogram.observe()` builds a label key per call — i.e. it
+allocates — and calling it once per scan would put an allocation on the control
+loop and undermine the property this ADR exists to protect. The cost of the
+chosen shape is that the exported quantiles are per-window and per-instance, and
+therefore not aggregatable across replicas the way buckets would be.
+
+**Health.** `blueprint-control-loop` is registered as an optional check.
+Disabled reports *healthy* (an intentionally-off subsystem is not a fault);
+a load failure reports *unhealthy* with the reason; enabled-but-not-running and
+a recently-missed deadline report *degraded* (the latter self-clears after
+`BLUEPRINT_CONTROL_LOOP_DEGRADED_WINDOW_MS`).
+
+**Definition format.** No blueprint definition ships with the repository — a
+production loop must be pointed at an operator-authored file, deliberately, so
+that nothing here can be mistaken for a plant-ready program. The authoring shape
+is `BlueprintDefinition` in `server/blueprint/types.ts`, validated by
+`server/blueprint/definition-schema.ts`. A minimal, complete example of the JSON
+that schema accepts:
+
+```json
+{
+  "id": "pump-interlock",
+  "name": "Pump start interlock",
+  "tags": [
+    { "name": "LEVEL",      "direction": "input",    "dataType": "float", "initial": 0 },
+    { "name": "ESTOP",      "direction": "input",    "dataType": "bool",  "initial": 0 },
+    { "name": "PERMIT",     "direction": "internal", "dataType": "bool" },
+    { "name": "RUN_CMD",    "direction": "output",   "dataType": "bool" },
+    { "name": "HIGH_LEVEL", "direction": "output",   "dataType": "bool" }
+  ],
+  "nodes": [
+    { "id": "hi",  "op": "GT",  "inputs": [{ "tag": "LEVEL" }, { "const": 80 }], "output": "HIGH_LEVEL" },
+    { "id": "ok",  "op": "NOT", "inputs": [{ "tag": "ESTOP" }],                  "output": "PERMIT" },
+    { "id": "run", "op": "AND", "inputs": [{ "tag": "PERMIT" }, { "tag": "HIGH_LEVEL" }], "output": "RUN_CMD" }
+  ],
+  "scanPeriodMs": 100
+}
+```
+
+The schema is `.strict()`: an unrecognised field is a rejection, not something
+ignored. `op` must be one of the names in `OP_TO_OPCODE`, and per-op arity is
+enforced by the compiler. Note that `RUN_CMD` above is computed and readable and
+nothing more — per the actuation boundary, no output reaches a field device.
+
+**Known gap.** The repository has no SIGTERM/shutdown orchestration, so
+`stop()` — which clears the timer and needs no draining, the scan being fully
+synchronous — is exercised by the test suite and available to callers, but is
+not yet wired to a process shutdown hook. That wiring belongs with a
+server-wide graceful-shutdown change, not with this one.
+
 ## Verification procedure (reference hardware)
 
 ```bash

--- a/server/blueprint/__tests__/control-loop.test.ts
+++ b/server/blueprint/__tests__/control-loop.test.ts
@@ -1,0 +1,558 @@
+/**
+ * Control-loop host tests — Issue #457.
+ *
+ * Covers the properties that make the loop safe to ship:
+ *   - disabled by default, and not switchable on by an accidental truthy value;
+ *   - when enabled it really executes the compiled program (inputs in → computed
+ *     outputs out) and advances its counters;
+ *   - stop() clears its timer and leaks nothing;
+ *   - a malformed / oversized / uncompilable blueprint fails CLOSED with a clear
+ *     error and cannot take down startup;
+ *   - health and Prometheus surfaces report the truth in each of those states.
+ *
+ * These are real timer tests against real files: no fake timers, no mocked fs.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  BlueprintControlLoop,
+  BlueprintControlLoopError,
+  describeBlueprintControlLoopHealth,
+  getBlueprintControlLoop,
+  loadBlueprintControlLoopConfig,
+  startBlueprintControlLoop,
+  type BlueprintControlLoopStatus,
+} from "../control-loop";
+import { registry } from "../../metrics/prometheus";
+import type { BlueprintDefinition } from "../types";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+/** SUM = A + B, plus a latch that sets itself on the first scan. */
+const ADDER: BlueprintDefinition = {
+  id: "adder",
+  name: "Two-input adder",
+  tags: [
+    { name: "A", direction: "input", dataType: "float", initial: 0 },
+    { name: "B", direction: "input", dataType: "float", initial: 0 },
+    { name: "ALWAYS", direction: "internal", dataType: "bool", initial: 1 },
+    { name: "SUM", direction: "output", dataType: "float" },
+    { name: "HEARTBEAT", direction: "output", dataType: "bool" },
+  ],
+  nodes: [
+    { id: "sum", op: "ADD", inputs: [{ tag: "A" }, { tag: "B" }], output: "SUM" },
+    {
+      id: "hb",
+      op: "LATCH",
+      inputs: [{ tag: "ALWAYS" }, { const: 0 }],
+      output: "HEARTBEAT",
+    },
+  ],
+  scanPeriodMs: 5,
+};
+
+const tempDirs: string[] = [];
+const liveLoops: BlueprintControlLoop[] = [];
+
+function writeDefinition(contents: string, filename = "blueprint.json"): string {
+  const dir = mkdtempSync(join(tmpdir(), "blueprint-control-loop-"));
+  tempDirs.push(dir);
+  const path = join(dir, filename);
+  writeFileSync(path, contents, "utf8");
+  return path;
+}
+
+function writeBlueprint(def: BlueprintDefinition): string {
+  return writeDefinition(JSON.stringify(def));
+}
+
+/** Build a loop from an explicit env map so no test depends on the real env. */
+function makeLoop(env: NodeJS.ProcessEnv): BlueprintControlLoop {
+  const loop = new BlueprintControlLoop(loadBlueprintControlLoopConfig(env));
+  liveLoops.push(loop);
+  return loop;
+}
+
+function enabledEnv(path: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    BLUEPRINT_CONTROL_LOOP_ENABLED: "true",
+    BLUEPRINT_CONTROL_LOOP_DEFINITION: path,
+    ...extra,
+  };
+}
+
+/** Poll until the predicate holds or the budget expires. Real timers. */
+async function waitFor(predicate: () => boolean, budgetMs = 3_000): Promise<void> {
+  const deadline = Date.now() + budgetMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error("timed out waiting for condition");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+afterEach(() => {
+  // Never leave a scan timer armed, even if an expectation threw mid-test.
+  while (liveLoops.length > 0) liveLoops.pop()?.stop();
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+// ── Configuration gating ────────────────────────────────────────────────────
+
+describe("BlueprintControlLoop — configuration gating", () => {
+  it("is disabled when no environment variables are set", () => {
+    const config = loadBlueprintControlLoopConfig({});
+    expect(config.enabled).toBe(false);
+    expect(config.definitionPath).toBeNull();
+  });
+
+  it("refuses to enable on anything other than the exact string \"true\"", () => {
+    for (const value of ["1", "yes", "on", "TRUE", "True", "true ", ""]) {
+      const config = loadBlueprintControlLoopConfig({
+        BLUEPRINT_CONTROL_LOOP_ENABLED: value,
+        BLUEPRINT_CONTROL_LOOP_DEFINITION: "/nonexistent.json",
+      });
+      expect(config.enabled).toBe(false);
+    }
+  });
+
+  it("enables only on the exact opt-in string", () => {
+    const config = loadBlueprintControlLoopConfig({
+      BLUEPRINT_CONTROL_LOOP_ENABLED: "true",
+      BLUEPRINT_CONTROL_LOOP_DEFINITION: "/some/blueprint.json",
+    });
+    expect(config.enabled).toBe(true);
+    expect(config.definitionPath).toBe("/some/blueprint.json");
+  });
+
+  it("rejects an unparseable numeric override instead of silently defaulting", () => {
+    expect(() =>
+      loadBlueprintControlLoopConfig({ BLUEPRINT_CONTROL_LOOP_PERIOD_MS: "not-a-number" }),
+    ).toThrow(BlueprintControlLoopError);
+  });
+
+  it("arms no timer when disabled", async () => {
+    const setInterval = vi.spyOn(globalThis, "setInterval");
+    const loop = makeLoop({});
+
+    expect(loop.start()).toBe(false);
+    expect(loop.isRunning).toBe(false);
+    expect(loop.status().state).toBe("disabled");
+    expect(setInterval).not.toHaveBeenCalled();
+
+    await sleep(30);
+    expect(loop.status().ticks).toBe(0);
+  });
+
+  it("the process singleton is disabled under the ambient test environment", () => {
+    const loop = startBlueprintControlLoop();
+    expect(loop.isRunning).toBe(false);
+    expect(getBlueprintControlLoop()).toBe(loop);
+  });
+});
+
+// ── Running ─────────────────────────────────────────────────────────────────
+
+describe("BlueprintControlLoop — enabled by flag", () => {
+  it("runs scans on a fixed cadence and advances its counters", async () => {
+    const loop = makeLoop(enabledEnv(writeBlueprint(ADDER)));
+
+    expect(loop.start()).toBe(true);
+    expect(loop.isRunning).toBe(true);
+
+    await waitFor(() => loop.status().ticks >= 5);
+
+    const status = loop.status();
+    expect(status.state).toBe("running");
+    expect(status.blueprintId).toBe("adder");
+    expect(status.scanPeriodMs).toBe(5);
+    expect(status.ticks).toBeGreaterThanOrEqual(5);
+    expect(status.windowSamples).toBeGreaterThanOrEqual(5);
+    expect(status.lastTickDurationMs).not.toBeNull();
+    expect(Number.isFinite(status.lastTickDurationMs ?? Number.NaN)).toBe(true);
+    expect(status.lastTickDurationMs ?? -1).toBeGreaterThanOrEqual(0);
+    expect(status.p50Ms).not.toBeNull();
+    expect(status.p99Ms).not.toBeNull();
+    expect(status.p99Ms ?? -1).toBeGreaterThanOrEqual(status.p50Ms ?? 0);
+    expect(status.maxMs ?? -1).toBeGreaterThanOrEqual(status.p99Ms ?? 0);
+    expect(status.loadFailures).toBe(0);
+    expect(status.lastError).toBeNull();
+  });
+
+  it("really executes the compiled program (inputs are read, outputs computed)", async () => {
+    const loop = makeLoop(enabledEnv(writeBlueprint(ADDER)));
+    loop.start();
+
+    expect(loop.inputCount).toBe(2);
+    expect(loop.outputCount).toBe(2);
+
+    // Stateful op advanced by the loop itself, with no external input at all.
+    await waitFor(() => loop.getTagValue("HEARTBEAT") === 1);
+
+    // Field-IN direction: values written between scans are consumed by the
+    // next scan and show up in the computed outputs.
+    loop.writeInputs(Float64Array.from([2, 40]));
+    const before = loop.status().ticks;
+    await waitFor(() => loop.status().ticks > before + 1);
+
+    const outputs = new Float64Array(loop.outputCount);
+    loop.readOutputs(outputs);
+    expect(loop.getTagValue("SUM")).toBe(42);
+    expect(Array.from(outputs)).toEqual([42, 1]);
+  });
+
+  it("start() is idempotent and arms exactly one timer", async () => {
+    const setInterval = vi.spyOn(globalThis, "setInterval");
+    const loop = makeLoop(enabledEnv(writeBlueprint(ADDER)));
+
+    expect(loop.start()).toBe(true);
+    expect(loop.start()).toBe(true);
+    expect(loop.start()).toBe(true);
+
+    expect(setInterval).toHaveBeenCalledTimes(1);
+    await waitFor(() => loop.status().ticks >= 3);
+    expect(loop.isRunning).toBe(true);
+  });
+
+  it("honours a scan-period override and compiles the blueprint with it", async () => {
+    const loop = makeLoop(
+      enabledEnv(writeBlueprint(ADDER), { BLUEPRINT_CONTROL_LOOP_PERIOD_MS: "20" }),
+    );
+    loop.start();
+
+    // The override must reach the compiled program, not just the timer, so that
+    // stateful ops integrate with the same dt the scheduler actually uses.
+    expect(loop.status().scanPeriodMs).toBe(20);
+
+    const startedAt = Date.now();
+    await waitFor(() => loop.status().ticks >= 3);
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(40);
+  });
+});
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+
+describe("BlueprintControlLoop — stop()", () => {
+  it("clears its interval and stops ticking", async () => {
+    const clearInterval = vi.spyOn(globalThis, "clearInterval");
+    const loop = makeLoop(enabledEnv(writeBlueprint(ADDER)));
+    loop.start();
+    await waitFor(() => loop.status().ticks >= 3);
+
+    loop.stop();
+    expect(clearInterval).toHaveBeenCalledTimes(1);
+    expect(loop.isRunning).toBe(false);
+    expect(loop.status().state).toBe("stopped");
+
+    const ticksAtStop = loop.status().ticks;
+    await sleep(50); // ≥ 10 scan periods
+    expect(loop.status().ticks).toBe(ticksAtStop);
+  });
+
+  it("is idempotent and does not clear a timer twice", async () => {
+    const loop = makeLoop(enabledEnv(writeBlueprint(ADDER)));
+    loop.start();
+    await waitFor(() => loop.status().ticks >= 1);
+
+    loop.stop();
+    const clearInterval = vi.spyOn(globalThis, "clearInterval");
+    loop.stop();
+    loop.stop();
+    expect(clearInterval).not.toHaveBeenCalled();
+    expect(loop.status().state).toBe("stopped");
+  });
+
+  it("can be restarted after a stop and keeps counting", async () => {
+    const loop = makeLoop(enabledEnv(writeBlueprint(ADDER)));
+    loop.start();
+    await waitFor(() => loop.status().ticks >= 2);
+    loop.stop();
+
+    const ticksAtStop = loop.status().ticks;
+    expect(loop.start()).toBe(true);
+    await waitFor(() => loop.status().ticks > ticksAtStop + 1);
+    expect(loop.status().state).toBe("running");
+  });
+});
+
+// ── Fail-closed load ────────────────────────────────────────────────────────
+
+describe("BlueprintControlLoop — fails closed at load", () => {
+  function expectFailedClosed(loop: BlueprintControlLoop, ...fragments: string[]): void {
+    const setInterval = vi.spyOn(globalThis, "setInterval");
+    let thrown: unknown;
+    try {
+      loop.start();
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(BlueprintControlLoopError);
+    for (const fragment of fragments) {
+      expect((thrown as Error).message).toContain(fragment);
+    }
+    expect(setInterval).not.toHaveBeenCalled();
+
+    const status = loop.status();
+    expect(status.state).toBe("failed");
+    expect(status.running).toBe(false);
+    expect(status.loadFailures).toBe(1);
+    expect(status.lastError).toContain(fragments[0] ?? "");
+  }
+
+  it("rejects an enabled loop with no definition path", () => {
+    expectFailedClosed(
+      makeLoop({ BLUEPRINT_CONTROL_LOOP_ENABLED: "true" }),
+      "BLUEPRINT_CONTROL_LOOP_DEFINITION",
+    );
+  });
+
+  it("rejects a missing file", () => {
+    const missing = join(tmpdir(), "definitely-not-here-457.json");
+    expectFailedClosed(makeLoop(enabledEnv(missing)), "cannot stat blueprint definition");
+  });
+
+  it("rejects invalid JSON", () => {
+    expectFailedClosed(makeLoop(enabledEnv(writeDefinition("{ not json"))), "not valid JSON");
+  });
+
+  it("rejects a schema violation (unknown op)", () => {
+    const path = writeDefinition(
+      JSON.stringify({
+        ...ADDER,
+        nodes: [{ id: "x", op: "TELEPORT", inputs: [{ tag: "A" }], output: "SUM" }],
+      }),
+    );
+    expectFailedClosed(makeLoop(enabledEnv(path)), "rejected", "schema validation failed");
+  });
+
+  it("rejects unknown fields rather than ignoring them", () => {
+    const path = writeDefinition(JSON.stringify({ ...ADDER, exploit: "payload" }));
+    expectFailedClosed(makeLoop(enabledEnv(path)), "rejected");
+  });
+
+  it("rejects a blueprint that exceeds the configured node ceiling", () => {
+    const path = writeBlueprint(ADDER);
+    expectFailedClosed(
+      makeLoop(enabledEnv(path, { BLUEPRINT_CONTROL_LOOP_MAX_NODES: "1" })),
+      "exceeding the configured maximum of 1",
+    );
+  });
+
+  it("rejects an oversized file before parsing it", () => {
+    // Structurally valid, just too big: size is the only reason it is rejected.
+    const path = writeBlueprint({ ...ADDER, name: "x".repeat(2_000) });
+    expectFailedClosed(
+      makeLoop(enabledEnv(path, { BLUEPRINT_CONTROL_LOOP_MAX_BYTES: "1024" })),
+      "exceeding the configured maximum of 1024 bytes",
+    );
+  });
+
+  it("rejects a semantically invalid blueprint the compiler refuses", () => {
+    const path = writeDefinition(
+      JSON.stringify({
+        ...ADDER,
+        nodes: [
+          { id: "a", op: "MOVE", inputs: [{ tag: "A" }], output: "SUM" },
+          { id: "b", op: "MOVE", inputs: [{ tag: "B" }], output: "SUM" },
+        ],
+      }),
+    );
+    expectFailedClosed(makeLoop(enabledEnv(path)), "failed to compile", "multiple drivers");
+  });
+
+  it("tryStart() swallows the failure so startup survives a bad blueprint", async () => {
+    const loop = makeLoop(enabledEnv(join(tmpdir(), "definitely-not-here-457.json")));
+
+    expect(() => loop.tryStart()).not.toThrow();
+    expect(loop.tryStart()).toBe(false);
+    expect(loop.isRunning).toBe(false);
+    expect(loop.status().state).toBe("failed");
+
+    await sleep(30);
+    expect(loop.status().ticks).toBe(0);
+  });
+
+  it("an unparseable configuration yields a disabled loop, not an exception", () => {
+    const loop = BlueprintControlLoop.failedToConfigure(new Error("BOOM"));
+    liveLoops.push(loop);
+
+    expect(loop.tryStart()).toBe(false);
+    expect(loop.isRunning).toBe(false);
+
+    const status = loop.status();
+    expect(status.state).toBe("failed");
+    expect(status.enabled).toBe(false);
+    expect(status.lastError).toBe("BOOM");
+  });
+
+  it("has no loaded blueprint to marshal IO against", () => {
+    const loop = makeLoop({});
+    expect(() => loop.writeInputs(Float64Array.from([1]))).toThrow(BlueprintControlLoopError);
+    expect(() => loop.readOutputs(new Float64Array(1))).toThrow(BlueprintControlLoopError);
+    expect(() => loop.getTagValue("SUM")).toThrow(BlueprintControlLoopError);
+  });
+});
+
+// ── Health surface ──────────────────────────────────────────────────────────
+
+describe("describeBlueprintControlLoopHealth", () => {
+  const base: BlueprintControlLoopStatus = {
+    state: "disabled",
+    enabled: false,
+    running: false,
+    definitionPath: null,
+    blueprintId: null,
+    blueprintName: null,
+    scanPeriodMs: null,
+    ticks: 0,
+    lastTickDurationMs: null,
+    missedDeadlines: 0,
+    missedDeadlineRecently: false,
+    overruns: 0,
+    windowSamples: 0,
+    p50Ms: null,
+    p99Ms: null,
+    maxMs: null,
+    loadFailures: 0,
+    lastError: null,
+    actuatesOutputs: false,
+  };
+
+  it("reports a deliberately-disabled loop as healthy", () => {
+    const health = describeBlueprintControlLoopHealth(base);
+    expect(health.status).toBe("healthy");
+    expect(health.message).toContain("disabled");
+  });
+
+  it("reports a load failure as unhealthy, carrying the reason", () => {
+    const health = describeBlueprintControlLoopHealth({
+      ...base,
+      state: "failed",
+      enabled: true,
+      lastError: "blueprint definition \"/x.json\" is not valid JSON",
+      loadFailures: 1,
+    });
+    expect(health.status).toBe("unhealthy");
+    expect(health.message).toContain("not valid JSON");
+  });
+
+  it("reports enabled-but-not-running as degraded", () => {
+    const health = describeBlueprintControlLoopHealth({
+      ...base,
+      state: "stopped",
+      enabled: true,
+    });
+    expect(health.status).toBe("degraded");
+  });
+
+  it("reports a healthy running loop, naming the no-actuation boundary", () => {
+    const health = describeBlueprintControlLoopHealth({
+      ...base,
+      state: "running",
+      enabled: true,
+      running: true,
+      blueprintId: "adder",
+      scanPeriodMs: 5,
+      ticks: 100,
+    });
+    expect(health.status).toBe("healthy");
+    expect(health.message).toContain("no actuation");
+  });
+
+  it("reports a recently-missed deadline as degraded", () => {
+    const health = describeBlueprintControlLoopHealth({
+      ...base,
+      state: "running",
+      enabled: true,
+      running: true,
+      missedDeadlines: 3,
+      missedDeadlineRecently: true,
+    });
+    expect(health.status).toBe("degraded");
+    expect(health.message).toContain("3 missed scan deadline");
+  });
+
+  it("describes a live loop truthfully end to end", async () => {
+    const loop = makeLoop(enabledEnv(writeBlueprint(ADDER)));
+    loop.start();
+    await waitFor(() => loop.status().ticks >= 3);
+
+    const status = loop.status();
+    expect(status.actuatesOutputs).toBe(false);
+    expect(["healthy", "degraded"]).toContain(describeBlueprintControlLoopHealth(status).status);
+
+    loop.stop();
+    expect(describeBlueprintControlLoopHealth(loop.status()).status).toBe("degraded");
+  });
+});
+
+// ── Prometheus surface ──────────────────────────────────────────────────────
+
+describe("BlueprintControlLoop — Prometheus surface", () => {
+  /** Read one series out of the real exposition text the /metrics endpoint serves. */
+  function metricValue(name: string, blueprint?: string): number | null {
+    const series = blueprint === undefined ? name : `${name}{blueprint="${blueprint}"}`;
+    for (const line of registry.metrics().split("\n")) {
+      if (line.startsWith("#")) continue;
+      const separator = line.lastIndexOf(" ");
+      if (separator < 0) continue;
+      if (line.slice(0, separator) === series) return Number(line.slice(separator + 1));
+    }
+    return null;
+  }
+
+  it("publishes running state, tick counts and window quantiles on the shared registry", async () => {
+    // A distinct blueprint id keeps this test's label series isolated from the
+    // counters other tests in this file already accumulated.
+    const probe = { ...ADDER, id: "metrics-probe" };
+    const loop = makeLoop(
+      // Publish every scan-ish so the assertion does not wait a full second.
+      enabledEnv(writeBlueprint(probe), { BLUEPRINT_CONTROL_LOOP_METRICS_INTERVAL_MS: "100" }),
+    );
+    loop.start();
+    expect(metricValue("scada_blueprint_control_loop_enabled")).toBe(1);
+    expect(metricValue("scada_blueprint_control_loop_running")).toBe(1);
+
+    await waitFor(
+      () => (metricValue("scada_blueprint_control_loop_window_samples", "metrics-probe") ?? 0) >= 5,
+    );
+
+    const exposition = registry.metrics();
+    expect(exposition).toContain(
+      'scada_blueprint_control_loop_scan_period_ms{blueprint="metrics-probe"} 5',
+    );
+    expect(
+      metricValue("scada_blueprint_control_loop_ticks_total", "metrics-probe"),
+    ).toBeGreaterThanOrEqual(5);
+    expect(
+      metricValue("scada_blueprint_control_loop_tick_p99_ms", "metrics-probe"),
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      metricValue("scada_blueprint_control_loop_last_tick_duration_ms", "metrics-probe"),
+    ).toBeGreaterThanOrEqual(0);
+
+    loop.stop();
+    expect(metricValue("scada_blueprint_control_loop_running")).toBe(0);
+  });
+
+  it("counts a fail-closed load as a load failure", () => {
+    const before = metricValue("scada_blueprint_control_loop_load_failures_total") ?? 0;
+    const loop = makeLoop(enabledEnv(join(tmpdir(), "definitely-not-here-457.json")));
+
+    loop.tryStart();
+
+    expect(metricValue("scada_blueprint_control_loop_load_failures_total")).toBe(before + 1);
+    expect(metricValue("scada_blueprint_control_loop_running")).toBe(0);
+  });
+});

--- a/server/blueprint/control-loop.ts
+++ b/server/blueprint/control-loop.ts
@@ -1,0 +1,737 @@
+/**
+ * Deterministic Blueprint Runtime — production control-loop host.
+ *
+ * Issue #457: [wave:2b] Deterministic Blueprint Runtime
+ *
+ * WHAT THIS IS
+ * ------------
+ * `BlueprintRuntime` (./runtime.ts) is an allocation-free interpreter, but an
+ * interpreter is inert until something drives it. This module is that driver:
+ * it loads a blueprint definition from disk, validates it, compiles it ONCE,
+ * pre-allocates every buffer at load time, and then drives `tickFast()` on a
+ * fixed cadence, recording real scheduling telemetry.
+ *
+ * WHAT THIS DELIBERATELY IS NOT — READ BEFORE ENABLING
+ * ---------------------------------------------------
+ * This host EXECUTES control logic; it does NOT ACTUATE anything.
+ *
+ *   - There is no field-bus, gateway, OPC-UA, Modbus, DNP3 or storage write
+ *     anywhere in this file. Enabling the loop creates no plant-output path
+ *     that did not already exist; computed outputs stay in the runtime's own
+ *     `Float64Array` and are only readable via {@link BlueprintControlLoop.readOutputs}.
+ *   - Input tags are only written by an explicit in-process caller of
+ *     {@link BlueprintControlLoop.writeInputs}. No IO binding ships in this
+ *     module, so on a default deployment the input tags hold their load-time
+ *     initial values and the loop is exercising the compiled program and the
+ *     scheduler — not closed-loop control of a plant.
+ *   - Binding real field IO (and the safety review that must accompany a write
+ *     path) is out of scope here on purpose.
+ *
+ * The loop is OFF unless `BLUEPRINT_CONTROL_LOOP_ENABLED` is exactly the string
+ * `"true"` AND `BLUEPRINT_CONTROL_LOOP_DEFINITION` names a readable blueprint
+ * file. Any other value leaves it disabled; there is no truthy-ish coercion, so
+ * it cannot be switched on by an accidental `1`/`yes`/`on`.
+ *
+ * HOT-PATH CONTRACT
+ * -----------------
+ * The measured scan is allocation-free. The timer callback
+ * ({@link BlueprintControlLoop.tickOnce}) does only numeric work around
+ * `tickFast()` — two `performance.now()` reads plus counter updates and one
+ * store into a pre-allocated `Float64Array` ring buffer — and contains no
+ * `await`/Promise, so the scan cannot be preempted mid-tick. The callback is
+ * bound once in the constructor, so arming the timer allocates no closure.
+ *
+ * ONE HONEST EXCEPTION. At most once per `metricsPublishIntervalMs` (default
+ * 1 s) the callback also runs {@link BlueprintControlLoop.publishMetrics}, and
+ * that path DOES allocate: it takes two `subarray` views to sort the sampling
+ * window, and the shared registry's `Gauge.set()`/`Counter.inc()` build a label
+ * key per call (`labelNames.map(...).join()`). Two consequences, stated rather
+ * than glossed:
+ *
+ *   - It cannot inflate a *measured* scan. Publication runs strictly AFTER the
+ *     tick's duration has been recorded, so the exported p50/p99/max describe
+ *     `tickFast()` alone.
+ *   - It is still work on the scan timer. Those ~1/s allocations are GC
+ *     pressure, and the publication itself delays the next timer arm slightly.
+ *     If that lateness ever matters it is not hidden — it surfaces as a missed
+ *     deadline in `missedDeadlines` / `scada_blueprint_control_loop_missed_deadlines_total`.
+ *
+ * Moving publication onto its own timer would make the scan callback allocation-
+ * free outright; it is left here deliberately so the loop owns exactly one timer.
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import { z } from "zod";
+import { log, logError } from "../logger.js";
+import { compileBlueprint } from "./compiler.js";
+import { parseBlueprintDefinition } from "./definition-schema.js";
+import { BlueprintRuntime } from "./runtime.js";
+import type { BlueprintDefinition, CompiledBlueprint } from "./types.js";
+import {
+  blueprintControlLoopEnabled,
+  blueprintControlLoopLastTickMs,
+  blueprintControlLoopLoadFailuresTotal,
+  blueprintControlLoopMissedDeadlinesTotal,
+  blueprintControlLoopOverrunsTotal,
+  blueprintControlLoopRunning,
+  blueprintControlLoopScanPeriodMs,
+  blueprintControlLoopTickMaxMs,
+  blueprintControlLoopTickP50Ms,
+  blueprintControlLoopTickP99Ms,
+  blueprintControlLoopTicksTotal,
+  blueprintControlLoopWindowSamples,
+} from "./metrics.js";
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+/** Thrown when the control loop cannot be configured or cannot load a blueprint. */
+export class BlueprintControlLoopError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BlueprintControlLoopError";
+  }
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+export const BlueprintControlLoopConfigSchema = z
+  .object({
+    /** Master switch. Only the exact string "true" sets this (see the loader). */
+    enabled: z.boolean().default(false),
+    /** Filesystem path of the blueprint definition JSON. Required when enabled. */
+    definitionPath: z.string().min(1).nullable().default(null),
+    /**
+     * Overrides the definition's `scanPeriodMs`. The override is applied to the
+     * definition BEFORE compilation so the cadence and the `dt` used by stateful
+     * ops (TON) can never disagree.
+     */
+    periodMsOverride: z.coerce.number().int().min(1).max(3_600_000).nullable().default(null),
+    /** Ring-buffer size for the scan-duration sampling window. */
+    latencyWindowSamples: z.coerce.number().int().min(16).max(65_536).default(1024),
+    /** How often window quantiles are published to Prometheus. */
+    metricsPublishIntervalMs: z.coerce.number().int().min(100).max(600_000).default(1_000),
+    /**
+     * Lateness (ms) tolerated before a scan counts as a missed deadline.
+     * Defaults to 25% of the scan period, floored at 1 ms.
+     */
+    jitterToleranceMsOverride: z.coerce.number().nonnegative().max(60_000).nullable().default(null),
+    /** How long a missed deadline keeps the health check in `degraded`. */
+    degradedWindowMs: z.coerce.number().int().min(1_000).max(3_600_000).default(60_000),
+    /** Hard ceiling on the definition file size, checked before it is read. */
+    maxDefinitionBytes: z.coerce
+      .number()
+      .int()
+      .min(1_024)
+      .max(64 * 1024 * 1024)
+      .default(4 * 1024 * 1024),
+    /** Hard ceiling on declared tags. */
+    maxTags: z.coerce.number().int().min(1).max(1_000_000).default(50_000),
+    /** Hard ceiling on declared nodes. */
+    maxNodes: z.coerce.number().int().min(1).max(1_000_000).default(50_000),
+  })
+  .strict();
+
+export type BlueprintControlLoopConfig = z.infer<typeof BlueprintControlLoopConfigSchema>;
+
+/**
+ * Build the control-loop configuration from environment variables.
+ *
+ * @throws {BlueprintControlLoopError} when a supplied value is unusable. The
+ *   singleton wrapper below turns that into a disabled, fail-closed loop rather
+ *   than letting it propagate into server startup.
+ */
+export function loadBlueprintControlLoopConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): BlueprintControlLoopConfig {
+  const parsed = BlueprintControlLoopConfigSchema.safeParse({
+    // Exact-match only: an accidental "1"/"yes"/"TRUE" leaves the loop OFF.
+    enabled: env.BLUEPRINT_CONTROL_LOOP_ENABLED === "true",
+    definitionPath: env.BLUEPRINT_CONTROL_LOOP_DEFINITION || undefined,
+    periodMsOverride: env.BLUEPRINT_CONTROL_LOOP_PERIOD_MS || undefined,
+    latencyWindowSamples: env.BLUEPRINT_CONTROL_LOOP_WINDOW_SAMPLES || undefined,
+    metricsPublishIntervalMs: env.BLUEPRINT_CONTROL_LOOP_METRICS_INTERVAL_MS || undefined,
+    jitterToleranceMsOverride: env.BLUEPRINT_CONTROL_LOOP_JITTER_MS || undefined,
+    degradedWindowMs: env.BLUEPRINT_CONTROL_LOOP_DEGRADED_WINDOW_MS || undefined,
+    maxDefinitionBytes: env.BLUEPRINT_CONTROL_LOOP_MAX_BYTES || undefined,
+    maxTags: env.BLUEPRINT_CONTROL_LOOP_MAX_TAGS || undefined,
+    maxNodes: env.BLUEPRINT_CONTROL_LOOP_MAX_NODES || undefined,
+  });
+  if (!parsed.success) {
+    const detail = parsed.error.issues
+      .map((issue) => `${issue.path.join(".") || "<root>"}: ${issue.message}`)
+      .join("; ");
+    throw new BlueprintControlLoopError(`invalid blueprint control-loop configuration — ${detail}`);
+  }
+  return parsed.data;
+}
+
+// ─── Status ───────────────────────────────────────────────────────────────────
+
+export type BlueprintControlLoopState = "disabled" | "stopped" | "running" | "failed";
+
+/**
+ * Point-in-time view of the loop. Declared as a type alias (not an interface) so
+ * it is assignable to `Record<string, unknown>` for the health surface.
+ */
+export type BlueprintControlLoopStatus = {
+  readonly state: BlueprintControlLoopState;
+  /** Configuration asked for the loop. */
+  readonly enabled: boolean;
+  /** The scan timer is currently armed. */
+  readonly running: boolean;
+  readonly definitionPath: string | null;
+  readonly blueprintId: string | null;
+  readonly blueprintName: string | null;
+  readonly scanPeriodMs: number | null;
+  readonly ticks: number;
+  readonly lastTickDurationMs: number | null;
+  readonly missedDeadlines: number;
+  /** A deadline was missed recently enough to still count as degraded. */
+  readonly missedDeadlineRecently: boolean;
+  readonly overruns: number;
+  readonly windowSamples: number;
+  readonly p50Ms: number | null;
+  readonly p99Ms: number | null;
+  readonly maxMs: number | null;
+  readonly loadFailures: number;
+  readonly lastError: string | null;
+  /**
+   * Always false. The host executes compiled control logic but has no field
+   * write path — see the module header. Reported so operators can confirm the
+   * boundary from /health instead of having to read the source.
+   */
+  readonly actuatesOutputs: false;
+};
+
+// ─── The host ─────────────────────────────────────────────────────────────────
+
+export class BlueprintControlLoop {
+  private readonly config: BlueprintControlLoopConfig;
+  private readonly configError: string | null;
+
+  private state: BlueprintControlLoopState;
+  private program: CompiledBlueprint | null = null;
+  private runtime: BlueprintRuntime | null = null;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  /** Bound once in the constructor: the timer must not allocate a closure per arm. */
+  private readonly onTimer: () => void;
+
+  private periodMs = 0;
+  private jitterToleranceMs = 0;
+
+  // ── Telemetry (plain numbers; updated from the hot callback) ──
+  private tickCount = 0;
+  private lastTickDurationMs = Number.NaN;
+  private missedDeadlines = 0;
+  private overruns = 0;
+  private loadFailures = 0;
+  private lastError: string | null = null;
+  private nextDeadlineAt = 0;
+  private lastMissedDeadlineAt = Number.NaN;
+  private lastPublishAt = 0;
+
+  // ── Pre-allocated sampling window (allocated once, never resized) ──
+  private readonly window: Float64Array;
+  private readonly windowScratch: Float64Array;
+  private windowHead = 0;
+  private windowCount = 0;
+
+  // ── Metric bookkeeping ──
+  /** Reused label object so publication does not allocate one per cycle. */
+  private metricLabels: { blueprint: string } = { blueprint: "" };
+  private publishedTicks = 0;
+  private publishedMissed = 0;
+  private publishedOverruns = 0;
+  private publishedLoadFailures = 0;
+  private disabledLogged = false;
+
+  constructor(config: BlueprintControlLoopConfig, configError: string | null = null) {
+    this.config = config;
+    this.configError = configError;
+    if (configError !== null) {
+      this.state = "failed";
+      this.lastError = configError;
+      this.loadFailures = 1;
+    } else {
+      this.state = config.enabled ? "stopped" : "disabled";
+    }
+    this.window = new Float64Array(config.latencyWindowSamples);
+    this.windowScratch = new Float64Array(config.latencyWindowSamples);
+    this.onTimer = () => {
+      this.tickOnce();
+    };
+  }
+
+  /**
+   * A loop that could not even parse its own configuration. It is permanently
+   * disabled and reports the reason; it exists so a bad env var degrades to
+   * "off, and here is why" instead of an exception during module wiring.
+   */
+  static failedToConfigure(err: unknown): BlueprintControlLoop {
+    return new BlueprintControlLoop(
+      BlueprintControlLoopConfigSchema.parse({}),
+      describeError(err),
+    );
+  }
+
+  // ─── Lifecycle ──────────────────────────────────────────────────────────────
+
+  /**
+   * Load (once) and arm the scan timer.
+   *
+   * Idempotent: calling it on a running loop is a no-op that returns `true`.
+   *
+   * @returns `true` when the loop is running on return; `false` when it is
+   *   disabled by configuration or permanently misconfigured.
+   * @throws {BlueprintControlLoopError} when enabled but the blueprint cannot be
+   *   loaded. The loop fails CLOSED: it stays stopped and no timer is armed.
+   *   Use {@link tryStart} at composition sites that must not be taken down by a
+   *   bad blueprint.
+   */
+  start(): boolean {
+    if (this.state === "running") return true;
+
+    if (this.configError !== null) {
+      this.publishMetrics();
+      return false;
+    }
+
+    if (!this.config.enabled) {
+      if (!this.disabledLogged) {
+        this.disabledLogged = true;
+        log(
+          "Blueprint control loop disabled (set BLUEPRINT_CONTROL_LOOP_ENABLED=true and " +
+            "BLUEPRINT_CONTROL_LOOP_DEFINITION=<path to blueprint json> to enable)",
+        );
+      }
+      this.publishMetrics();
+      return false;
+    }
+
+    if (this.runtime === null) {
+      try {
+        this.load();
+      } catch (err) {
+        this.state = "failed";
+        this.lastError = describeError(err);
+        this.loadFailures++;
+        this.publishMetrics();
+        throw err instanceof BlueprintControlLoopError
+          ? err
+          : new BlueprintControlLoopError(this.lastError);
+      }
+    }
+
+    const now = performance.now();
+    this.nextDeadlineAt = now + this.periodMs;
+    this.lastPublishAt = now;
+    this.state = "running";
+    this.lastError = null;
+    this.timer = setInterval(this.onTimer, this.periodMs);
+    this.publishMetrics();
+
+    log(
+      `Blueprint control loop started: blueprint="${this.program?.id ?? "?"}" ` +
+        `period=${this.periodMs}ms instructions=${this.program?.instructionCount ?? 0} ` +
+        `tags=${this.program?.tagCount ?? 0} (execution only — no field write path)`,
+    );
+    return true;
+  }
+
+  /**
+   * Start, failing closed. A configuration or blueprint-load error is recorded,
+   * logged and swallowed so a malformed blueprint can never take down server
+   * startup. This is the entry point server composition uses.
+   */
+  tryStart(): boolean {
+    try {
+      return this.start();
+    } catch (err) {
+      logError(err, "Blueprint control loop refused to start (failing closed; loop is OFF)");
+      return false;
+    }
+  }
+
+  /**
+   * Disarm the scan timer. Idempotent.
+   *
+   * Draining is trivially complete on return: `tickFast()` is fully synchronous
+   * and JavaScript is single-threaded, so no scan can be in flight once
+   * `clearInterval` has run. Counters and the compiled program are retained so
+   * post-stop health/metrics still report truthfully what happened.
+   */
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (this.state === "running") {
+      this.state = "stopped";
+      log(`Blueprint control loop stopped after ${this.tickCount} scan(s)`);
+    }
+    this.publishMetrics();
+  }
+
+  // ─── Load ───────────────────────────────────────────────────────────────────
+
+  /**
+   * Read → size-check → validate → compile → pre-allocate. Every failure mode
+   * raises {@link BlueprintControlLoopError} naming the file and the reason.
+   */
+  private load(): void {
+    const path = this.config.definitionPath;
+    if (path === null) {
+      throw new BlueprintControlLoopError(
+        "BLUEPRINT_CONTROL_LOOP_ENABLED=true requires BLUEPRINT_CONTROL_LOOP_DEFINITION " +
+          "to point at a blueprint definition JSON file",
+      );
+    }
+
+    let byteSize: number;
+    try {
+      byteSize = statSync(path).size;
+    } catch (err) {
+      throw new BlueprintControlLoopError(
+        `cannot stat blueprint definition "${path}": ${describeError(err)}`,
+      );
+    }
+    if (byteSize > this.config.maxDefinitionBytes) {
+      throw new BlueprintControlLoopError(
+        `blueprint definition "${path}" is ${byteSize} bytes, exceeding the configured ` +
+          `maximum of ${this.config.maxDefinitionBytes} bytes`,
+      );
+    }
+
+    let text: string;
+    try {
+      text = readFileSync(path, "utf8");
+    } catch (err) {
+      throw new BlueprintControlLoopError(
+        `cannot read blueprint definition "${path}": ${describeError(err)}`,
+      );
+    }
+
+    let raw: unknown;
+    try {
+      raw = JSON.parse(text) as unknown;
+    } catch (err) {
+      throw new BlueprintControlLoopError(
+        `blueprint definition "${path}" is not valid JSON: ${describeError(err)}`,
+      );
+    }
+
+    let def: BlueprintDefinition;
+    try {
+      def = parseBlueprintDefinition(raw, {
+        maxTags: this.config.maxTags,
+        maxNodes: this.config.maxNodes,
+      });
+    } catch (err) {
+      throw new BlueprintControlLoopError(
+        `blueprint definition "${path}" rejected: ${describeError(err)}`,
+      );
+    }
+
+    if (this.config.periodMsOverride !== null) {
+      def = { ...def, scanPeriodMs: this.config.periodMsOverride };
+    }
+
+    let program: CompiledBlueprint;
+    try {
+      program = compileBlueprint(def);
+    } catch (err) {
+      throw new BlueprintControlLoopError(
+        `blueprint "${def.id}" from "${path}" failed to compile: ${describeError(err)}`,
+      );
+    }
+
+    // Everything below allocates ONCE, here, at load time.
+    this.program = program;
+    this.runtime = new BlueprintRuntime(program);
+    this.periodMs = program.scanPeriodMs;
+    this.jitterToleranceMs =
+      this.config.jitterToleranceMsOverride ?? Math.max(1, this.periodMs * 0.25);
+    this.metricLabels = { blueprint: program.id };
+  }
+
+  // ─── Hot path ───────────────────────────────────────────────────────────────
+
+  /**
+   * One scheduled scan.
+   *
+   * Everything up to and including the `this.window[head] = durationMs` store is
+   * allocation-free: numeric locals, typed-array writes and counter increments
+   * only. The trailing `publishMetrics()` call is throttled to at most once per
+   * `metricsPublishIntervalMs` and DOES allocate (subarray views + registry
+   * label keys) — see the module header. It runs after the scan duration has
+   * already been recorded, so it can never inflate a measured scan.
+   */
+  private tickOnce(): void {
+    const rt = this.runtime;
+    if (rt === null) return;
+
+    const startedAt = performance.now();
+
+    // A missed deadline is an inter-arrival gap larger than period + tolerance;
+    // the reference is the previous callback entry, so one late scan is counted
+    // once rather than poisoning every subsequent scan.
+    if (startedAt - this.nextDeadlineAt > this.jitterToleranceMs) {
+      this.missedDeadlines++;
+      this.lastMissedDeadlineAt = startedAt;
+    }
+
+    rt.tickFast();
+
+    const durationMs = performance.now() - startedAt;
+    this.lastTickDurationMs = durationMs;
+    this.tickCount++;
+    if (durationMs > this.periodMs) this.overruns++;
+
+    const head = this.windowHead;
+    this.window[head] = durationMs;
+    this.windowHead = head + 1 === this.window.length ? 0 : head + 1;
+    if (this.windowCount < this.window.length) this.windowCount++;
+
+    this.nextDeadlineAt = startedAt + this.periodMs;
+
+    if (startedAt - this.lastPublishAt >= this.config.metricsPublishIntervalMs) {
+      this.lastPublishAt = startedAt;
+      this.publishMetrics();
+    }
+  }
+
+  // ─── IO surface (called between scans, never inside one) ────────────────────
+
+  /**
+   * Bulk-write the input tags, in `inputSlots` order. Allocation-free.
+   *
+   * Safe to call from anywhere on the event loop: `tickFast()` is synchronous,
+   * so a caller necessarily runs BETWEEN scans and can never observe or produce
+   * a half-updated tag buffer.
+   *
+   * This is the field-IN direction only. There is no corresponding field-OUT
+   * (actuation) method anywhere in this class — see the module header.
+   */
+  writeInputs(values: Float64Array): void {
+    this.requireRuntime().writeInputs(values);
+  }
+
+  /** Bulk-read the output tags into a caller-supplied buffer. Allocation-free. */
+  readOutputs(destination: Float64Array): void {
+    this.requireRuntime().readOutputs(destination);
+  }
+
+  /** Read a single tag by name (diagnostics — uses the name→slot Map). */
+  getTagValue(name: string): number {
+    return this.requireRuntime().get(name);
+  }
+
+  /** Number of input slots of the loaded blueprint (buffer sizing). */
+  get inputCount(): number {
+    return this.requireRuntime().inputCount;
+  }
+
+  /** Number of output slots of the loaded blueprint (buffer sizing). */
+  get outputCount(): number {
+    return this.requireRuntime().outputCount;
+  }
+
+  get isRunning(): boolean {
+    return this.state === "running";
+  }
+
+  private requireRuntime(): BlueprintRuntime {
+    const rt = this.runtime;
+    if (rt === null) {
+      throw new BlueprintControlLoopError("blueprint control loop has no loaded blueprint");
+    }
+    return rt;
+  }
+
+  // ─── Observability ──────────────────────────────────────────────────────────
+
+  /** Point-in-time snapshot. Safe to call at any time; does not perturb the loop. */
+  status(): BlueprintControlLoopStatus {
+    const samples = this.sortWindowIntoScratch();
+    return {
+      state: this.state,
+      enabled: this.config.enabled,
+      running: this.state === "running",
+      definitionPath: this.config.definitionPath,
+      blueprintId: this.program?.id ?? null,
+      blueprintName: this.program?.name ?? null,
+      scanPeriodMs: this.program === null ? null : this.periodMs,
+      ticks: this.tickCount,
+      lastTickDurationMs: Number.isNaN(this.lastTickDurationMs) ? null : this.lastTickDurationMs,
+      missedDeadlines: this.missedDeadlines,
+      missedDeadlineRecently: this.missedDeadlineRecently(),
+      overruns: this.overruns,
+      windowSamples: samples,
+      p50Ms: this.quantile(samples, 50),
+      p99Ms: this.quantile(samples, 99),
+      maxMs: samples === 0 ? null : this.windowScratch[samples - 1],
+      loadFailures: this.loadFailures,
+      lastError: this.lastError,
+      actuatesOutputs: false,
+    };
+  }
+
+  private missedDeadlineRecently(): boolean {
+    if (Number.isNaN(this.lastMissedDeadlineAt)) return false;
+    return performance.now() - this.lastMissedDeadlineAt <= this.config.degradedWindowMs;
+  }
+
+  /**
+   * Copy the valid part of the ring buffer into the pre-allocated scratch array
+   * and sort it in place. Returns the sample count.
+   *
+   * The ring fills from index 0 and only wraps once full, so the valid region is
+   * always `[0, windowCount)`. Called from status()/publishMetrics() only —
+   * never from the tick.
+   */
+  private sortWindowIntoScratch(): number {
+    const n = this.windowCount;
+    if (n === 0) return 0;
+    const view = this.windowScratch.subarray(0, n);
+    view.set(this.window.subarray(0, n));
+    view.sort();
+    return n;
+  }
+
+  /** Nearest-rank percentile over the already-sorted scratch prefix. */
+  private quantile(sampleCount: number, percentile: number): number | null {
+    if (sampleCount === 0) return null;
+    const rank = Math.ceil((percentile / 100) * sampleCount);
+    const index = Math.min(sampleCount - 1, Math.max(0, rank - 1));
+    return this.windowScratch[index];
+  }
+
+  /**
+   * Mirror the loop's numeric state onto the shared Prometheus registry.
+   * Deliberately NOT called per tick — see ./metrics.ts for why.
+   */
+  private publishMetrics(): void {
+    blueprintControlLoopEnabled.set(this.config.enabled ? 1 : 0);
+    blueprintControlLoopRunning.set(this.state === "running" ? 1 : 0);
+
+    const loadFailureDelta = this.loadFailures - this.publishedLoadFailures;
+    if (loadFailureDelta > 0) {
+      blueprintControlLoopLoadFailuresTotal.inc({}, loadFailureDelta);
+      this.publishedLoadFailures = this.loadFailures;
+    }
+
+    if (this.program === null) return;
+    const labels = this.metricLabels;
+
+    const tickDelta = this.tickCount - this.publishedTicks;
+    if (tickDelta > 0) {
+      blueprintControlLoopTicksTotal.inc(labels, tickDelta);
+      this.publishedTicks = this.tickCount;
+    }
+    const missedDelta = this.missedDeadlines - this.publishedMissed;
+    if (missedDelta > 0) {
+      blueprintControlLoopMissedDeadlinesTotal.inc(labels, missedDelta);
+      this.publishedMissed = this.missedDeadlines;
+    }
+    const overrunDelta = this.overruns - this.publishedOverruns;
+    if (overrunDelta > 0) {
+      blueprintControlLoopOverrunsTotal.inc(labels, overrunDelta);
+      this.publishedOverruns = this.overruns;
+    }
+
+    blueprintControlLoopScanPeriodMs.set(this.periodMs, labels);
+    if (!Number.isNaN(this.lastTickDurationMs)) {
+      blueprintControlLoopLastTickMs.set(this.lastTickDurationMs, labels);
+    }
+
+    const samples = this.sortWindowIntoScratch();
+    blueprintControlLoopWindowSamples.set(samples, labels);
+    if (samples > 0) {
+      blueprintControlLoopTickP50Ms.set(this.quantile(samples, 50) ?? 0, labels);
+      blueprintControlLoopTickP99Ms.set(this.quantile(samples, 99) ?? 0, labels);
+      blueprintControlLoopTickMaxMs.set(this.windowScratch[samples - 1], labels);
+    }
+  }
+}
+
+// ─── Health surface ───────────────────────────────────────────────────────────
+
+export interface BlueprintControlLoopHealth {
+  readonly status: "healthy" | "degraded" | "unhealthy";
+  readonly message: string;
+}
+
+/**
+ * Map a status snapshot onto the health vocabulary used by server/health.
+ *
+ * Rules, chosen so the report is truthful rather than flattering:
+ *   - not configured to run        → healthy ("off" is not a fault)
+ *   - configuration/load failed    → unhealthy, carrying the reason
+ *   - asked to run but not running → degraded
+ *   - running, deadline missed recently → degraded (self-clears after the window)
+ *   - running cleanly              → healthy
+ */
+export function describeBlueprintControlLoopHealth(
+  status: BlueprintControlLoopStatus,
+): BlueprintControlLoopHealth {
+  if (status.state === "failed") {
+    return {
+      status: "unhealthy",
+      message: status.lastError ?? "blueprint control loop failed to load",
+    };
+  }
+  if (!status.enabled) {
+    return {
+      status: "healthy",
+      message: "disabled (set BLUEPRINT_CONTROL_LOOP_ENABLED=true to enable)",
+    };
+  }
+  if (!status.running) {
+    return { status: "degraded", message: "enabled by configuration but not running" };
+  }
+  if (status.missedDeadlineRecently) {
+    return {
+      status: "degraded",
+      message: `running with ${status.missedDeadlines} missed scan deadline(s)`,
+    };
+  }
+  return {
+    status: "healthy",
+    message: `running ${status.blueprintId ?? "?"} every ${status.scanPeriodMs ?? 0}ms (execution only, no actuation)`,
+  };
+}
+
+// ─── Singleton wiring (mirrors server/services/flux/index.ts) ─────────────────
+
+let _loop: BlueprintControlLoop | null = null;
+
+/**
+ * Get or create the process-wide control loop. Never throws: an unparseable
+ * configuration yields a permanently-disabled loop that reports why.
+ */
+export function getBlueprintControlLoop(): BlueprintControlLoop {
+  if (_loop === null) {
+    try {
+      _loop = new BlueprintControlLoop(loadBlueprintControlLoopConfig());
+    } catch (err) {
+      logError(err, "Blueprint control loop configuration rejected (loop stays OFF)");
+      _loop = BlueprintControlLoop.failedToConfigure(err);
+    }
+  }
+  return _loop;
+}
+
+/**
+ * Start the control loop if configuration enables it. Fails closed and never
+ * throws, so server startup cannot be taken down by a bad blueprint.
+ */
+export function startBlueprintControlLoop(): BlueprintControlLoop {
+  const loop = getBlueprintControlLoop();
+  loop.tryStart();
+  return loop;
+}

--- a/server/blueprint/definition-schema.ts
+++ b/server/blueprint/definition-schema.ts
@@ -1,0 +1,121 @@
+/**
+ * Deterministic Blueprint Runtime — authoring-form validation.
+ *
+ * Issue #457: [wave:2b] Deterministic Blueprint Runtime
+ *
+ * `compileBlueprint()` assumes a structurally well-formed {@link BlueprintDefinition}:
+ * it validates *semantics* (arity, tag references, cycles) but happily dereferences
+ * fields whose presence the TypeScript types merely assert. A definition loaded
+ * from disk is untrusted input, so it goes through this Zod schema first.
+ *
+ * The schema is deliberately `.strict()`: an unrecognised field is a rejection,
+ * not something to ignore. Combined with the size limits enforced by
+ * {@link parseBlueprintDefinition}, this is the "fail closed at load" boundary —
+ * a malformed or oversized blueprint produces a clear error and the control loop
+ * refuses to start, rather than the process crashing or executing something the
+ * author did not write.
+ */
+
+import { z } from "zod";
+import {
+  OP_TO_OPCODE,
+  OPERAND_STRIDE,
+  type BlueprintDefinition,
+  type BlueprintOp,
+} from "./types.js";
+
+/** Thrown when a candidate blueprint definition is rejected. */
+export class BlueprintDefinitionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BlueprintDefinitionError";
+  }
+}
+
+/**
+ * Op names derived from the compiler/runtime opcode table so the schema can
+ * never drift from the set of ops the runtime can actually execute.
+ */
+const BLUEPRINT_OPS = Object.keys(OP_TO_OPCODE) as [BlueprintOp, ...BlueprintOp[]];
+
+export const BlueprintOperandSchema = z.union([
+  z.object({ tag: z.string().min(1) }).strict(),
+  z.object({ const: z.number().finite() }).strict(),
+]);
+
+export const TagDescriptorSchema = z
+  .object({
+    name: z.string().min(1),
+    direction: z.enum(["input", "output", "internal"]),
+    dataType: z.enum(["bool", "int", "float"]),
+    initial: z.number().finite().optional(),
+  })
+  .strict();
+
+export const BlueprintNodeSchema = z
+  .object({
+    id: z.string().min(1),
+    op: z.enum(BLUEPRINT_OPS),
+    // Per-op arity is checked by the compiler; OPERAND_STRIDE is the hard
+    // structural bound the compiled instruction stream can encode.
+    inputs: z.array(BlueprintOperandSchema).max(OPERAND_STRIDE),
+    output: z.string().min(1),
+    param: z.number().finite().optional(),
+  })
+  .strict();
+
+export const BlueprintDefinitionSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    tags: z.array(TagDescriptorSchema).min(1),
+    nodes: z.array(BlueprintNodeSchema).min(1),
+    /** Nominal scan period. Also the `dt` used by stateful ops (TON). */
+    scanPeriodMs: z.number().int().min(1).max(3_600_000).optional(),
+  })
+  .strict();
+
+/** Structural size ceilings applied on top of the schema. */
+export interface BlueprintDefinitionLimits {
+  readonly maxTags: number;
+  readonly maxNodes: number;
+}
+
+function formatIssues(error: z.ZodError): string {
+  const shown = error.issues.slice(0, 5).map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join(".") : "<root>";
+    return `${path}: ${issue.message}`;
+  });
+  const extra = error.issues.length > shown.length ? ` (+${error.issues.length - shown.length} more)` : "";
+  return `${shown.join("; ")}${extra}`;
+}
+
+/**
+ * Validate an untrusted value as a {@link BlueprintDefinition}.
+ *
+ * @throws {BlueprintDefinitionError} with a message naming the offending field
+ *   or limit. Never returns a partially-validated definition.
+ */
+export function parseBlueprintDefinition(
+  value: unknown,
+  limits: BlueprintDefinitionLimits,
+): BlueprintDefinition {
+  const parsed = BlueprintDefinitionSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new BlueprintDefinitionError(`schema validation failed — ${formatIssues(parsed.error)}`);
+  }
+  const def = parsed.data;
+
+  if (def.tags.length > limits.maxTags) {
+    throw new BlueprintDefinitionError(
+      `blueprint declares ${def.tags.length} tags, exceeding the configured maximum of ${limits.maxTags}`,
+    );
+  }
+  if (def.nodes.length > limits.maxNodes) {
+    throw new BlueprintDefinitionError(
+      `blueprint declares ${def.nodes.length} nodes, exceeding the configured maximum of ${limits.maxNodes}`,
+    );
+  }
+
+  return def;
+}

--- a/server/blueprint/index.ts
+++ b/server/blueprint/index.ts
@@ -27,4 +27,25 @@ export { compileBlueprint, BlueprintCompileError } from "./compiler.js";
 
 export { BlueprintRuntime, type TickResult } from "./runtime.js";
 
+export {
+  BlueprintDefinitionSchema,
+  BlueprintDefinitionError,
+  parseBlueprintDefinition,
+  type BlueprintDefinitionLimits,
+} from "./definition-schema.js";
+
+export {
+  BlueprintControlLoop,
+  BlueprintControlLoopError,
+  BlueprintControlLoopConfigSchema,
+  describeBlueprintControlLoopHealth,
+  getBlueprintControlLoop,
+  loadBlueprintControlLoopConfig,
+  startBlueprintControlLoop,
+  type BlueprintControlLoopConfig,
+  type BlueprintControlLoopHealth,
+  type BlueprintControlLoopState,
+  type BlueprintControlLoopStatus,
+} from "./control-loop.js";
+
 export { makeControlFarmBlueprint, makeInputVector } from "./fixtures.js";

--- a/server/blueprint/metrics.ts
+++ b/server/blueprint/metrics.ts
@@ -1,0 +1,141 @@
+/**
+ * Prometheus metrics for the deterministic blueprint control loop.
+ *
+ * Issue #457: [wave:2b] Deterministic Blueprint Runtime
+ *
+ * Registered on the shared 0xSCADA registry (server/metrics/prometheus.ts) so
+ * they are exported by the existing /metrics endpoint. The registry adds the
+ * `scada_` prefix, so the exposed names are:
+ *
+ *   scada_blueprint_control_loop_enabled
+ *   scada_blueprint_control_loop_running
+ *   scada_blueprint_control_loop_ticks_total{blueprint}
+ *   scada_blueprint_control_loop_missed_deadlines_total{blueprint}
+ *   scada_blueprint_control_loop_overruns_total{blueprint}
+ *   scada_blueprint_control_loop_load_failures_total
+ *   scada_blueprint_control_loop_scan_period_ms{blueprint}
+ *   scada_blueprint_control_loop_last_tick_duration_ms{blueprint}
+ *   scada_blueprint_control_loop_tick_p50_ms{blueprint}
+ *   scada_blueprint_control_loop_tick_p99_ms{blueprint}
+ *   scada_blueprint_control_loop_tick_max_ms{blueprint}
+ *   scada_blueprint_control_loop_window_samples{blueprint}
+ *
+ * WHY GAUGES AND NOT A LATENCY HISTOGRAM
+ * --------------------------------------
+ * A histogram would be the idiomatic shape for a latency SLO, but this
+ * registry's `Histogram.observe()` builds a label key on every call
+ * (`labelNames.map(...).join()`), i.e. it allocates per observation. Observing
+ * once per tick would therefore put an allocation on the control-loop timer
+ * callback and undermine the bounded-allocation property this issue exists to
+ * guarantee. Instead the loop keeps per-tick timings in a pre-allocated ring
+ * buffer (zero allocation) and publishes summary gauges — p50/p99/max over that
+ * window — on a slow cadence (default once per second). The exported quantiles
+ * are therefore per-window and per-instance; they are NOT aggregatable across
+ * replicas the way histogram buckets would be. That trade-off is deliberate and
+ * is documented in ADR-0026.
+ *
+ * Label cardinality: `blueprint` is the compiled blueprint id. Exactly one
+ * control loop exists per process, so cardinality is 1.
+ */
+
+import { registry } from "../metrics/prometheus.js";
+
+type MetricLabels = Record<string, string>;
+
+interface CounterMetric {
+  inc(labels?: MetricLabels, value?: number): void;
+  get(labels?: MetricLabels): number;
+  reset(): void;
+  collect(): Array<{ labels: MetricLabels; value: number }>;
+}
+
+interface GaugeMetric {
+  set(value: number, labels?: MetricLabels): void;
+  get(labels?: MetricLabels): number;
+  reset(): void;
+  collect(): Array<{ labels: MetricLabels; value: number }>;
+}
+
+/** 1 when the control loop is enabled by configuration, 0 when it is not. */
+export const blueprintControlLoopEnabled: GaugeMetric = registry.gauge(
+  "blueprint_control_loop_enabled",
+  "Blueprint control loop enabled by configuration (1=enabled, 0=disabled)",
+);
+
+/** 1 while the scan timer is armed, 0 otherwise (disabled, stopped or failed). */
+export const blueprintControlLoopRunning: GaugeMetric = registry.gauge(
+  "blueprint_control_loop_running",
+  "Blueprint control loop scan timer armed (1=running, 0=not running)",
+);
+
+/** Completed scans since the loop was loaded. */
+export const blueprintControlLoopTicksTotal: CounterMetric = registry.counter(
+  "blueprint_control_loop_ticks_total",
+  "Total blueprint control-loop scans executed",
+  ["blueprint"],
+);
+
+/**
+ * Scans whose inter-arrival gap exceeded the scan period plus the configured
+ * jitter tolerance — i.e. the host scheduler delivered the timer late.
+ */
+export const blueprintControlLoopMissedDeadlinesTotal: CounterMetric = registry.counter(
+  "blueprint_control_loop_missed_deadlines_total",
+  "Blueprint control-loop scans delivered later than period + jitter tolerance",
+  ["blueprint"],
+);
+
+/** Scans whose own execution time exceeded the scan period. */
+export const blueprintControlLoopOverrunsTotal: CounterMetric = registry.counter(
+  "blueprint_control_loop_overruns_total",
+  "Blueprint control-loop scans whose execution exceeded the scan period",
+  ["blueprint"],
+);
+
+/** Fail-closed load/configuration rejections (blueprint never started). */
+export const blueprintControlLoopLoadFailuresTotal: CounterMetric = registry.counter(
+  "blueprint_control_loop_load_failures_total",
+  "Blueprint control-loop load/configuration failures (loop refused to start)",
+);
+
+/** Configured scan period in milliseconds. */
+export const blueprintControlLoopScanPeriodMs: GaugeMetric = registry.gauge(
+  "blueprint_control_loop_scan_period_ms",
+  "Blueprint control-loop scan period in milliseconds",
+  ["blueprint"],
+);
+
+/** Duration of the most recent scan, in milliseconds. */
+export const blueprintControlLoopLastTickMs: GaugeMetric = registry.gauge(
+  "blueprint_control_loop_last_tick_duration_ms",
+  "Duration of the most recent blueprint control-loop scan in milliseconds",
+  ["blueprint"],
+);
+
+/** Median scan duration over the sampling window. */
+export const blueprintControlLoopTickP50Ms: GaugeMetric = registry.gauge(
+  "blueprint_control_loop_tick_p50_ms",
+  "Median blueprint control-loop scan duration over the sampling window (ms)",
+  ["blueprint"],
+);
+
+/** p99 scan duration over the sampling window — the #457 SLO signal. */
+export const blueprintControlLoopTickP99Ms: GaugeMetric = registry.gauge(
+  "blueprint_control_loop_tick_p99_ms",
+  "p99 blueprint control-loop scan duration over the sampling window (ms)",
+  ["blueprint"],
+);
+
+/** Worst scan duration in the sampling window. */
+export const blueprintControlLoopTickMaxMs: GaugeMetric = registry.gauge(
+  "blueprint_control_loop_tick_max_ms",
+  "Worst blueprint control-loop scan duration in the sampling window (ms)",
+  ["blueprint"],
+);
+
+/** How many samples the published quantiles were computed from. */
+export const blueprintControlLoopWindowSamples: GaugeMetric = registry.gauge(
+  "blueprint_control_loop_window_samples",
+  "Number of scan-duration samples backing the published quantiles",
+  ["blueprint"],
+);

--- a/server/health/index.ts
+++ b/server/health/index.ts
@@ -15,6 +15,7 @@ import { registry, metricsHandler } from '../metrics';
 import { fieldSimulator } from '../simulator';
 import { storeAndForwardService } from '../gateway/store-and-forward';
 import { getBridgeHealthStatus } from '../bridge';
+import { describeBlueprintControlLoopHealth, getBlueprintControlLoop } from '../blueprint/control-loop';
 
 // ── Prometheus health gauges ─────────────────────────────────────────────────
 // These gauges let Prometheus scrape health status as numeric metrics.
@@ -129,6 +130,26 @@ healthManager.registerSimple(
   },
   false, // Optional, depends on configuration
 );
+
+// 9. Deterministic blueprint control loop (#457).
+//    Optional and OFF by default. "Disabled" is reported as healthy — an
+//    intentionally-off subsystem is not a fault — while a fail-closed load error
+//    is reported as unhealthy with the reason attached.
+healthManager.register({
+  name: 'blueprint-control-loop',
+  required: false,
+  check: async () => {
+    const status = getBlueprintControlLoop().status();
+    const health = describeBlueprintControlLoopHealth(status);
+    return {
+      name: 'blueprint-control-loop',
+      status: health.status,
+      lastCheck: new Date(),
+      message: health.message,
+      details: status,
+    };
+  },
+});
 
 // ── Sync health → Prometheus after each check cycle ──────────────────────────
 healthManager.onCheckComplete((result) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,6 +19,7 @@ import { gatewayManager } from "./gateway";
 import { startFluxIntegration } from "./services/flux";
 import { natsPublisher } from "./services/nats";
 import { logAnchorBackendBootState } from "./bridge/anchor-backend";
+import { startBlueprintControlLoop } from "./blueprint/control-loop";
 
 // Re-export log for backward compatibility
 export { log } from "./logger";
@@ -195,6 +196,14 @@ registerSwaggerRoutes(app, gatewayConfig);
       // Record the boot-resolved anchor routing: runtime switches (#455) are
       // process-local, so a restart reverts to env and this makes that visible.
       logAnchorBackendBootState();
+
+      // Deterministic blueprint control loop (#457). OFF unless
+      // BLUEPRINT_CONTROL_LOOP_ENABLED === "true" and a blueprint file is
+      // configured. It executes compiled control logic on a fixed cadence and
+      // publishes scheduling telemetry; it has NO field write path, so enabling
+      // it cannot actuate a plant. Fails closed: a bad blueprint is logged and
+      // the loop stays off rather than taking the server down.
+      startBlueprintControlLoop();
 
       // Start periodic health monitoring (every 30 s)
       healthManager.startPeriodicCheck(30_000);


### PR DESCRIPTION
## Problem

`server/blueprint/` shipped a real, well-tested, allocation-free interpreter that **nothing in production ever constructed**. `new BlueprintRuntime(...)` appeared only in `server/blueprint/__tests__/runtime.test.ts` and `bench/blueprint-runtime/locked.bench.ts`, and there was no control loop on `main` at all. As deployed, the deterministic runtime executed nothing, so none of the guarantees in ADR-0026 were observable on a running system.

## Fix

Adds `server/blueprint/control-loop.ts`: a host that loads a blueprint definition from disk, validates it, compiles it once via the existing `compileBlueprint()`, pre-allocates every buffer at load time, and drives `tickFast()` from a single `setInterval` at the compiled scan period. Composed into `server/index.ts` alongside the other startup services.

**Gated OFF by default**, matching this repo's existing opt-in convention (`ENABLE_BLOCKCHAIN === 'true'` in `server/blockchain.ts`, `SPARKPLUG_BROKER_URL`, `FLUX_URL`): the loop starts only when `BLUEPRINT_CONTROL_LOOP_ENABLED` is *exactly* the string `"true"` **and** `BLUEPRINT_CONTROL_LOOP_DEFINITION` names a readable file. No truthy coercion — `1`/`yes`/`on`/`TRUE`/`true ` leave it off (tested).

**Execution, not actuation.** This PR makes the runtime *run*; it does not make it actuate. The host contains no field-bus, gateway, OPC-UA/Modbus/DNP3 or storage write of any kind, so enabling it creates no plant-output path that did not already exist. Computed outputs stay in the runtime's own `Float64Array`. The only IO method is `writeInputs()` (the field-IN direction, i.e. a plant read); there is no output-publishing counterpart. `status().actuatesOutputs` is a hard-coded `false` surfaced through `/health` so operators can confirm the boundary without reading the source.

**Fails closed at load.** Size-checked via `statSync` *before* the file is read → `JSON.parse` → `.strict()` Zod schema whose op enum is derived from `OP_TO_OPCODE` (so it cannot drift from the executable opcode set) → configurable tag/node ceilings → compile. Every failure raises `BlueprintControlLoopError` naming the file and the reason; `tryStart()` logs and swallows it, so a bad blueprint cannot take down server startup. An unparseable *configuration* yields a permanently-disabled loop rather than an exception during module wiring.

**Hot-path contract.** The interpreter, compiler, types, fixtures and the whole `bench/` tree are byte-for-byte unmodified. The measured scan is allocation-free: the timer callback does only numeric work around `tickFast()` — two `performance.now()` reads, counter updates and one store into a pre-allocated ring buffer — the callback is bound once in the constructor (no closure per arm), and there is no `await`/Promise, so a scan cannot be preempted mid-tick.

One honest exception, stated rather than glossed: at most once per `BLUEPRINT_CONTROL_LOOP_METRICS_INTERVAL_MS` (default 1 s) that same callback also publishes metrics, and *that* path allocates — two `subarray` views plus the registry's per-call label key (`labelNames.map(...).join()`). It runs strictly after the tick's duration has been recorded, so it can never inflate a measured scan, but it is real work on the scan timer, and any resulting lateness is not hidden — it surfaces as a missed deadline. Moving publication to its own timer would remove even that; it is kept on one timer deliberately. Documented in the module header and ADR-0026.

**Observability on the existing surfaces.** Metrics go on the existing `server/metrics` registry under `scada_blueprint_control_loop_*` (enabled/running gauges; ticks/missed-deadline/overrun/load-failure counters; scan-period, last-tick and p50/p99/max/window-samples gauges), following the naming and structural-interface style of `server/protocols/iec61850-goose/metrics.ts` — no parallel registry. A `blueprint-control-loop` check is registered on the existing `healthManager`: disabled → healthy (an intentionally-off subsystem is not a fault), load failure → unhealthy with the reason, enabled-but-not-running or a recently-missed deadline → degraded (self-clearing).

Gauges rather than a latency histogram because this registry's `Histogram.observe()` builds a label key per call — it allocates — and observing per scan would put an allocation on the control loop. The trade-off (per-window, per-instance quantiles that don't aggregate across replicas) is documented in `server/blueprint/metrics.ts` and ADR-0026.

## Verification

Everything below was actually run in the worktree:

- `npx tsc --noEmit` → exits 0, no output.
- `npx vitest run` → `Test Files 96 passed | 2 skipped (98)` / `Tests 2056 passed | 5 skipped (2061)`. Baseline on `main` is 95 files / 2024 passing with 2 files + 5 tests skipped, so this adds 1 file and 32 tests and regresses nothing.
- `npx tsx bench/blueprint-runtime/locked.bench.ts` → unmodified and unweakened; prints `p99 SLO : MET` with 0 GC pauses (numbers below).

New tests (`server/blueprint/__tests__/control-loop.test.ts`, 32 cases, real timers and real temp files — no fake timers, no mocked `fs`):

- disabled by default; arms no timer; not switchable on by `1`/`yes`/`on`/`TRUE`/`true `;
- enabled-by-flag runs scans and advances ticks / window samples / quantiles;
- the loop **genuinely executes** the compiled program — a stateful op advances with no external input, and values written between scans produce computed outputs (`2 + 40 → SUM = 42` read back through `readOutputs`);
- `start()` is idempotent and arms exactly one interval (asserted with a `setInterval` spy);
- `stop()` clears its interval (`clearInterval` spy), stops ticking over 10 scan periods, is idempotent, and restarts cleanly;
- fail-closed for: no definition path, missing file, invalid JSON, unknown op, unknown top-level field, node-count ceiling, byte ceiling, and a compiler rejection (multiple drivers) — each asserted to arm **no** timer, and `tryStart()` asserted not to throw;
- health mapping is truthful in all five states, and the Prometheus surface is read back out of the real exposition text.

The execution test is non-vacuous by construction: commenting out `rt.tickFast()` in `tickOnce()` fails it and only it, because neither `SUM === 42` nor the LATCH-driven `HEARTBEAT === 1` can become true unless the interval really drives the compiled program.

## Caveats

- **The sub-1ms p99 claim is not asserted by this PR.** On this Windows x86_64 / Node v24 dev host the benchmark prints `samples 100,000 / min 0.0052 / p50 0.0058 / p90 0.0063 / p99 0.0111 / p99.9 0.0319 / max 0.1932 / mean 0.0060 / stddev 0.0017 ms`, 0 GC pauses, `p99 SLO : MET`. Run-to-run the worst single tick has been seen above 1 ms (2.54 ms on one run) — the benchmark gates on p99 only, and that behaviour is unchanged. Per ADR-0026 the binding gate is a reference-ARM CI run (1 OCPU / 6 GB), which cannot be executed here.
- **The loop executes but does not actuate**, by design. With no in-process caller of `writeInputs()` and no consumer of `readOutputs()`, an enabled loop exercises the compiled program, the scheduler and the telemetry — not closed-loop control of a plant. Field-IO binding is deliberately out of scope; it needs the safety review a write path requires. Concretely: this moves #457 from "never constructed" to "constructible and observable by an operator", not to "doing useful control".
- **No sample blueprint ships**, on purpose — pointing production at a toy definition would be worse than authoring one. To make the format usable anyway, ADR-0026 now carries a complete worked JSON example (validated by actually loading and running it), and `.env.example` points at it.
- **`stop()` is not wired to a shutdown hook** because the repo has no SIGTERM/SIGINT orchestration anywhere (verified: no matches in `server/` outside tests). An enabled loop's interval will hold the event loop open. It is exercised by tests and reachable via `getBlueprintControlLoop().stop()`; wiring belongs with a server-wide graceful-shutdown change. Recorded as a known gap in the ADR.
- **Metric staleness:** publication is throttled (default 1 s), so gauge values can be that stale. Counters are published as deltas, so nothing is lost, only delayed.
- **Path disclosure:** the health `details` payload includes `definitionPath` (and `lastError`, which embeds the path on failure), and `/api/health` is in `gatewayConfig.publicRoutes`, i.e. unauthenticated — note `healthRouter` is mounted before `routes.ts` registers its own handler, so the full-detail response is the one served. This matches the existing convention (`createBlockchainCheck` already puts the RPC URL in a public message), but flagging it rather than silently diverging — happy to scrub it if you want a different policy for that route.
- **Health wiring coverage:** the check is tested via the pure `describeBlueprintControlLoopHealth()` mapping; instantiating `server/health/index.ts` pulls in storage, blockchain, simulator, store-and-forward and the bridges, which is a heavier integration than this PR should stand up. The 20 lines of pass-through wiring are covered by the typecheck only.
- **Timing-based tests** use 5 ms periods with poll-until-condition waits capped at 3 s and `>=` thresholds rather than exact tick counts. They pass consistently here and `afterEach` stops every loop created, but they are inherently more fragile on a loaded CI runner than fake-timer tests would be.
- **New dependency edges:** `control-loop.ts` imports `../logger.js` and `../metrics/prometheus.js`. `runtime.ts` / `compiler.ts` / `types.ts` / `fixtures.ts` stay dependency-free, so the benchmark's import graph is unchanged.

Refs #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)