### PR TITLE
fix(deps): clear high-severity brace-expansion advisory without breaking minimatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3012,16 +3012,6 @@
         "minimist": "^1.1.0"
       }
     },
-    "node_modules/azure-iot-mqtt-base/node_modules/help-me": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
-      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.6",
-        "readable-stream": "^3.6.0"
-      }
-    },
     "node_modules/azure-iot-mqtt-base/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -3115,10 +3105,14 @@
       "license": "ISC"
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3235,13 +3229,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -3368,29 +3365,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/cacache/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/cacache/node_modules/glob": {
@@ -3683,12 +3657,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
       "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -5053,12 +5021,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5223,27 +5185,6 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -5601,17 +5542,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -6776,18 +6706,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -7562,15 +7480,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-parse": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
   "overrides": {
     "uuid": "11.1.1",
     "esbuild": "0.28.1",
+    "help-me": "^5.0.0",
+    "brace-expansion": "5.0.8",
     "hardhat": {
       "adm-zip": "0.6.0"
     },


### PR DESCRIPTION
Turns `main` green again. `npm audit --audit-level=high` has been failing on main — and therefore on all 14 open PRs — since **GHSA-mh99-v99m-4gvg** (brace-expansion DoS, high) was published on 2026-07-24.

## Why the obvious fix is wrong

The advisory reports `vulnerable_version_range: <= 5.0.7`, `first_patched_version: 5.0.8`, with **no backport** to the 1.x/2.x maintenance lines — so our `brace-expansion@1.1.16` is genuinely flagged, not a false positive.

The tree reached brace-expansion two ways:

```
cacache -> glob@13 -> minimatch@10   -> brace-expansion@5.0.7
azure-iot-device-mqtt -> azure-iot-mqtt-base -> mqtt@4
  -> help-me@3 -> glob@7 -> minimatch@3.1.5 -> brace-expansion@1.1.16
```

A blanket `"brace-expansion": "5.0.8"` override **would have turned CI green and broken production.** brace-expansion 5.x moved its CommonJS entry to a named export:

```js
require("brace-expansion") // -> { EXPANSION_MAX, EXPANSION_MAX_LENGTH, expand }
```

but `minimatch@3.1.5` does `var expand = require("brace-expansion")` (minimatch.js:10) and calls `expand(pattern)` (line 271). Forcing 5.0.8 there throws `expand is not a function` at runtime — on the **Azure IoT MQTT telemetry path**, a live SCADA device path that `npm audit` would have reported as clean.

## What this does instead

Cut the vulnerable subtree out rather than force an incompatible major:

- `help-me@5` has **zero dependencies**, so overriding it removes `glob@7`, `minimatch@3` and `brace-expansion@1.1.16` from the tree entirely (-152 lockfile lines).
- The only remaining consumer is `minimatch@10`, which requests `^5.0.2` and uses the named export correctly — so pinning `brace-expansion` to `5.0.8` is then an in-major, API-compatible bump.
- `help-me` is referenced only by `mqtt@4`s `bin/` CLI scripts (`bin/mqtt.js`, `bin/pub.js`, `bin/sub.js`), never by its library entry (`mqtt.js`), so the Azure transport is unaffected.

The Azure chain is preserved intact: `azure-iot-device-mqtt@1.16.4 -> azure-iot-mqtt-base@1.13.3 -> mqtt@4.3.8`.

## Verification

| Check | Result |
|---|---|
| `npm audit --audit-level=high` | **0 vulnerabilities**, exit 0 (was: 7 high, exit 1) |
| `require("azure-iot-device-mqtt")` | loads OK — `Mqtt, MqttWs, clientFromConnectionString` |
| `tsc --noEmit` | clean |
| `vitest run` | **2024 passed / 5 skipped / 0 failed** (95 files) |
| remaining `brace-expansion` consumers | only `minimatch@10.2.4` (`^5.0.2`) — no callable-default consumer left |

🤖 Generated with [Claude Code](https://claude.com/claude-code)