### PR TITLE
fix(validators): serve the validator dashboard through an authenticated server proxy (#453)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,19 @@ BLUEPRINT_CONTROL_LOOP_DEGRADED_WINDOW_MS=60000
 BLUEPRINT_CONTROL_LOOP_MAX_BYTES=4194304
 BLUEPRINT_CONTROL_LOOP_MAX_TAGS=50000
 BLUEPRINT_CONTROL_LOOP_MAX_NODES=50000
+# Validator Dashboard (Issue #453)
+# CSV of oxscada node base URLs whose :9090 `/status` RPC the SERVER polls on
+# behalf of the dashboard (GET /api/validators). This is deliberately NOT a
+# VITE_-prefixed variable: the browser must never learn or contact node URLs
+# directly, because that breaks under TLS (mixed content) and would require
+# permissive CORS on every node. Leave blank to disable the proxy entirely —
+# with no URLs configured the route reports `configured: false` and performs
+# no outbound requests.
+ANCHOR_NODE_URLS=
+# Per-node request timeout for the server-side poll (ms). Clamped to 250..10000.
+VALIDATOR_RPC_TIMEOUT_MS=3000
+# Maximum node fetches in flight at once. Clamped to 1..16.
+VALIDATOR_RPC_MAX_CONCURRENCY=4
+# Cache TTL (ms) for the aggregated view. Bounds outbound load no matter how
+# many operators have the dashboard open. Clamped to 0..60000.
+VALIDATOR_RPC_CACHE_TTL_MS=2000

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,9 @@ import Integrity from './pages/integrity';
 import AnchorBackend from './pages/admin/AnchorBackend';
 import ApiCredentialControl from './components/ApiCredentialControl';
 
+// Validator Dashboard (issue #453)
+import ValidatorDashboard from './pages/ValidatorDashboard';
+
 const App: React.FC = () => {
   return (
     <div style={{ backgroundColor: '#0a0a0a', minHeight: '100vh', color: '#e5e5e5' }}>
@@ -68,6 +71,11 @@ const App: React.FC = () => {
               Integrity
             </a>
           </Link>
+          <Link href="/validators">
+            <a style={{ color: '#e5e5e5', textDecoration: 'none', fontSize: 14 }}>
+              Validators
+            </a>
+          </Link>
           <Link href="/admin/anchor-backend">
             <a style={{ color: '#e5e5e5', textDecoration: 'none', fontSize: 14 }}>
               Anchor Backend
@@ -89,6 +97,9 @@ const App: React.FC = () => {
           <Route path="/intelligence" component={Intelligence} />
           <Route path="/security" component={SecurityCompliance} />
           <Route path="/integrity" component={Integrity} />
+
+          {/* Validator Dashboard (issue #453) */}
+          <Route path="/validators" component={ValidatorDashboard} />
 
           {/* Admin: Anchor-Backend Switch UX (issue #455) */}
           <Route path="/admin/anchor-backend" component={AnchorBackend} />

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -13,11 +13,17 @@ export {
   type UseWebSocketOptions, 
   type UseWebSocketReturn 
 } from "./use-websocket";
-export { 
-  useEventStream, 
-  type StreamEvent, 
-  type EventFilter, 
-  type UseEventStreamOptions, 
+export {
+  useEventStream,
+  type StreamEvent,
+  type EventFilter,
+  type UseEventStreamOptions,
   type UseEventStreamReturn,
   type StreamMetrics,
 } from "./use-event-stream";
+// Validator Dashboard (issue #453) — same-origin /api/validators proxy
+export {
+  useValidatorOverview,
+  type UseValidatorOverviewOptions,
+  type UseValidatorOverviewReturn,
+} from "./use-validator-overview";

--- a/client/src/hooks/use-validator-overview.ts
+++ b/client/src/hooks/use-validator-overview.ts
@@ -1,0 +1,106 @@
+/**
+ * useValidatorOverview — polls the same-origin `/api/validators` proxy.
+ *
+ * Issue #453 — [wave:2a] Validator Dashboard.
+ *
+ * The browser makes exactly one kind of request: a relative GET to
+ * `/api/validators`. Node URLs are server-side configuration (`ANCHOR_NODE_URLS`)
+ * and never reach the client, so the dashboard works unchanged behind TLS and
+ * needs no CORS grant from any node.
+ *
+ * Convention note: the 0xSCADA client uses custom hooks + fetch rather than
+ * TanStack Query (no QueryClientProvider is mounted in `main.tsx`). This hook
+ * follows the established `use-event-stream` / `use-tag-stream` pattern.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ValidatorOverview } from '@shared/types/services/validator-dashboard';
+import { fetchValidatorOverview, ValidatorApiError } from '../lib/validator-api';
+
+export interface UseValidatorOverviewOptions {
+  /**
+   * Poll cadence in millis. Default 3s — comfortably under the 8s stale window.
+   * The server caches its own node polls, so a faster client does not translate
+   * into more load on the validator fleet.
+   */
+  pollIntervalMs?: number;
+  /** Set false to suspend polling (e.g. while the operator has no API key). */
+  enabled?: boolean;
+}
+
+export interface UseValidatorOverviewReturn {
+  /** Last successful response, or null until the first one lands. */
+  overview: ValidatorOverview | null;
+  /** True until the first request settles. */
+  loading: boolean;
+  /** Last error message, cleared on the next success. */
+  error: string | null;
+  /** HTTP status of the last failure (401/403 drive the credential hint). */
+  errorStatus: number | null;
+  /** CLIENT-clock millis at which `overview` was received; null if none yet. */
+  receivedAt: number | null;
+  /** Force an immediate poll. */
+  refresh: () => void;
+}
+
+export function useValidatorOverview(
+  options: UseValidatorOverviewOptions = {},
+): UseValidatorOverviewReturn {
+  const { pollIntervalMs = 3000, enabled = true } = options;
+
+  const [overview, setOverview] = useState<ValidatorOverview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [errorStatus, setErrorStatus] = useState<number | null>(null);
+  const [receivedAt, setReceivedAt] = useState<number | null>(null);
+
+  const [tick, setTick] = useState(0);
+  const refresh = useCallback(() => setTick((t) => t + 1), []);
+
+  // Guards against a slow response landing after unmount / a newer cycle.
+  const cycleRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    const cycle = ++cycleRef.current;
+
+    async function runCycle(): Promise<void> {
+      try {
+        const next = await fetchValidatorOverview(controller.signal);
+        if (cancelled || cycleRef.current !== cycle) return;
+        setOverview(next);
+        setReceivedAt(Date.now());
+        setError(null);
+        setErrorStatus(null);
+      } catch (err) {
+        if (cancelled || cycleRef.current !== cycle) return;
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        // A failed poll keeps the previous overview on screen; it simply ages
+        // out into 'stale' rather than blanking the operator's view.
+        setError(err instanceof Error ? err.message : 'Validator API request failed');
+        setErrorStatus(err instanceof ValidatorApiError ? err.status : null);
+      } finally {
+        if (!cancelled && cycleRef.current === cycle) setLoading(false);
+      }
+    }
+
+    void runCycle();
+    const id = setInterval(() => void runCycle(), pollIntervalMs);
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      clearInterval(id);
+    };
+  }, [pollIntervalMs, enabled, tick]);
+
+  return { overview, loading, error, errorStatus, receivedAt, refresh };
+}
+
+export default useValidatorOverview;

--- a/client/src/lib/__tests__/validator-api.test.ts
+++ b/client/src/lib/__tests__/validator-api.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the same-origin validator API client (issue #453).
+ *
+ * The review's first finding was that the dashboard talked to nodes straight
+ * from the browser. These tests pin the replacement behaviour: exactly one
+ * relative URL, the operator credential attached, and a contract-checked body.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  VALIDATOR_OVERVIEW_PATH,
+  ValidatorApiError,
+  fetchValidatorOverview,
+} from '../validator-api';
+import { _resetApiCredentialForTests, setApiCredential } from '../api-credential';
+import type { ValidatorOverview } from '@shared/types/services/validator-dashboard';
+
+const overview: ValidatorOverview = {
+  configured: true,
+  generatedAt: 1_700_000_000_000,
+  cached: false,
+  provenance: {
+    verified: false,
+    method: 'none',
+    detail: 'Node-reported and unsigned.',
+  },
+  nodes: [
+    {
+      label: 'node-a:9090',
+      reachable: true,
+      error: null,
+      observedAt: 1_700_000_000_000,
+      status: {
+        nodeId: 'node-a',
+        height: 10,
+        role: 'validator',
+        reportedOrderParameter: 0.98,
+        reportedMeanPhase: 1.2,
+        localPhase: 1.19,
+        peers: 1,
+        mempool: 0,
+        uptimeTicks: 5,
+        peerPhases: [],
+      },
+    },
+  ],
+  validators: [
+    {
+      id: 'node-a',
+      phase: 1.19,
+      naturalFrequency: null,
+      lastUpdatedUnixSeconds: null,
+      reportedBy: ['node-a:9090'],
+      disputed: false,
+    },
+  ],
+  coherence: { r: 1, meanPhase: 1.19, count: 1 },
+  unavailableMetrics: [{ metric: 'attestation-rate-per-round', reason: 'not exposed by /status' }],
+};
+
+beforeEach(() => {
+  _resetApiCredentialForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  _resetApiCredentialForTests();
+});
+
+describe('fetchValidatorOverview', () => {
+  it('calls exactly one relative, same-origin path — never a node URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(overview), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchValidatorOverview();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const requested = String(fetchMock.mock.calls[0][0]);
+    expect(requested).toBe(VALIDATOR_OVERVIEW_PATH);
+    expect(requested).toBe('/api/validators');
+    // No scheme, host or node port may appear in a client-issued request.
+    expect(requested).not.toMatch(/^https?:/);
+    expect(requested).not.toContain('9090');
+  });
+
+  it('attaches the operator API key so the guarded route is reachable', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(overview), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    setApiCredential('reader-key');
+
+    await fetchValidatorOverview();
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(new Headers(init.headers).get('X-API-Key')).toBe('reader-key');
+  });
+
+  it('returns the parsed overview on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify(overview), { status: 200 })),
+    );
+    const result = await fetchValidatorOverview();
+    expect(result.provenance.verified).toBe(false);
+    expect(result.validators[0].id).toBe('node-a');
+  });
+
+  it('surfaces 401 and 403 with an actionable message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 401 })));
+    await expect(fetchValidatorOverview()).rejects.toMatchObject({ status: 401 });
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 403 })));
+    const err = await fetchValidatorOverview().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ValidatorApiError);
+    expect((err as ValidatorApiError).message).toContain('validators.read');
+  });
+
+  it('rejects a body that does not match the shared contract', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({ configured: true }), { status: 200 })),
+    );
+    await expect(fetchValidatorOverview()).rejects.toBeInstanceOf(ValidatorApiError);
+  });
+
+  it('rejects a non-JSON body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('<html>', { status: 200 })));
+    await expect(fetchValidatorOverview()).rejects.toBeInstanceOf(ValidatorApiError);
+  });
+
+  it('wraps a transport failure rather than leaking the raw rejection', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Failed to fetch')));
+    await expect(fetchValidatorOverview()).rejects.toBeInstanceOf(ValidatorApiError);
+  });
+});

--- a/client/src/lib/__tests__/validator-metrics.test.ts
+++ b/client/src/lib/__tests__/validator-metrics.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the PURE validator-dashboard presentation logic (issue #453).
+ *
+ * Covers stale detection against the client clock, clock-discipline helpers
+ * (server clock vs node clock), the coherence threshold, and the
+ * self-reported-vs-derived order-parameter cross-check that exists because node
+ * reports are unsigned.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  STALE_THRESHOLD_MS,
+  COHERENCE_RED_THRESHOLD,
+  classifyNodeHealth,
+  formatAge,
+  isCoherenceCritical,
+  nodeSampleLagMs,
+  orderParameterDivergence,
+  shortId,
+  validatorSampleAgeMs,
+} from '../validator-metrics';
+import type {
+  ValidatorNodeView,
+  ValidatorOverview,
+} from '@shared/types/services/validator-dashboard';
+
+const NOW = 1_700_000_000_000;
+
+function nodeView(over: Partial<ValidatorNodeView> = {}): ValidatorNodeView {
+  return {
+    label: 'node-a:9090',
+    reachable: true,
+    error: null,
+    observedAt: NOW,
+    status: {
+      nodeId: 'node-a',
+      height: 10,
+      role: 'validator',
+      reportedOrderParameter: 0.98,
+      reportedMeanPhase: 1.2,
+      localPhase: 1.19,
+      peers: 1,
+      mempool: 0,
+      uptimeTicks: 5,
+      peerPhases: [],
+    },
+    ...over,
+  };
+}
+
+function overviewWith(nodes: ValidatorNodeView[], r: number): ValidatorOverview {
+  return {
+    configured: true,
+    generatedAt: NOW,
+    cached: false,
+    provenance: { verified: false, method: 'none', detail: 'unsigned' },
+    nodes,
+    validators: [],
+    coherence: { r, meanPhase: 0, count: nodes.length },
+    unavailableMetrics: [],
+  };
+}
+
+describe('classifyNodeHealth', () => {
+  it('is live for a reachable node with a fresh overview', () => {
+    expect(classifyNodeHealth(nodeView(), 0)).toBe('live');
+  });
+
+  it('turns stale strictly under 10s so a dead validator surfaces in time', () => {
+    expect(STALE_THRESHOLD_MS).toBeLessThan(10_000);
+    expect(classifyNodeHealth(nodeView(), STALE_THRESHOLD_MS)).toBe('stale');
+  });
+
+  it('stays live one millisecond before the threshold', () => {
+    expect(classifyNodeHealth(nodeView(), STALE_THRESHOLD_MS - 1)).toBe('live');
+  });
+
+  it('reports error when the server could not reach the node, however fresh', () => {
+    expect(classifyNodeHealth(nodeView({ reachable: false, status: null }), 0)).toBe('error');
+  });
+
+  it('keeps error precedence over staleness', () => {
+    expect(classifyNodeHealth({ reachable: false }, 60_000)).toBe('error');
+  });
+});
+
+describe('nodeSampleLagMs', () => {
+  it('measures a node sample against the aggregate on the same (server) clock', () => {
+    expect(nodeSampleLagMs({ generatedAt: NOW }, { observedAt: NOW - 1500 })).toBe(1500);
+  });
+
+  it('clamps negative skew to zero', () => {
+    expect(nodeSampleLagMs({ generatedAt: NOW }, { observedAt: NOW + 5000 })).toBe(0);
+  });
+});
+
+describe('formatAge', () => {
+  it('formats seconds, minutes, and hours', () => {
+    expect(formatAge(3_000)).toBe('3s ago');
+    expect(formatAge(90_000)).toBe('1m ago');
+    expect(formatAge(3 * 3_600_000)).toBe('3h ago');
+  });
+
+  it('clamps negative ages to 0', () => {
+    expect(formatAge(-5)).toBe('0s ago');
+  });
+});
+
+describe('validatorSampleAgeMs', () => {
+  it('converts the node-reported unix SECONDS into an age in millis', () => {
+    const tenSecondsAgo = NOW / 1000 - 10;
+    expect(validatorSampleAgeMs({ lastUpdatedUnixSeconds: tenSecondsAgo }, NOW)).toBe(10_000);
+  });
+
+  it('returns null when the node did not timestamp the sample', () => {
+    // /status has no per-oscillator timestamp for a node's own local_phase.
+    expect(validatorSampleAgeMs({ lastUpdatedUnixSeconds: null }, NOW)).toBeNull();
+  });
+
+  it('clamps a node clock running ahead of the server to zero', () => {
+    expect(validatorSampleAgeMs({ lastUpdatedUnixSeconds: NOW / 1000 + 60 }, NOW)).toBe(0);
+  });
+});
+
+describe('isCoherenceCritical', () => {
+  it('flags below the default threshold and not at or above it', () => {
+    expect(isCoherenceCritical(COHERENCE_RED_THRESHOLD - 0.01)).toBe(true);
+    expect(isCoherenceCritical(COHERENCE_RED_THRESHOLD)).toBe(false);
+    expect(isCoherenceCritical(0.99)).toBe(false);
+  });
+
+  it('respects a custom threshold', () => {
+    expect(isCoherenceCritical(0.85, 0.9)).toBe(true);
+  });
+});
+
+describe('orderParameterDivergence', () => {
+  it('returns null when no reachable node reported an order parameter', () => {
+    const overview = overviewWith([nodeView({ reachable: false, status: null })], 0.9);
+    expect(orderParameterDivergence(overview)).toBeNull();
+  });
+
+  it('reports the worst gap between a node’s claim and the derived value', () => {
+    const overview = overviewWith(
+      [
+        nodeView(),
+        nodeView({
+          label: 'node-b:9090',
+          status: { ...nodeView().status!, nodeId: 'node-b', reportedOrderParameter: 0.5 },
+        }),
+      ],
+      0.98,
+    );
+    // node-b claims 0.5 while the phases it published derive to 0.98.
+    expect(orderParameterDivergence(overview)).toBeCloseTo(0.48, 6);
+  });
+
+  it('is ~0 when every node’s claim matches the derived value', () => {
+    expect(orderParameterDivergence(overviewWith([nodeView()], 0.98))).toBeCloseTo(0, 6);
+  });
+});
+
+describe('shortId', () => {
+  it('leaves short ids untouched', () => {
+    expect(shortId('node-1')).toBe('node-1');
+  });
+
+  it('truncates long ids with an ellipsis', () => {
+    expect(shortId('0x1234567890abcdef1234')).toBe('0x1234…1234');
+  });
+});

--- a/client/src/lib/validator-api.ts
+++ b/client/src/lib/validator-api.ts
@@ -1,0 +1,84 @@
+/**
+ * validator-api.ts — same-origin client for the Validator Dashboard (issue #453).
+ *
+ * This module is deliberately the ONLY way the dashboard obtains validator data,
+ * and it can only ever reach one URL: the relative, same-origin
+ * `/api/validators`. There is no node URL, no configurable host and no
+ * `import.meta.env` read anywhere in the client bundle.
+ *
+ * That is the point of the endpoint. Talking to each node's `:9090` RPC from the
+ * browser breaks under TLS (the page is https, the node is http → blocked mixed
+ * content) and requires every node to serve permissive CORS headers. Going
+ * through the server removes both problems and lets the request be authenticated
+ * with the operator's control-plane API key, which `apiFetch` attaches.
+ *
+ * The response is validated against the shared Zod schema, so a server/client
+ * contract drift surfaces as a parse error rather than as `undefined` in the UI.
+ */
+
+import {
+  validatorOverviewSchema,
+  type ValidatorOverview,
+} from '@shared/types/services/validator-dashboard';
+import { apiFetch } from './api-credential';
+
+/** The single, relative endpoint this client is allowed to call. */
+export const VALIDATOR_OVERVIEW_PATH = '/api/validators';
+
+/** Error carrying the HTTP status so the UI can distinguish 401/403 from 5xx. */
+export class ValidatorApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number | null,
+  ) {
+    super(message);
+    this.name = 'ValidatorApiError';
+  }
+}
+
+/** Map a transport/HTTP failure onto an operator-readable message. */
+function describeStatus(status: number): string {
+  if (status === 401) return 'Not authenticated — set an API key with the validators.read scope.';
+  if (status === 403) return 'This API key lacks the validators.read scope.';
+  if (status === 503) return 'The validator proxy is unavailable.';
+  return `Validator API returned HTTP ${status}.`;
+}
+
+/**
+ * Fetch the aggregated validator overview from the server-side proxy.
+ *
+ * Throws `ValidatorApiError` on transport failure, a non-2xx status, or a
+ * response that does not match the shared contract.
+ */
+export async function fetchValidatorOverview(signal?: AbortSignal): Promise<ValidatorOverview> {
+  let res: Response;
+  try {
+    res = await apiFetch(VALIDATOR_OVERVIEW_PATH, { signal, headers: { accept: 'application/json' } });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') throw err;
+    throw new ValidatorApiError(
+      err instanceof Error ? err.message : 'Validator API request failed',
+      null,
+    );
+  }
+
+  if (!res.ok) {
+    throw new ValidatorApiError(describeStatus(res.status), res.status);
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    throw new ValidatorApiError('Validator API returned a non-JSON body.', res.status);
+  }
+
+  const parsed = validatorOverviewSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new ValidatorApiError(
+      `Validator API response did not match the expected contract: ${parsed.error.message}`,
+      res.status,
+    );
+  }
+  return parsed.data;
+}

--- a/client/src/lib/validator-metrics.ts
+++ b/client/src/lib/validator-metrics.ts
@@ -1,0 +1,132 @@
+/**
+ * validator-metrics.ts — PURE presentation logic for the Validator Dashboard.
+ *
+ * Issue #453 — [wave:2a] Validator Dashboard.
+ *
+ * Everything here is a pure function of its inputs (no fetch, no React, no
+ * implicit clock — `now` is always passed in). The numeric aggregation the
+ * dashboard displays (Kuramoto coherence, phase merge) is computed server-side
+ * in `server/blockchain/validator-dashboard.ts` from the data the server itself
+ * polled; this module only classifies and formats what the API returned.
+ *
+ * CLOCK DISCIPLINE: three different clocks appear in the payload and mixing them
+ * silently would produce nonsense ages, so each helper states which one it uses.
+ *   - client clock  → how old the last successful API response is
+ *   - server clock  → `generatedAt` / `observedAt`, comparable only to each other
+ *   - node clock    → `lastUpdatedUnixSeconds`, set by the reporting node
+ */
+
+import type {
+  ValidatorNodeView,
+  ValidatorOverview,
+  ValidatorRow,
+} from '@shared/types/services/validator-dashboard';
+
+// ─── Staleness ───────────────────────────────────────────────────────────────
+
+/**
+ * The dashboard is "stale" when the last successful `/api/validators` response
+ * is older than this. The verification criterion for #453 is that killing a
+ * validator shows up in under 10s, so the threshold sits below that and the
+ * poll interval sits well below the threshold.
+ */
+export const STALE_THRESHOLD_MS = 8000;
+
+export type NodeHealth = 'live' | 'stale' | 'error';
+
+/**
+ * Classify one node row.
+ *
+ * `overviewAgeMs` is measured on the CLIENT clock: it is `Date.now()` minus the
+ * moment this browser received the overview. It is never derived from the
+ * server's `generatedAt`, because the two clocks are unrelated.
+ *
+ * - 'error' → the server could not reach or parse this node on its last poll.
+ * - 'stale' → the node answered, but the whole overview is older than the
+ *             threshold (poll stopped, request failing, tab suspended).
+ * - 'live'  → reachable and fresh.
+ */
+export function classifyNodeHealth(
+  node: Pick<ValidatorNodeView, 'reachable'>,
+  overviewAgeMs: number,
+  thresholdMs: number = STALE_THRESHOLD_MS,
+): NodeHealth {
+  if (!node.reachable) return 'error';
+  if (overviewAgeMs >= thresholdMs) return 'stale';
+  return 'live';
+}
+
+/**
+ * How far behind the aggregate a single node's sample was, in millis.
+ * Both operands are the SERVER's clock, so this comparison is well-defined.
+ * Negative skew is clamped to 0.
+ */
+export function nodeSampleLagMs(
+  overview: Pick<ValidatorOverview, 'generatedAt'>,
+  node: Pick<ValidatorNodeView, 'observedAt'>,
+): number {
+  return Math.max(0, overview.generatedAt - node.observedAt);
+}
+
+/** Human "Ns ago" style age string. */
+export function formatAge(ageMs: number): string {
+  const clamped = ageMs < 0 ? 0 : ageMs;
+  const s = Math.floor(clamped / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  return `${h}h ago`;
+}
+
+/**
+ * Age of a validator's phase sample, in millis, or null when the node did not
+ * timestamp it (`/status` carries no per-oscillator timestamp for a node's own
+ * `local_phase`).
+ *
+ * CAVEAT: `lastUpdatedUnixSeconds` comes from the reporting NODE's clock while
+ * `generatedAt` comes from the server's. A skewed node produces a skewed age,
+ * which is exactly why the dashboard labels this column as node-reported.
+ */
+export function validatorSampleAgeMs(
+  row: Pick<ValidatorRow, 'lastUpdatedUnixSeconds'>,
+  generatedAtMs: number,
+): number | null {
+  if (row.lastUpdatedUnixSeconds === null) return null;
+  return Math.max(0, generatedAtMs - row.lastUpdatedUnixSeconds * 1000);
+}
+
+// ─── Coherence thresholds ────────────────────────────────────────────────────
+
+/** Default coherence floor below which the indicator turns red. */
+export const COHERENCE_RED_THRESHOLD = 0.7;
+
+/** Whether a coherence value is below the alarm threshold (turns red). */
+export function isCoherenceCritical(r: number, threshold: number = COHERENCE_RED_THRESHOLD): boolean {
+  return r < threshold;
+}
+
+/**
+ * Largest absolute gap between the coherence the server derived from the merged
+ * phase set and what each node self-reported as its `order_parameter`, or null
+ * when no reachable node reported one.
+ *
+ * A large gap means the nodes' own claim disagrees with the arithmetic on the
+ * phases they published. With unsigned reports that is the only cross-check
+ * available, so it is surfaced rather than hidden.
+ */
+export function orderParameterDivergence(overview: ValidatorOverview): number | null {
+  let worst: number | null = null;
+  for (const node of overview.nodes) {
+    if (!node.status) continue;
+    const gap = Math.abs(node.status.reportedOrderParameter - overview.coherence.r);
+    if (worst === null || gap > worst) worst = gap;
+  }
+  return worst;
+}
+
+/** Truncate a long id (e.g. a hex node id) for display. */
+export function shortId(id: string): string {
+  if (id.length <= 12) return id;
+  return `${id.slice(0, 6)}…${id.slice(-4)}`;
+}

--- a/client/src/pages/ValidatorDashboard.tsx
+++ b/client/src/pages/ValidatorDashboard.tsx
@@ -1,0 +1,411 @@
+/**
+ * ValidatorDashboard — operator surface for the oxscada validator set.
+ *
+ * Issue #453 — [wave:2a] Validator Dashboard.
+ *
+ * Data comes from the authenticated, same-origin `/api/validators` proxy. This
+ * component contains no node URL, no port number and no cross-origin fetch: the
+ * server owns `ANCHOR_NODE_URLS` and does the `:9090` polling, which is what
+ * makes the page work behind TLS without a CORS grant from every node.
+ *
+ * It renders three things an operator needs to read together:
+ *   - the PROVENANCE of the data (unsigned node reports — never presented as
+ *     attested fact), including which validators the reporting nodes disagree about
+ *   - per-node reachability and per-validator Kuramoto phase
+ *   - an explicit list of the metrics the node RPC cannot supply, so a blank
+ *     panel is never mistaken for "zero"
+ *
+ * Classification/formatting comes from the pure `lib/validator-metrics` helpers;
+ * the numeric aggregation is done server-side on the data the server polled.
+ */
+
+import React from 'react';
+import type {
+  ValidatorNodeView,
+  ValidatorOverview,
+  ValidatorProvenance,
+  ValidatorRow,
+} from '@shared/types/services/validator-dashboard';
+import { useValidatorOverview } from '../hooks/use-validator-overview';
+import {
+  STALE_THRESHOLD_MS,
+  COHERENCE_RED_THRESHOLD,
+  classifyNodeHealth,
+  formatAge,
+  isCoherenceCritical,
+  nodeSampleLagMs,
+  orderParameterDivergence,
+  shortId,
+  validatorSampleAgeMs,
+  type NodeHealth,
+} from '../lib/validator-metrics';
+
+const HEALTH_COLORS: Record<NodeHealth, string> = {
+  live: '#22c55e',
+  stale: '#f59e0b',
+  error: '#ef4444',
+};
+
+const PANEL: React.CSSProperties = {
+  backgroundColor: '#111827',
+  borderRadius: 8,
+  padding: 20,
+};
+
+const StatusDot: React.FC<{ color: string }> = ({ color }) => (
+  <span
+    style={{
+      display: 'inline-block',
+      width: 10,
+      height: 10,
+      borderRadius: '50%',
+      backgroundColor: color,
+      marginRight: 6,
+    }}
+  />
+);
+
+// ─── Provenance banner ───────────────────────────────────────────────────────
+
+/**
+ * Always rendered, never collapsible. The whole point of #453's review is that
+ * an operator must not be able to mistake unsigned node claims for attested facts.
+ */
+const ProvenanceBanner: React.FC<{ provenance: ValidatorProvenance; disputedCount: number }> = ({
+  provenance,
+  disputedCount,
+}) => {
+  const verified = provenance.verified;
+  return (
+    <div
+      role="note"
+      aria-label="Data provenance"
+      data-testid="validator-provenance"
+      data-verified={String(verified)}
+      data-method={provenance.method}
+      style={{
+        padding: '12px 16px',
+        marginBottom: 20,
+        borderRadius: 8,
+        border: `1px solid ${verified ? '#22c55e' : '#f59e0b'}`,
+        backgroundColor: verified ? '#052e16' : '#3f2d09',
+      }}
+    >
+      <div style={{ fontWeight: 'bold', color: verified ? '#22c55e' : '#f59e0b', fontSize: 14 }}>
+        {verified
+          ? `Verified — signatures checked (${provenance.method})`
+          : 'UNVERIFIED — unsigned node reports'}
+      </div>
+      <div style={{ color: '#d4d4d4', fontSize: 13, marginTop: 6, lineHeight: 1.5 }}>
+        {provenance.detail}
+      </div>
+      {disputedCount > 0 && (
+        <div style={{ color: '#f59e0b', fontSize: 13, marginTop: 6, fontWeight: 'bold' }}>
+          {disputedCount} validator{disputedCount === 1 ? '' : 's'} reported with conflicting phases
+          by different nodes.
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── Coherence ───────────────────────────────────────────────────────────────
+
+const CoherenceIndicator: React.FC<{ overview: ValidatorOverview }> = ({ overview }) => {
+  const { r, count } = overview.coherence;
+  const critical = isCoherenceCritical(r, COHERENCE_RED_THRESHOLD);
+  const color = critical ? '#ef4444' : r >= 0.9 ? '#22c55e' : '#f59e0b';
+  const divergence = orderParameterDivergence(overview);
+
+  return (
+    <div style={{ ...PANEL, border: `1px solid ${critical ? '#ef4444' : '#374151'}` }}>
+      <div style={{ fontSize: 12, color: '#888', marginBottom: 8 }}>
+        Kuramoto coherence — derived from the reported phase set
+      </div>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+        <span style={{ fontSize: 40, fontWeight: 'bold', color }}>{r.toFixed(3)}</span>
+        <span style={{ fontSize: 14, color: '#888' }}>r over {count} oscillators</span>
+      </div>
+
+      <div style={{ position: 'relative', height: 10, backgroundColor: '#0a0a0a', borderRadius: 5, marginTop: 12 }}>
+        <div
+          style={{
+            width: `${Math.round(Math.min(1, Math.max(0, r)) * 100)}%`,
+            height: '100%',
+            backgroundColor: color,
+            borderRadius: 5,
+          }}
+        />
+        <div
+          title={`red threshold ${COHERENCE_RED_THRESHOLD}`}
+          style={{
+            position: 'absolute',
+            left: `${COHERENCE_RED_THRESHOLD * 100}%`,
+            top: -3,
+            width: 2,
+            height: 16,
+            backgroundColor: '#e5e5e5',
+          }}
+        />
+      </div>
+
+      {critical && (
+        <div style={{ marginTop: 10, color: '#ef4444', fontSize: 13, fontWeight: 'bold' }}>
+          Coherence below {COHERENCE_RED_THRESHOLD} — the reported validator set is desynchronizing.
+        </div>
+      )}
+
+      {divergence !== null && (
+        <div style={{ marginTop: 10, fontSize: 12, color: divergence > 0.05 ? '#f59e0b' : '#666' }}>
+          Largest gap vs. a node&apos;s self-reported order parameter: {divergence.toFixed(3)}
+          {divergence > 0.05 && ' — a node’s claim disagrees with the phases it published.'}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── Node health ─────────────────────────────────────────────────────────────
+
+const NodeHealthPanel: React.FC<{ overview: ValidatorOverview; overviewAgeMs: number }> = ({
+  overview,
+  overviewAgeMs,
+}) => (
+  <div style={PANEL}>
+    <div style={{ fontSize: 12, color: '#888', marginBottom: 12 }}>Node health</div>
+    {overview.nodes.length === 0 ? (
+      <p style={{ color: '#666', fontSize: 13, margin: 0 }}>No nodes configured on the server.</p>
+    ) : (
+      overview.nodes.map((node: ValidatorNodeView) => {
+        const health = classifyNodeHealth(node, overviewAgeMs);
+        return (
+          <div
+            key={node.label}
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'baseline',
+              gap: 12,
+              marginBottom: 8,
+              fontSize: 13,
+            }}
+          >
+            <span style={{ fontFamily: 'monospace' }}>
+              <StatusDot color={HEALTH_COLORS[health]} />
+              {node.label}
+              {node.status && (
+                <span style={{ color: '#666', marginLeft: 8 }}>
+                  h{node.status.height} · {node.status.role} · {node.status.peers}p · mempool{' '}
+                  {node.status.mempool}
+                </span>
+              )}
+            </span>
+            <span style={{ color: HEALTH_COLORS[health], textAlign: 'right' }}>
+              {health === 'error'
+                ? (node.error ?? 'unreachable')
+                : `${health} · sampled ${formatAge(nodeSampleLagMs(overview, node))}`}
+            </span>
+          </div>
+        );
+      })
+    )}
+    <div style={{ marginTop: 8, fontSize: 11, color: '#666' }}>
+      The view turns stale after {(STALE_THRESHOLD_MS / 1000).toFixed(0)}s without a successful
+      refresh. Node polling happens on the server; the browser only calls /api/validators.
+    </div>
+  </div>
+);
+
+// ─── Validator table ─────────────────────────────────────────────────────────
+
+const ValidatorTable: React.FC<{ rows: ValidatorRow[]; generatedAt: number }> = ({
+  rows,
+  generatedAt,
+}) => (
+  <div style={{ ...PANEL, padding: 24 }}>
+    <h2 style={{ fontSize: 18, marginTop: 0, marginBottom: 4 }}>Validator set</h2>
+    <p style={{ fontSize: 12, color: '#888', marginTop: 0, marginBottom: 16 }}>
+      As reported by the nodes above. Not attested — a node can list validators that do not exist.
+    </p>
+    {rows.length === 0 ? (
+      <p style={{ color: '#666', fontSize: 13, margin: 0 }}>
+        No validators reported by any reachable node.
+      </p>
+    ) : (
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+          <thead>
+            <tr style={{ borderBottom: '2px solid #333', textAlign: 'left', color: '#888' }}>
+              <th style={{ padding: '8px 4px' }}>Validator</th>
+              <th>Phase (rad)</th>
+              <th>Natural freq (Hz)</th>
+              <th>Node-reported age</th>
+              <th>Reported by</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const ageMs = validatorSampleAgeMs(row, generatedAt);
+              return (
+                <tr key={row.id} style={{ borderBottom: '1px solid #222' }}>
+                  <td style={{ padding: '8px 4px', fontFamily: 'monospace' }} title={row.id}>
+                    <StatusDot color={row.disputed ? HEALTH_COLORS.stale : HEALTH_COLORS.live} />
+                    {shortId(row.id)}
+                    {row.disputed && (
+                      <span style={{ color: '#f59e0b', marginLeft: 8, fontFamily: 'inherit' }}>
+                        disputed
+                      </span>
+                    )}
+                  </td>
+                  <td style={{ fontFamily: 'monospace' }}>{row.phase.toFixed(3)}</td>
+                  <td style={{ fontFamily: 'monospace' }}>
+                    {row.naturalFrequency === null ? '—' : row.naturalFrequency.toFixed(3)}
+                  </td>
+                  <td style={{ color: '#888' }}>{ageMs === null ? '—' : formatAge(ageMs)}</td>
+                  <td style={{ color: '#888', fontFamily: 'monospace' }}>
+                    {row.reportedBy.join(', ')}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    )}
+  </div>
+);
+
+// ─── Unavailable metrics ─────────────────────────────────────────────────────
+
+const UnavailableMetrics: React.FC<{ overview: ValidatorOverview }> = ({ overview }) => {
+  if (overview.unavailableMetrics.length === 0) return null;
+  return (
+    <div style={{ ...PANEL, padding: 24, marginTop: 24 }} data-testid="validator-unavailable-metrics">
+      <h2 style={{ fontSize: 18, marginTop: 0, marginBottom: 4 }}>Not available from this RPC</h2>
+      <p style={{ fontSize: 12, color: '#888', marginTop: 0, marginBottom: 16 }}>
+        Requested by the wave-2a design but not exposed by the oxscada node. Shown here rather than
+        rendered as an empty chart, which would read as &ldquo;zero&rdquo;.
+      </p>
+      <ul style={{ margin: 0, paddingLeft: 20, color: '#d4d4d4', fontSize: 13, lineHeight: 1.6 }}>
+        {overview.unavailableMetrics.map((item) => (
+          <li key={item.metric} style={{ marginBottom: 8 }}>
+            <code style={{ fontFamily: 'monospace', color: '#e5e5e5' }}>{item.metric}</code> —{' '}
+            <span style={{ color: '#888' }}>{item.reason}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+const ValidatorDashboard: React.FC = () => {
+  const { overview, loading, error, errorStatus, receivedAt, refresh } = useValidatorOverview();
+
+  // Age of the on-screen data on the CLIENT clock — the only clock this browser
+  // can compare `Date.now()` against.
+  const overviewAgeMs = receivedAt === null ? Number.POSITIVE_INFINITY : Date.now() - receivedAt;
+  const reachable = overview ? overview.nodes.filter((n) => n.reachable).length : 0;
+  const disputedCount = overview ? overview.validators.filter((v) => v.disputed).length : 0;
+  const needsCredential = errorStatus === 401 || errorStatus === 403;
+
+  return (
+    <div style={{ padding: 24, backgroundColor: '#0a0a0a', color: '#e5e5e5', minHeight: '100vh' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 8,
+        }}
+      >
+        <h1 style={{ margin: 0, fontSize: 28 }}>Validator Dashboard</h1>
+        <button
+          type="button"
+          onClick={refresh}
+          style={{
+            padding: '8px 16px',
+            backgroundColor: '#1f2937',
+            border: '1px solid #374151',
+            borderRadius: 6,
+            color: '#e5e5e5',
+            cursor: 'pointer',
+            fontSize: 13,
+          }}
+        >
+          Refresh
+        </button>
+      </div>
+      <p style={{ color: '#888', fontSize: 14, margin: '0 0 20px' }}>
+        Server-polled oxscada :9090 RPC via /api/validators
+        {overview && ` — ${reachable}/${overview.nodes.length} nodes reachable`}
+        {receivedAt !== null && (
+          <span style={{ marginLeft: 8, color: '#666' }}>
+            · updated {new Date(receivedAt).toLocaleTimeString()}
+          </span>
+        )}
+      </p>
+
+      {error && (
+        <div
+          role="alert"
+          style={{
+            padding: '12px 16px',
+            marginBottom: 20,
+            borderRadius: 8,
+            border: '1px solid #ef4444',
+            backgroundColor: '#450a0a',
+            color: '#fca5a5',
+            fontSize: 13,
+          }}
+        >
+          {error}
+          {needsCredential && (
+            <span style={{ display: 'block', marginTop: 6, color: '#fecaca' }}>
+              Paste an API key granting <code style={{ fontFamily: 'monospace' }}>validators.read</code>{' '}
+              into the header credential box.
+            </span>
+          )}
+        </div>
+      )}
+
+      {loading && overview === null && (
+        <div style={{ ...PANEL, padding: 24, textAlign: 'center', color: '#888' }}>
+          Loading validator overview…
+        </div>
+      )}
+
+      {overview && !overview.configured && (
+        <div style={{ ...PANEL, padding: 24, color: '#f59e0b' }}>
+          No validator nodes configured. Set{' '}
+          <code style={{ fontFamily: 'monospace' }}>ANCHOR_NODE_URLS</code> in the server environment
+          (csv of node base URLs). The server performs no outbound request until it is set.
+        </div>
+      )}
+
+      {overview && overview.configured && (
+        <>
+          <ProvenanceBanner provenance={overview.provenance} disputedCount={disputedCount} />
+
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+              gap: 16,
+              marginBottom: 24,
+            }}
+          >
+            <CoherenceIndicator overview={overview} />
+            <NodeHealthPanel overview={overview} overviewAgeMs={overviewAgeMs} />
+          </div>
+
+          <ValidatorTable rows={overview.validators} generatedAt={overview.generatedAt} />
+          <UnavailableMetrics overview={overview} />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ValidatorDashboard;

--- a/docs/blockchain/validator-monitoring.md
+++ b/docs/blockchain/validator-monitoring.md
@@ -106,6 +106,74 @@ monitor.onAlert((alert, node) => {
 });
 ```
 
+## Operator Dashboard — `GET /api/validators` (issue #453)
+
+The React Validator Dashboard (`/validators`) does **not** talk to `:9090`. The
+browser makes a single same-origin request to `GET /api/validators`; the server
+polls the nodes listed in `ANCHOR_NODE_URLS` and returns an aggregate. Two
+reasons this is a proxy and not a direct browser fetch:
+
+- **TLS.** A dashboard served over `https` cannot fetch `http://node:9090` —
+  browsers block it as mixed content.
+- **CORS.** A direct fetch would require every node to serve permissive
+  cross-origin headers.
+
+`ANCHOR_NODE_URLS` is deliberately **not** `VITE_`-prefixed, so node URLs never
+enter the client bundle. With it unset the route makes no outbound request and
+answers `{"configured": false, ...}`.
+
+### Authorization
+
+The route is guarded by `requireControlPlaneAccess({ scopes: ['validators.read'] })`
+and fails closed: anonymous callers get 401, an out-of-scope key gets 403. Grant
+it in `API_KEYS`, e.g. `somekey:validator-reader:validators.read`.
+
+### Provenance — read this before acting on the data
+
+`/status` responses are **unsigned**, and this repository holds no registry of
+validator public keys. Nothing in the aggregate is cryptographically verified: a
+node can report an arbitrary validator set, arbitrary phases and an arbitrary
+order parameter. Every response therefore carries
+
+```json
+"provenance": { "verified": false, "method": "none", "detail": "..." }
+```
+
+and the dashboard renders it as a permanent banner. Per-node
+response-signature verification is issue #454's work; when it lands, this field
+becomes a real per-node result instead of a fixed value. Until then the surface
+is diagnostic telemetry, not attested fact.
+
+Because reports are unverified, the aggregate does **not** average conflicting
+phases: a validator whose phase is reported differently by two nodes is flagged
+`disputed`, and the dashboard shows the largest gap between the coherence
+derived from the published phases and each node's self-reported
+`order_parameter`.
+
+### Bounded server-side fetching
+
+A slow or hostile node cannot hang the API:
+
+| Bound | Default | Env |
+|-------|---------|-----|
+| Per-node request timeout (covers the body read) | 3000 ms | `VALIDATOR_RPC_TIMEOUT_MS` (250–10000) |
+| Concurrent node fetches | 4 | `VALIDATOR_RPC_MAX_CONCURRENCY` (1–16) |
+| Aggregate cache TTL (also de-duplicates concurrent requests) | 2000 ms | `VALIDATOR_RPC_CACHE_TTL_MS` (0–60000) |
+| Response body cap | 256 KiB | fixed |
+| Configured nodes | 32 | fixed |
+| Retries | **none** — exactly one attempt per node per poll | — |
+
+Only `http:` and `https:` URLs are accepted; other schemes are dropped. A node
+that fails becomes one errored row rather than a failed request.
+
+### Metrics this RPC cannot supply
+
+Sub-wave 2a asked for per-round attestation health and anchor-batch throughput.
+The oxscada `:9090` surface exposes neither — `/status` has no attest/miss record
+and `/events` carries bridged SCADA events, not consensus attestations. Rather
+than synthesise them, the response lists them in `unavailableMetrics` and the
+dashboard renders that list, so an empty panel is never mistaken for "zero".
+
 ## API
 
 - `addNode(config)` — Register a validator node

--- a/docs/security/api-gateway-keys.md
+++ b/docs/security/api-gateway-keys.md
@@ -45,6 +45,7 @@ narrower control-route policy applies:
 | `safety.resume` | Blueprint safe-state resume |
 | `tuning.write`, `tuning.approve` | Tuning changes and human approvals |
 | `control.write` | Digital-twin control operations |
+| `validators.read` | Validator Dashboard proxy (`GET /api/validators`); read-only aggregate of the `ANCHOR_NODE_URLS` fleet |
 | `security.admin` | HSM control operations |
 | `websocket.admin` | Streaming-client administration |
 

--- a/server/blockchain/__tests__/validator-dashboard.test.ts
+++ b/server/blockchain/__tests__/validator-dashboard.test.ts
@@ -1,0 +1,562 @@
+/**
+ * Unit tests for the Validator Dashboard server-side aggregation (issue #453).
+ *
+ * Covers the properties the review demanded:
+ *   - the server, not the browser, owns node URLs and only speaks http(s)
+ *   - outbound work is bounded: timeout, byte cap, concurrency cap, no retry
+ *   - a slow or hostile node degrades to one errored row instead of hanging
+ *   - provenance is reported as UNVERIFIED and never silently upgraded
+ *   - metrics the node RPC cannot supply are declared, not synthesised
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  MAX_NODES,
+  PHASE_DISAGREEMENT_RADIANS,
+  UNAVAILABLE_METRICS,
+  _resetValidatorDashboardCache,
+  buildOverview,
+  collectValidatorOverview,
+  getValidatorOverview,
+  kuramotoCoherence,
+  loadValidatorDashboardConfig,
+  mapWithConcurrency,
+  mergeValidatorPhases,
+  nodeLabel,
+  parseNodeUrls,
+  pollNodeStatus,
+  toPhaseSamples,
+  type DashboardFetch,
+  type ValidatorDashboardConfig,
+} from '../validator-dashboard';
+import type {
+  ValidatorNodeView,
+  ValidatorPhaseSample,
+} from '@shared/types/services/validator-dashboard';
+
+const NOW = 1_700_000_000_000;
+
+/** A payload in the authoritative 0xSCADA-node /status shape. */
+function nodeStatusPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    node_id: 'node-a',
+    height: 1042,
+    role: 'validator',
+    order_parameter: 0.97,
+    mean_phase: 1.234,
+    local_phase: 1.229,
+    peer_phases: [
+      { node_id: 'node-b', phase: 1.24, natural_freq: 0.5, last_updated: 1_699_999_990 },
+    ],
+    peers: 2,
+    mempool: 7,
+    uptime_ticks: 123_456,
+    ...overrides,
+  };
+}
+
+function jsonFetch(payload: unknown, init: ResponseInit = {}): DashboardFetch {
+  return () => Promise.resolve(new Response(JSON.stringify(payload), { status: 200, ...init }));
+}
+
+afterEach(() => {
+  _resetValidatorDashboardCache();
+  vi.restoreAllMocks();
+});
+
+// ── Configuration ──────────────────────────────────────────────────────────
+
+describe('parseNodeUrls', () => {
+  it('returns [] for empty / nullish input', () => {
+    expect(parseNodeUrls(undefined)).toEqual([]);
+    expect(parseNodeUrls(null)).toEqual([]);
+    expect(parseNodeUrls('')).toEqual([]);
+    expect(parseNodeUrls(' , , ')).toEqual([]);
+  });
+
+  it('normalises, trims and de-duplicates while preserving order', () => {
+    expect(parseNodeUrls('http://a:9090/, http://b:9090 , http://a:9090')).toEqual([
+      'http://a:9090',
+      'http://b:9090',
+    ]);
+  });
+
+  it('drops non-http(s) schemes so a typo cannot become a file read', () => {
+    expect(parseNodeUrls('file:///etc/passwd,data:text/plain;base64,AA,http://ok:9090')).toEqual([
+      'http://ok:9090',
+    ]);
+  });
+
+  it('drops unparseable entries instead of throwing', () => {
+    expect(parseNodeUrls('not a url,http://ok:9090')).toEqual(['http://ok:9090']);
+  });
+
+  it('caps the node count regardless of how long the env value is', () => {
+    const csv = Array.from({ length: MAX_NODES + 10 }, (_, i) => `http://n${i}:9090`).join(',');
+    expect(parseNodeUrls(csv)).toHaveLength(MAX_NODES);
+  });
+});
+
+describe('nodeLabel', () => {
+  it('exposes host[:port] only — no scheme and no path', () => {
+    expect(nodeLabel('http://validator-1.internal:9090')).toBe('validator-1.internal:9090');
+    expect(nodeLabel('https://v2.example.com/rpc')).toBe('v2.example.com');
+  });
+});
+
+describe('loadValidatorDashboardConfig', () => {
+  it('defaults to no nodes, so nothing is polled until an operator opts in', () => {
+    const config = loadValidatorDashboardConfig({});
+    expect(config.nodeUrls).toEqual([]);
+    expect(config.timeoutMs).toBe(3000);
+    expect(config.maxConcurrency).toBe(4);
+  });
+
+  it('clamps hostile / absurd values into the supported range', () => {
+    const high = loadValidatorDashboardConfig({
+      VALIDATOR_RPC_TIMEOUT_MS: '99999999',
+      VALIDATOR_RPC_MAX_CONCURRENCY: '10000',
+      VALIDATOR_RPC_CACHE_TTL_MS: '99999999',
+    });
+    expect(high.timeoutMs).toBe(10_000);
+    expect(high.maxConcurrency).toBe(16);
+    expect(high.cacheTtlMs).toBe(60_000);
+
+    const low = loadValidatorDashboardConfig({
+      VALIDATOR_RPC_TIMEOUT_MS: '-5',
+      VALIDATOR_RPC_MAX_CONCURRENCY: '0',
+      VALIDATOR_RPC_CACHE_TTL_MS: '-1',
+    });
+    expect(low.timeoutMs).toBe(250);
+    expect(low.maxConcurrency).toBe(1);
+    expect(low.cacheTtlMs).toBe(0);
+  });
+
+  it('falls back to defaults for non-numeric values', () => {
+    const config = loadValidatorDashboardConfig({ VALIDATOR_RPC_TIMEOUT_MS: 'soon' });
+    expect(config.timeoutMs).toBe(3000);
+  });
+});
+
+// ── Bounded transport ──────────────────────────────────────────────────────
+
+describe('mapWithConcurrency', () => {
+  it('never exceeds the limit and preserves input order', async () => {
+    let active = 0;
+    let peak = 0;
+    const items = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    const out = await mapWithConcurrency(items, 3, async (n) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      active -= 1;
+      return n * 2;
+    });
+
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(out).toEqual([2, 4, 6, 8, 10, 12, 14, 16]);
+  });
+
+  it('treats a zero/negative limit as one worker rather than spawning none', async () => {
+    const out = await mapWithConcurrency([1, 2], 0, async (n) => n);
+    expect(out).toEqual([1, 2]);
+  });
+});
+
+describe('pollNodeStatus', () => {
+  it('maps a real /status payload onto the dashboard view', async () => {
+    const view = await pollNodeStatus('http://node-a:9090', {
+      timeoutMs: 1000,
+      fetchImpl: jsonFetch(nodeStatusPayload()),
+      now: () => NOW,
+    });
+
+    expect(view.reachable).toBe(true);
+    expect(view.error).toBeNull();
+    expect(view.label).toBe('node-a:9090');
+    expect(view.observedAt).toBe(NOW);
+    expect(view.status).toMatchObject({
+      nodeId: 'node-a',
+      height: 1042,
+      role: 'validator',
+      reportedOrderParameter: 0.97,
+      localPhase: 1.229,
+      peers: 2,
+      mempool: 7,
+      uptimeTicks: 123_456,
+    });
+    expect(view.status?.peerPhases).toEqual([
+      { nodeId: 'node-b', phase: 1.24, naturalFrequency: 0.5, lastUpdatedUnixSeconds: 1_699_999_990 },
+    ]);
+  });
+
+  it('requests exactly /status on the configured base URL', async () => {
+    const spy = vi.fn(jsonFetch(nodeStatusPayload()));
+    await pollNodeStatus('http://node-a:9090', { timeoutMs: 1000, fetchImpl: spy });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toBe('http://node-a:9090/status');
+  });
+
+  it('captures a non-2xx response instead of throwing', async () => {
+    const view = await pollNodeStatus('http://node-a:9090', {
+      timeoutMs: 1000,
+      fetchImpl: () => Promise.resolve(new Response('nope', { status: 503 })),
+    });
+    expect(view.reachable).toBe(false);
+    expect(view.status).toBeNull();
+    expect(view.error).toContain('503');
+  });
+
+  it('captures a schema-drifted payload instead of throwing', async () => {
+    const view = await pollNodeStatus('http://node-a:9090', {
+      timeoutMs: 1000,
+      fetchImpl: jsonFetch({ node_id: 'a' }),
+    });
+    expect(view.reachable).toBe(false);
+    expect(view.error).toBeTruthy();
+  });
+
+  it('captures invalid JSON instead of throwing', async () => {
+    const view = await pollNodeStatus('http://node-a:9090', {
+      timeoutMs: 1000,
+      fetchImpl: () => Promise.resolve(new Response('{{{', { status: 200 })),
+    });
+    expect(view.reachable).toBe(false);
+    expect(view.error).toBeTruthy();
+  });
+
+  it('rejects an oversized body declared through content-length', async () => {
+    const view = await pollNodeStatus('http://node-a:9090', {
+      timeoutMs: 1000,
+      maxResponseBytes: 64,
+      fetchImpl: jsonFetch(nodeStatusPayload(), { headers: { 'content-length': '999999' } }),
+    });
+    expect(view.reachable).toBe(false);
+    expect(view.error).toContain('cap');
+  });
+
+  it('aborts a streamed body that exceeds the cap even without content-length', async () => {
+    // A hostile node that answers fast and then never stops. Without the byte
+    // cap only the timeout would bound this, which is long enough to stream a
+    // great deal of memory into the process.
+    let chunksSent = 0;
+    const flood = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        chunksSent += 1;
+        controller.enqueue(new Uint8Array(1024));
+      },
+    });
+
+    const view = await pollNodeStatus('http://node-a:9090', {
+      timeoutMs: 5000,
+      maxResponseBytes: 4096,
+      fetchImpl: () => Promise.resolve(new Response(flood, { status: 200 })),
+    });
+
+    expect(view.reachable).toBe(false);
+    expect(view.error).toContain('cap');
+    // Bounded: the read stopped shortly after crossing 4 KiB, not at infinity.
+    expect(chunksSent).toBeLessThan(64);
+  });
+
+  it('times out a hanging node and makes exactly one attempt (no retry)', async () => {
+    const fetchImpl = vi.fn<DashboardFetch>(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener('abort', () =>
+            reject(new DOMException('The operation was aborted.', 'AbortError')),
+          );
+        }),
+    );
+
+    const started = Date.now();
+    const view = await pollNodeStatus('http://slow:9090', { timeoutMs: 30, fetchImpl });
+
+    expect(view.reachable).toBe(false);
+    expect(view.status).toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+
+  it('truncates a node-controlled error message', async () => {
+    const view = await pollNodeStatus('http://node-a:9090', {
+      timeoutMs: 1000,
+      fetchImpl: () => Promise.reject(new Error('x'.repeat(5000))),
+    });
+    expect(view.error?.length).toBeLessThanOrEqual(200);
+  });
+});
+
+// ── Pure aggregation ───────────────────────────────────────────────────────
+
+describe('kuramotoCoherence', () => {
+  it('returns r=0 for an empty set', () => {
+    expect(kuramotoCoherence([]).r).toBe(0);
+  });
+
+  it('returns r=1 for perfectly aligned phases', () => {
+    const out = kuramotoCoherence([1.2, 1.2, 1.2]);
+    expect(out.r).toBeCloseTo(1, 6);
+    expect(out.count).toBe(3);
+  });
+
+  it('returns r≈0 for anti-phase oscillators', () => {
+    expect(kuramotoCoherence([0, Math.PI]).r).toBeCloseTo(0, 6);
+  });
+
+  it('is rotation-invariant and tracks the cluster mean phase', () => {
+    const a = kuramotoCoherence([0, 0.1, -0.1]);
+    const b = kuramotoCoherence([1, 1.1, 0.9]);
+    expect(a.r).toBeCloseTo(b.r, 6);
+    expect(b.meanPhase).toBeCloseTo(1, 6);
+  });
+});
+
+describe('toPhaseSamples', () => {
+  const view: ValidatorNodeView = {
+    label: 'node-a:9090',
+    reachable: true,
+    error: null,
+    observedAt: NOW,
+    status: {
+      nodeId: 'node-a',
+      height: 1,
+      role: 'validator',
+      reportedOrderParameter: 0.9,
+      reportedMeanPhase: 1,
+      localPhase: 1.229,
+      peers: 1,
+      mempool: 0,
+      uptimeTicks: 1,
+      peerPhases: [
+        { nodeId: 'node-b', phase: 1.24, naturalFrequency: 0.5, lastUpdatedUnixSeconds: 1_699_999_990 },
+      ],
+    },
+  };
+
+  it('emits the reporting node itself plus every peer', () => {
+    const samples = toPhaseSamples(view);
+    expect(samples).toHaveLength(2);
+    expect(samples[0]).toMatchObject({ id: 'node-a', phase: 1.229, self: true });
+    expect(samples[1]).toMatchObject({ id: 'node-b', phase: 1.24, self: false });
+  });
+
+  it('leaves the self entry without invented frequency or timestamp', () => {
+    // /status exposes local_phase but no local natural_freq / last_updated.
+    const self = toPhaseSamples(view)[0];
+    expect(self.naturalFrequency).toBeNull();
+    expect(self.lastUpdatedUnixSeconds).toBeNull();
+  });
+
+  it('emits nothing for an unreachable node', () => {
+    expect(toPhaseSamples({ ...view, reachable: false, status: null })).toEqual([]);
+  });
+});
+
+describe('mergeValidatorPhases', () => {
+  const sample = (over: Partial<ValidatorPhaseSample>): ValidatorPhaseSample => ({
+    id: 'v1',
+    phase: 1,
+    naturalFrequency: 0.5,
+    lastUpdatedUnixSeconds: 100,
+    self: false,
+    reportedBy: 'node-a:9090',
+    ...over,
+  });
+
+  it('dedupes by id and keeps the freshest sample', () => {
+    const rows = mergeValidatorPhases([
+      sample({ phase: 1.0, lastUpdatedUnixSeconds: 100, reportedBy: 'node-a:9090' }),
+      sample({ phase: 1.01, lastUpdatedUnixSeconds: 200, reportedBy: 'node-b:9090' }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].phase).toBeCloseTo(1.01);
+    expect(rows[0].reportedBy).toEqual(['node-a:9090', 'node-b:9090']);
+  });
+
+  it('flags disagreement instead of averaging conflicting reports away', () => {
+    const rows = mergeValidatorPhases([
+      sample({ phase: 0, lastUpdatedUnixSeconds: 100, reportedBy: 'node-a:9090' }),
+      sample({ phase: 3, lastUpdatedUnixSeconds: 200, reportedBy: 'node-b:9090' }),
+    ]);
+    expect(rows[0].disputed).toBe(true);
+  });
+
+  it('does not flag agreement within the tolerance', () => {
+    const rows = mergeValidatorPhases([
+      sample({ phase: 1, reportedBy: 'node-a:9090' }),
+      sample({ phase: 1 + PHASE_DISAGREEMENT_RADIANS / 2, reportedBy: 'node-b:9090' }),
+    ]);
+    expect(rows[0].disputed).toBe(false);
+  });
+
+  it('prefers a node’s first-hand report when timestamps cannot decide', () => {
+    const rows = mergeValidatorPhases([
+      sample({ id: 'node-a', phase: 9, lastUpdatedUnixSeconds: null, self: false, reportedBy: 'node-b:9090' }),
+      sample({ id: 'node-a', phase: 2, lastUpdatedUnixSeconds: null, self: true, reportedBy: 'node-a:9090' }),
+    ]);
+    expect(rows[0].phase).toBe(2);
+  });
+
+  it('sorts rows by validator id', () => {
+    const rows = mergeValidatorPhases([sample({ id: 'zz' }), sample({ id: 'aa' })]);
+    expect(rows.map((r) => r.id)).toEqual(['aa', 'zz']);
+  });
+});
+
+describe('buildOverview', () => {
+  it('reports UNVERIFIED provenance and never claims verification', () => {
+    const overview = buildOverview([], { configured: true, generatedAt: NOW, cached: false });
+    expect(overview.provenance.verified).toBe(false);
+    expect(overview.provenance.method).toBe('none');
+    expect(overview.provenance.detail).toMatch(/unsigned/i);
+  });
+
+  it('declares the metrics the node RPC cannot supply instead of synthesising them', () => {
+    const overview = buildOverview([], { configured: true, generatedAt: NOW, cached: false });
+    expect(overview.unavailableMetrics.map((m) => m.metric)).toEqual(
+      UNAVAILABLE_METRICS.map((m) => m.metric),
+    );
+    expect(overview.unavailableMetrics.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Collection + cache ─────────────────────────────────────────────────────
+
+const twoNodeConfig: ValidatorDashboardConfig = {
+  nodeUrls: ['http://node-a:9090', 'http://node-b:9090'],
+  timeoutMs: 1000,
+  maxConcurrency: 2,
+  cacheTtlMs: 5000,
+};
+
+describe('collectValidatorOverview', () => {
+  it('makes no outbound request when no nodes are configured', async () => {
+    const fetchImpl = vi.fn<DashboardFetch>(jsonFetch(nodeStatusPayload()));
+    const overview = await collectValidatorOverview({
+      config: { ...twoNodeConfig, nodeUrls: [] },
+      fetchImpl,
+      now: () => NOW,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(overview.configured).toBe(false);
+    expect(overview.nodes).toEqual([]);
+    expect(overview.validators).toEqual([]);
+  });
+
+  it('aggregates every reachable node and derives coherence from merged phases', async () => {
+    const fetchImpl: DashboardFetch = (url) =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify(
+            url.startsWith('http://node-a')
+              ? nodeStatusPayload()
+              : nodeStatusPayload({
+                  node_id: 'node-b',
+                  local_phase: 1.24,
+                  peer_phases: [
+                    { node_id: 'node-a', phase: 1.229, natural_freq: 0.4, last_updated: 1_699_999_995 },
+                  ],
+                }),
+          ),
+          { status: 200 },
+        ),
+      );
+
+    const overview = await collectValidatorOverview({
+      config: twoNodeConfig,
+      fetchImpl,
+      now: () => NOW,
+    });
+
+    expect(overview.configured).toBe(true);
+    expect(overview.nodes.map((n) => n.label)).toEqual(['node-a:9090', 'node-b:9090']);
+    expect(overview.validators.map((v) => v.id)).toEqual(['node-a', 'node-b']);
+    // Both phases are ~1.23 rad apart by 0.011 → near-perfect coherence.
+    expect(overview.coherence.count).toBe(2);
+    expect(overview.coherence.r).toBeGreaterThan(0.99);
+  });
+
+  it('degrades one dead node into an errored row without failing the request', async () => {
+    const fetchImpl: DashboardFetch = (url) =>
+      url.startsWith('http://node-a')
+        ? Promise.resolve(new Response(JSON.stringify(nodeStatusPayload()), { status: 200 }))
+        : Promise.reject(new Error('ECONNREFUSED'));
+
+    const overview = await collectValidatorOverview({
+      config: twoNodeConfig,
+      fetchImpl,
+      now: () => NOW,
+    });
+
+    expect(overview.nodes[0].reachable).toBe(true);
+    expect(overview.nodes[1].reachable).toBe(false);
+    expect(overview.nodes[1].error).toContain('ECONNREFUSED');
+    // The reachable node's data still renders.
+    expect(overview.validators.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getValidatorOverview caching', () => {
+  it('serves a second call from cache instead of re-polling the fleet', async () => {
+    const fetchImpl = vi.fn<DashboardFetch>(jsonFetch(nodeStatusPayload()));
+    let clock = NOW;
+
+    const first = await getValidatorOverview({
+      config: twoNodeConfig,
+      fetchImpl,
+      now: () => clock,
+    });
+    expect(first.cached).toBe(false);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    clock += 100;
+    const second = await getValidatorOverview({
+      config: twoNodeConfig,
+      fetchImpl,
+      now: () => clock,
+    });
+    expect(second.cached).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('de-duplicates concurrent requests into a single fleet poll', async () => {
+    const fetchImpl = vi.fn<DashboardFetch>(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () => resolve(new Response(JSON.stringify(nodeStatusPayload()), { status: 200 })),
+            5,
+          ),
+        ),
+    );
+
+    const [a, b, c] = await Promise.all([
+      getValidatorOverview({ config: twoNodeConfig, fetchImpl, now: () => NOW }),
+      getValidatorOverview({ config: twoNodeConfig, fetchImpl, now: () => NOW }),
+      getValidatorOverview({ config: twoNodeConfig, fetchImpl, now: () => NOW }),
+    ]);
+
+    // Two nodes polled once between them, not six times.
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(a.generatedAt).toBe(b.generatedAt);
+    expect(b.generatedAt).toBe(c.generatedAt);
+  });
+
+  it('re-polls once the cache expires', async () => {
+    const fetchImpl = vi.fn<DashboardFetch>(jsonFetch(nodeStatusPayload()));
+    let clock = NOW;
+    const config = { ...twoNodeConfig, cacheTtlMs: 1000 };
+
+    await getValidatorOverview({ config, fetchImpl, now: () => clock });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    clock += 1001;
+    const refreshed = await getValidatorOverview({ config, fetchImpl, now: () => clock });
+    expect(refreshed.cached).toBe(false);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+});

--- a/server/blockchain/validator-dashboard.ts
+++ b/server/blockchain/validator-dashboard.ts
@@ -1,0 +1,523 @@
+/**
+ * Validator Dashboard aggregation (issue #453).
+ *
+ * Server-side companion to `GET /api/validators`. The browser must never reach
+ * an oxscada node directly — doing so breaks under TLS (mixed content) and
+ * depends on every node running permissive CORS — so all `:9090` polling happens
+ * here, from the operator-configured `ANCHOR_NODE_URLS`.
+ *
+ * The `/status` wire schema is NOT redefined here. It is parsed with
+ * `parseOxscadaStatus` from `./validator-health`, which mirrors the authoritative
+ * `0xSCADA-node/src/rpc.rs` shape (see docs/blockchain/validator-monitoring.md).
+ *
+ * PROVENANCE: `/status` responses are unsigned and this deployment holds no
+ * registered validator public keys, so nothing here is cryptographically
+ * verified. Every aggregate carries `UNVERIFIED_NODE_REPORT` and the dashboard
+ * renders it. See the note on that constant for why verification is deferred to
+ * issue #454 rather than faked here.
+ *
+ * BOUNDING: a slow or hostile node must not be able to hang `/api/validators`.
+ * Every outbound request is bounded by (a) a per-request timeout that also
+ * covers the body read, (b) a response byte cap, (c) a cap on how many fetches
+ * run concurrently, and (d) exactly one attempt — there is no retry. A short
+ * response cache with in-flight de-duplication bounds outbound load regardless
+ * of how many operators have the dashboard open.
+ */
+
+import {
+  UNVERIFIED_NODE_REPORT,
+  type Coherence,
+  type UnavailableMetric,
+  type ValidatorNodeView,
+  type ValidatorOverview,
+  type ValidatorPhaseSample,
+  type ValidatorRow,
+} from '@shared/types/services/validator-dashboard';
+import { parseOxscadaStatus, type OxscadaStatus } from './validator-health';
+
+// ─── Limits ──────────────────────────────────────────────────────────────────
+
+/** Hard cap on configured nodes, independent of how long the env value is. */
+export const MAX_NODES = 32;
+/** Largest `/status` body accepted from a node before the read is aborted. */
+export const MAX_RESPONSE_BYTES = 256 * 1024;
+
+const TIMEOUT_MS_DEFAULT = 3_000;
+const TIMEOUT_MS_MIN = 250;
+const TIMEOUT_MS_MAX = 10_000;
+
+const CONCURRENCY_DEFAULT = 4;
+const CONCURRENCY_MIN = 1;
+const CONCURRENCY_MAX = 16;
+
+const CACHE_TTL_MS_DEFAULT = 2_000;
+const CACHE_TTL_MS_MIN = 0;
+const CACHE_TTL_MS_MAX = 60_000;
+
+/**
+ * Two reporting nodes whose phase samples for the same validator differ by more
+ * than this are treated as disagreeing rather than silently merged.
+ */
+export const PHASE_DISAGREEMENT_RADIANS = 0.05;
+
+// ─── Configuration ───────────────────────────────────────────────────────────
+
+export interface ValidatorDashboardConfig {
+  /** Normalised node base URLs. Empty means the feature is not configured. */
+  nodeUrls: string[];
+  timeoutMs: number;
+  maxConcurrency: number;
+  cacheTtlMs: number;
+}
+
+/**
+ * Parse the `ANCHOR_NODE_URLS` csv into normalised, de-duplicated base URLs.
+ *
+ * Only `http:` and `https:` are accepted — an operator typo must not turn into
+ * a `file:` or `data:` read. Unparseable and non-HTTP entries are dropped rather
+ * than throwing, so one bad entry cannot take the whole dashboard down. The
+ * result is capped at `MAX_NODES`. Pure; exported for tests.
+ */
+export function parseNodeUrls(csv: string | undefined | null): string[] {
+  if (!csv) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of csv.split(',')) {
+    const trimmed = raw.trim().replace(/\/+$/, '');
+    if (!trimmed) continue;
+    let parsed: URL;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      continue;
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue;
+    const normalized = `${parsed.protocol}//${parsed.host}${parsed.pathname.replace(/\/+$/, '')}`;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(normalized);
+    if (out.length >= MAX_NODES) break;
+  }
+  return out;
+}
+
+/**
+ * Display label for a node: host[:port] only. Deliberately scheme-less and
+ * path-less so the response identifies a node for troubleshooting without
+ * handing the browser something it could fetch.
+ */
+export function nodeLabel(nodeUrl: string): string {
+  try {
+    return new URL(nodeUrl).host;
+  } catch {
+    return nodeUrl;
+  }
+}
+
+function clampInt(raw: string | undefined, fallback: number, min: number, max: number): number {
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(value)));
+}
+
+/** Read the dashboard configuration from the environment. Pure in `env`. */
+export function loadValidatorDashboardConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ValidatorDashboardConfig {
+  return {
+    nodeUrls: parseNodeUrls(env.ANCHOR_NODE_URLS),
+    timeoutMs: clampInt(env.VALIDATOR_RPC_TIMEOUT_MS, TIMEOUT_MS_DEFAULT, TIMEOUT_MS_MIN, TIMEOUT_MS_MAX),
+    maxConcurrency: clampInt(
+      env.VALIDATOR_RPC_MAX_CONCURRENCY,
+      CONCURRENCY_DEFAULT,
+      CONCURRENCY_MIN,
+      CONCURRENCY_MAX,
+    ),
+    cacheTtlMs: clampInt(env.VALIDATOR_RPC_CACHE_TTL_MS, CACHE_TTL_MS_DEFAULT, CACHE_TTL_MS_MIN, CACHE_TTL_MS_MAX),
+  };
+}
+
+// ─── Bounded transport ───────────────────────────────────────────────────────
+
+/** Injectable for tests; defaults to the global fetch (Node 18+). */
+export type DashboardFetch = (
+  url: string,
+  init: { signal: AbortSignal; headers: Record<string, string> },
+) => Promise<Response>;
+
+/**
+ * Read a response body with a hard byte cap. A hostile node that answers fast
+ * but never stops would otherwise be limited only by the request timeout, which
+ * is long enough to stream a great deal of memory into the process.
+ */
+async function readBoundedText(res: Response, maxBytes: number): Promise<string> {
+  const declared = res.headers.get('content-length');
+  if (declared !== null) {
+    const size = Number(declared);
+    if (Number.isFinite(size) && size > maxBytes) {
+      throw new Error(`response body exceeds the ${maxBytes}-byte cap (content-length ${size})`);
+    }
+  }
+
+  const body = res.body;
+  if (!body) return '';
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        throw new Error(`response body exceeds the ${maxBytes}-byte cap`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    // Releases the connection when we bailed out early; a no-op once drained.
+    await reader.cancel().catch(() => undefined);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+export interface PollOptions {
+  timeoutMs: number;
+  fetchImpl?: DashboardFetch;
+  maxResponseBytes?: number;
+  /** Wall clock, injectable so aggregation is deterministic in tests. */
+  now?: () => number;
+}
+
+/**
+ * Poll one node's `/status`. Exactly one attempt, no retry. Never throws:
+ * failures are captured into the returned view so one dead node cannot fail the
+ * whole request.
+ */
+export async function pollNodeStatus(
+  nodeUrl: string,
+  options: PollOptions,
+): Promise<ValidatorNodeView> {
+  const fetchImpl = options.fetchImpl ?? ((url, init) => fetch(url, init));
+  const maxBytes = options.maxResponseBytes ?? MAX_RESPONSE_BYTES;
+  const now = options.now ?? Date.now;
+  const label = nodeLabel(nodeUrl);
+
+  const controller = new AbortController();
+  // The timer covers the body read as well as the headers, so a node that
+  // answers immediately and then trickles bytes is still bounded.
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+  try {
+    const res = await fetchImpl(`${nodeUrl}/status`, {
+      signal: controller.signal,
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) {
+      throw new Error(`/status returned HTTP ${res.status}`);
+    }
+    const text = await readBoundedText(res, maxBytes);
+    const parsed = parseOxscadaStatus(JSON.parse(text) as unknown);
+    return {
+      label,
+      reachable: true,
+      error: null,
+      observedAt: now(),
+      status: toStatusView(parsed),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      label,
+      reachable: false,
+      // The message can echo node-controlled text, so keep it short and never
+      // include the full URL (which may carry internal topology detail).
+      error: message.slice(0, 200),
+      observedAt: now(),
+      status: null,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function toStatusView(status: OxscadaStatus): NonNullable<ValidatorNodeView['status']> {
+  return {
+    nodeId: status.node_id,
+    height: status.height,
+    role: status.role,
+    reportedOrderParameter: status.order_parameter,
+    reportedMeanPhase: status.mean_phase,
+    localPhase: status.local_phase,
+    peers: status.peers,
+    mempool: status.mempool,
+    uptimeTicks: status.uptime_ticks,
+    peerPhases: status.peer_phases.map((peer) => ({
+      nodeId: peer.node_id,
+      phase: peer.phase,
+      naturalFrequency: peer.natural_freq,
+      lastUpdatedUnixSeconds: peer.last_updated,
+    })),
+  };
+}
+
+/**
+ * Run `fn` over `items` with at most `limit` in flight, preserving input order.
+ * Pure control flow; exported for tests.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const effectiveLimit = Math.max(1, Math.trunc(limit));
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index], index);
+    }
+  }
+
+  const workers: Array<Promise<void>> = [];
+  for (let i = 0; i < Math.min(effectiveLimit, items.length); i++) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+  return results;
+}
+
+// ─── Aggregation (pure) ──────────────────────────────────────────────────────
+
+/**
+ * Kuramoto order parameter r·e^{iψ} = (1/N) Σ e^{iθ_k} — the canonical measure
+ * of phase coherence. N=0 gives r=0; N=1 gives r=1 (an oscillator is trivially
+ * coherent with itself).
+ */
+export function kuramotoCoherence(phases: readonly number[]): Coherence {
+  const count = phases.length;
+  if (count === 0) return { r: 0, meanPhase: 0, count: 0 };
+
+  let sumCos = 0;
+  let sumSin = 0;
+  for (const phase of phases) {
+    sumCos += Math.cos(phase);
+    sumSin += Math.sin(phase);
+  }
+  const meanCos = sumCos / count;
+  const meanSin = sumSin / count;
+  return {
+    r: Math.min(1, Math.hypot(meanCos, meanSin)),
+    meanPhase: Math.atan2(meanSin, meanCos),
+    count,
+  };
+}
+
+/**
+ * Flatten a node's `/status` into phase samples: the node's own `local_phase`
+ * plus every entry of `peer_phases`. `/status` carries no natural frequency or
+ * per-oscillator timestamp for the reporting node itself, so those are null
+ * rather than borrowed from a peer entry.
+ */
+export function toPhaseSamples(view: ValidatorNodeView): ValidatorPhaseSample[] {
+  const status = view.status;
+  if (!status) return [];
+  const samples: ValidatorPhaseSample[] = [
+    {
+      id: status.nodeId,
+      phase: status.localPhase,
+      naturalFrequency: null,
+      lastUpdatedUnixSeconds: null,
+      self: true,
+      reportedBy: view.label,
+    },
+  ];
+  for (const peer of status.peerPhases) {
+    samples.push({
+      id: peer.nodeId,
+      phase: peer.phase,
+      naturalFrequency: peer.naturalFrequency,
+      lastUpdatedUnixSeconds: peer.lastUpdatedUnixSeconds,
+      self: false,
+      reportedBy: view.label,
+    });
+  }
+  return samples;
+}
+
+/**
+ * Merge phase samples from every reachable node into one row per validator id.
+ *
+ * The freshest sample (largest `last_updated`) wins; a node's report about
+ * itself is preferred over a peer's hearsay at equal freshness. Because no
+ * report is authenticated, conflicting phases are not averaged away — the row
+ * is flagged `disputed` so an operator can see that reporting nodes disagree.
+ */
+export function mergeValidatorPhases(samples: readonly ValidatorPhaseSample[]): ValidatorRow[] {
+  const byId = new Map<string, { best: ValidatorPhaseSample; reporters: Set<string>; disputed: boolean }>();
+
+  for (const sample of samples) {
+    const existing = byId.get(sample.id);
+    if (!existing) {
+      byId.set(sample.id, { best: sample, reporters: new Set([sample.reportedBy]), disputed: false });
+      continue;
+    }
+    existing.reporters.add(sample.reportedBy);
+    if (Math.abs(existing.best.phase - sample.phase) > PHASE_DISAGREEMENT_RADIANS) {
+      existing.disputed = true;
+    }
+    if (isFresher(sample, existing.best)) {
+      existing.best = sample;
+    }
+  }
+
+  const rows: ValidatorRow[] = [...byId.values()].map((entry) => ({
+    id: entry.best.id,
+    phase: entry.best.phase,
+    naturalFrequency: entry.best.naturalFrequency,
+    lastUpdatedUnixSeconds: entry.best.lastUpdatedUnixSeconds,
+    reportedBy: [...entry.reporters].sort(),
+    disputed: entry.disputed,
+  }));
+
+  rows.sort((a, b) => a.id.localeCompare(b.id));
+  return rows;
+}
+
+function isFresher(candidate: ValidatorPhaseSample, incumbent: ValidatorPhaseSample): boolean {
+  const candidateTs = candidate.lastUpdatedUnixSeconds;
+  const incumbentTs = incumbent.lastUpdatedUnixSeconds;
+  if (candidateTs !== null && incumbentTs !== null) return candidateTs > incumbentTs;
+  // A node's own report is first-hand; prefer it when timestamps cannot decide.
+  if (candidate.self !== incumbent.self) return candidate.self;
+  return candidateTs !== null && incumbentTs === null;
+}
+
+/**
+ * Metrics sub-wave 2a asked for that the oxscada `:9090` RPC does not expose.
+ * Declared explicitly instead of being synthesised from a placeholder source.
+ */
+export const UNAVAILABLE_METRICS: readonly UnavailableMetric[] = Object.freeze([
+  Object.freeze({
+    metric: 'attestation-rate-per-round',
+    reason:
+      'The oxscada /status RPC reports phase, height, peers and mempool but no per-round ' +
+      'attest/miss record, and /events carries bridged SCADA events rather than consensus ' +
+      'attestations. No attestation rate is computed.',
+  }),
+  Object.freeze({
+    metric: 'anchor-batch-throughput',
+    reason:
+      'No anchor-batch counters exist on the oxscada /status RPC and this server exposes no ' +
+      'batch-anchoring metrics source. No throughput series is computed.',
+  }),
+]);
+
+/** Assemble the response body from already-polled node views. Pure. */
+export function buildOverview(
+  nodes: readonly ValidatorNodeView[],
+  options: { configured: boolean; generatedAt: number; cached: boolean },
+): ValidatorOverview {
+  const samples = nodes.flatMap(toPhaseSamples);
+  const validators = mergeValidatorPhases(samples);
+  return {
+    configured: options.configured,
+    generatedAt: options.generatedAt,
+    cached: options.cached,
+    provenance: UNVERIFIED_NODE_REPORT,
+    nodes: [...nodes],
+    validators,
+    coherence: kuramotoCoherence(validators.map((row) => row.phase)),
+    unavailableMetrics: [...UNAVAILABLE_METRICS],
+  };
+}
+
+// ─── Cached, single-flight collection ────────────────────────────────────────
+
+export interface CollectOptions {
+  config?: ValidatorDashboardConfig;
+  fetchImpl?: DashboardFetch;
+  now?: () => number;
+}
+
+/**
+ * Poll every configured node once, bounded by the configured concurrency, and
+ * build the aggregate. No caching — `getValidatorOverview` layers that on top.
+ */
+export async function collectValidatorOverview(
+  options: CollectOptions = {},
+): Promise<ValidatorOverview> {
+  const config = options.config ?? loadValidatorDashboardConfig();
+  const now = options.now ?? Date.now;
+
+  if (config.nodeUrls.length === 0) {
+    return buildOverview([], { configured: false, generatedAt: now(), cached: false });
+  }
+
+  const nodes = await mapWithConcurrency(config.nodeUrls, config.maxConcurrency, (nodeUrl) =>
+    pollNodeStatus(nodeUrl, {
+      timeoutMs: config.timeoutMs,
+      fetchImpl: options.fetchImpl,
+      now,
+    }),
+  );
+
+  return buildOverview(nodes, { configured: true, generatedAt: now(), cached: false });
+}
+
+interface CacheEntry {
+  overview: ValidatorOverview;
+  expiresAt: number;
+}
+
+let cached: CacheEntry | undefined;
+let inFlight: Promise<ValidatorOverview> | undefined;
+
+/**
+ * Cached, de-duplicated view used by the HTTP route. Concurrent requests share
+ * one poll and a fresh result is reused for `cacheTtlMs`, so the outbound load
+ * on the node fleet is bounded no matter how many dashboards are open.
+ */
+export async function getValidatorOverview(options: CollectOptions = {}): Promise<ValidatorOverview> {
+  const config = options.config ?? loadValidatorDashboardConfig();
+  const now = options.now ?? Date.now;
+  const at = now();
+
+  if (cached && cached.expiresAt > at) {
+    return { ...cached.overview, cached: true };
+  }
+  if (inFlight) {
+    const shared = await inFlight;
+    return { ...shared, cached: true };
+  }
+
+  const request = collectValidatorOverview({ ...options, config, now })
+    .then((overview) => {
+      cached = { overview, expiresAt: now() + config.cacheTtlMs };
+      return overview;
+    })
+    .finally(() => {
+      inFlight = undefined;
+    });
+
+  inFlight = request;
+  return request;
+}
+
+/** Test hook: drop the cached aggregate and any in-flight poll. */
+export function _resetValidatorDashboardCache(): void {
+  cached = undefined;
+  inFlight = undefined;
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -32,6 +32,7 @@ import { blueprintRoutes } from "./routes/blueprints";
 import { vendorRoutes } from "./routes/vendors";
 import { codegenRoutes } from "./routes/codegen";
 import { adminAnchorRoutes } from "./routes/admin-anchor"; // #455 Anchor-Backend Switch UX
+import { validatorRoutes } from "./routes/validators"; // #453 Validator Dashboard proxy
 import { getFluxPublisher } from "./services/flux";
 
 import { tagStreamServer } from "./websocket/tag-stream";
@@ -83,6 +84,7 @@ export async function registerRoutes(
   app.use("/api", vendorRoutes);
   app.use("/api", codegenRoutes);
   app.use("/api/admin/anchor-backend", adminAnchorRoutes); // #455 Anchor-Backend Switch UX
+  app.use("/api/validators", validatorRoutes); // #453 Validator Dashboard (server-side node polling)
 
   // Convenience routes for agent outputs and proposals (redirect to agentRoutes)
   app.get("/api/agent-outputs", async (req, res, next) => {

--- a/server/routes/__tests__/validators-auth.test.ts
+++ b/server/routes/__tests__/validators-auth.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Authorization contract for the Validator Dashboard proxy (issue #453).
+ *
+ * The route replaces browser-side node polling, so it is the only path an
+ * operator has to the fleet's topology and health. It must fail closed for
+ * anonymous callers and reject credentials that lack `validators.read` — the
+ * review explicitly rejected an unauthenticated read surface.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import express from 'express';
+import { createServer, type Server } from 'node:http';
+
+import { _resetControlPlaneAuthCache } from '../../middleware/control-plane-auth';
+import { _resetValidatorDashboardCache } from '../../blockchain/validator-dashboard';
+import { validatorRoutes } from '../validators';
+
+let server: Server;
+let baseUrl: string;
+
+const originalApiKeys = process.env.API_KEYS;
+const originalNodeUrls = process.env.ANCHOR_NODE_URLS;
+
+beforeAll(async () => {
+  process.env.API_KEYS = [
+    'reader-key:validator-reader:validators.read',
+    'other-key:other-service:twin.read',
+    'admin-key:platform-admin:admin',
+  ].join(',');
+  // Unset so the route performs no outbound request during the auth tests.
+  delete process.env.ANCHOR_NODE_URLS;
+  _resetControlPlaneAuthCache();
+  _resetValidatorDashboardCache();
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/validators', validatorRoutes);
+
+  await new Promise<void>((resolve) => {
+    server = createServer(app);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      baseUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  if (originalApiKeys === undefined) delete process.env.API_KEYS;
+  else process.env.API_KEYS = originalApiKeys;
+  if (originalNodeUrls === undefined) delete process.env.ANCHOR_NODE_URLS;
+  else process.env.ANCHOR_NODE_URLS = originalNodeUrls;
+  _resetControlPlaneAuthCache();
+  _resetValidatorDashboardCache();
+});
+
+describe('GET /api/validators authorization', () => {
+  it('fails closed for an anonymous caller', async () => {
+    const res = await fetch(`${baseUrl}/api/validators`);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects an unknown credential', async () => {
+    const res = await fetch(`${baseUrl}/api/validators`, {
+      headers: { 'x-api-key': 'not-a-key' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a credential passed in the query string', async () => {
+    const res = await fetch(`${baseUrl}/api/validators?api_key=reader-key`);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a credential from an unrelated service', async () => {
+    const res = await fetch(`${baseUrl}/api/validators`, {
+      headers: { 'x-api-key': 'other-key' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('allows the validators.read scope', async () => {
+    const res = await fetch(`${baseUrl}/api/validators`, {
+      headers: { 'x-api-key': 'reader-key' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('allows an admin credential', async () => {
+    const res = await fetch(`${baseUrl}/api/validators`, {
+      headers: { 'x-api-key': 'admin-key' },
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('GET /api/validators response contract', () => {
+  it('reports unconfigured and unverified provenance with no nodes configured', async () => {
+    _resetValidatorDashboardCache();
+    const res = await fetch(`${baseUrl}/api/validators`, {
+      headers: { 'x-api-key': 'reader-key' },
+    });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      configured: boolean;
+      nodes: unknown[];
+      provenance: { verified: boolean; method: string };
+      unavailableMetrics: unknown[];
+    };
+
+    expect(body.configured).toBe(false);
+    expect(body.nodes).toEqual([]);
+    // Provenance is always present, and never claims verification this build
+    // does not perform.
+    expect(body.provenance.verified).toBe(false);
+    expect(body.provenance.method).toBe('none');
+    expect(body.unavailableMetrics.length).toBeGreaterThan(0);
+  });
+});

--- a/server/routes/validators.ts
+++ b/server/routes/validators.ts
@@ -1,0 +1,58 @@
+/**
+ * Validator Dashboard API (issue #453).
+ *
+ *   GET /api/validators — aggregated, server-polled view of the oxscada
+ *   validator set configured in `ANCHOR_NODE_URLS`.
+ *
+ * WHY THIS EXISTS AS A PROXY
+ * The dashboard used to poll each node's `:9090` RPC straight from the browser.
+ * That breaks the moment the UI is served over TLS (blocked mixed content) and
+ * it forces every node to run permissive CORS. Polling here means the browser
+ * only ever issues a same-origin request, and node URLs never leave the server.
+ *
+ * AUTH: guarded by the repository's real control-plane guard at a read scope.
+ * The node fleet's topology and health is operational intelligence, so the route
+ * fails closed for anonymous callers.
+ *
+ * PROVENANCE: the aggregate is unsigned node-reported telemetry. The response
+ * carries an explicit `provenance` block with `verified: false` and the UI
+ * renders it; see shared/types/services/validator-dashboard.ts.
+ */
+
+import { Router } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
+
+import { getValidatorOverview } from '../blockchain/validator-dashboard';
+import { logError } from '../logger';
+import { requireControlPlaneAccess } from '../middleware/control-plane-auth';
+
+const router = Router();
+
+const requireValidatorRead = requireControlPlaneAccess({
+  scopes: ['validators.read'],
+});
+
+/** Express 4 does not catch async rejections — wrap every async handler. */
+function asyncHandler(fn: (req: Request, res: Response) => Promise<unknown>): RequestHandler {
+  return (req, res) => {
+    fn(req, res).catch((error: unknown) => {
+      logError(error, 'validator dashboard request failed');
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Failed to collect validator overview' });
+      }
+    });
+  };
+}
+
+router.get(
+  '/',
+  requireValidatorRead,
+  asyncHandler(async (_req, res) => {
+    // getValidatorOverview never rejects on a node failure: unreachable nodes
+    // are reported per-node so one dead validator cannot 500 the dashboard.
+    const overview = await getValidatorOverview();
+    res.json(overview);
+  }),
+);
+
+export { router as validatorRoutes };

--- a/shared/types/services/validator-dashboard.ts
+++ b/shared/types/services/validator-dashboard.ts
@@ -1,0 +1,196 @@
+/**
+ * Validator Dashboard API contract (issue #453).
+ *
+ * The browser NEVER talks to an oxscada node. It calls the same-origin,
+ * authenticated `GET /api/validators` proxy, which polls the operator-configured
+ * `ANCHOR_NODE_URLS` server-side and returns the aggregated view defined here.
+ * Keeping the contract in `shared/` means the server response and the client
+ * parser are validated against a single Zod schema.
+ *
+ * PROVENANCE WARNING — read before treating any of this as fact.
+ * The oxscada `:9090` `/status` RPC returns an unsigned JSON document. This
+ * repository has no registry of validator public keys, so the proxy cannot
+ * verify that a node's claimed validator set is authentic: a node can report an
+ * arbitrary peer list, arbitrary phases and an arbitrary order parameter. Every
+ * response therefore carries an explicit `provenance` block with
+ * `verified: false`, and the dashboard renders it. Do not use this surface as
+ * the basis for an operator action that assumes attested facts.
+ */
+
+import { z } from 'zod';
+
+// ─── Provenance ─────────────────────────────────────────────────────────────
+
+/** How (or whether) node-reported data was cryptographically authenticated. */
+export const validatorProvenanceSchema = z.object({
+  /**
+   * True only when every included node response was verified against a
+   * registered public key. Currently always false — see `method`/`detail`.
+   */
+  verified: z.boolean(),
+  /** Verification algorithm actually applied. `none` means no verification ran. */
+  method: z.enum(['none', 'ed25519']),
+  /** Operator-readable explanation of the verification status. */
+  detail: z.string(),
+});
+export type ValidatorProvenance = z.infer<typeof validatorProvenanceSchema>;
+
+/**
+ * The single provenance value this build can honestly report.
+ *
+ * Signature verification is not implemented here because the two things it
+ * needs do not exist on this branch: the oxscada `/status` response carries no
+ * signature field (see `docs/blockchain/validator-monitoring.md` for the
+ * authoritative schema), and there is no registered-validator-pubkey store to
+ * verify one against. Issue #454 is the work item that introduces per-node
+ * response-signature verification; when it lands, this constant is replaced by
+ * a real per-node verification result rather than a fixed value.
+ */
+export const UNVERIFIED_NODE_REPORT: ValidatorProvenance = Object.freeze({
+  verified: false,
+  method: 'none',
+  detail:
+    'Node-reported and unsigned. The oxscada /status RPC returns no signature and this ' +
+    'deployment has no registered validator public keys, so a node can report an arbitrary ' +
+    'validator set. Treat as advisory telemetry, not attested fact.',
+});
+
+// ─── Per-validator phase sample (from a node /status) ────────────────────────
+
+/**
+ * One oscillator in the Kuramoto coupling model, as reported by a node.
+ * Field names map 1:1 onto `0xSCADA-node`'s `/status` payload:
+ *   id                    ← `node_id` (or `peer_phases[].node_id`)
+ *   phase                 ← `local_phase` / `peer_phases[].phase`
+ *   naturalFrequency      ← `peer_phases[].natural_freq`
+ *   lastUpdatedUnixSeconds← `peer_phases[].last_updated`
+ */
+export const validatorPhaseSampleSchema = z.object({
+  id: z.string().min(1),
+  /** Oscillator phase in radians. */
+  phase: z.number(),
+  /**
+   * Natural frequency (Hz). Null for the reporting node's own entry: `/status`
+   * exposes `local_phase` but no local natural frequency.
+   */
+  naturalFrequency: z.number().nullable(),
+  /**
+   * `last_updated` exactly as the node reported it — UNIX SECONDS per the
+   * documented node schema. Null for the reporting node's own entry, which
+   * `/status` does not timestamp per-oscillator.
+   */
+  lastUpdatedUnixSeconds: z.number().nullable(),
+  /** True when this sample is the reporting node's own `local_phase`. */
+  self: z.boolean(),
+  /** Display label of the node that reported this sample. */
+  reportedBy: z.string(),
+});
+export type ValidatorPhaseSample = z.infer<typeof validatorPhaseSampleSchema>;
+
+// ─── Per-node view ───────────────────────────────────────────────────────────
+
+/** One `peer_phases[]` entry of an oxscada `/status` payload, camel-cased. */
+export const peerPhaseViewSchema = z.object({
+  nodeId: z.string(),
+  phase: z.number(),
+  naturalFrequency: z.number(),
+  /** `last_updated` as reported — UNIX SECONDS per the documented node schema. */
+  lastUpdatedUnixSeconds: z.number(),
+});
+export type PeerPhaseView = z.infer<typeof peerPhaseViewSchema>;
+
+/** The subset of an oxscada `/status` payload the dashboard renders. */
+export const nodeStatusViewSchema = z.object({
+  nodeId: z.string(),
+  height: z.number(),
+  role: z.string(),
+  /** Kuramoto order parameter as SELF-REPORTED by this node (0..1). */
+  reportedOrderParameter: z.number(),
+  reportedMeanPhase: z.number(),
+  localPhase: z.number(),
+  peers: z.number(),
+  mempool: z.number(),
+  uptimeTicks: z.number(),
+  peerPhases: z.array(peerPhaseViewSchema),
+});
+export type NodeStatusView = z.infer<typeof nodeStatusViewSchema>;
+
+export const validatorNodeViewSchema = z.object({
+  /**
+   * Host[:port] of the configured node URL. Deliberately scheme-less and
+   * path-less: it identifies the node for troubleshooting without handing the
+   * browser a fetchable endpoint.
+   */
+  label: z.string(),
+  reachable: z.boolean(),
+  /** Populated when the poll failed; null on success. */
+  error: z.string().nullable(),
+  /** Server wall-clock millis at which this sample was taken. */
+  observedAt: z.number().int().nonnegative(),
+  status: nodeStatusViewSchema.nullable(),
+});
+export type ValidatorNodeView = z.infer<typeof validatorNodeViewSchema>;
+
+// ─── Merged validator row ────────────────────────────────────────────────────
+
+export const validatorRowSchema = z.object({
+  id: z.string().min(1),
+  phase: z.number(),
+  naturalFrequency: z.number().nullable(),
+  lastUpdatedUnixSeconds: z.number().nullable(),
+  /** Labels of every node that reported this validator, sorted. */
+  reportedBy: z.array(z.string()),
+  /**
+   * True when reporting nodes disagree about this validator's phase by more
+   * than `PHASE_DISAGREEMENT_RADIANS`. Unsigned reports make disagreement the
+   * only divergence signal available, so it is surfaced rather than averaged away.
+   */
+  disputed: z.boolean(),
+});
+export type ValidatorRow = z.infer<typeof validatorRowSchema>;
+
+// ─── Coherence ───────────────────────────────────────────────────────────────
+
+export const coherenceSchema = z.object({
+  /** Kuramoto order parameter r ∈ [0,1] derived from the merged phase set. */
+  r: z.number(),
+  /** Mean phase ψ (radians). */
+  meanPhase: z.number(),
+  /** Number of oscillators that contributed. */
+  count: z.number().int().nonnegative(),
+});
+export type Coherence = z.infer<typeof coherenceSchema>;
+
+// ─── Metrics the node RPC cannot supply ──────────────────────────────────────
+
+/**
+ * Machine-readable "we do not have this" list. Sub-wave 2a asked for
+ * per-round attestation health and anchor-batch throughput; the oxscada
+ * `:9090` surface exposes neither, so they are declared missing instead of
+ * being synthesised.
+ */
+export const unavailableMetricSchema = z.object({
+  metric: z.string(),
+  reason: z.string(),
+});
+export type UnavailableMetric = z.infer<typeof unavailableMetricSchema>;
+
+// ─── Aggregate response ──────────────────────────────────────────────────────
+
+export const validatorOverviewSchema = z.object({
+  /** False when ANCHOR_NODE_URLS is unset: no outbound request is made at all. */
+  configured: z.boolean(),
+  /** Server wall-clock millis the aggregate was produced. */
+  generatedAt: z.number().int().nonnegative(),
+  /**
+   * True when this body was served from the server-side cache rather than a
+   * fresh poll. The cache bounds outbound load independent of client count.
+   */
+  cached: z.boolean(),
+  provenance: validatorProvenanceSchema,
+  nodes: z.array(validatorNodeViewSchema),
+  validators: z.array(validatorRowSchema),
+  coherence: coherenceSchema,
+  unavailableMetrics: z.array(unavailableMetricSchema),
+});
+export type ValidatorOverview = z.infer<typeof validatorOverviewSchema>;


### PR DESCRIPTION
> Supersedes the stale draft #526, which was opened against a `main` that has since moved 73 commits and is now conflicting. This branch is built on current `main` and fixes the defect that draft left open.

Closes #453. Supersedes #514, which was rejected for two operational gaps.

## The two gaps, closed

**1. The browser polled nodes directly.** That breaks the moment the UI is served over TLS (page is `https`, node is `http` → blocked mixed content) and depends on every node serving permissive CORS.

New `GET /api/validators` polls the nodes in `ANCHOR_NODE_URLS` server-side and returns one aggregate. The client now knows exactly one endpoint — the relative path `/api/validators` — and constructs no node URL anywhere; `oxscada-rpc.ts` and `use-validator-nodes.ts` from the #514 slice are gone (note: they never landed on `main`, so this branch's diff against `main` shows no deletion hunks for them). `ANCHOR_NODE_URLS` is deliberately **not** `VITE_`-prefixed, so node URLs never enter the client bundle. A test asserts the issued URL is relative, matches no `^https?:`, and contains no `9090`.

**2. The data was unauthenticated at both ends.**

- *Route auth*: guarded by `requireControlPlaneAccess({ scopes: ['validators.read'] })` — the repo's real control-plane guard from #576, not a new one. 401 anonymous, 401 unknown key, 401 query-string credential, 403 out-of-scope, 200 for `validators.read` and `admin`; all six covered. The new scope is registered in `docs/security/api-gateway-keys.md`.
- *Data provenance*: **signature verification is not implemented and this PR does not claim it.** It is not reachable here — the oxscada `/status` payload carries no signature field (per main's own `parseOxscadaStatus`), and there is no validator-pubkey registry to verify against; that is #454's work. So every response carries machine-readable `provenance: { verified: false, method: "none", detail }` and the dashboard renders it as a permanent, non-dismissible **UNVERIFIED — unsigned node reports** banner. Because reports are unverified, conflicting phase claims are not averaged away: rows where nodes disagree by >0.05 rad are flagged `disputed`, and the UI shows the worst gap between the coherence derived from the published phases and each node's self-reported `order_parameter`.

## Bounded server-side fetching

A slow or hostile node cannot hang the API:

| Bound | Default | Env |
|---|---|---|
| Per-node timeout (AbortController also covers the body read) | 3000 ms | `VALIDATOR_RPC_TIMEOUT_MS` (250–10000) |
| Concurrent node fetches | 4 | `VALIDATOR_RPC_MAX_CONCURRENCY` (1–16) |
| Aggregate cache TTL + in-flight de-duplication | 2000 ms | `VALIDATOR_RPC_CACHE_TTL_MS` (0–60000) |
| Response body cap (enforced while streaming) | 256 KiB | fixed |
| Configured nodes | 32 | fixed |
| Retries | **none** — one attempt per node per poll | — |

Only `http:`/`https:` URLs are accepted. A failing node becomes one errored row, not a failed request. With `ANCHOR_NODE_URLS` unset the route makes no outbound request at all and answers `{"configured": false}` — the feature is off by default and opt-in.

## Wire-schema correction — please read

The slice defined its own camelCase `/status` + `/events` contract because it was cut before #442 landed. #442 is now on main, so the proxy parses with `parseOxscadaStatus` from `server/blockchain/validator-health.ts` instead of a second, divergent contract that no real node would satisfy.

Consequence: **the attestation-rate and anchor-throughput panels are removed.** The `:9090` surface exposes no per-round attest/miss record, and `/events` carries bridged SCADA events rather than consensus attestations. Rather than invent a schema or synthesise numbers, the response returns an `unavailableMetrics` list naming each missing metric and why, and the dashboard renders it — so an empty panel is never misread as "zero". This deletes code praised in review, so it is called out explicitly rather than buried. (It also overlaps #456, separately flagged for being backed by a PRNG instead of real attestation data.)

## Rebase conflicts

`.env.example` and `client/src/App.tsx` conflicted against current main; both resolved as **unions**. #455's anchor-backend nav link, route and full env block are all retained alongside the new validator surface — the raw conflict would have dropped the Anchor Backend nav link, since it straddled a shared closing tag.

## Verification

- `npx tsc --noEmit` → exits 0, no output.
- `npx vitest run` → **99 files / 2097 passing**, 2 files + 5 tests skipped. Baseline on main: 95 / 2024 with the same skips. +73 tests, no regressions, no new skips.
- Mutation-tested for non-vacuity: removing the route guard fails 4 auth tests (200 vs 401/403); neutering the abort timer hangs the timeout test (5024 ms, "Test timed out in 5000ms"); flipping provenance to `verified: true` fails the provenance assertion.
- No conflict markers remain anywhere in the tree.
- Not exercised against a live oxscada node — none available in this environment.

## Known gaps

- No component test for the dashboard's own rendering; the repo has no RTL harness for pages. `data-testid="validator-provenance"` / `data-verified` hooks are in place for a future one.
- `parseNodeUrls` drops malformed or non-http(s) entries silently (no log line), so an operator typo removes a node from the view without a signal.
- Existing deployments must add `validators.read` to `API_KEYS` (e.g. `key:validator-reader:validators.read`) or use an `admin`/`*` key, otherwise the dashboard shows a 403 with a hint to set a credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
