### PR TITLE
fix(#454): replay-proof cross-node state reads + real validator registry seeding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ SIMULATOR_INTERVAL_MS=10000
 ENABLE_API_KEYS=false
 # Comma-separated key:name:scope+scope records. Missing scopes grant nothing.
 # Anchor switching requires operator+anchor.admin.
+# Cross-node live-state reads (GET /api/nodes/:id/state/:key) require operator.
+# Validator-registry writes (POST /api/nodes, POST /api/nodes/:id/pubkeys)
+# require operator+validator.admin — docs/blockchain/cross-node-state-queries.md.
 # Generate real secrets outside source control; this placeholder is not valid.
 # Use an explicit `*` only for a deliberately unrestricted gateway key.
 API_KEYS=

--- a/docs/blockchain/cross-node-state-queries.md
+++ b/docs/blockchain/cross-node-state-queries.md
@@ -1,0 +1,175 @@
+# Cross-Node State Queries (`/api/nodes/:id/state/:key`)
+
+## Overview
+
+Operators investigating a divergence need to ask a *specific* validator what it
+believes about a key ("what does validator 2 think about event X?"). That answer
+is only useful if the server can prove three things before showing it:
+
+1. **It really came from that validator** — Ed25519 signature verified against a
+   public key held in this server's database, never one supplied in the payload.
+2. **It answers *this* request** — the signature covers a random challenge the
+   server minted moments ago, and the validator's own observation timestamp
+   falls inside a bounded window.
+3. **It is not a rolled-back view** — the reported block height is not below the
+   highest height this server has already accepted for that `(validator, key)`
+   pair.
+
+If any of those fails, no value reaches the client.
+
+Implementation:
+
+| Concern | File |
+|---|---|
+| Canonical message, Ed25519 verify, freshness bounds | `server/blockchain/state-signature.ts` |
+| Validator RPC transport + error taxonomy | `server/blockchain/node-client.ts` |
+| Route, authz, rate limit, anti-rollback | `server/routes/nodes.ts` |
+| Registry + high-water-mark persistence | `server/storage.ts` |
+| Tables | `migrations/0007_validator_registry.sql`, `shared/schema.ts` |
+
+## The signed message (`oxscada-state-v2`)
+
+```
+oxscada-state-v2\n<key>\n<blockHeight>\n<nonce>\n<observedAt>\n<canonicalJson(value)>
+```
+
+* `oxscada-state-v2` is domain separation: a signature minted for another purpose
+  cannot be replayed as a state attestation.
+* `nonce` is 16 random bytes chosen by *this server* per request and passed to the
+  validator as `?nonce=`.
+* `observedAt` is the validator's ISO-8601 observation time.
+* `canonicalJson` sorts object keys recursively so both sides serialize identical
+  bytes.
+
+Response body:
+
+```json
+{
+  "key": "event-X",
+  "value": { "reading": 42 },
+  "blockHeight": 4300,
+  "nonce": "<echoed challenge>",
+  "observedAt": "2026-07-27T10:00:00.000Z",
+  "keyId": "node-key-1",
+  "signature": "<hex ed25519>"
+}
+```
+
+## What is enforced where
+
+**Enforced by this server, unconditionally:**
+
+* Public key resolution from `validator_pubkeys` by the exact `keyId` the response
+  names. An unregistered node, an unregistered/retired `keyId`, or a non-Ed25519
+  algorithm is refused — the registry, not the payload, decides trust.
+* Ed25519 verification of the canonical message, before anything is returned.
+* `observedAt` within `[now - 30s, now + 5s]`.
+* Per-`(node, key)` monotonic block height, persisted in
+  `validator_state_watermarks`. Equal heights are fine (the same block read
+  twice); a regression is refused. The advanced mark is written *before* the
+  answer is returned, and a failure to read or write it fails the request closed.
+
+**Requires a node-side change (NOT in this repository):**
+
+The nonce round-trip has a producer half that lives in the oxscada validator
+(`0xSCADA-node`, the Rust node — see `docs/blockchain/validator-monitoring.md`),
+not here. That node must:
+
+1. read the `?nonce=` query parameter on `GET /state/:key`,
+2. include it and its own `observedAt` in the canonical signed message above,
+3. echo both in the response body.
+
+Until a validator ships that, the proxy does **not** silently downgrade to the
+old `(key, value, blockHeight)`-only signature. `NodeRpcClient` classifies a
+response missing `nonce`/`observedAt` as `state-protocol-incompatible` (HTTP 502)
+and no value is returned. The timestamp window and the block-height high-water
+mark are enforced regardless of what the node implements, but they are weaker on
+their own: without the nonce, a response captured within the freshness window at
+the current height could still be replayed. That is the honest limit of what this
+repository can enforce alone.
+
+## Seeding the validator registry
+
+`migrations/0007_validator_registry.sql` creates the tables and inserts **no
+rows**. There is no safe default validator set: a hard-coded RPC URL or public
+key would be a silent trust decision baked into the schema. An empty registry
+fails closed — every read answers `404 unknown-validator`.
+
+Registration is an explicit, admin-authenticated operation. `validator.admin`
+scope is required (an `admin`/`*` gateway key satisfies it); a plain `operator`
+key gets 403.
+
+```bash
+# 1. Register the validator and its RPC endpoint (http/https only).
+curl -X POST http://localhost:5000/api/nodes \
+  -H "X-API-Key: $ADMIN_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"id":"validator-2","name":"Validator 2","rpcUrl":"http://10.0.0.12:9090","region":"east"}'
+
+# 2. Register the Ed25519 public key its responses are signed with.
+#    Rejected at registration time if it is not a PEM SPKI Ed25519 key.
+curl -X POST http://localhost:5000/api/nodes/validator-2/pubkeys \
+  -H "X-API-Key: $ADMIN_API_KEY" -H 'Content-Type: application/json' \
+  -d "{\"keyId\":\"node-key-1\",\"publicKeyPem\":\"$(cat validator2.pub.pem)\"}"
+
+# 3. Read state as an operator.
+curl http://localhost:5000/api/nodes/validator-2/state/event-X \
+  -H "X-API-Key: $OPERATOR_API_KEY"
+
+# Rotation: POST a new keyId, then retire the old one.
+curl -X DELETE http://localhost:5000/api/nodes/validator-2/pubkeys/node-key-0 \
+  -H "X-API-Key: $ADMIN_API_KEY"
+```
+
+This works against the development SQLite database as well as Postgres —
+`server/storage.ts` implements both paths, so the feature does not require a
+hand-seeded Postgres to be usable or testable.
+
+## Endpoints
+
+| Method | Path | Access | Purpose |
+|---|---|---|---|
+| `GET` | `/api/nodes` | operator | List registered validators (no key material) |
+| `POST` | `/api/nodes` | `validator.admin` | Register / update a validator |
+| `POST` | `/api/nodes/:id/pubkeys` | `validator.admin` | Register / rotate a verification key |
+| `DELETE` | `/api/nodes/:id/pubkeys/:keyId` | `validator.admin` | Retire a verification key |
+| `GET` | `/api/nodes/:id/state/:key` | operator | Signed cross-node state read |
+
+State reads are rate limited to 60/min per operator identity (falling back to the
+client IP for an unnamed key).
+
+## Error codes
+
+| HTTP | `code` | Meaning |
+|---|---|---|
+| 400 | `invalid-params` / `invalid-body` | Request failed Zod validation |
+| 400 | `invalid-public-key` | Not a PEM SPKI Ed25519 public key |
+| 401 | — | No / unknown API key |
+| 403 | — | Key lacks the required role or scope |
+| 404 | `unknown-validator` | Validator not registered, or disabled |
+| 404 | `key-not-found` | Validator reports the state key is unknown |
+| 404 | `no-matching-pubkey` (DELETE) | No active key with that `keyId` |
+| 409 | `no-matching-pubkey` | No active Ed25519 key for the `keyId` the response named |
+| 502 | `validator-unreachable` | Could not reach the validator |
+| 502 | `validator-rpc-error` | Validator returned a non-OK / malformed response |
+| 502 | `state-protocol-incompatible` | Validator still speaks v1: no freshness proof |
+| 502 | `validator-key-id-missing` | Response did not name a signing key |
+| 502 | `signature-invalid` | Signature did not verify (`reason` narrows it) |
+| 502 | `response-not-fresh` | `reason`: `nonce-mismatch` (replay), `stale-response`, `future-response`, `key-mismatch`, `invalid-observed-at` |
+| 502 | `state-rollback` | `reason`: `block-height-regression`; includes `highestAcceptedBlockHeight` |
+| 503 | `rollback-check-unavailable` | High-water mark could not be read or persisted — fail closed |
+| 504 | `validator-timeout` | Validator did not answer within the deadline |
+| 500 | `registry-error` | Registry lookup/write failed |
+
+## Tests
+
+* `server/__tests__/cross-node-state.test.ts` — canonical message and Ed25519
+  unit tests, plus route integration against a real local validator: happy path,
+  in-flight tamper, verbatim replay of a captured valid response, stale and
+  future timestamps, block-height regression, fail-closed watermark store,
+  unreachable/timeout/404/409 shapes, rate limiting.
+* `server/__tests__/validator-registry.test.ts` — the seeding path against a real
+  in-memory SQLite database with the production wiring (no injected registry,
+  watermark store or RPC client): empty registry fails closed, operator keys
+  cannot seed, admin registration persists, the signed read then works, the
+  high-water mark is persisted and a regression is refused, retiring the key
+  fails closed again.

--- a/migrations/0007_validator_registry.sql
+++ b/migrations/0007_validator_registry.sql
@@ -1,0 +1,72 @@
+-- Migration: 0007_validator_registry
+-- Issue: #454 - [wave:2a] Cross-Node State Queries (per-validator /state/:key proxy)
+-- Description: Validator node registry, registered verification public keys, and
+--   the per-(node, key) anti-rollback high-water mark.
+--
+--   Backs GET /api/nodes/:id/state/:key: the server resolves a validator's RPC
+--   endpoint (validator_nodes), verifies the validator's signed response against
+--   a registered Ed25519 public key (validator_pubkeys), and refuses answers
+--   that report a block height below the highest one already accepted for that
+--   (validator, key) pair (validator_state_watermarks).
+--
+--   SEEDING: this migration deliberately inserts no rows. There is no safe
+--   built-in validator set — a hard-coded RPC URL or public key would be a
+--   silent trust decision baked into the schema. Registration is an explicit,
+--   admin-authenticated operation: POST /api/nodes and POST /api/nodes/:id/pubkeys
+--   (see docs/blockchain/cross-node-state-queries.md). An empty registry fails
+--   closed: every /state/:key query answers 404 unknown-validator.
+-- Date: 2026-07-27
+
+-- ─── Validator Nodes ──────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS validator_nodes (
+  id VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  rpc_url VARCHAR(512) NOT NULL,
+  operator_id VARCHAR(255),
+  region VARCHAR(64),
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_validator_nodes_operator_id ON validator_nodes(operator_id);
+CREATE INDEX IF NOT EXISTS idx_validator_nodes_enabled ON validator_nodes(enabled);
+
+-- ─── Validator Public Keys ────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS validator_pubkeys (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  node_id VARCHAR(64) NOT NULL REFERENCES validator_nodes(id) ON DELETE CASCADE,
+  algorithm VARCHAR(32) NOT NULL DEFAULT 'ed25519',
+  public_key_pem TEXT NOT NULL,
+  -- NOT NULL: the proxy resolves the exact key named by the validator response,
+  -- so an unnamed key could never be selected and must not be registerable.
+  key_id VARCHAR(128) NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  retired_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_validator_pubkeys_node_id ON validator_pubkeys(node_id);
+CREATE INDEX IF NOT EXISTS idx_validator_pubkeys_node_active ON validator_pubkeys(node_id, active);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_validator_pubkeys_node_key_id
+  ON validator_pubkeys(node_id, key_id);
+
+-- ─── State Freshness High-Water Marks ────────────────────────────────────────
+-- Highest block height the server has ever accepted for a (validator, key)
+-- pair. A later answer reporting a lower height is a rolled-back view of state
+-- and is rejected with `state-rollback`. Persisted (not in-process) so the
+-- check survives restarts and holds across replicas sharing this database.
+
+CREATE TABLE IF NOT EXISTS validator_state_watermarks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  node_id VARCHAR(64) NOT NULL REFERENCES validator_nodes(id) ON DELETE CASCADE,
+  state_key VARCHAR(512) NOT NULL,
+  block_height BIGINT NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_validator_state_watermarks_node_key
+  ON validator_state_watermarks(node_id, state_key);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1784780403000,
       "tag": "0006_blueprint_instance_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1784780404000,
+      "tag": "0007_validator_registry",
+      "breakpoints": true
     }
   ]
 }

--- a/server/__tests__/cross-node-state.test.ts
+++ b/server/__tests__/cross-node-state.test.ts
@@ -1,0 +1,1003 @@
+/**
+ * Cross-Node State Query Test Suite (#454)
+ *
+ * Covers the per-validator `/state/:key` proxy end to end:
+ *   - Unit: canonical signing message + Ed25519 signature verification, incl.
+ *     the security-critical tamper case, and the freshness bounds.
+ *   - Integration: a REAL local fake validator node (http.Server on port 0)
+ *     returns a signed payload; the route proxies, verifies and returns it.
+ *     We then have the fake node tamper its response *after signing* and assert
+ *     the route returns the distinct `signature-invalid` (502) shape.
+ *   - Replay/freshness (the defect this suite exists to pin down): a captured,
+ *     still-cryptographically-valid response replayed verbatim is REJECTED
+ *     (`response-not-fresh` / `nonce-mismatch`), as are observations outside the
+ *     timestamp window and a block height that regresses below the accepted
+ *     high-water mark (`state-rollback`). A watermark store that cannot be read
+ *     or written fails the request closed (503) instead of answering blind.
+ *   - Error taxonomy: validator-unreachable (502), validator-timeout (504),
+ *     key-not-found (404), unknown-validator (404), no-matching-pubkey (409),
+ *     state-protocol-incompatible (502), and per-operator rate limiting (429).
+ *
+ * Seeding of the validator registry is covered against a real database in
+ * `server/__tests__/validator-registry.test.ts`.
+ *
+ * No supertest dependency (not in package.json): we mount the router on a real
+ * Express app + http.Server and drive it with the global `fetch` (Node 18+),
+ * matching the http.createServer + listen(0) convention in websocket.test.ts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import express from "express";
+import { createServer, type Server } from "http";
+import {
+  generateKeyPairSync,
+  sign as cryptoSign,
+  type KeyObject,
+} from "node:crypto";
+
+import {
+  buildStateSigningMessage,
+  canonicalJsonStringify,
+  verifySignedStateResponse,
+  verifyStateResponseFreshness,
+  type SignedStateResponse,
+} from "../blockchain/state-signature";
+import { NodeRpcClient } from "../blockchain/node-client";
+import {
+  createNodeRoutes,
+  operatorKeyExtractor,
+  type StateWatermarkStore,
+  type ValidatorRegistry,
+} from "../routes/nodes";
+import type {
+  ValidatorNodeRecord,
+  ValidatorPubkeyRecord,
+  ValidatorStateWatermarkRecord,
+} from "../storage";
+import { _resetControlPlaneAuthCache } from "../middleware/control-plane-auth";
+
+// ─── Test signing helpers (simulate what a validator does) ─────────────────────
+
+function makeKeyPair(): { publicKeyPem: string; privateKey: KeyObject } {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+  return { publicKeyPem, privateKey };
+}
+
+function signState(
+  privateKey: KeyObject,
+  params: {
+    key: string;
+    value: unknown;
+    blockHeight: number;
+    keyId?: string;
+    nonce?: string;
+    observedAt?: string;
+  },
+): SignedStateResponse {
+  const signedFields = {
+    ...params,
+    nonce: params.nonce ?? "test-nonce",
+    observedAt: params.observedAt ?? new Date().toISOString(),
+  };
+  const message = Buffer.from(buildStateSigningMessage(signedFields), "utf8");
+  const signature = cryptoSign(null, message, privateKey).toString("hex");
+  return {
+    key: signedFields.key,
+    value: signedFields.value,
+    blockHeight: signedFields.blockHeight,
+    nonce: signedFields.nonce,
+    observedAt: signedFields.observedAt,
+    keyId: params.keyId,
+    signature,
+  };
+}
+
+// =============================================================================
+// UNIT: canonical message + signature verification
+// =============================================================================
+
+describe("canonicalJsonStringify", () => {
+  it("sorts object keys deterministically and recursively", () => {
+    const a = canonicalJsonStringify({ b: 1, a: { d: 4, c: 3 } });
+    const b = canonicalJsonStringify({ a: { c: 3, d: 4 }, b: 1 });
+    expect(a).toBe(b);
+    expect(a).toBe('{"a":{"c":3,"d":4},"b":1}');
+  });
+
+  it("preserves array order", () => {
+    expect(canonicalJsonStringify([3, 1, 2])).toBe("[3,1,2]");
+  });
+
+  it("handles null and primitives", () => {
+    expect(canonicalJsonStringify(null)).toBe("null");
+    expect(canonicalJsonStringify(42)).toBe("42");
+    expect(canonicalJsonStringify("x")).toBe('"x"');
+  });
+
+  it("preserves the special __proto__ JSON key", () => {
+    const withProtoKey = JSON.parse(
+      '{"__proto__":{"admin":true},"x":1}',
+    ) as Record<string, unknown>;
+    expect(canonicalJsonStringify(withProtoKey)).toBe(
+      '{"__proto__":{"admin":true},"x":1}',
+    );
+  });
+});
+
+describe("buildStateSigningMessage", () => {
+  it("is domain-separated and field-ordered", () => {
+    const msg = buildStateSigningMessage({
+      key: "k",
+      value: { x: 1 },
+      blockHeight: 7,
+      nonce: "challenge-1",
+      observedAt: "2026-07-23T00:00:00.000Z",
+    });
+    expect(msg).toBe(
+      'oxscada-state-v2\nk\n7\nchallenge-1\n2026-07-23T00:00:00.000Z\n{"x":1}',
+    );
+  });
+
+  it("is stable regardless of value object key order", () => {
+    const common = {
+      key: "k",
+      blockHeight: 1,
+      nonce: "challenge-1",
+      observedAt: "2026-07-23T00:00:00.000Z",
+    };
+    const m1 = buildStateSigningMessage({ ...common, value: { a: 1, b: 2 } });
+    const m2 = buildStateSigningMessage({ ...common, value: { b: 2, a: 1 } });
+    expect(m1).toBe(m2);
+  });
+});
+
+describe("verifySignedStateResponse", () => {
+  const { publicKeyPem, privateKey } = makeKeyPair();
+
+  it("accepts a correctly signed response", () => {
+    const signed = signState(privateKey, { key: "temp", value: { c: 21 }, blockHeight: 100 });
+    expect(verifySignedStateResponse(signed, publicKeyPem)).toEqual({ valid: true });
+  });
+
+  it("rejects a tampered VALUE (security-critical)", () => {
+    const signed = signState(privateKey, { key: "temp", value: { c: 21 }, blockHeight: 100 });
+    const tampered = { ...signed, value: { c: 999 } };
+    const result = verifySignedStateResponse(tampered, publicKeyPem);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.reason).toBe("signature-mismatch");
+  });
+
+  it("rejects a tampered KEY", () => {
+    const signed = signState(privateKey, { key: "temp", value: 1, blockHeight: 1 });
+    const result = verifySignedStateResponse({ ...signed, key: "pressure" }, publicKeyPem);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a tampered blockHeight", () => {
+    const signed = signState(privateKey, { key: "temp", value: 1, blockHeight: 1 });
+    const result = verifySignedStateResponse({ ...signed, blockHeight: 2 }, publicKeyPem);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a signature from a DIFFERENT key", () => {
+    const other = makeKeyPair();
+    const signed = signState(other.privateKey, { key: "temp", value: 1, blockHeight: 1 });
+    const result = verifySignedStateResponse(signed, publicKeyPem);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.reason).toBe("signature-mismatch");
+  });
+
+  it("reports missing-signature", () => {
+    const r = verifySignedStateResponse(
+      {
+        key: "k",
+        value: 1,
+        blockHeight: 1,
+        nonce: "n",
+        observedAt: new Date().toISOString(),
+        signature: "",
+      },
+      publicKeyPem,
+    );
+    expect(r).toEqual({ valid: false, reason: "missing-signature" });
+  });
+
+  it("reports malformed-signature for non-hex / odd length", () => {
+    const r = verifySignedStateResponse(
+      {
+        key: "k",
+        value: 1,
+        blockHeight: 1,
+        nonce: "n",
+        observedAt: new Date().toISOString(),
+        signature: "zz",
+      },
+      publicKeyPem,
+    );
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.reason).toBe("malformed-signature");
+  });
+
+  it("reports malformed-pubkey for garbage PEM", () => {
+    const signed = signState(privateKey, { key: "k", value: 1, blockHeight: 1 });
+    const r = verifySignedStateResponse(signed, "not a pem");
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.reason).toBe("malformed-pubkey");
+  });
+
+  it("rejects a well-formed non-Ed25519 public key", () => {
+    const { publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const rsaPublicKeyPem = publicKey
+      .export({ type: "spki", format: "pem" })
+      .toString();
+    const signed = signState(privateKey, { key: "k", value: 1, blockHeight: 1 });
+    expect(verifySignedStateResponse(signed, rsaPublicKeyPem)).toEqual({
+      valid: false,
+      reason: "malformed-pubkey",
+    });
+  });
+});
+
+describe("verifyStateResponseFreshness", () => {
+  const response = signState(makeKeyPair().privateKey, {
+    key: "temp",
+    value: 21,
+    blockHeight: 10,
+    nonce: "current-challenge",
+    observedAt: "2026-07-23T00:00:20.000Z",
+  });
+
+  it("accepts a response answering the current challenge inside the window", () => {
+    expect(
+      verifyStateResponseFreshness(response, {
+        key: "temp",
+        nonce: "current-challenge",
+        nowMs: Date.parse("2026-07-23T00:00:30.000Z"),
+      }),
+    ).toEqual({ valid: true });
+  });
+
+  it("rejects a captured response replayed for a new challenge", () => {
+    expect(
+      verifyStateResponseFreshness(response, {
+        key: "temp",
+        nonce: "different-challenge",
+        nowMs: Date.parse("2026-07-23T00:00:30.000Z"),
+      }),
+    ).toEqual({ valid: false, reason: "nonce-mismatch" });
+  });
+
+  it("rejects an observation older than the freshness window", () => {
+    expect(
+      verifyStateResponseFreshness(response, {
+        key: "temp",
+        nonce: "current-challenge",
+        // 45s after the observation, with a 30s window.
+        nowMs: Date.parse("2026-07-23T00:01:05.000Z"),
+        maxAgeMs: 30_000,
+      }),
+    ).toEqual({ valid: false, reason: "stale-response" });
+  });
+
+  it("rejects an observation dated beyond the tolerated future skew", () => {
+    expect(
+      verifyStateResponseFreshness(response, {
+        key: "temp",
+        nonce: "current-challenge",
+        nowMs: Date.parse("2026-07-23T00:00:00.000Z"),
+        maxFutureSkewMs: 5_000,
+      }),
+    ).toEqual({ valid: false, reason: "future-response" });
+  });
+
+  it("rejects a response signed for a different key than the one requested", () => {
+    expect(
+      verifyStateResponseFreshness(response, {
+        key: "pressure",
+        nonce: "current-challenge",
+        nowMs: Date.parse("2026-07-23T00:00:30.000Z"),
+      }),
+    ).toEqual({ valid: false, reason: "key-mismatch" });
+  });
+
+  it("rejects an unparseable observedAt", () => {
+    expect(
+      verifyStateResponseFreshness(
+        { ...response, observedAt: "not-a-timestamp" },
+        { key: "temp", nonce: "current-challenge", nowMs: 0 },
+      ),
+    ).toEqual({ valid: false, reason: "invalid-observed-at" });
+  });
+});
+
+// =============================================================================
+// INTEGRATION: route + real fake validator node
+// =============================================================================
+
+interface FakeNodeControls {
+  /** When set, the node tampers its signed value after signing. */
+  tamper: boolean;
+  /** Keys the node "knows"; querying an unknown key yields 404. */
+  knownKeys: Set<string>;
+  nonceOverride?: string;
+  observedAtOffsetMs?: number;
+  keyIdOverride?: string | null;
+  legacyV1?: boolean;
+  blockHeightOverride?: number;
+  /**
+   * When set, the node returns this exact previously-captured body instead of
+   * answering the new challenge — a verbatim replay of a once-valid response.
+   */
+  replayBody?: SignedStateResponse;
+  /** Last body the node actually returned (used to capture a replay source). */
+  lastBody?: SignedStateResponse;
+}
+
+/** Stand up a real local fake validator node returning signed state responses. */
+function startFakeNode(privateKey: KeyObject, controls: FakeNodeControls): Promise<{ server: Server; url: string }> {
+  const app = express();
+
+  app.get("/state/:key", (req, res) => {
+    const key = decodeURIComponent(req.params.key);
+    if (!controls.knownKeys.has(key)) {
+      res.status(404).json({ error: "key not found", key });
+      return;
+    }
+    if (controls.replayBody) {
+      // Verbatim replay of a captured response, ignoring the new challenge.
+      res.status(200).json(controls.replayBody);
+      return;
+    }
+    const value = { reading: 42, key };
+    const blockHeight = controls.blockHeightOverride ?? 1234;
+    const requestNonce =
+      typeof req.query.nonce === "string" ? req.query.nonce : "";
+    const signed = signState(privateKey, {
+      key,
+      value,
+      blockHeight,
+      keyId:
+        controls.keyIdOverride === null
+          ? undefined
+          : (controls.keyIdOverride ?? "node-key-1"),
+      nonce: controls.nonceOverride ?? requestNonce,
+      observedAt: new Date(
+        Date.now() + (controls.observedAtOffsetMs ?? 0),
+      ).toISOString(),
+    });
+
+    if (controls.tamper) {
+      // Mutate the value AFTER signing — exactly the in-flight tamper the issue
+      // requires the server to detect.
+      signed.value = { reading: 9999, key };
+    }
+    if (controls.legacyV1) {
+      res.status(200).json({
+        key: signed.key,
+        value: signed.value,
+        blockHeight: signed.blockHeight,
+        keyId: signed.keyId,
+        signature: signed.signature,
+      });
+      return;
+    }
+    controls.lastBody = signed;
+    res.status(200).json(signed);
+  });
+
+  return new Promise((resolve) => {
+    const server = createServer(app);
+    server.listen(0, () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+/**
+ * In-memory high-water-mark store with the same compare-and-set semantics as
+ * the persisted one in `server/storage.ts`: the mark only ever advances.
+ */
+function createMemoryWatermarks(): StateWatermarkStore & {
+  marks: Map<string, ValidatorStateWatermarkRecord>;
+} {
+  const marks = new Map<string, ValidatorStateWatermarkRecord>();
+  const id = (nodeId: string, stateKey: string) => `${nodeId}::${stateKey}`;
+  return {
+    marks,
+    async get(nodeId, stateKey) {
+      return marks.get(id(nodeId, stateKey)) ?? null;
+    },
+    async record(nodeId, stateKey, blockHeight, observedAt) {
+      const existing = marks.get(id(nodeId, stateKey));
+      if (!existing || existing.blockHeight < blockHeight) {
+        const next = { nodeId, stateKey, blockHeight, observedAt };
+        marks.set(id(nodeId, stateKey), next);
+        return next;
+      }
+      return existing;
+    },
+  };
+}
+
+/** Mount the cross-node route on a real Express server for end-to-end testing. */
+function startProxyServer(
+  registry: ValidatorRegistry,
+  client: NodeRpcClient,
+  watermarks: StateWatermarkStore = createMemoryWatermarks(),
+): Promise<{ server: Server; baseUrl: string }> {
+  const app = express();
+  app.use("/api/nodes", createNodeRoutes({ registry, client, watermarks }));
+  return new Promise((resolve) => {
+    const server = createServer(app);
+    server.listen(0, () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe("GET /api/nodes/:id/state/:key (integration)", () => {
+  const apiKey = "node-state-read-key";
+  const originalApiKeys = process.env.API_KEYS;
+  const { publicKeyPem, privateKey } = makeKeyPair();
+  const controls: FakeNodeControls = { tamper: false, knownKeys: new Set(["event-X"]) };
+
+  let fakeNode: { server: Server; url: string };
+  let proxy: { server: Server; baseUrl: string };
+
+  function fetchAsOperator(
+    url: string,
+    init: RequestInit = {},
+  ): Promise<Response> {
+    const headers = new Headers(init.headers);
+    headers.set("x-api-key", apiKey);
+    return fetch(url, { ...init, headers });
+  }
+
+  function buildRegistry(rpcUrl: string, withPubkey = true): ValidatorRegistry {
+    const node: ValidatorNodeRecord = {
+      id: "validator-2",
+      name: "Validator 2",
+      rpcUrl,
+      operatorId: "operator-acme",
+      region: "east",
+      enabled: true,
+    };
+    const pubkey: ValidatorPubkeyRecord = {
+      nodeId: "validator-2",
+      algorithm: "ed25519",
+      publicKeyPem,
+      keyId: "node-key-1",
+      active: true,
+    };
+    return {
+      getNode: async (id) => (id === "validator-2" ? node : null),
+      getActivePubkey: async (id, keyId) =>
+        id === "validator-2" &&
+        keyId === "node-key-1" &&
+        withPubkey
+          ? pubkey
+          : null,
+      listNodes: async () => [node],
+      upsertNode: async () => node,
+      upsertPubkey: async () => pubkey,
+      retirePubkey: async () => true,
+    };
+  }
+
+  beforeAll(async () => {
+    process.env.API_KEYS = `${apiKey}:node-state-reader:operator`;
+    _resetControlPlaneAuthCache();
+    fakeNode = await startFakeNode(privateKey, controls);
+  });
+
+  beforeEach(() => {
+    controls.tamper = false;
+    controls.nonceOverride = undefined;
+    controls.observedAtOffsetMs = undefined;
+    controls.keyIdOverride = undefined;
+    controls.legacyV1 = false;
+    controls.blockHeightOverride = undefined;
+    controls.replayBody = undefined;
+    controls.lastBody = undefined;
+  });
+
+  afterAll(async () => {
+    await closeServer(fakeNode.server);
+    if (originalApiKeys === undefined) delete process.env.API_KEYS;
+    else process.env.API_KEYS = originalApiKeys;
+    _resetControlPlaneAuthCache();
+  });
+
+  afterAll(async () => {
+    if (proxy) await closeServer(proxy.server);
+  });
+
+  it("proxies, verifies the signature and returns the value (happy path)", async () => {
+    controls.tamper = false;
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+    const res = await fetchAsOperator(`${proxy.baseUrl}/api/nodes/validator-2/state/event-X`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.verified).toBe(true);
+    expect(body.nodeId).toBe("validator-2");
+    expect(body.key).toBe("event-X");
+    expect(body.value).toEqual({ reading: 42, key: "event-X" });
+    expect(typeof body.signature).toBe("string");
+    await closeServer(proxy.server);
+  });
+
+  it("requires a local operator API key before proxying live state", async () => {
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+    const res = await fetch(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(res.status).toBe(401);
+    await closeServer(proxy.server);
+  });
+
+  it("rejects a validly signed response replayed for another challenge", async () => {
+    controls.nonceOverride = "captured-old-challenge";
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+    const res = await fetchAsOperator(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({
+      code: "response-not-fresh",
+      reason: "nonce-mismatch",
+    });
+    await closeServer(proxy.server);
+  });
+
+  it("rejects a captured valid response replayed verbatim", async () => {
+    // 1. Make one genuine request so the node produces a real, valid, signed
+    //    response — the exact thing an attacker on the path would capture.
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+    const first = await fetchAsOperator(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(first.status).toBe(200);
+    const captured = controls.lastBody;
+    expect(captured).toBeDefined();
+
+    // 2. The node now returns that captured body verbatim for a NEW request.
+    //    Its signature is still cryptographically valid — only the challenge
+    //    binding exposes it.
+    controls.replayBody = captured;
+    const replayed = await fetchAsOperator(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(replayed.status).toBe(502);
+    expect(await replayed.json()).toMatchObject({
+      code: "response-not-fresh",
+      reason: "nonce-mismatch",
+    });
+    await closeServer(proxy.server);
+  });
+
+  it("rejects an observation older than the freshness window", async () => {
+    controls.observedAtOffsetMs = -120_000;
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+    const res = await fetchAsOperator(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({
+      code: "response-not-fresh",
+      reason: "stale-response",
+    });
+    await closeServer(proxy.server);
+  });
+
+  it("rejects an observation dated beyond the tolerated future skew", async () => {
+    controls.observedAtOffsetMs = 120_000;
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+    const res = await fetchAsOperator(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({
+      code: "response-not-fresh",
+      reason: "future-response",
+    });
+    await closeServer(proxy.server);
+  });
+
+  it("rejects a blockHeight that regresses below the accepted high-water mark", async () => {
+    const watermarks = createMemoryWatermarks();
+    proxy = await startProxyServer(
+      buildRegistry(fakeNode.url),
+      new NodeRpcClient(),
+      watermarks,
+    );
+
+    controls.blockHeightOverride = 5000;
+    const advance = await fetchAsOperator(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(advance.status).toBe(200);
+    expect(watermarks.marks.get("validator-2::event-X")?.blockHeight).toBe(5000);
+
+    // A perfectly fresh, correctly signed answer — but from a rolled-back view.
+    controls.blockHeightOverride = 4999;
+    const regressed = await fetchAsOperator(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(regressed.status).toBe(502);
+    expect(await regressed.json()).toMatchObject({
+      code: "state-rollback",
+      reason: "block-height-regression",
+      blockHeight: 4999,
+      highestAcceptedBlockHeight: 5000,
+    });
+
+    // The rejected answer must not have lowered the mark.
+    expect(watermarks.marks.get("validator-2::event-X")?.blockHeight).toBe(5000);
+    await closeServer(proxy.server);
+  });
+
+  it("accepts a repeat read at the same blockHeight and tracks keys separately", async () => {
+    const watermarks = createMemoryWatermarks();
+    proxy = await startProxyServer(
+      buildRegistry(fakeNode.url),
+      new NodeRpcClient(),
+      watermarks,
+    );
+    controls.knownKeys.add("event-Y");
+
+    controls.blockHeightOverride = 900;
+    expect(
+      (await fetchAsOperator(`${proxy.baseUrl}/api/nodes/validator-2/state/event-X`)).status,
+    ).toBe(200);
+    // Same height again: not a rollback, must still be served.
+    expect(
+      (await fetchAsOperator(`${proxy.baseUrl}/api/nodes/validator-2/state/event-X`)).status,
+    ).toBe(200);
+    // A different key has its own mark, so a lower height there is fine.
+    controls.blockHeightOverride = 12;
+    expect(
+      (await fetchAsOperator(`${proxy.baseUrl}/api/nodes/validator-2/state/event-Y`)).status,
+    ).toBe(200);
+
+    expect(watermarks.marks.get("validator-2::event-X")?.blockHeight).toBe(900);
+    expect(watermarks.marks.get("validator-2::event-Y")?.blockHeight).toBe(12);
+    controls.knownKeys.delete("event-Y");
+    await closeServer(proxy.server);
+  });
+
+  it("fails closed when the high-water mark cannot be read", async () => {
+    const broken: StateWatermarkStore = {
+      get: async () => {
+        throw new Error("watermark backend down");
+      },
+      record: async () => {
+        throw new Error("watermark backend down");
+      },
+    };
+    proxy = await startProxyServer(
+      buildRegistry(fakeNode.url),
+      new NodeRpcClient(),
+      broken,
+    );
+    const res = await fetchAsOperator(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({
+      code: "rollback-check-unavailable",
+    });
+    await closeServer(proxy.server);
+  });
+
+  it("fails closed when the advanced high-water mark cannot be persisted", async () => {
+    const unpersistable: StateWatermarkStore = {
+      get: async () => null,
+      record: async () => {
+        throw new Error("disk full");
+      },
+    };
+    proxy = await startProxyServer(
+      buildRegistry(fakeNode.url),
+      new NodeRpcClient(),
+      unpersistable,
+    );
+    const res = await fetchAsOperator(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({
+      code: "rollback-check-unavailable",
+    });
+    await closeServer(proxy.server);
+  });
+
+  it("reports a clear v1-to-v2 producer incompatibility", async () => {
+    controls.legacyV1 = true;
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+    const res = await fetchAsOperator(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({
+      code: "state-protocol-incompatible",
+      expectedProtocol: "oxscada-state-v2",
+      incompatibleFields: ["nonce", "observedAt"],
+    });
+    await closeServer(proxy.server);
+  });
+
+  it("requires an exact active Ed25519 keyId match", async () => {
+    controls.keyIdOverride = "rotated-unknown-key";
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+    const res = await fetchAsOperator(
+      `${proxy.baseUrl}/api/nodes/validator-2/state/event-X`,
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      code: "no-matching-pubkey",
+      keyId: "rotated-unknown-key",
+    });
+    await closeServer(proxy.server);
+  });
+
+  it("returns 502 signature-invalid when the node tampers the response in-flight", async () => {
+    controls.tamper = true;
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+    const res = await fetchAsOperator(`${proxy.baseUrl}/api/nodes/validator-2/state/event-X`);
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.code).toBe("signature-invalid");
+    expect(body.reason).toBe("signature-mismatch");
+    controls.tamper = false;
+    await closeServer(proxy.server);
+  });
+
+  it("returns 404 key-not-found for an unknown key", async () => {
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+    const res = await fetchAsOperator(`${proxy.baseUrl}/api/nodes/validator-2/state/does-not-exist`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("key-not-found");
+    await closeServer(proxy.server);
+  });
+
+  it("returns 404 unknown-validator for an unregistered id", async () => {
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+    const res = await fetchAsOperator(`${proxy.baseUrl}/api/nodes/validator-99/state/event-X`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("unknown-validator");
+    await closeServer(proxy.server);
+  });
+
+  it("returns 502 validator-unreachable when the node is down", async () => {
+    // Point the registry at a port nothing is listening on.
+    const deadRegistry = buildRegistry("http://127.0.0.1:1");
+    proxy = await startProxyServer(deadRegistry, new NodeRpcClient({ timeoutMs: 1000 }));
+    const res = await fetchAsOperator(`${proxy.baseUrl}/api/nodes/validator-2/state/event-X`);
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.code).toBe("validator-unreachable");
+    await closeServer(proxy.server);
+  });
+
+  it("returns 504 validator-timeout when the node is too slow", async () => {
+    // Fake slow node that never responds within the deadline.
+    const slow = createServer((_req, res) => {
+      // Intentionally never end the response.
+      void res;
+    });
+    await new Promise<void>((r) => slow.listen(0, () => r()));
+    const addr = slow.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+    const slowRegistry = buildRegistry(`http://127.0.0.1:${port}`);
+    proxy = await startProxyServer(slowRegistry, new NodeRpcClient({ timeoutMs: 200 }));
+    const res = await fetchAsOperator(`${proxy.baseUrl}/api/nodes/validator-2/state/event-X`);
+    expect(res.status).toBe(504);
+    const body = await res.json();
+    expect(body.code).toBe("validator-timeout");
+    await closeServer(proxy.server);
+    await closeServer(slow);
+  });
+
+  it("returns 409 when no verification pubkey is registered", async () => {
+    proxy = await startProxyServer(buildRegistry(fakeNode.url, /* withPubkey */ false), new NodeRpcClient());
+    const res = await fetchAsOperator(`${proxy.baseUrl}/api/nodes/validator-2/state/event-X`);
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("no-matching-pubkey");
+    await closeServer(proxy.server);
+  });
+
+  it("rate-limits per-operator (returns 429 once the window is exhausted)", async () => {
+    // Acceptance criterion: requests are rate-limited per operator. The in-router
+    // sliding-window limit is 60 req/min keyed by operator (IP fallback here, since
+    // all requests originate from 127.0.0.1 they share one bucket). The 61st request
+    // in the window must be rejected with 429 — proving the limiter is actually wired,
+    // not just that the key extractor exists.
+    controls.tamper = false;
+    proxy = await startProxyServer(buildRegistry(fakeNode.url), new NodeRpcClient());
+
+    let sawRateLimited = false;
+    let lastStatus = 0;
+    // 60 are allowed; the 61st should trip the limiter. Issue sequentially so the
+    // sliding-window counter is deterministic.
+    for (let i = 0; i < 61; i++) {
+      const res = await fetchAsOperator(`${proxy.baseUrl}/api/nodes/validator-2/state/event-X`);
+      lastStatus = res.status;
+      await res.body?.cancel().catch(() => undefined);
+      if (res.status === 429) {
+        sawRateLimited = true;
+        break;
+      }
+    }
+    expect(sawRateLimited).toBe(true);
+    expect(lastStatus).toBe(429);
+    await closeServer(proxy.server);
+  });
+});
+
+// =============================================================================
+// UNIT: NodeRpcClient error taxonomy (injected fetch, no real socket)
+// =============================================================================
+
+describe("NodeRpcClient", () => {
+  it("maps a 404 to StateKeyNotFoundError", async () => {
+    const client = new NodeRpcClient({
+      fetchImpl: async () => ({ ok: false, status: 404, json: async () => ({}), text: async () => "nf" }),
+    });
+    await expect(client.getState("v1", "http://x", "k", "challenge-1")).rejects.toMatchObject({ code: "key-not-found" });
+  });
+
+  it("maps an AbortError to NodeTimeoutError", async () => {
+    const client = new NodeRpcClient({
+      timeoutMs: 50,
+      fetchImpl: async (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            const e = new Error("aborted");
+            e.name = "AbortError";
+            reject(e);
+          });
+        }),
+    });
+    await expect(client.getState("v1", "http://x", "k", "challenge-1")).rejects.toMatchObject({ code: "validator-timeout" });
+  });
+
+  it("maps a network throw to NodeUnreachableError", async () => {
+    const client = new NodeRpcClient({
+      fetchImpl: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    await expect(client.getState("v1", "http://x", "k", "challenge-1")).rejects.toMatchObject({ code: "validator-unreachable" });
+  });
+
+  it("refuses to query without a per-request challenge", async () => {
+    const client = new NodeRpcClient({
+      fetchImpl: async () => {
+        throw new Error("must not reach the network");
+      },
+    });
+    await expect(client.getState("v1", "http://x", "k", "")).rejects.toThrow(
+      /non-empty per-request nonce/,
+    );
+  });
+
+  it("sends the challenge as a ?nonce= query parameter", async () => {
+    let requested = "";
+    const client = new NodeRpcClient({
+      fetchImpl: async (url) => {
+        requested = url;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            key: "k",
+            value: 1,
+            blockHeight: 7,
+            nonce: "challenge-1",
+            observedAt: new Date().toISOString(),
+            keyId: "node-key-1",
+            signature: "00",
+          }),
+          text: async () => "",
+        };
+      },
+    });
+    await client.getState("v1", "http://x/", "a b", "challenge-1");
+    expect(requested).toBe("http://x/state/a%20b?nonce=challenge-1");
+  });
+
+  it("rejects a malformed signed-state body as NodeRpcError", async () => {
+    const client = new NodeRpcClient({
+      fetchImpl: async () => ({ ok: true, status: 200, json: async () => ({ nope: true }), text: async () => "" }),
+    });
+    await expect(client.getState("v1", "http://x", "k", "challenge-1")).rejects.toMatchObject({ code: "validator-rpc-error" });
+  });
+
+  it.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["negative", -1],
+    ["fractional", 12.5],
+    ["beyond MAX_SAFE_INTEGER", 1e308],
+  ])(
+    "refuses a %s blockHeight that could poison the anti-rollback mark",
+    async (_label, blockHeight) => {
+      const client = new NodeRpcClient({
+        fetchImpl: async () => ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            key: "k",
+            value: 1,
+            blockHeight,
+            nonce: "challenge-1",
+            observedAt: new Date().toISOString(),
+            keyId: "node-key-1",
+            signature: "00",
+          }),
+          text: async () => "",
+        }),
+      });
+
+      await expect(
+        client.getState("v1", "http://x", "k", "challenge-1"),
+      ).rejects.toMatchObject({ code: "validator-rpc-error" });
+    },
+  );
+
+  it("classifies a legacy response without v2 freshness fields", async () => {
+    const client = new NodeRpcClient({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          key: "k",
+          value: 1,
+          blockHeight: 7,
+          keyId: "legacy-key",
+          signature: "00",
+        }),
+        text: async () => "",
+      }),
+    });
+
+    await expect(client.getState("v1", "http://x", "k", "challenge-1")).rejects.toMatchObject({
+      code: "state-protocol-incompatible",
+      expectedProtocol: "oxscada-state-v2",
+      incompatibleFields: ["nonce", "observedAt"],
+    });
+  });
+});
+
+// =============================================================================
+// UNIT: operator rate-limit key extraction
+// =============================================================================
+
+describe("operatorKeyExtractor", () => {
+  it("prefers the API key name", () => {
+    const req = { apiKeyName: "acme", header: () => undefined, ip: "1.2.3.4" } as never;
+    expect(operatorKeyExtractor(req)).toBe("operator:acme");
+  });
+
+  it("ignores an unauthenticated x-operator-id header", () => {
+    const req = { header: (h: string) => (h === "x-operator-id" ? "op-7" : undefined), ip: "1.2.3.4" } as never;
+    expect(operatorKeyExtractor(req)).toBe("ip:1.2.3.4");
+  });
+
+  it("falls back to IP", () => {
+    const req = { header: () => undefined, ip: "9.9.9.9" } as never;
+    expect(operatorKeyExtractor(req)).toBe("ip:9.9.9.9");
+  });
+});

--- a/server/__tests__/validator-registry.test.ts
+++ b/server/__tests__/validator-registry.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Validator Registry Seeding + Anti-Rollback Persistence (#454)
+ *
+ * The first attempt at the cross-node state proxy was rejected for two reasons:
+ * it had no replay/freshness protection, and it was "non-functional outside a
+ * seeded Postgres — the validator_nodes/validator_pubkeys tables have DDL but
+ * no seed".
+ *
+ * This suite closes both against a REAL database. Nothing here is stubbed: the
+ * router is built with its production dependencies (`createNodeRoutes()` with no
+ * injected registry, watermark store or RPC client), talking to the real
+ * `server/storage.ts` on an in-memory SQLite database and to a real local
+ * validator over HTTP. It proves, in order, that:
+ *
+ *   1. An empty registry FAILS CLOSED — an unregistered validator is never
+ *      trusted, it is rejected with 404 unknown-validator.
+ *   2. The registry is seeded through an admin-authenticated route, not by hand
+ *      editing SQL, and an operator-only key cannot seed it.
+ *   3. Once seeded, the signed read works end to end with no manual DB setup.
+ *   4. The block-height high-water mark is actually persisted, and a later
+ *      answer that regresses below it is refused.
+ *   5. Retiring the registered key makes reads fail closed again.
+ *
+ * Runs sequentially: the cases build on each other's persisted state on purpose,
+ * because "the state survived the previous request" is part of what is asserted.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import { createServer, type Server } from "http";
+import {
+  generateKeyPairSync,
+  sign as cryptoSign,
+  type KeyObject,
+} from "node:crypto";
+
+import { buildStateSigningMessage } from "../blockchain/state-signature";
+
+const ADMIN_KEY = "validator-registry-admin-key";
+const OPERATOR_KEY = "validator-registry-operator-key";
+const NODE_ID = "validator-1";
+const STATE_KEY = "event-X";
+const KEY_ID = "node-key-1";
+
+interface NodeControls {
+  blockHeight: number;
+  knownKeys: Set<string>;
+}
+
+describe.sequential("validator registry seeding + persistence (#454)", () => {
+  let database: typeof import("../storage");
+  let createNodeRoutes: typeof import("../routes/nodes").createNodeRoutes;
+
+  let publicKeyPem: string;
+  let privateKey: KeyObject;
+  let fakeNode: Server;
+  let fakeNodeUrl: string;
+  let proxy: Server;
+  let baseUrl: string;
+
+  const controls: NodeControls = {
+    blockHeight: 4200,
+    knownKeys: new Set([STATE_KEY]),
+  };
+
+  const originalEnv = {
+    apiKeys: process.env.API_KEYS,
+    forcePostgres: process.env.FORCE_POSTGRES,
+    sqlitePath: process.env.SQLITE_DATABASE_PATH,
+  };
+
+  function request(url: string, apiKey: string, init: RequestInit = {}): Promise<Response> {
+    const headers = new Headers(init.headers);
+    headers.set("x-api-key", apiKey);
+    if (init.body !== undefined) headers.set("content-type", "application/json");
+    return fetch(url, { ...init, headers });
+  }
+
+  beforeAll(async () => {
+    // Force the development SQLite path so the whole feature is exercised
+    // without a Postgres instance — the point of the seeding fix.
+    process.env.FORCE_POSTGRES = "false";
+    process.env.SQLITE_DATABASE_PATH = ":memory:";
+    process.env.API_KEYS =
+      `${ADMIN_KEY}:validator-admin:admin,${OPERATOR_KEY}:validator-operator:operator`;
+
+    database = await import("../storage");
+    await database.initializeDatabase();
+    ({ createNodeRoutes } = await import("../routes/nodes"));
+    const auth = await import("../middleware/control-plane-auth");
+    auth._resetControlPlaneAuthCache();
+
+    const pair = generateKeyPairSync("ed25519");
+    privateKey = pair.privateKey;
+    publicKeyPem = pair.publicKey.export({ type: "spki", format: "pem" }).toString();
+
+    // A real validator: signs the server-supplied nonce and its own timestamp.
+    const nodeApp = express();
+    nodeApp.get("/state/:key", (req, res) => {
+      const key = decodeURIComponent(req.params.key);
+      if (!controls.knownKeys.has(key)) {
+        res.status(404).json({ error: "key not found", key });
+        return;
+      }
+      const nonce = typeof req.query.nonce === "string" ? req.query.nonce : "";
+      const observedAt = new Date().toISOString();
+      const value = { reading: 42, key };
+      const signature = cryptoSign(
+        null,
+        Buffer.from(
+          buildStateSigningMessage({
+            key,
+            value,
+            blockHeight: controls.blockHeight,
+            nonce,
+            observedAt,
+          }),
+          "utf8",
+        ),
+        privateKey,
+      ).toString("hex");
+      res.status(200).json({
+        key,
+        value,
+        blockHeight: controls.blockHeight,
+        nonce,
+        observedAt,
+        keyId: KEY_ID,
+        signature,
+      });
+    });
+
+    fakeNode = createServer(nodeApp);
+    await new Promise<void>((resolve) => fakeNode.listen(0, () => resolve()));
+    const nodeAddr = fakeNode.address();
+    fakeNodeUrl = `http://127.0.0.1:${typeof nodeAddr === "object" && nodeAddr ? nodeAddr.port : 0}`;
+
+    // NOTE: no injected deps — this is the production wiring.
+    const proxyApp = express();
+    proxyApp.use("/api/nodes", createNodeRoutes());
+    proxy = createServer(proxyApp);
+    await new Promise<void>((resolve) => proxy.listen(0, () => resolve()));
+    const proxyAddr = proxy.address();
+    baseUrl = `http://127.0.0.1:${typeof proxyAddr === "object" && proxyAddr ? proxyAddr.port : 0}`;
+    // Transforming + importing the server modules on a cold cache can exceed
+    // vitest's default 10s hook budget on Windows.
+  }, 60_000);
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => proxy.close(() => resolve()));
+    await new Promise<void>((resolve) => fakeNode.close(() => resolve()));
+    await database.closeDatabase();
+
+    if (originalEnv.apiKeys === undefined) delete process.env.API_KEYS;
+    else process.env.API_KEYS = originalEnv.apiKeys;
+    if (originalEnv.forcePostgres === undefined) delete process.env.FORCE_POSTGRES;
+    else process.env.FORCE_POSTGRES = originalEnv.forcePostgres;
+    if (originalEnv.sqlitePath === undefined) delete process.env.SQLITE_DATABASE_PATH;
+    else process.env.SQLITE_DATABASE_PATH = originalEnv.sqlitePath;
+
+    const auth = await import("../middleware/control-plane-auth");
+    auth._resetControlPlaneAuthCache();
+  });
+
+  it("fails closed on an empty registry: an unregistered validator is rejected", async () => {
+    const res = await request(
+      `${baseUrl}/api/nodes/${NODE_ID}/state/${STATE_KEY}`,
+      OPERATOR_KEY,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ code: "unknown-validator" });
+    expect(await database.getValidatorNode(NODE_ID)).toBeNull();
+  });
+
+  it("refuses registry writes from an operator key without validator.admin", async () => {
+    const res = await request(`${baseUrl}/api/nodes`, OPERATOR_KEY, {
+      method: "POST",
+      body: JSON.stringify({ id: NODE_ID, name: "Validator 1", rpcUrl: fakeNodeUrl }),
+    });
+    expect(res.status).toBe(403);
+    expect(await database.getValidatorNode(NODE_ID)).toBeNull();
+  });
+
+  it("refuses registry writes with no credentials at all", async () => {
+    const res = await fetch(`${baseUrl}/api/nodes`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: NODE_ID, name: "Validator 1", rpcUrl: fakeNodeUrl }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a non-http(s) RPC endpoint", async () => {
+    const res = await request(`${baseUrl}/api/nodes`, ADMIN_KEY, {
+      method: "POST",
+      body: JSON.stringify({
+        id: NODE_ID,
+        name: "Validator 1",
+        rpcUrl: "file:///etc/passwd",
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "invalid-body" });
+  });
+
+  it("registers a validator through the admin route and persists it", async () => {
+    const res = await request(`${baseUrl}/api/nodes`, ADMIN_KEY, {
+      method: "POST",
+      body: JSON.stringify({
+        id: NODE_ID,
+        name: "Validator 1",
+        rpcUrl: fakeNodeUrl,
+        region: "east",
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    // Read straight from storage: the row is really in the database.
+    expect(await database.getValidatorNode(NODE_ID)).toMatchObject({
+      id: NODE_ID,
+      name: "Validator 1",
+      rpcUrl: fakeNodeUrl,
+      region: "east",
+      enabled: true,
+    });
+  });
+
+  it("still fails closed with a node but no registered verification key", async () => {
+    const res = await request(
+      `${baseUrl}/api/nodes/${NODE_ID}/state/${STATE_KEY}`,
+      OPERATOR_KEY,
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ code: "no-matching-pubkey" });
+  });
+
+  it("rejects key material that is not an Ed25519 SPKI PEM", async () => {
+    const res = await request(`${baseUrl}/api/nodes/${NODE_ID}/pubkeys`, ADMIN_KEY, {
+      method: "POST",
+      body: JSON.stringify({ keyId: KEY_ID, publicKeyPem: "-----BEGIN PUBLIC KEY-----junk" }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "invalid-public-key" });
+    expect(await database.getActiveValidatorPubkey(NODE_ID, KEY_ID)).toBeNull();
+  });
+
+  it("rejects an RSA key, which this scheme could never verify", async () => {
+    const { publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const res = await request(`${baseUrl}/api/nodes/${NODE_ID}/pubkeys`, ADMIN_KEY, {
+      method: "POST",
+      body: JSON.stringify({
+        keyId: KEY_ID,
+        publicKeyPem: publicKey.export({ type: "spki", format: "pem" }).toString(),
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "invalid-public-key" });
+  });
+
+  it("rejects key registration for an unregistered validator", async () => {
+    const res = await request(`${baseUrl}/api/nodes/validator-99/pubkeys`, ADMIN_KEY, {
+      method: "POST",
+      body: JSON.stringify({ keyId: KEY_ID, publicKeyPem }),
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ code: "unknown-validator" });
+  });
+
+  it("registers the Ed25519 verification key and persists it", async () => {
+    const res = await request(`${baseUrl}/api/nodes/${NODE_ID}/pubkeys`, ADMIN_KEY, {
+      method: "POST",
+      body: JSON.stringify({ keyId: KEY_ID, publicKeyPem }),
+    });
+    expect(res.status).toBe(200);
+    expect(await database.getActiveValidatorPubkey(NODE_ID, KEY_ID)).toMatchObject({
+      nodeId: NODE_ID,
+      keyId: KEY_ID,
+      algorithm: "ed25519",
+      active: true,
+      publicKeyPem,
+    });
+  });
+
+  it("serves a verified cross-node read with no hand-seeded database", async () => {
+    controls.blockHeight = 4200;
+    const res = await request(
+      `${baseUrl}/api/nodes/${NODE_ID}/state/${STATE_KEY}`,
+      OPERATOR_KEY,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      nodeId: NODE_ID,
+      key: STATE_KEY,
+      value: { reading: 42, key: STATE_KEY },
+      blockHeight: 4200,
+      keyId: KEY_ID,
+      verified: true,
+    });
+  });
+
+  it("persisted the block-height high-water mark", async () => {
+    const mark = await database.getValidatorStateWatermark(NODE_ID, STATE_KEY);
+    expect(mark).toMatchObject({
+      nodeId: NODE_ID,
+      stateKey: STATE_KEY,
+      blockHeight: 4200,
+    });
+  });
+
+  it("advances the persisted mark on a higher block height", async () => {
+    controls.blockHeight = 4300;
+    const res = await request(
+      `${baseUrl}/api/nodes/${NODE_ID}/state/${STATE_KEY}`,
+      OPERATOR_KEY,
+    );
+    expect(res.status).toBe(200);
+    expect(
+      (await database.getValidatorStateWatermark(NODE_ID, STATE_KEY))?.blockHeight,
+    ).toBe(4300);
+  });
+
+  it("rejects a correctly signed, fresh answer that regresses below the mark", async () => {
+    controls.blockHeight = 4299;
+    const res = await request(
+      `${baseUrl}/api/nodes/${NODE_ID}/state/${STATE_KEY}`,
+      OPERATOR_KEY,
+    );
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({
+      code: "state-rollback",
+      reason: "block-height-regression",
+      blockHeight: 4299,
+      highestAcceptedBlockHeight: 4300,
+    });
+    // The refused answer must not have lowered the persisted mark.
+    expect(
+      (await database.getValidatorStateWatermark(NODE_ID, STATE_KEY))?.blockHeight,
+    ).toBe(4300);
+  });
+
+  it("never lowers the persisted mark, even called directly with a lower height", async () => {
+    // The route refuses a regression before it would ever write, so exercise the
+    // storage compare-and-set on its own: this is the guard that stops two
+    // replicas racing the mark backwards.
+    const lowered = await database.recordValidatorStateWatermark(
+      NODE_ID,
+      STATE_KEY,
+      1,
+      new Date(),
+    );
+    expect(lowered.blockHeight).toBe(4300);
+
+    const raised = await database.recordValidatorStateWatermark(
+      NODE_ID,
+      STATE_KEY,
+      4301,
+      new Date(),
+    );
+    expect(raised.blockHeight).toBe(4301);
+
+    // Put the mark back where the route left it for the remaining cases.
+    expect(
+      (await database.getValidatorStateWatermark(NODE_ID, STATE_KEY))?.blockHeight,
+    ).toBe(4301);
+  });
+
+  it("lists registered validators for an operator without exposing key material", async () => {
+    const res = await request(`${baseUrl}/api/nodes`, OPERATOR_KEY);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { nodes: Record<string, unknown>[] };
+    expect(body.nodes).toHaveLength(1);
+    expect(body.nodes[0]).toMatchObject({ id: NODE_ID, rpcUrl: fakeNodeUrl });
+    expect(JSON.stringify(body)).not.toContain("BEGIN PUBLIC KEY");
+  });
+
+  it("fails closed again once the verification key is retired", async () => {
+    const retire = await request(
+      `${baseUrl}/api/nodes/${NODE_ID}/pubkeys/${KEY_ID}`,
+      ADMIN_KEY,
+      { method: "DELETE" },
+    );
+    expect(retire.status).toBe(200);
+    expect(await database.getActiveValidatorPubkey(NODE_ID, KEY_ID)).toBeNull();
+
+    controls.blockHeight = 4400;
+    const res = await request(
+      `${baseUrl}/api/nodes/${NODE_ID}/state/${STATE_KEY}`,
+      OPERATOR_KEY,
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ code: "no-matching-pubkey" });
+  });
+
+  it("reports 404 when retiring a key that is not registered", async () => {
+    const res = await request(
+      `${baseUrl}/api/nodes/${NODE_ID}/pubkeys/never-registered`,
+      ADMIN_KEY,
+      { method: "DELETE" },
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ code: "no-matching-pubkey" });
+  });
+});

--- a/server/blockchain/node-client.ts
+++ b/server/blockchain/node-client.ts
@@ -1,0 +1,294 @@
+/**
+ * oxscada Validator RPC Client (#454)
+ *
+ * Thin HTTP client used by the cross-node state proxy to ask a *specific*
+ * validator for its view of a state key. The client speaks the oxscada RPC
+ * `state_get` request and returns the validator's signed response verbatim —
+ * signature verification is performed by the route layer, NOT here, so this
+ * client stays a transport concern.
+ *
+ * Failure taxonomy (so the route can map to distinct status codes):
+ *   - `NodeUnreachableError`  → connection refused / DNS / network error  → 502
+ *   - `NodeTimeoutError`      → request exceeded the deadline             → 504
+ *   - `StateKeyNotFoundError` → validator reports the key is unknown      → 404
+ *   - `NodeRpcError`          → any other non-OK RPC response             → 502
+ *
+ * The `fetch` implementation is injectable so the client (and the whole proxy)
+ * can be integration-tested against a local fake node without monkey-patching
+ * globals.
+ */
+
+import type { SignedStateResponse } from "./state-signature";
+
+/** Minimal subset of the global `fetch` we depend on (keeps it test-injectable). */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+}>;
+
+export interface NodeClientOptions {
+  /** Per-request timeout in milliseconds. Default 5000. */
+  timeoutMs?: number;
+  /** Injectable fetch (defaults to global fetch). */
+  fetchImpl?: FetchLike;
+}
+
+// ─── Error taxonomy ───────────────────────────────────────────────────────────
+
+export class NodeUnreachableError extends Error {
+  readonly code = "validator-unreachable" as const;
+  constructor(
+    public readonly nodeId: string,
+    cause?: unknown,
+  ) {
+    super(`Validator ${nodeId} unreachable: ${describeCause(cause)}`);
+    this.name = "NodeUnreachableError";
+  }
+}
+
+export class NodeTimeoutError extends Error {
+  readonly code = "validator-timeout" as const;
+  constructor(
+    public readonly nodeId: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(`Validator ${nodeId} did not respond within ${timeoutMs}ms`);
+    this.name = "NodeTimeoutError";
+  }
+}
+
+export class StateKeyNotFoundError extends Error {
+  readonly code = "key-not-found" as const;
+  constructor(
+    public readonly nodeId: string,
+    public readonly key: string,
+  ) {
+    super(`Key "${key}" not found on validator ${nodeId}`);
+    this.name = "StateKeyNotFoundError";
+  }
+}
+
+export class NodeRpcError extends Error {
+  readonly code = "validator-rpc-error" as const;
+  constructor(
+    public readonly nodeId: string,
+    public readonly httpStatus: number,
+    detail?: string,
+  ) {
+    super(
+      `Validator ${nodeId} RPC error (HTTP ${httpStatus})${detail ? `: ${detail}` : ""}`,
+    );
+    this.name = "NodeRpcError";
+  }
+}
+
+export type StateProtocolV2Field = "nonce" | "observedAt";
+
+/**
+ * The upstream validator returned the legacy signed-state shape. Treat this as
+ * a rollout incompatibility, not as a generic transport/RPC failure: accepting
+ * v1 would remove the request challenge and freshness guarantees.
+ */
+export class StateProtocolVersionError extends Error {
+  readonly code = "state-protocol-incompatible" as const;
+  readonly expectedProtocol = "oxscada-state-v2" as const;
+
+  constructor(
+    public readonly nodeId: string,
+    public readonly incompatibleFields: readonly StateProtocolV2Field[],
+  ) {
+    super(
+      `Validator ${nodeId} returned an incompatible signed-state response; ` +
+        `oxscada-state-v2 requires valid ${incompatibleFields.join(" and ")}`,
+    );
+    this.name = "StateProtocolVersionError";
+  }
+}
+
+function describeCause(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === "string") return cause;
+  return "network error";
+}
+
+// ─── Response validation ───────────────────────────────────────────────────────
+
+/**
+ * Runtime guard for the validator's `state_get` response. We deliberately do
+ * NOT throw here for missing fields beyond signalling shape problems — the
+ * signature check downstream is the real authority on integrity, but we still
+ * reject structurally-broken payloads early.
+ */
+function isSignedStateResponse(body: unknown): body is SignedStateResponse {
+  if (body === null || typeof body !== "object") return false;
+  const b = body as Record<string, unknown>;
+  return (
+    typeof b.key === "string" &&
+    isUsableBlockHeight(b.blockHeight) &&
+    typeof b.nonce === "string" &&
+    typeof b.observedAt === "string" &&
+    typeof b.signature === "string" &&
+    (b.keyId === undefined || typeof b.keyId === "string") &&
+    "value" in b
+  );
+}
+
+/**
+ * A block height the anti-rollback high-water mark can actually be compared and
+ * persisted against.
+ *
+ * `typeof x === "number"` alone is not enough. `NaN` makes every `<` comparison
+ * false, so a `NaN` height would sail past the rollback check; `Infinity` or a
+ * value above `Number.MAX_SAFE_INTEGER` would either fail the (BIGINT / INTEGER
+ * NOT NULL) insert or pin the mark at a height no honest validator can ever
+ * reach again — permanently refusing every later read of that (node, key) pair,
+ * with no reset path. Reject the shape at the transport boundary instead.
+ */
+function isUsableBlockHeight(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function incompatibleStateV2Fields(body: unknown): StateProtocolV2Field[] {
+  if (body === null || typeof body !== "object") return [];
+  const b = body as Record<string, unknown>;
+  const hasSignedStateCore =
+    typeof b.key === "string" &&
+    typeof b.blockHeight === "number" &&
+    typeof b.signature === "string" &&
+    "value" in b;
+  if (!hasSignedStateCore) return [];
+
+  const incompatible: StateProtocolV2Field[] = [];
+  if (typeof b.nonce !== "string") incompatible.push("nonce");
+  if (typeof b.observedAt !== "string") incompatible.push("observedAt");
+  return incompatible;
+}
+
+/** A node not found / disabled in the registry — surfaced separately by the route. */
+export class UnknownValidatorError extends Error {
+  readonly code = "unknown-validator" as const;
+  constructor(public readonly nodeId: string) {
+    super(`Unknown or disabled validator: ${nodeId}`);
+    this.name = "UnknownValidatorError";
+  }
+}
+
+// ─── Client ──────────────────────────────────────────────────────────────────
+
+export class NodeRpcClient {
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(options: NodeClientOptions = {}) {
+    this.timeoutMs = options.timeoutMs ?? 5000;
+    // Fall back to the global fetch (Node 18+). Captured lazily so tests that
+    // pass `fetchImpl` never touch the global.
+    const injected = options.fetchImpl;
+    this.fetchImpl =
+      injected ??
+      ((input, init) =>
+        (globalThis.fetch as unknown as FetchLike)(input, init));
+  }
+
+  /**
+   * Query a validator's signed view of a single state key.
+   *
+   * @param nodeId  Registry id of the validator (for error messages).
+   * @param rpcUrl  Base RPC URL of the validator (no trailing path required).
+   * @param key     State key to query.
+   * @param nonce   Per-request challenge the validator must sign and echo.
+   *                Required — an omitted challenge would silently remove the
+   *                replay binding, so there is no "no nonce" call shape.
+   * @throws NodeTimeoutError | NodeUnreachableError | StateKeyNotFoundError |
+   *         NodeRpcError | StateProtocolVersionError
+   */
+  async getState(
+    nodeId: string,
+    rpcUrl: string,
+    key: string,
+    nonce: string,
+  ): Promise<SignedStateResponse> {
+    if (!nonce) {
+      throw new Error("getState requires a non-empty per-request nonce");
+    }
+    const query = `?nonce=${encodeURIComponent(nonce)}`;
+    const url = `${rpcUrl.replace(/\/$/, "")}/state/${encodeURIComponent(key)}${query}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    let res: Awaited<ReturnType<FetchLike>>;
+    try {
+      res = await this.fetchImpl(url, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      });
+    } catch (err) {
+      // AbortError → timeout; everything else is a transport/network failure.
+      if (isAbortError(err)) {
+        throw new NodeTimeoutError(nodeId, this.timeoutMs);
+      }
+      throw new NodeUnreachableError(nodeId, err);
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (res.status === 404) {
+      throw new StateKeyNotFoundError(nodeId, key);
+    }
+
+    if (!res.ok) {
+      let detail: string | undefined;
+      try {
+        detail = (await res.text()).slice(0, 256);
+      } catch {
+        /* ignore body read failure */
+      }
+      throw new NodeRpcError(nodeId, res.status, detail);
+    }
+
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch (err) {
+      throw new NodeRpcError(
+        nodeId,
+        res.status,
+        `invalid JSON: ${describeCause(err)}`,
+      );
+    }
+
+    const incompatibleFields = incompatibleStateV2Fields(body);
+    if (incompatibleFields.length > 0) {
+      throw new StateProtocolVersionError(nodeId, incompatibleFields);
+    }
+
+    if (!isSignedStateResponse(body)) {
+      throw new NodeRpcError(
+        nodeId,
+        res.status,
+        "malformed signed-state response",
+      );
+    }
+
+    return body;
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === "AbortError" ||
+      (err as { code?: string }).code === "ABORT_ERR")
+  );
+}

--- a/server/blockchain/state-signature.ts
+++ b/server/blockchain/state-signature.ts
@@ -1,0 +1,268 @@
+/**
+ * Cross-Node State Signature Verification (#454)
+ *
+ * Pure, dependency-free helpers for the signature half of the per-validator
+ * `/state/:key` proxy. A validator returns a value for a key together with a
+ * signature over a canonical representation of
+ * `(key, value, blockHeight, nonce, observedAt)`.
+ * Before the server hands the response back to an operator it MUST verify that
+ * signature against the validator's registered public key.
+ *
+ * ## Signature scheme
+ * We use **Ed25519** via Node's built-in `node:crypto` module (`crypto.verify`
+ * / `crypto.sign` with a `null` digest algorithm). This matches the repo's
+ * existing reliance on `node:crypto` for signing (see `server/integrity/hsm.ts`)
+ * and requires NO new dependency. Ed25519 is deterministic, has small keys, and
+ * is a natural fit for validator identity keys.
+ *
+ * Keys are exchanged as PEM-encoded SPKI public keys (the standard
+ * `-----BEGIN PUBLIC KEY-----` format) which is what `crypto.generateKeyPairSync`
+ * emits and what we store in the `validator_pubkeys` table.
+ *
+ * ## Replay / freshness (`oxscada-state-v2`)
+ * A signature over `(key, value, blockHeight)` alone is replayable: a captured
+ * valid response stays valid forever. v2 therefore binds the signature to a
+ * per-request, server-chosen `nonce` and to the validator's `observedAt`
+ * timestamp, and the proxy checks both before returning anything.
+ *
+ * The nonce half of that contract has a producer requirement that CANNOT be
+ * satisfied from this repository: the oxscada validator (the geth fork, a
+ * separate codebase) must read the `?nonce=` query parameter, sign it together
+ * with its own `observedAt`, and echo both in the response body. This module
+ * and `node-client.ts` fail closed rather than pretend otherwise — a response
+ * missing `nonce`/`observedAt` is rejected as `state-protocol-incompatible`
+ * and never verified as if it were fresh.
+ *
+ * The two checks that are enforceable purely server-side — the timestamp
+ * window here, and the persisted per-(node, key) block-height high-water mark
+ * in `server/routes/nodes.ts` — hold regardless of what the node implements.
+ *
+ * This module is intentionally free of Express / DB / network imports so the
+ * verification logic can be unit-tested in isolation.
+ */
+
+import {
+  verify as cryptoVerify,
+  createPublicKey,
+  KeyObject,
+} from "node:crypto";
+
+/**
+ * The payload a validator returns for a state query, prior to verification.
+ * Mirrors the on-the-wire shape produced by the oxscada RPC `state_get` method.
+ */
+export interface SignedStateResponse {
+  /** The key that was queried. Echoed back by the validator. */
+  key: string;
+  /**
+   * The validator's value for that key. `null` is a valid signed answer for a
+   * known-but-empty key; a *missing* key is signalled out-of-band (see
+   * `node-client.ts` / route 404 handling), not by signing `null`.
+   */
+  value: unknown;
+  /** Block height / sequence at which this value was observed. */
+  blockHeight: number;
+  /** Per-request challenge supplied by the proxy. */
+  nonce: string;
+  /** ISO-8601 time at which the validator observed the value. */
+  observedAt: string;
+  /** Optional identifier of the key the validator signed with (for rotation). */
+  keyId?: string;
+  /** Hex-encoded Ed25519 signature over the canonical message. */
+  signature: string;
+}
+
+/** Discriminated outcome of verifying a signed state response. */
+export type SignatureVerificationResult =
+  | { valid: true }
+  | { valid: false; reason: SignatureFailureReason; detail?: string };
+
+export type SignatureFailureReason =
+  | "missing-signature"
+  | "malformed-signature"
+  | "malformed-pubkey"
+  | "signature-mismatch";
+
+export type FreshnessFailureReason =
+  | "key-mismatch"
+  | "nonce-mismatch"
+  | "invalid-observed-at"
+  | "stale-response"
+  | "future-response";
+
+export type FreshnessVerificationResult =
+  { valid: true } | { valid: false; reason: FreshnessFailureReason };
+
+/**
+ * Build the canonical, deterministic message that is signed/verified.
+ *
+ * Determinism is critical: the validator and the server must serialize the
+ * exact same bytes or every signature would appear invalid. We therefore:
+ *   - fix field order explicitly (do not rely on object key ordering),
+ *   - JSON-serialize the value with sorted object keys so semantically-equal
+ *     objects always produce identical bytes.
+ *
+ * Format:
+ * `oxscada-state-v2\n<key>\n<blockHeight>\n<nonce>\n<observedAt>\n<canonicalJson(value)>`
+ *
+ * The `oxscada-state-v2` domain-separation prefix prevents a signature minted
+ * for some other purpose from being replayed as a state attestation.
+ */
+export function buildStateSigningMessage(params: {
+  key: string;
+  value: unknown;
+  blockHeight: number;
+  nonce: string;
+  observedAt: string;
+}): string {
+  const canonicalValue = canonicalJsonStringify(params.value);
+  return [
+    "oxscada-state-v2",
+    params.key,
+    String(params.blockHeight),
+    params.nonce,
+    params.observedAt,
+    canonicalValue,
+  ].join("\n");
+}
+
+/**
+ * Verify that a validly signed response belongs to this request and is recent.
+ * A captured response cannot satisfy a new random nonce, while the timestamp
+ * bounds prevent a validator from returning an indefinitely old observation.
+ */
+export function verifyStateResponseFreshness(
+  response: SignedStateResponse,
+  expected: {
+    key: string;
+    nonce: string;
+    nowMs?: number;
+    maxAgeMs?: number;
+    maxFutureSkewMs?: number;
+  },
+): FreshnessVerificationResult {
+  if (response.key !== expected.key) {
+    return { valid: false, reason: "key-mismatch" };
+  }
+  if (response.nonce !== expected.nonce) {
+    return { valid: false, reason: "nonce-mismatch" };
+  }
+
+  const observedAtMs = Date.parse(response.observedAt);
+  if (!Number.isFinite(observedAtMs)) {
+    return { valid: false, reason: "invalid-observed-at" };
+  }
+
+  const nowMs = expected.nowMs ?? Date.now();
+  const maxAgeMs = expected.maxAgeMs ?? 30_000;
+  const maxFutureSkewMs = expected.maxFutureSkewMs ?? 5_000;
+  if (observedAtMs < nowMs - maxAgeMs) {
+    return { valid: false, reason: "stale-response" };
+  }
+  if (observedAtMs > nowMs + maxFutureSkewMs) {
+    return { valid: false, reason: "future-response" };
+  }
+  return { valid: true };
+}
+
+/**
+ * Deterministically stringify a JSON value with object keys sorted recursively.
+ * Arrays preserve order; primitives serialize as standard JSON. Used so the
+ * canonical signing message is byte-stable regardless of key insertion order.
+ */
+export function canonicalJsonStringify(value: unknown): string {
+  return JSON.stringify(sortValue(value));
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortValue);
+  }
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    // A normal `{}` treats the own key "__proto__" as a prototype setter.
+    // A null-prototype dictionary preserves every JSON key in the signed bytes.
+    const sorted: Record<string, unknown> = Object.create(null);
+    for (const k of Object.keys(obj).sort()) {
+      sorted[k] = sortValue(obj[k]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * Parse a PEM-encoded SPKI public key into a KeyObject.
+ * Returns `null` if the PEM is malformed / not an Ed25519 key we can use.
+ */
+export function parsePublicKeyPem(publicKeyPem: string): KeyObject | null {
+  try {
+    const key = createPublicKey({ key: publicKeyPem, format: "pem" });
+    return key.asymmetricKeyType === "ed25519" ? key : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify a validator's signed state response against a registered public key.
+ *
+ * This is the security-critical path called from the route *before* returning
+ * to the client. It never throws — all failure modes map to a discriminated
+ * `{ valid: false, reason }` so the caller can choose the right status code.
+ *
+ * @param response   The (possibly tampered) response received from the node.
+ * @param publicKeyPem PEM SPKI public key registered for this validator.
+ */
+export function verifySignedStateResponse(
+  response: SignedStateResponse,
+  publicKeyPem: string,
+): SignatureVerificationResult {
+  if (!response.signature || typeof response.signature !== "string") {
+    return { valid: false, reason: "missing-signature" };
+  }
+
+  // Hex must be even-length, non-empty, and valid hex characters.
+  if (
+    response.signature.length === 0 ||
+    response.signature.length % 2 !== 0 ||
+    !/^[0-9a-fA-F]+$/.test(response.signature)
+  ) {
+    return { valid: false, reason: "malformed-signature" };
+  }
+
+  const key = parsePublicKeyPem(publicKeyPem);
+  if (!key) {
+    return { valid: false, reason: "malformed-pubkey" };
+  }
+
+  let signatureBytes: Buffer;
+  try {
+    signatureBytes = Buffer.from(response.signature, "hex");
+  } catch {
+    return { valid: false, reason: "malformed-signature" };
+  }
+
+  const message = Buffer.from(
+    buildStateSigningMessage({
+      key: response.key,
+      value: response.value,
+      blockHeight: response.blockHeight,
+      nonce: response.nonce,
+      observedAt: response.observedAt,
+    }),
+    "utf8",
+  );
+
+  let ok = false;
+  try {
+    // Ed25519: pass `null` as the digest algorithm — the key type selects the
+    // scheme. Returns false (not throws) for a mismatched signature, but we
+    // guard against unexpected key/scheme errors too.
+    ok = cryptoVerify(null, message, key, signatureBytes);
+  } catch {
+    return { valid: false, reason: "malformed-signature" };
+  }
+
+  return ok ? { valid: true } : { valid: false, reason: "signature-mismatch" };
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -27,6 +27,7 @@ import { predictiveMaintenanceService } from "./services/predictive";
 import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
+import { nodeRoutes } from "./routes/nodes"; // #454: cross-node state queries
 import { blueprintRoutes } from "./routes/blueprints";
 import { vendorRoutes } from "./routes/vendors";
 import { codegenRoutes } from "./routes/codegen";
@@ -72,6 +73,7 @@ export async function registerRoutes(
   app.use("/api/governance", governanceRoutes);
   app.use("/api/security", securityRoutes);
   app.use("/api/geometry", geometryRoutes(getFluxPublisher()));
+  app.use("/api/nodes", nodeRoutes); // #454: GET /api/nodes/:id/state/:key
 
   // Blueprint / vendor / codegen surfaces (extracted from this file, #446).
   // vendorRoutes and codegenRoutes span several top-level prefixes

--- a/server/routes/nodes.ts
+++ b/server/routes/nodes.ts
@@ -1,0 +1,724 @@
+/**
+ * Cross-Node State Query Routes (#454)
+ *
+ * Operator endpoint to inspect a *specific* validator's view of a state key —
+ * useful for divergence investigations ("what does validator 2 think about
+ * event X?"), plus the admin surface that seeds the validator registry the
+ * query depends on.
+ *
+ *   GET    /api/nodes                        (operator) list registered validators
+ *   POST   /api/nodes                        (admin)    register / update a validator
+ *   POST   /api/nodes/:id/pubkeys            (admin)    register / rotate a verification key
+ *   DELETE /api/nodes/:id/pubkeys/:keyId     (admin)    retire a verification key
+ *   GET    /api/nodes/:id/state/:key         (operator) signed cross-node state read
+ *
+ * Read flow:
+ *   1. Resolve the validator (id) from the registry.
+ *   2. Mint a fresh random nonce and proxy `state_get` to the validator's RPC.
+ *   3. Resolve the exact Ed25519 public key the response names, from the DB
+ *      registry — never from the payload.
+ *   4. VERIFY the signature against that key BEFORE returning anything.
+ *   5. Check freshness: the signed nonce must equal the one we just minted and
+ *      the signed observation time must fall inside a bounded skew window.
+ *   6. Check anti-rollback: the reported blockHeight must not be below the
+ *      highest height already accepted for this (validator, key) pair, and the
+ *      new high-water mark must be persisted before we answer.
+ *   7. Only then return the value + signature.
+ *
+ * ## What is enforced where (and what needs a node-side change)
+ *
+ * Steps 3, 4, 6 are fully enforced by this server against its own database and
+ * hold no matter what the validator does.
+ *
+ * Step 5's nonce binding requires the validator to speak `oxscada-state-v2`:
+ * it must read the `?nonce=` query parameter, include it and its own
+ * `observedAt` timestamp in the canonical signed message, and echo both in the
+ * response body. That producer lives in the oxscada node (geth fork), NOT in
+ * this repository, so it cannot be implemented here. Until a node ships v2 the
+ * proxy does not silently downgrade: `NodeRpcClient` rejects a v1-shaped
+ * response with `state-protocol-incompatible` (502) and no value reaches the
+ * operator. The freshness contract is specified in
+ * `server/blockchain/state-signature.ts` and documented in
+ * `docs/blockchain/cross-node-state-queries.md`.
+ *
+ * Distinct error status codes (acceptance criteria):
+ *   - validator-unreachable         → 502  (cannot reach the node)
+ *   - validator-timeout             → 504  (node too slow)
+ *   - signature-invalid             → 502  (proxied OK but signature failed)
+ *   - response-not-fresh            → 502  (replayed nonce / timestamp outside window)
+ *   - state-rollback                → 502  (blockHeight below the accepted high-water mark)
+ *   - rollback-check-unavailable    → 503  (cannot read/persist the high-water mark)
+ *   - state-protocol-incompatible   → 502  (node still speaks v1, no freshness proof)
+ *   - key-not-found                 → 404
+ *   - unknown-validator             → 404  (id not in registry / disabled)
+ *   - no-matching-pubkey            → 409  (no active Ed25519 key for the named keyId)
+ *
+ * Rate-limited per-operator using the existing sliding-window limiter
+ * (`server/middleware/api-gateway.ts`). The bucket key is the operator id.
+ * INTEGRATION (#447): once Redis-backed limiting lands, swap the in-memory
+ * `rateLimitMiddleware` for the Redis limiter keyed the same way — the
+ * `keyExtractor` below is the seam and stays unchanged.
+ */
+
+import express, { Router, type Request, type Response } from "express";
+import { z } from "zod";
+import pino from "pino";
+import { randomBytes } from "node:crypto";
+import { rateLimitMiddleware } from "../middleware/api-gateway";
+import {
+  controlPlanePrincipal,
+  requireControlPlaneAccess,
+} from "../middleware/control-plane-auth";
+import {
+  NodeRpcClient,
+  NodeUnreachableError,
+  NodeTimeoutError,
+  StateKeyNotFoundError,
+  StateProtocolVersionError,
+  NodeRpcError,
+  UnknownValidatorError,
+} from "../blockchain/node-client";
+import {
+  parsePublicKeyPem,
+  verifySignedStateResponse,
+  verifyStateResponseFreshness,
+  type SignedStateResponse,
+} from "../blockchain/state-signature";
+import {
+  getValidatorNode,
+  listValidatorNodes,
+  upsertValidatorNode,
+  getActiveValidatorPubkey,
+  upsertValidatorPubkey,
+  retireValidatorPubkey,
+  getValidatorStateWatermark,
+  recordValidatorStateWatermark,
+  type ValidatorNodeRecord,
+  type ValidatorPubkeyRecord,
+  type ValidatorStateWatermarkRecord,
+} from "../storage";
+
+const logger = pino({ name: "node-state-routes" });
+
+// ─── Registry abstraction (injectable for tests) ───────────────────────────────
+
+/**
+ * Resolves validator metadata + the public key the server uses to verify a
+ * validator's signed responses, and owns the registration (seeding) writes.
+ * Backed by the DB via `server/storage.ts` in production; an in-memory
+ * implementation is injected in tests.
+ */
+export interface ValidatorRegistry {
+  getNode(id: string): Promise<ValidatorNodeRecord | null>;
+  getActivePubkey(
+    nodeId: string,
+    keyId: string,
+  ): Promise<ValidatorPubkeyRecord | null>;
+  listNodes(): Promise<ValidatorNodeRecord[]>;
+  upsertNode(input: {
+    id: string;
+    name: string;
+    rpcUrl: string;
+    operatorId?: string | null;
+    region?: string | null;
+    enabled?: boolean;
+  }): Promise<ValidatorNodeRecord>;
+  upsertPubkey(input: {
+    nodeId: string;
+    keyId: string;
+    publicKeyPem: string;
+    algorithm?: string;
+    active?: boolean;
+  }): Promise<ValidatorPubkeyRecord>;
+  retirePubkey(nodeId: string, keyId: string): Promise<boolean>;
+}
+
+/**
+ * Persisted per-(validator, key) high-water mark of the highest block height
+ * whose signed answer has already been served. This is what makes the
+ * anti-rollback check survive a restart and hold across replicas.
+ */
+export interface StateWatermarkStore {
+  get(
+    nodeId: string,
+    stateKey: string,
+  ): Promise<ValidatorStateWatermarkRecord | null>;
+  record(
+    nodeId: string,
+    stateKey: string,
+    blockHeight: number,
+    observedAt: Date,
+  ): Promise<ValidatorStateWatermarkRecord>;
+}
+
+const defaultRegistry: ValidatorRegistry = {
+  getNode: getValidatorNode,
+  getActivePubkey: getActiveValidatorPubkey,
+  listNodes: listValidatorNodes,
+  upsertNode: upsertValidatorNode,
+  upsertPubkey: upsertValidatorPubkey,
+  retirePubkey: retireValidatorPubkey,
+};
+
+const defaultWatermarks: StateWatermarkStore = {
+  get: getValidatorStateWatermark,
+  record: recordValidatorStateWatermark,
+};
+
+// ─── Validation ────────────────────────────────────────────────────────────────
+
+// Validator ids and keys are URL path params. Keep them conservative: the id
+// matches the registry id format; the key is any non-empty, reasonably-sized
+// string (the value namespace of the validator is opaque to us).
+const ValidatorIdSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[A-Za-z0-9._-]+$/, "invalid validator id");
+const KeyIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9._:-]+$/, "invalid key id");
+
+const ParamsSchema = z.object({
+  id: ValidatorIdSchema,
+  key: z.string().min(1).max(512),
+});
+
+/**
+ * A validator RPC endpoint the proxy will make outbound requests to. Restricted
+ * to http/https so an admin typo cannot turn the proxy into a file:// or
+ * gopher:// fetcher.
+ */
+const RpcUrlSchema = z
+  .string()
+  .min(1)
+  .max(512)
+  .refine((value) => {
+    try {
+      const parsed = new URL(value);
+      return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+      return false;
+    }
+  }, "rpcUrl must be an absolute http(s) URL");
+
+const RegisterNodeSchema = z
+  .object({
+    id: ValidatorIdSchema,
+    name: z.string().trim().min(1).max(255),
+    rpcUrl: RpcUrlSchema,
+    operatorId: z.string().trim().min(1).max(255).nullable().optional(),
+    region: z.string().trim().min(1).max(64).nullable().optional(),
+    enabled: z.boolean().optional(),
+  })
+  .strict();
+
+const RegisterPubkeySchema = z
+  .object({
+    keyId: KeyIdSchema,
+    publicKeyPem: z.string().min(1).max(8192),
+    // Only Ed25519 is verifiable by `verifySignedStateResponse`; accepting any
+    // other algorithm here would register a key that can never validate.
+    algorithm: z.literal("ed25519").optional(),
+  })
+  .strict();
+
+// ─── Freshness / anti-rollback policy ─────────────────────────────────────────
+
+/**
+ * How far in the past a validator's `observedAt` may be, and how far a clock may
+ * legitimately run ahead of ours. Deliberately tight: this endpoint reports what
+ * a node believes *right now*, so a minute-old answer is not useful and an
+ * unbounded window would make a captured response replayable forever if a nonce
+ * ever collided.
+ */
+const MAX_OBSERVATION_AGE_MS = 30_000;
+const MAX_FUTURE_SKEW_MS = 5_000;
+
+// ─── Per-operator rate limiting ─────────────────────────────────────────────────
+
+/**
+ * Extract the rate-limit bucket from a server-authenticated API-key identity.
+ * An arbitrary operator header must not let an unauthenticated caller rotate
+ * rate-limit buckets.
+ */
+export function operatorKeyExtractor(req: Request): string {
+  const apiKeyName = (req as { apiKeyName?: string }).apiKeyName;
+  if (apiKeyName) return `operator:${apiKeyName}`;
+  return `ip:${req.ip || "unknown"}`;
+}
+
+const stateQueryRateLimit = rateLimitMiddleware({
+  windowMs: 60_000,
+  maxRequests: 60,
+  keyExtractor: operatorKeyExtractor,
+});
+const requireNodeStateRead = requireControlPlaneAccess({
+  roles: ["operator"],
+});
+/**
+ * Registry writes decide which remote endpoints and which public keys this
+ * server will trust, so they are gated behind an explicit admin scope rather
+ * than plain operator access. `admin` / `*` keys satisfy this by construction.
+ */
+const requireValidatorAdmin = requireControlPlaneAccess({
+  roles: ["operator"],
+  scopes: ["validator.admin"],
+});
+
+// ─── Router factory ──────────────────────────────────────────────────────────
+
+export interface NodeRoutesDeps {
+  registry?: ValidatorRegistry;
+  client?: NodeRpcClient;
+  watermarks?: StateWatermarkStore;
+  /** Injectable clock so freshness bounds are testable without sleeping. */
+  now?: () => number;
+}
+
+/**
+ * Build the cross-node state router. Dependencies are injectable so the route
+ * can be integration-tested against a local fake node + in-memory registry.
+ */
+export function createNodeRoutes(deps: NodeRoutesDeps = {}): Router {
+  const router = Router();
+  const registry = deps.registry ?? defaultRegistry;
+  const client = deps.client ?? new NodeRpcClient();
+  const watermarks = deps.watermarks ?? defaultWatermarks;
+  const now = deps.now ?? (() => Date.now());
+
+  // Parse JSON bodies locally: this router must not depend on a body parser
+  // having been installed by whatever composition root mounts it.
+  router.use(express.json({ limit: "64kb" }));
+
+  // ── Registry (seeding) surface ─────────────────────────────────────────────
+
+  /** GET / — list registered validators. No key material is returned. */
+  router.get("/", requireNodeStateRead, async (_req: Request, res: Response) => {
+    try {
+      const nodes = await registry.listNodes();
+      return res.status(200).json({ nodes });
+    } catch (err) {
+      logger.error({ err: (err as Error).message }, "validator registry list failed");
+      return res.status(500).json({
+        error: "Failed to list validators",
+        code: "registry-error",
+      });
+    }
+  });
+
+  /**
+   * POST / — register or update a validator node.
+   *
+   * This is the supported seeding path: the registry ships empty on purpose (a
+   * migration cannot know your validator set), and an empty registry fails
+   * closed because every /state/:key read 404s with `unknown-validator`.
+   */
+  router.post("/", requireValidatorAdmin, async (req: Request, res: Response) => {
+    const parsed = RegisterNodeSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: "Invalid validator registration",
+        code: "invalid-body",
+        details: parsed.error.issues.map((i) => ({
+          path: i.path.join("."),
+          message: i.message,
+        })),
+      });
+    }
+
+    try {
+      const node = await registry.upsertNode(parsed.data);
+      logger.info(
+        { nodeId: node.id, by: controlPlanePrincipal(req).name },
+        "validator node registered",
+      );
+      return res.status(200).json({ node });
+    } catch (err) {
+      logger.error(
+        { err: (err as Error).message, nodeId: parsed.data.id },
+        "validator node registration failed",
+      );
+      return res.status(500).json({
+        error: "Failed to register validator",
+        code: "registry-error",
+      });
+    }
+  });
+
+  /**
+   * POST /:id/pubkeys — register (or rotate) the Ed25519 key whose signatures
+   * this server will accept from that validator.
+   */
+  router.post(
+    "/:id/pubkeys",
+    requireValidatorAdmin,
+    async (req: Request, res: Response) => {
+      const id = ValidatorIdSchema.safeParse(req.params.id);
+      if (!id.success) {
+        return res.status(400).json({
+          error: "Invalid validator id",
+          code: "invalid-params",
+        });
+      }
+
+      const parsed = RegisterPubkeySchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: "Invalid public key registration",
+          code: "invalid-body",
+          details: parsed.error.issues.map((i) => ({
+            path: i.path.join("."),
+            message: i.message,
+          })),
+        });
+      }
+
+      // Reject unusable key material at registration time rather than letting
+      // every later query fail with an opaque `malformed-pubkey`.
+      if (!parsePublicKeyPem(parsed.data.publicKeyPem)) {
+        return res.status(400).json({
+          error: "publicKeyPem is not a PEM-encoded Ed25519 SPKI public key",
+          code: "invalid-public-key",
+        });
+      }
+
+      try {
+        const node = await registry.getNode(id.data);
+        if (!node) {
+          const unknown = new UnknownValidatorError(id.data);
+          return res.status(404).json({
+            error: unknown.message,
+            code: unknown.code,
+            nodeId: id.data,
+          });
+        }
+
+        const pubkey = await registry.upsertPubkey({
+          nodeId: id.data,
+          keyId: parsed.data.keyId,
+          publicKeyPem: parsed.data.publicKeyPem,
+          algorithm: parsed.data.algorithm ?? "ed25519",
+          active: true,
+        });
+        logger.info(
+          {
+            nodeId: id.data,
+            keyId: pubkey.keyId,
+            by: controlPlanePrincipal(req).name,
+          },
+          "validator verification key registered",
+        );
+        return res.status(200).json({
+          nodeId: pubkey.nodeId,
+          keyId: pubkey.keyId,
+          algorithm: pubkey.algorithm,
+          active: pubkey.active,
+        });
+      } catch (err) {
+        logger.error(
+          { err: (err as Error).message, nodeId: id.data },
+          "validator key registration failed",
+        );
+        return res.status(500).json({
+          error: "Failed to register validator key",
+          code: "registry-error",
+        });
+      }
+    },
+  );
+
+  /** DELETE /:id/pubkeys/:keyId — retire a key so its signatures stop verifying. */
+  router.delete(
+    "/:id/pubkeys/:keyId",
+    requireValidatorAdmin,
+    async (req: Request, res: Response) => {
+      const params = z
+        .object({ id: ValidatorIdSchema, keyId: KeyIdSchema })
+        .safeParse(req.params);
+      if (!params.success) {
+        return res.status(400).json({
+          error: "Invalid request parameters",
+          code: "invalid-params",
+        });
+      }
+
+      try {
+        const retired = await registry.retirePubkey(
+          params.data.id,
+          params.data.keyId,
+        );
+        if (!retired) {
+          return res.status(404).json({
+            error: `No active key ${params.data.keyId} registered for validator ${params.data.id}`,
+            code: "no-matching-pubkey",
+            nodeId: params.data.id,
+            keyId: params.data.keyId,
+          });
+        }
+        logger.info(
+          {
+            nodeId: params.data.id,
+            keyId: params.data.keyId,
+            by: controlPlanePrincipal(req).name,
+          },
+          "validator verification key retired",
+        );
+        return res.status(200).json({
+          nodeId: params.data.id,
+          keyId: params.data.keyId,
+          active: false,
+        });
+      } catch (err) {
+        logger.error(
+          { err: (err as Error).message, nodeId: params.data.id },
+          "validator key retirement failed",
+        );
+        return res.status(500).json({
+          error: "Failed to retire validator key",
+          code: "registry-error",
+        });
+      }
+    },
+  );
+
+  // ── Signed cross-node read ─────────────────────────────────────────────────
+
+  /**
+   * GET /:id/state/:key
+   * Proxy a state query to validator `:id` and return its signed response after
+   * verifying the signature, the request freshness and the block-height
+   * high-water mark.
+   */
+  router.get(
+    "/:id/state/:key",
+    requireNodeStateRead,
+    stateQueryRateLimit,
+    async (req: Request, res: Response) => {
+    const parsed = ParamsSchema.safeParse(req.params);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: "Invalid request parameters",
+        code: "invalid-params",
+        details: parsed.error.issues.map((i) => ({ path: i.path.join("."), message: i.message })),
+      });
+    }
+    const { id, key } = parsed.data;
+
+    // 1. Resolve the validator before making any outbound request.
+    let node: ValidatorNodeRecord | null;
+    try {
+      node = await registry.getNode(id);
+    } catch (err) {
+      logger.error({ err: (err as Error).message, nodeId: id }, "validator registry lookup failed");
+      return res.status(500).json({ error: "Failed to resolve validator", code: "registry-error" });
+    }
+
+    if (!node || node.enabled === false) {
+      const unknown = new UnknownValidatorError(id);
+      return res.status(404).json({ error: unknown.message, code: unknown.code, nodeId: id });
+    }
+
+    // 2. Proxy the state query to the validator's RPC under a fresh challenge.
+    const nonce = randomBytes(16).toString("hex");
+    let signed: SignedStateResponse;
+    try {
+      signed = await client.getState(id, node.rpcUrl, key, nonce);
+    } catch (err) {
+      return handleClientError(err, res, id, key);
+    }
+
+    // 3. Resolve the exact active Ed25519 key named by the response. Selecting
+    // an arbitrary active key is unsafe during key rotation.
+    if (!signed.keyId || signed.keyId.length > 128) {
+      return res.status(502).json({
+        error: "Validator response did not identify a usable signing key",
+        code: "validator-key-id-missing",
+        nodeId: id,
+        key,
+      });
+    }
+
+    let pubkey: ValidatorPubkeyRecord | null;
+    try {
+      pubkey = await registry.getActivePubkey(id, signed.keyId);
+    } catch (err) {
+      logger.error(
+        { err: (err as Error).message, nodeId: id, keyId: signed.keyId },
+        "validator public-key lookup failed",
+      );
+      return res.status(500).json({
+        error: "Failed to resolve validator signing key",
+        code: "registry-error",
+      });
+    }
+
+    if (
+      !pubkey ||
+      pubkey.nodeId !== id ||
+      pubkey.keyId !== signed.keyId ||
+      pubkey.active !== true ||
+      pubkey.algorithm.toLowerCase() !== "ed25519"
+    ) {
+      return res.status(409).json({
+        error: `No matching active Ed25519 public key registered for validator ${id}`,
+        code: "no-matching-pubkey",
+        nodeId: id,
+        keyId: signed.keyId,
+      });
+    }
+
+    // 4. Verify integrity before returning any value.
+    const verdict = verifySignedStateResponse(signed, pubkey.publicKeyPem);
+    if (!verdict.valid) {
+      logger.warn(
+        { nodeId: id, key, reason: verdict.reason },
+        "validator state response failed signature verification",
+      );
+      // Proxied successfully but the payload is not trustworthy. 502 Bad Gateway
+      // with a distinct code so clients can distinguish from a transport error.
+      return res.status(502).json({
+        error: "Validator response failed signature verification",
+        code: "signature-invalid",
+        reason: verdict.reason,
+        nodeId: id,
+        key,
+      });
+    }
+
+    // 5. Verify request freshness: the signature must cover the challenge we
+    // just minted, and the observation must fall inside the skew window. A
+    // captured-and-replayed response fails the nonce check here.
+    const freshness = verifyStateResponseFreshness(signed, {
+      key,
+      nonce,
+      nowMs: now(),
+      maxAgeMs: MAX_OBSERVATION_AGE_MS,
+      maxFutureSkewMs: MAX_FUTURE_SKEW_MS,
+    });
+    if (!freshness.valid) {
+      logger.warn(
+        { nodeId: id, key, reason: freshness.reason },
+        "validator state response failed freshness verification",
+      );
+      return res.status(502).json({
+        error: "Validator response failed freshness verification",
+        code: "response-not-fresh",
+        reason: freshness.reason,
+        nodeId: id,
+        key,
+      });
+    }
+
+    // 6. Anti-rollback: never serve a height below one already accepted for
+    // this (validator, key). Equal heights are legitimate (the same block read
+    // twice); only a regression is refused.
+    let watermark: ValidatorStateWatermarkRecord | null;
+    try {
+      watermark = await watermarks.get(id, key);
+    } catch (err) {
+      logger.error(
+        { err: (err as Error).message, nodeId: id, key },
+        "state watermark lookup failed",
+      );
+      return res.status(503).json({
+        error: "Cannot verify state freshness: high-water mark unavailable",
+        code: "rollback-check-unavailable",
+        nodeId: id,
+        key,
+      });
+    }
+
+    if (watermark && signed.blockHeight < watermark.blockHeight) {
+      logger.warn(
+        {
+          nodeId: id,
+          key,
+          blockHeight: signed.blockHeight,
+          highestAcceptedBlockHeight: watermark.blockHeight,
+        },
+        "validator state response regressed below the accepted block height",
+      );
+      return res.status(502).json({
+        error: "Validator reported a block height below the highest already accepted",
+        code: "state-rollback",
+        reason: "block-height-regression",
+        nodeId: id,
+        key,
+        blockHeight: signed.blockHeight,
+        highestAcceptedBlockHeight: watermark.blockHeight,
+      });
+    }
+
+    // Persist the advanced mark BEFORE answering. If we cannot, a later
+    // rollback would go undetected, so fail closed rather than serve blind.
+    try {
+      await watermarks.record(
+        id,
+        key,
+        signed.blockHeight,
+        new Date(signed.observedAt),
+      );
+    } catch (err) {
+      logger.error(
+        { err: (err as Error).message, nodeId: id, key },
+        "state watermark persist failed",
+      );
+      return res.status(503).json({
+        error: "Cannot record state freshness: high-water mark not persisted",
+        code: "rollback-check-unavailable",
+        nodeId: id,
+        key,
+      });
+    }
+
+    // 7. Return the verified value + signature.
+    return res.status(200).json({
+      nodeId: id,
+      key: signed.key,
+      value: signed.value,
+      blockHeight: signed.blockHeight,
+      observedAt: signed.observedAt,
+      signature: signed.signature,
+      keyId: signed.keyId,
+      verified: true,
+    });
+    },
+  );
+
+  return router;
+}
+
+/** Map node-client errors onto distinct HTTP status codes + stable `code`s. */
+function handleClientError(err: unknown, res: Response, nodeId: string, key: string): Response {
+  if (err instanceof StateKeyNotFoundError) {
+    return res.status(404).json({ error: err.message, code: "key-not-found", nodeId, key });
+  }
+  if (err instanceof NodeTimeoutError) {
+    return res.status(504).json({ error: err.message, code: "validator-timeout", nodeId });
+  }
+  if (err instanceof NodeUnreachableError) {
+    return res.status(502).json({ error: err.message, code: "validator-unreachable", nodeId });
+  }
+  if (err instanceof StateProtocolVersionError) {
+    return res.status(502).json({
+      error: err.message,
+      code: err.code,
+      nodeId,
+      expectedProtocol: err.expectedProtocol,
+      incompatibleFields: err.incompatibleFields,
+    });
+  }
+  if (err instanceof NodeRpcError) {
+    return res.status(502).json({ error: err.message, code: "validator-rpc-error", nodeId, httpStatus: err.httpStatus });
+  }
+  logger.error({ err: (err as Error).message, nodeId, key }, "unexpected error proxying state query");
+  return res.status(502).json({ error: "Failed to query validator state", code: "validator-error", nodeId });
+}
+
+/** Default router instance for mounting in `server/routes.ts`. */
+export const nodeRoutes = createNodeRoutes();
+
+export default nodeRoutes;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -182,6 +182,36 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_control_module_instances_type_name
   ON control_module_instances(control_module_type_id, name);
 `;
 
+/**
+ * Validator registry tables for the development SQLite database (#454).
+ *
+ * Mirrors `migrations/0007_validator_registry.sql`. Without this the cross-node
+ * `/state/:key` proxy would only ever be usable against a hand-seeded Postgres,
+ * which was the reason the first attempt at this feature was rejected.
+ */
+const validatorRegistrySqliteSchema = `
+CREATE TABLE IF NOT EXISTS validator_nodes (
+  id TEXT PRIMARY KEY, name TEXT NOT NULL, rpc_url TEXT NOT NULL,
+  operator_id TEXT, region TEXT, enabled INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS validator_pubkeys (
+  id TEXT PRIMARY KEY, node_id TEXT NOT NULL REFERENCES validator_nodes(id) ON DELETE CASCADE,
+  algorithm TEXT NOT NULL DEFAULT 'ed25519', public_key_pem TEXT NOT NULL,
+  key_id TEXT NOT NULL, active INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL, retired_at INTEGER,
+  UNIQUE(node_id, key_id)
+);
+CREATE TABLE IF NOT EXISTS validator_state_watermarks (
+  id TEXT PRIMARY KEY, node_id TEXT NOT NULL REFERENCES validator_nodes(id) ON DELETE CASCADE,
+  state_key TEXT NOT NULL, block_height INTEGER NOT NULL,
+  observed_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+  UNIQUE(node_id, state_key)
+);
+CREATE INDEX IF NOT EXISTS idx_validator_pubkeys_node_active
+  ON validator_pubkeys(node_id, active);
+`;
+
 function toSnakeCase(value: string): string {
   return value.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 }
@@ -320,6 +350,7 @@ async function openSqliteDatabase(databasePath: string): Promise<void> {
     const client = new Database(databasePath, (error) => error ? reject(error) : resolve(client));
   });
   await sqliteExec(blueprintSqliteSchema);
+  await sqliteExec(validatorRegistrySqliteSchema);
 }
 
 export const initializeDatabase = async () => {
@@ -594,6 +625,377 @@ async function runStorageTransaction<T>(operation: () => Promise<T>): Promise<T>
     });
   });
 }
+
+// ─── Validator Registry Access (#454: Cross-Node State Queries) ────────────────
+// DB access goes through this module per repo conventions. These helpers back the
+// per-validator `/state/:key` proxy in `server/routes/nodes.ts`:
+//   * `validator_nodes`             — which validators exist and where their RPC is
+//   * `validator_pubkeys`           — the Ed25519 keys their responses are verified against
+//   * `validator_state_watermarks`  — per-(node, key) highest accepted block height
+//
+// Both the Postgres and the SQLite development database are implemented, so the
+// feature is usable without hand-seeding a Postgres instance. Every lookup is
+// fail-closed by construction: an unregistered node or an unregistered key
+// resolves to `null` and the route refuses to return validator data.
+
+export interface ValidatorNodeRecord {
+  id: string;
+  name: string;
+  rpcUrl: string;
+  operatorId?: string | null;
+  region?: string | null;
+  enabled: boolean;
+}
+
+export interface ValidatorPubkeyRecord {
+  nodeId: string;
+  algorithm: string;
+  publicKeyPem: string;
+  keyId: string;
+  active: boolean;
+}
+
+export interface ValidatorStateWatermarkRecord {
+  nodeId: string;
+  stateKey: string;
+  blockHeight: number;
+  observedAt: Date;
+}
+
+export interface UpsertValidatorNodeInput {
+  id: string;
+  name: string;
+  rpcUrl: string;
+  operatorId?: string | null;
+  region?: string | null;
+  enabled?: boolean;
+}
+
+export interface UpsertValidatorPubkeyInput {
+  nodeId: string;
+  keyId: string;
+  publicKeyPem: string;
+  algorithm?: string;
+  active?: boolean;
+}
+
+function toValidatorNodeRecord(row: Record<string, unknown>): ValidatorNodeRecord {
+  return {
+    id: String(row.id),
+    name: String(row.name),
+    rpcUrl: String(row.rpcUrl),
+    operatorId: (row.operatorId as string | null | undefined) ?? null,
+    region: (row.region as string | null | undefined) ?? null,
+    enabled: Boolean(row.enabled),
+  };
+}
+
+function toValidatorPubkeyRecord(row: Record<string, unknown>): ValidatorPubkeyRecord {
+  return {
+    nodeId: String(row.nodeId),
+    algorithm: String(row.algorithm),
+    publicKeyPem: String(row.publicKeyPem),
+    keyId: String(row.keyId),
+    active: Boolean(row.active),
+  };
+}
+
+/** Resolve a validator node by its registry id, or null if unknown. */
+export const getValidatorNode = async (id: string): Promise<ValidatorNodeRecord | null> => {
+  return withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      const rows = await sqliteAll(
+        'SELECT * FROM validator_nodes WHERE id = ? LIMIT 1',
+        [id],
+      );
+      const row = rows[0];
+      return row ? toValidatorNodeRecord(decodeSqliteRow(row)) : null;
+    }
+    const rows = await requireDatabase()
+      .select()
+      .from(schema.validatorNodes)
+      .where(eq(schema.validatorNodes.id, id))
+      .limit(1);
+    const row = rows[0] as Record<string, unknown> | undefined;
+    return row ? toValidatorNodeRecord(row) : null;
+  });
+};
+
+/** List every registered validator node (admin surface). */
+export const listValidatorNodes = async (): Promise<ValidatorNodeRecord[]> => {
+  return withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      const rows = await sqliteAll('SELECT * FROM validator_nodes ORDER BY id');
+      return rows.map((row) => toValidatorNodeRecord(decodeSqliteRow(row)));
+    }
+    const rows = await requireDatabase()
+      .select()
+      .from(schema.validatorNodes)
+      .orderBy(schema.validatorNodes.id);
+    return (rows as Record<string, unknown>[]).map(toValidatorNodeRecord);
+  });
+};
+
+/**
+ * Register (or update) a validator node. This is the seeding path for the
+ * cross-node state proxy — see `POST /api/nodes` in `server/routes/nodes.ts`.
+ */
+export const upsertValidatorNode = async (
+  input: UpsertValidatorNodeInput,
+): Promise<ValidatorNodeRecord> => {
+  const enabled = input.enabled ?? true;
+  const operatorId = input.operatorId ?? null;
+  const region = input.region ?? null;
+
+  return withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      const now = Date.now();
+      await sqliteRun(
+        `INSERT INTO validator_nodes (id, name, rpc_url, operator_id, region, enabled, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           name = excluded.name,
+           rpc_url = excluded.rpc_url,
+           operator_id = excluded.operator_id,
+           region = excluded.region,
+           enabled = excluded.enabled,
+           updated_at = excluded.updated_at`,
+        [input.id, input.name, input.rpcUrl, operatorId, region, enabled ? 1 : 0, now, now],
+      );
+      const rows = await sqliteAll('SELECT * FROM validator_nodes WHERE id = ?', [input.id]);
+      return toValidatorNodeRecord(decodeSqliteRow(rows[0]));
+    }
+
+    const [row] = await requireDatabase()
+      .insert(schema.validatorNodes)
+      .values({
+        id: input.id,
+        name: input.name,
+        rpcUrl: input.rpcUrl,
+        operatorId,
+        region,
+        enabled,
+      })
+      .onConflictDoUpdate({
+        target: schema.validatorNodes.id,
+        set: {
+          name: input.name,
+          rpcUrl: input.rpcUrl,
+          operatorId,
+          region,
+          enabled,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+    return toValidatorNodeRecord(row as Record<string, unknown>);
+  });
+};
+
+/**
+ * Resolve the active Ed25519 verification key a validator named in its response.
+ * Returns null when the (node, keyId) pair is unregistered, retired, or is not
+ * an Ed25519 key — all of which the route treats as "do not trust this answer".
+ */
+export const getActiveValidatorPubkey = async (
+  nodeId: string,
+  keyId: string,
+): Promise<ValidatorPubkeyRecord | null> => {
+  return withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      const rows = await sqliteAll(
+        `SELECT * FROM validator_pubkeys
+         WHERE node_id = ? AND key_id = ? AND active = 1 AND algorithm = 'ed25519'
+         LIMIT 1`,
+        [nodeId, keyId],
+      );
+      const row = rows[0];
+      return row ? toValidatorPubkeyRecord(decodeSqliteRow(row)) : null;
+    }
+    const rows = await requireDatabase()
+      .select()
+      .from(schema.validatorPubkeys)
+      .where(and(
+        eq(schema.validatorPubkeys.nodeId, nodeId),
+        eq(schema.validatorPubkeys.keyId, keyId),
+        eq(schema.validatorPubkeys.active, true),
+        eq(schema.validatorPubkeys.algorithm, 'ed25519'),
+      ))
+      .limit(1);
+    const row = rows[0] as Record<string, unknown> | undefined;
+    return row ? toValidatorPubkeyRecord(row) : null;
+  });
+};
+
+/** Register (or rotate) a validator verification key. */
+export const upsertValidatorPubkey = async (
+  input: UpsertValidatorPubkeyInput,
+): Promise<ValidatorPubkeyRecord> => {
+  const algorithm = input.algorithm ?? 'ed25519';
+  const active = input.active ?? true;
+
+  return withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      await sqliteRun(
+        `INSERT INTO validator_pubkeys (id, node_id, algorithm, public_key_pem, key_id, active, created_at, retired_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+         ON CONFLICT(node_id, key_id) DO UPDATE SET
+           algorithm = excluded.algorithm,
+           public_key_pem = excluded.public_key_pem,
+           active = excluded.active,
+           retired_at = NULL`,
+        [randomUUID(), input.nodeId, algorithm, input.publicKeyPem, input.keyId, active ? 1 : 0, Date.now()],
+      );
+      const rows = await sqliteAll(
+        'SELECT * FROM validator_pubkeys WHERE node_id = ? AND key_id = ?',
+        [input.nodeId, input.keyId],
+      );
+      return toValidatorPubkeyRecord(decodeSqliteRow(rows[0]));
+    }
+
+    const [row] = await requireDatabase()
+      .insert(schema.validatorPubkeys)
+      .values({
+        nodeId: input.nodeId,
+        algorithm,
+        publicKeyPem: input.publicKeyPem,
+        keyId: input.keyId,
+        active,
+      })
+      .onConflictDoUpdate({
+        target: [schema.validatorPubkeys.nodeId, schema.validatorPubkeys.keyId],
+        set: {
+          algorithm,
+          publicKeyPem: input.publicKeyPem,
+          active,
+          retiredAt: null,
+        },
+      })
+      .returning();
+    return toValidatorPubkeyRecord(row as Record<string, unknown>);
+  });
+};
+
+/** Retire a validator key so its signatures stop being accepted. */
+export const retireValidatorPubkey = async (
+  nodeId: string,
+  keyId: string,
+): Promise<boolean> => {
+  return withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      const rows = await sqliteAll(
+        'SELECT id FROM validator_pubkeys WHERE node_id = ? AND key_id = ? AND active = 1',
+        [nodeId, keyId],
+      );
+      if (rows.length === 0) return false;
+      await sqliteRun(
+        'UPDATE validator_pubkeys SET active = 0, retired_at = ? WHERE node_id = ? AND key_id = ?',
+        [Date.now(), nodeId, keyId],
+      );
+      return true;
+    }
+    const updated = await requireDatabase()
+      .update(schema.validatorPubkeys)
+      .set({ active: false, retiredAt: new Date() })
+      .where(and(
+        eq(schema.validatorPubkeys.nodeId, nodeId),
+        eq(schema.validatorPubkeys.keyId, keyId),
+        eq(schema.validatorPubkeys.active, true),
+      ))
+      .returning();
+    return (updated as unknown[]).length > 0;
+  });
+};
+
+/**
+ * Highest block height already accepted for `(nodeId, stateKey)`, or null when
+ * this pair has never been queried. Used as the anti-rollback high-water mark.
+ */
+export const getValidatorStateWatermark = async (
+  nodeId: string,
+  stateKey: string,
+): Promise<ValidatorStateWatermarkRecord | null> => {
+  return withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      const rows = await sqliteAll(
+        'SELECT * FROM validator_state_watermarks WHERE node_id = ? AND state_key = ? LIMIT 1',
+        [nodeId, stateKey],
+      );
+      const row = rows[0];
+      if (!row) return null;
+      return {
+        nodeId: String(row.node_id),
+        stateKey: String(row.state_key),
+        blockHeight: Number(row.block_height),
+        observedAt: new Date(Number(row.observed_at)),
+      };
+    }
+    const rows = await requireDatabase()
+      .select()
+      .from(schema.validatorStateWatermarks)
+      .where(and(
+        eq(schema.validatorStateWatermarks.nodeId, nodeId),
+        eq(schema.validatorStateWatermarks.stateKey, stateKey),
+      ))
+      .limit(1);
+    const row = rows[0] as Record<string, unknown> | undefined;
+    if (!row) return null;
+    return {
+      nodeId: String(row.nodeId),
+      stateKey: String(row.stateKey),
+      blockHeight: Number(row.blockHeight),
+      observedAt: new Date(row.observedAt as string | number | Date),
+    };
+  });
+};
+
+/**
+ * Advance the `(nodeId, stateKey)` high-water mark to `blockHeight`, but never
+ * lower it. The conditional `ON CONFLICT ... WHERE` makes the compare-and-set
+ * atomic in the database, so concurrent server replicas sharing one database
+ * cannot race the mark backwards. Returns the mark in force after the write.
+ */
+export const recordValidatorStateWatermark = async (
+  nodeId: string,
+  stateKey: string,
+  blockHeight: number,
+  observedAt: Date,
+): Promise<ValidatorStateWatermarkRecord> => {
+  await withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      await sqliteRun(
+        `INSERT INTO validator_state_watermarks (id, node_id, state_key, block_height, observed_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(node_id, state_key) DO UPDATE SET
+           block_height = excluded.block_height,
+           observed_at = excluded.observed_at,
+           updated_at = excluded.updated_at
+         WHERE validator_state_watermarks.block_height < excluded.block_height`,
+        [randomUUID(), nodeId, stateKey, blockHeight, observedAt.getTime(), Date.now()],
+      );
+      return;
+    }
+    if (!pgClient) throw new Error('PostgreSQL client is not initialized');
+    await pgClient.query(
+      `INSERT INTO validator_state_watermarks (node_id, state_key, block_height, observed_at, updated_at)
+       VALUES ($1, $2, $3, $4, NOW())
+       ON CONFLICT (node_id, state_key) DO UPDATE SET
+         block_height = EXCLUDED.block_height,
+         observed_at = EXCLUDED.observed_at,
+         updated_at = NOW()
+       WHERE validator_state_watermarks.block_height < EXCLUDED.block_height`,
+      [nodeId, stateKey, blockHeight, observedAt.toISOString()],
+    );
+  });
+
+  const current = await getValidatorStateWatermark(nodeId, stateKey);
+  if (!current) {
+    throw new Error(
+      `Watermark for ${nodeId}/${stateKey} disappeared immediately after being written`,
+    );
+  }
+  return current;
+};
 
 // Export storage object as expected by health/index.ts
 export const storage = {

--- a/shared/__tests__/schema-parity.test.ts
+++ b/shared/__tests__/schema-parity.test.ts
@@ -1,21 +1,33 @@
 import { describe, it, expect } from 'vitest';
 import { getTableColumns, getTableName } from 'drizzle-orm';
 import type { Table } from 'drizzle-orm';
-import { alarms as pgAlarms, alarmHistory as pgAlarmHistory } from '../schema';
+import {
+  alarms as pgAlarms,
+  alarmHistory as pgAlarmHistory,
+  validatorNodes as pgValidatorNodes,
+  validatorPubkeys as pgValidatorPubkeys,
+  validatorStateWatermarks as pgValidatorStateWatermarks,
+} from '../schema';
 import {
   alarms as sqliteAlarms,
   alarmHistory as sqliteAlarmHistory,
+  validatorNodes as sqliteValidatorNodes,
+  validatorPubkeys as sqliteValidatorPubkeys,
+  validatorStateWatermarks as sqliteValidatorStateWatermarks,
 } from '../schema-sqlite';
 
 /**
  * Schema parity (issue #7): `shared/schema.ts` (Postgres, source of truth) and
- * `shared/schema-sqlite.ts` (dev-mode fallback) must define the same alarm
- * tables. Column *types* legitimately differ per dialect (pgEnum → text,
- * jsonb → text, timestamptz → integer), but the table names, property keys,
- * and SQL column names must match so alarm-touching code behaves the same in
- * dev SQLite as in production Postgres. If either schema adds, drops, or
- * renames an alarm column without the other, this suite fails instead of the
+ * `shared/schema-sqlite.ts` (dev-mode fallback) must define the same tables.
+ * Column *types* legitimately differ per dialect (pgEnum → text, jsonb → text,
+ * timestamptz → integer, bigint → integer), but the table names, property keys,
+ * and SQL column names must match so the code that touches them behaves the
+ * same in dev SQLite as in production Postgres. If either schema adds, drops,
+ * or renames a column without the other, this suite fails instead of the
  * divergence surfacing as a silent no-op at runtime.
+ *
+ * Covers the alarm tables (#7) and the validator registry backing the
+ * cross-node state proxy (#454).
  */
 
 const sqlColumnNames = (table: Table): string[] =>
@@ -29,9 +41,16 @@ const propertyKeys = (table: Table): string[] =>
 const cases = [
   { name: 'alarms', pg: pgAlarms, sqlite: sqliteAlarms },
   { name: 'alarm_history', pg: pgAlarmHistory, sqlite: sqliteAlarmHistory },
+  { name: 'validator_nodes', pg: pgValidatorNodes, sqlite: sqliteValidatorNodes },
+  { name: 'validator_pubkeys', pg: pgValidatorPubkeys, sqlite: sqliteValidatorPubkeys },
+  {
+    name: 'validator_state_watermarks',
+    pg: pgValidatorStateWatermarks,
+    sqlite: sqliteValidatorStateWatermarks,
+  },
 ] as const;
 
-describe('alarm schema parity (Postgres vs SQLite dev fallback)', () => {
+describe('schema parity (Postgres vs SQLite dev fallback)', () => {
   for (const { name, pg, sqlite } of cases) {
     describe(name, () => {
       it('uses the same SQL table name', () => {

--- a/shared/schema-sqlite.ts
+++ b/shared/schema-sqlite.ts
@@ -290,6 +290,47 @@ export const alarmHistory = sqliteTable("alarm_history", {
   createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
 });
 
+// ─── Validator Registry (#454) ───────────────────────────────────────────────
+// Dev-mode parity with the Postgres schema (`shared/schema.ts`) for the
+// cross-node `/state/:key` proxy. timestamptz → integer timestamp, boolean →
+// integer(mode boolean), bigint → integer, following this file's conventions.
+// The development database is created from the matching DDL in
+// `server/storage.ts` (`validatorRegistrySqliteSchema`); these declarations pin
+// the column contract against Postgres via
+// `shared/__tests__/schema-parity.test.ts`, and every column is exercised
+// against the live dev database by `server/__tests__/validator-registry.test.ts`.
+
+export const validatorNodes = sqliteTable("validator_nodes", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  rpcUrl: text("rpc_url").notNull(),
+  operatorId: text("operator_id"),
+  region: text("region"),
+  enabled: integer("enabled", { mode: "boolean" }).default(true).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+});
+
+export const validatorPubkeys = sqliteTable("validator_pubkeys", {
+  id: text("id").primaryKey(),
+  nodeId: text("node_id").notNull(),
+  algorithm: text("algorithm").default("ed25519").notNull(),
+  publicKeyPem: text("public_key_pem").notNull(),
+  keyId: text("key_id").notNull(),
+  active: integer("active", { mode: "boolean" }).default(true).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+  retiredAt: integer("retired_at", { mode: "timestamp" }),
+});
+
+export const validatorStateWatermarks = sqliteTable("validator_state_watermarks", {
+  id: text("id").primaryKey(),
+  nodeId: text("node_id").notNull(),
+  stateKey: text("state_key").notNull(),
+  blockHeight: integer("block_height").notNull(),
+  observedAt: integer("observed_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+});
+
 // Basic exports for compatibility
 export const insertSiteSchema = {
   parse: (data: any) => data // Simple pass-through for development

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -23,6 +23,7 @@ import {
   timestamp,
   boolean,
   integer,
+  bigint,
   real,
   jsonb,
   pgEnum,
@@ -543,6 +544,74 @@ export const controllers = pgTable("controllers", {
   vendorIdx: index("idx_controllers_vendor").on(table.vendorId),
 }));
 
+// ─── Validator Nodes & Pubkeys (#454: Cross-Node State Queries) ───────────────
+// Additive — these tables back the per-validator /state/:key proxy so the server
+// can resolve a validator's RPC endpoint and verify its signed responses against
+// a registered public key before returning them to the operator.
+
+export const validatorNodes = pgTable("validator_nodes", {
+  // Human/operator-facing node id used in the URL (e.g. "validator-2").
+  id: varchar("id", { length: 64 }).primaryKey(),
+  name: varchar("name", { length: 255 }).notNull(),
+  // Base URL of the oxscada RPC endpoint, e.g. "http://10.0.0.12:9090"
+  // (see docs/blockchain/validator-monitoring.md for the node RPC surface).
+  rpcUrl: varchar("rpc_url", { length: 512 }).notNull(),
+  // Owning operator, for inventory/reporting. NOT the rate-limit bucket: state
+  // reads are bucketed by the caller's authenticated API-key identity, which is
+  // a property of the requester rather than of the validator being queried.
+  operatorId: varchar("operator_id", { length: 255 }),
+  region: varchar("region", { length: 64 }),
+  enabled: boolean("enabled").default(true).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  operatorIdIdx: index("idx_validator_nodes_operator_id").on(table.operatorId),
+  enabledIdx: index("idx_validator_nodes_enabled").on(table.enabled),
+}));
+
+export const validatorPubkeys = pgTable("validator_pubkeys", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  nodeId: varchar("node_id", { length: 64 }).notNull().references(() => validatorNodes.id, { onDelete: "cascade" }),
+  // Signature scheme of the registered key. Default is ed25519 (node:crypto).
+  algorithm: varchar("algorithm", { length: 32 }).default("ed25519").notNull(),
+  // PEM-encoded SPKI public key (one row per active/rotated key).
+  publicKeyPem: text("public_key_pem").notNull(),
+  // Short fingerprint identifying which key the validator signed with. Required:
+  // the proxy resolves the exact key named by the response so a rotated-out key
+  // can never be substituted for the active one.
+  keyId: varchar("key_id", { length: 128 }).notNull(),
+  active: boolean("active").default(true).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  retiredAt: timestamp("retired_at", { withTimezone: true }),
+}, (table) => ({
+  nodeIdIdx: index("idx_validator_pubkeys_node_id").on(table.nodeId),
+  nodeActiveIdx: index("idx_validator_pubkeys_node_active").on(table.nodeId, table.active),
+  nodeKeyIdIdx: uniqueIndex("idx_validator_pubkeys_node_key_id").on(table.nodeId, table.keyId),
+}));
+
+/**
+ * Per-(validator, state key) high-water mark of the highest block height the
+ * server has ever accepted a signed answer for.
+ *
+ * This is the persisted half of the anti-rollback check in
+ * `server/routes/nodes.ts`: a validator that answers a *fresh* challenge but
+ * reports a block height below the mark is serving a rolled-back view of state,
+ * and the proxy refuses to hand it to an operator. Persisting the mark (rather
+ * than keeping it in process memory) is what makes the check survive restarts
+ * and hold across server replicas sharing one database.
+ */
+export const validatorStateWatermarks = pgTable("validator_state_watermarks", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  nodeId: varchar("node_id", { length: 64 }).notNull().references(() => validatorNodes.id, { onDelete: "cascade" }),
+  // Named `state_key` rather than `key` to avoid quoting a SQL keyword.
+  stateKey: varchar("state_key", { length: 512 }).notNull(),
+  blockHeight: bigint("block_height", { mode: "number" }).notNull(),
+  observedAt: timestamp("observed_at", { withTimezone: true }).notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  nodeKeyIdx: uniqueIndex("idx_validator_state_watermarks_node_key").on(table.nodeId, table.stateKey),
+}));
+
 // ─── Schema Exports ──────────────────────────────────────────────────────────
 
 // Insert schemas for validation
@@ -562,6 +631,9 @@ export const insertDesignSpecificationSchema = createInsertSchema(designSpecific
 export const insertGeneratedCodeSchema = createInsertSchema(generatedCode);
 export const insertDataTypeMappingSchema = createInsertSchema(dataTypeMappings);
 export const insertControllerSchema = createInsertSchema(controllers);
+export const insertValidatorNodeSchema = createInsertSchema(validatorNodes);
+export const insertValidatorPubkeySchema = createInsertSchema(validatorPubkeys);
+export const insertValidatorStateWatermarkSchema = createInsertSchema(validatorStateWatermarks);
 
 // Type exports
 export type Site = typeof sites.$inferSelect;
@@ -596,3 +668,9 @@ export type DataTypeMapping = typeof dataTypeMappings.$inferSelect;
 export type InsertDataTypeMapping = typeof dataTypeMappings.$inferInsert;
 export type Controller = typeof controllers.$inferSelect;
 export type InsertController = typeof controllers.$inferInsert;
+export type ValidatorNode = typeof validatorNodes.$inferSelect;
+export type ValidatorPubkey = typeof validatorPubkeys.$inferSelect;
+export type ValidatorStateWatermark = typeof validatorStateWatermarks.$inferSelect;
+export type InsertValidatorNode = typeof validatorNodes.$inferInsert;
+export type InsertValidatorPubkey = typeof validatorPubkeys.$inferInsert;
+export type InsertValidatorStateWatermark = typeof validatorStateWatermarks.$inferInsert;


### PR DESCRIPTION
> Supersedes the stale draft #527, which was opened against a `main` that has since moved 73 commits and is now conflicting. This branch is built on current `main` and fixes the defect that draft left open.

Closes #454. Rebuilds the wave:2a cross-node state slice on current main and fixes the two blockers from the review of #514.

## What was wrong

The previous slice delivered real Ed25519 verification (domain-separated canonical message, pubkey from the DB registry, verified before returning), but:

1. **No replay/freshness protection.** The signature covered only `(key, value, blockHeight)` — no nonce, no timestamp — and the route never checked monotonicity, so a captured signed response could be replayed indefinitely.
2. **Non-functional outside a seeded Postgres.** `validator_nodes` / `validator_pubkeys` had DDL but no seed path at all.

## Replay / freshness

`GET /api/nodes/:id/state/:key` still resolves the Ed25519 key by the exact `keyId` the response names, from the DB registry (never the payload), and verifies the signature **before** anything is returned. On top of that the answer must now survive:

| Check | Failure |
|---|---|
| Signed nonce equals the 16 random bytes the server minted for *this* request | 502 `response-not-fresh` / `nonce-mismatch` |
| `observedAt` inside `[now-30s, now+5s]` | 502 `response-not-fresh` / `stale-response` \| `future-response` |
| `blockHeight` is a safe, non-negative integer | 502 `validator-rpc-error` |
| `blockHeight` not below the persisted per-`(node, key)` high-water mark | 502 `state-rollback` / `block-height-regression` |
| High-water mark readable **and** writable | 503 `rollback-check-unavailable` (fail closed) |

Canonical message is now `oxscada-state-v2\n<key>\n<blockHeight>\n<nonce>\n<observedAt>\n<canonicalJson(value)>`. `NodeRpcClient.getState` requires a non-empty nonce so the challenge cannot be dropped by accident. Equal block heights are still served — the same block read twice is legitimate; only a regression is refused, and a refused answer never lowers the mark.

The block-height shape check matters more than it looks: `typeof x === "number"` alone would admit a signed `NaN`, and `NaN < mark` is false, so a rolled-back view would sail through the rollback gate; `Infinity` or `1e308` would pin the mark at a height no honest validator can reach again. Both are refused at the transport boundary.

The new `validator_state_watermarks` table is advanced with a conditional `INSERT .. ON CONFLICT (node_id, state_key) DO UPDATE .. WHERE existing.block_height < EXCLUDED.block_height`, so the compare-and-set is atomic in the database and concurrent replicas cannot race the mark backwards.

### Honest scope note — read this before merging

The nonce round-trip has a producer half that lives in the oxscada validator (`0xSCADA-node`), **not in this repository** — there is no Go/Rust node source here to change. The node must read `?nonce=`, sign it with its own `observedAt`, and echo both. Rather than pretend a nonce is enforced against a node that never echoes it, `NodeRpcClient` rejects a v1-shaped response with `state-protocol-incompatible` (502) and returns no value. Note this is not merely a policy choice: a v1 body carries neither `nonce` nor `observedAt`, so *no* freshness property could be derived from it even if we wanted to downgrade gracefully. **Consequence: until a node ships v2, this endpoint returns 502 against real hardware rather than data.** The timestamp window and the block-height high-water mark are enforced regardless of what the node ships. Spelled out in `server/blockchain/state-signature.ts`, `server/routes/nodes.ts` and the new doc.

## Seeding

`migrations/0007_validator_registry.sql` (renumbered off the `0003` slot main now uses; `meta/_journal.json` updated) creates the tables and **inserts no rows on purpose** — a hard-coded validator set would be a silent trust decision baked into the schema. An empty registry fails closed: every read is `404 unknown-validator`.

Registration is explicit and admin-authenticated through the existing `requireControlPlaneAccess`:

| Method | Path | Access |
|---|---|---|
| `GET` | `/api/nodes` | operator |
| `POST` | `/api/nodes` | `validator.admin` |
| `POST` | `/api/nodes/:id/pubkeys` | `validator.admin` |
| `DELETE` | `/api/nodes/:id/pubkeys/:keyId` | `validator.admin` |
| `GET` | `/api/nodes/:id/state/:key` | operator |

`rpcUrl` is restricted to http/https. Key material is rejected at registration time unless it parses as a PEM SPKI Ed25519 key. `server/storage.ts` implements the registry and watermark helpers for **both** Postgres and the development SQLite database, so this works — and is tested — with no hand-seeded Postgres.

## Tests

No storage mocks.

- `server/__tests__/cross-node-state.test.ts` — makes one genuine request, captures the node's real signed body, replays it verbatim, and asserts it is rejected even though the signature is still valid; out-of-window and future timestamps; block-height regression with the mark unchanged; NaN/Infinity/negative/fractional/oversized block heights; equal height and per-key independence; watermark store failing on read and on write both fail closed; unreachable / timeout / 404 / 409 / 429 taxonomy.
- `server/__tests__/validator-registry.test.ts` — production wiring (`createNodeRoutes()` with no injected deps) against a real in-memory SQLite DB and a real local validator: empty registry fails closed → operator cannot seed → admin seeds → signed read works → mark persisted → regression refused → storage CAS refuses to lower it → retiring the key fails closed again.
- `shared/__tests__/schema-parity.test.ts` extended from 2 to 5 tables.

## Conflict resolution against main

`control-plane-auth.ts` and `api-gateway.ts` take main's #576 versions verbatim (the slice carried an older, weaker copy of the same guard) — neither file appears in the diff. `shared/schema.ts` and `server/storage.ts` keep main's blueprint-persistence work in full and append the validator tables/helpers alongside it. `.env.example` merges both key-scope notes.

## Verification

`npx tsc --noEmit` exits 0. `npx vitest run`: **97 files passed / 2 skipped, 2106 tests passed / 5 skipped** (baseline 95 files / 2024 passing with the same skips). No conflict markers remain anywhere in the tree.

## Known follow-ups (not addressed here)

- The high-water mark only ever rises, with no expiry or admin reset. A validator legitimately resynced below its previous height will keep returning `state-rollback` for that `(node, key)` until the row is cleared. A reset route is a privileged way to weaken the check, so its shape is left to a maintainer.
- The Postgres paths (drizzle upserts, the raw compare-and-set, migration 0007) are typechecked but unexecuted — there is no Postgres in CI here. The SQLite equivalents are covered by real tests.
- `rpcUrl` is http/https-restricted but has no private-IP denylist, and `fetch` follows redirects. Admin-gated and nothing unsigned is ever returned, but worth hardening.

Docs: `docs/blockchain/cross-node-state-queries.md`.
---

**Migration numbering — cross-PR coordination.** This branch adds its migration as `0007_*` because that
was the next free slot on `main` (which has `0001`, `0002`, `0003_blueprint_persistence`,
`0006_blueprint_instance_identity`). Two sibling PRs in this batch also add a `0007_*` migration:
`0007_validator_registry` (#454), `0007_blueprint_safe_state_log` (#459) and `0007_modbus_register_map`
(#462). They are independent and each is self-consistent, but whichever merges second and third will need
renumbering plus a `migrations/meta/_journal.json` update. Flagging it here rather than guessing a merge
order.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
