### PR TITLE
fix(scheduler): tick-aware SCHED_FIFO as explicit opt-in, fail-soft on bad env (#458)

### DIFF
--- a/docs/operations/preempt-rt.md
+++ b/docs/operations/preempt-rt.md
@@ -1,0 +1,313 @@
+# Enabling PREEMPT_RT for the Tick-Aware Scheduler
+
+The 0xSCADA scheduler can pin an explicitly identified, dedicated control
+process to real-time scheduling (`SCHED_FIFO`) so that ticks meet a
+deterministic budget. It never elevates the Express process implicitly. The
+real-time path also requires a kernel built with **PREEMPT_RT** (the
+fully-preemptible real-time patch set, mainlined as of Linux 6.12).
+
+**Real-time scheduling is off by default.** Three independent conditions must
+all hold before a single privileged call is made:
+
+1. `OXSCADA_RT_ENABLED=true` is set (explicit operator opt-in), **and**
+2. a composition root calls `applyScheduler()` with the PID of a *separate*
+   control process, **and**
+3. the host is PREEMPT_RT with `chrt(1)` available.
+
+If any of those is missing — or if any `OXSCADA_RT_*` value is malformed — the
+scheduler stays in `fallback`, skips the privileged call entirely, logs one
+warning, and reports the held posture in `/health`.
+
+> **Safety note.** Nothing applies scheduling as an import side effect.
+> `SCHED_FIFO` is starvation-capable: pinning the process that serves
+> Express/WebSocket would let a hot loop starve the rest of the box. The
+> scheduler refuses `pid === process.pid` outright, so an in-process control
+> loop can never elevate the API server. As long as the control loop shares the
+> API server's process (the current deployment shape) `fallback` is the correct
+> and expected result, and `/health` says so.
+
+This document explains how to put a target host into `realtime` mode.
+
+---
+
+## TL;DR
+
+```bash
+# 1. Boot a PREEMPT_RT kernel (see per-distro instructions below).
+uname -v | grep -q PREEMPT_RT && echo "RT kernel ✓" || echo "stock kernel ✗"
+
+# 2. Run the control loop in a process separate from the API server.
+# The composition root must retain its PID and call:
+# applyScheduler({ kind: "dedicated-control-process", pid: controlPid })
+
+# 3. Confirm chrt(1) is present (util-linux). The scheduler shells out to it.
+command -v chrt
+
+# 4. Explicitly opt in, then grant only the dedicated process RT capability.
+export OXSCADA_RT_ENABLED=true
+
+# 5. Verify. Until a dedicated control-process composition root exists,
+# fallback is the expected, honest result.
+curl -s localhost:5000/api/health | jq '.services[] | select(.name=="scheduler")'
+# → status:"healthy", details.schedulingMode:"fallback", details.applied:false
+```
+
+---
+
+## How the scheduler decides
+
+`server/blueprint/scheduler.ts` runs capability detection in this order:
+
+1. **Platform** — not Linux ⇒ always `fallback`.
+2. **`/sys/kernel/realtime`** — if it reads `1`, the kernel is authoritatively
+   PREEMPT_RT.
+3. **`uname`** — version/release string contains `PREEMPT_RT` (or a legacy
+   `-rtN` tag).
+4. **`/sys/kernel/debug/sched/preempt`** — active preemption model is `(rt)`.
+
+Detection only runs **after** the opt-in check passes: an opted-out or
+misconfigured deployment does not even read `/sys`. If any of (2)–(4) is
+positive, `chrt(1)` is available, explicit opt-in is set, and the caller supplies
+a valid PID different from the calling process, the scheduler applies
+`SCHED_FIFO` to that dedicated process at the configured priority (default
+**50**). Missing or malformed configuration, a missing dedicated target, the
+calling process's own PID, or an apply failure all produce a safe fallback
+instead of crashing or elevating the control plane.
+
+`chrt -p <pid>` changes the policy of a whole process. A future native binding
+may target an individual control thread, but the current contract is
+intentionally limited to a separate process.
+
+### Configuration
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `OXSCADA_RT_ENABLED` | unset (`fallback`) | `true`/`1` opts in; a dedicated process PID is still required. Any other value is treated as *disabled* and reported. |
+| `OXSCADA_RT_PRIORITY` | `50` | SCHED_FIFO priority, integer 1–99 (higher = more urgent). |
+| `OXSCADA_RT_POLICY` | `SCHED_FIFO` | `SCHED_FIFO`, `SCHED_RR`, or `SCHED_OTHER`. |
+
+Parsing is strict on purpose: `OXSCADA_RT_PRIORITY` must be a plain decimal
+integer inside `[1, 99]`. Empty, non-numeric, fractional, out-of-range,
+exponent (`1e2`) and hex (`0x40`) values are all **rejected** rather than
+silently coerced into a plausible-looking priority. A rejected value is logged
+once with a clear message and the process continues under normal scheduling —
+it never aborts startup. The same holds for an unknown `OXSCADA_RT_POLICY` or a
+non-boolean `OXSCADA_RT_ENABLED`.
+
+Priority **50** matches `CONFIG_OXSCADA_RT_PRIORITY` in `kernel/Kconfig.oxscada`
+and deliberately leaves headroom below kernel threads (e.g. `ksoftirqd`,
+network IRQ threads) that typically run at 80–99.
+
+### Where scheduling gets applied
+
+`server/blueprint/scheduler.ts` exposes exactly one entry point that can make a
+privileged call:
+
+```ts
+import { applyScheduler } from "./server/blueprint";
+
+// Only from a composition root that owns a SEPARATE control process:
+const status = applyScheduler({ kind: "dedicated-control-process", pid: controlPid });
+if (status.mode !== "realtime") log.warn(status.error);
+```
+
+`BlueprintTickLoop` (`server/blueprint/tick-loop.ts`) accepts the same
+target as an option and forwards it at `start()`. Its `TickFn` seam is what the
+deterministic runtime from #457 plugs into:
+
+```ts
+const loop = new BlueprintTickLoop({ blueprintId: bp.id, periodMs: 10 });
+loop.setTickFn(() => runtime.tickFast());
+loop.start();
+```
+
+Not to be confused with `BlueprintControlLoop` (`server/blueprint/control-loop.ts`,
+#457): that is the gated production *host* composed into `server/index.ts`, which
+loads a definition from disk and arms a plain `setInterval` inside the API server
+process. It deliberately does not take a scheduler target — the API process must
+never be pinned to `SCHED_FIFO`. `BlueprintTickLoop` is the timing/telemetry
+wrapper a future dedicated control process would use instead.
+
+No module — including `server/health` — applies scheduling on import.
+
+---
+
+## Per-distribution: installing a PREEMPT_RT kernel
+
+### Debian / Ubuntu
+
+Recent Debian (12+) and Ubuntu (24.04+) ship RT-enabled kernels:
+
+```bash
+# Debian 12+: the "rt" flavour from the standard archive.
+sudo apt-get update
+sudo apt-get install linux-image-rt-amd64
+
+# Ubuntu (Ubuntu Pro real-time kernel):
+sudo pro attach <token>
+sudo pro enable realtime-kernel
+```
+
+Reboot, then verify:
+
+```bash
+uname -v          # expect: "... SMP PREEMPT_RT ..."
+cat /sys/kernel/realtime 2>/dev/null   # expect: 1 (on kernels that export it)
+```
+
+### RHEL / Rocky / AlmaLinux
+
+Use the Real Time variant (CodeReady Builder / the `rt` repo):
+
+```bash
+sudo subscription-manager repos --enable rhel-9-for-x86_64-rt-rpms   # RHEL
+sudo dnf groupinstall RT
+sudo grub2-set-default 0   # ensure the kernel-rt entry boots
+sudo reboot
+```
+
+`tuned-profiles-realtime` + the `realtime` tuned profile is recommended:
+
+```bash
+sudo dnf install tuned-profiles-realtime
+sudo tuned-adm profile realtime
+```
+
+### Building from source (any distro)
+
+```bash
+# Mainline >= 6.12 has PREEMPT_RT in-tree. For older trees, apply the patch:
+#   https://wiki.linuxfoundation.org/realtime/start
+make menuconfig
+#   General setup → Preemption Model → "Fully Preemptible Kernel (Real-Time)"
+#   (CONFIG_PREEMPT_RT=y)
+make -j"$(nproc)" && sudo make modules_install install
+sudo reboot
+```
+
+`kernel/Kconfig.oxscada` documents the matching 0xSCADA kernel options
+(`CONFIG_OXSCADA_RT`, `CONFIG_OXSCADA_RT_PRIORITY`) for the in-tree driver path.
+
+---
+
+## Granting real-time scheduling rights (no runtime root)
+
+`SCHED_FIFO` requires `CAP_SYS_NICE` and a sufficient `RLIMIT_RTPRIO`. Grant
+those only to the future dedicated control-process unit, not the API server:
+
+```ini
+# /etc/systemd/system/oxscada-control.service
+[Service]
+ExecStart=/usr/bin/node /opt/oxscada/dist/control-process.js
+# Allow the service to set RT priorities up to 99 without root.
+AmbientCapabilities=CAP_SYS_NICE
+LimitRTPRIO=99
+# Pin to isolated/housekeeping-free CPUs for the lowest jitter (optional).
+# CPUAffinity=2 3
+Environment=OXSCADA_RT_PRIORITY=50
+Environment=OXSCADA_RT_ENABLED=true
+```
+
+`dist/control-process.js` does **not exist yet** — it is the composition root
+that would own a dedicated control process, call `applyScheduler()` with its own
+child/worker PID, and drive `BlueprintTickLoop`. Do not deploy this unit
+until that executable and its verified field-I/O binding exist. Until then the
+scheduler is a mechanism with no production caller and `/health` correctly
+reports `fallback`.
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart oxscada-control
+```
+
+For non-systemd hosts, grant rtprio via `/etc/security/limits.d/`:
+
+```
+@oxscada   -   rtprio   99
+```
+
+### Recommended host tuning for low jitter
+
+These are not required for `realtime` mode but materially reduce tick jitter:
+
+- **CPU isolation:** `isolcpus=2,3 nohz_full=2,3 rcu_nocbs=2,3` on the kernel
+  cmdline, then pin the service to the isolated CPUs.
+- **Disable deep C-states:** boot with `intel_idle.max_cstate=1 processor.max_cstate=1`.
+- **Disable SMT** if determinism matters more than throughput.
+- **`tuned-adm profile realtime`** (RHEL) bundles most of the above.
+
+---
+
+## Verifying the result
+
+### From the application
+
+```bash
+curl -s localhost:5000/api/health | jq '.services[] | select(.name=="scheduler").details'
+# realtime:
+#   { "schedulingMode": "realtime", "policy": "SCHED_FIFO", "priority": 50,
+#     "applied": true,  "requested": true,  "realtimeKernel": true }
+# fallback:
+#   { "schedulingMode": "fallback", "policy": "SCHED_OTHER", "priority": 0,
+#     "applied": false, "requested": false, "realtimeKernel": false }
+```
+
+`applied` is the ground truth — it is `true` only when the privileged call
+actually succeeded. `requested` distinguishes "we never asked" (opt-in absent or
+config rejected) from "we asked and it failed", and `realtimeKernel` reports the
+host independently of whether we got the policy. The check is registered as
+non-required, so a `fallback` posture never marks the node not-ready.
+
+### From the OS
+
+```bash
+# Confirm the policy is applied only to the dedicated control process.
+CONTROL_PID="$(pgrep -f 'control-process')"
+ps -L -o pid,tid,cls,rtprio,comm -p "${CONTROL_PID}"
+# cls "FF" = SCHED_FIFO; rtprio shows the priority.
+
+chrt -p "${CONTROL_PID}"
+# → "current scheduling policy: SCHED_FIFO" / "current scheduling priority: 50"
+```
+
+### Tick telemetry (`/metrics`)
+
+`BlueprintTickLoop` publishes these on every tick, in `realtime` **and** in
+`fallback` mode, so you can watch jitter on a stock kernel too. They are
+appended to the same `/api/metrics` scrape as the `scada_`-prefixed metrics.
+
+Note that the series only exist once something actually drives a control loop —
+until the deterministic runtime from #457 is wired into a loop in production,
+these metrics are present in the exposition but carry no samples:
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `blueprint_tick_jitter_ns` | gauge | Most-recent deviation of the actual tick period from target (ns). |
+| `blueprint_tick_missed_deadlines_total` | counter | Ticks whose execution exceeded the deadline budget. |
+| `blueprint_tick_wcet_ns` | gauge | Worst-case tick execution time in the rolling window (ns). |
+| `oxscada_blueprint_tick_duration_seconds` | histogram | Distribution of tick execution durations (s). |
+
+Example alerting rule:
+
+```yaml
+- alert: BlueprintMissingDeadlines
+  expr: rate(blueprint_tick_missed_deadlines_total[5m]) > 0
+  for: 2m
+  labels: { severity: high }
+  annotations:
+    summary: "Blueprint {{ $labels.blueprint }} is missing tick deadlines"
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `schedulingMode: fallback` with a held/target message | Opt-in or dedicated process PID is absent | Expected until the production composition root is wired; never pass the API server PID. |
+| Startup warning: `OXSCADA_RT_PRIORITY='…' is not an integer` / `outside the valid SCHED_FIFO range` | Malformed env value | Set a plain decimal integer in `[1, 99]`. The server keeps running under normal scheduling — this never aborts startup. |
+| Startup warning: `OXSCADA_RT_ENABLED='…' is not a boolean` | Typo in the opt-in flag | Use `true` or `1`; anything else is treated as disabled. |
+| `schedulingMode: fallback` on an RT kernel | apply failed (no `CAP_SYS_NICE` / `RLIMIT_RTPRIO`) | Grant capability via the systemd unit above; check the startup warning. |
+| Startup warning: "no chrt(1) available" | `util-linux` not installed | `apt install util-linux` / `dnf install util-linux`. |
+| High `blueprint_tick_jitter_ns` despite `realtime` | competing kernel threads / power management | Isolate CPUs, disable C-states, run `tuned-adm profile realtime`. |
+| Warning appears repeatedly | _should not happen_ — the scheduler warns once | File a bug; the single-warning guard is in `TickScheduler.warnOnce`. |

--- a/server/blueprint/__tests__/scheduler-health.test.ts
+++ b/server/blueprint/__tests__/scheduler-health.test.ts
@@ -1,0 +1,44 @@
+/**
+ * `/health` scheduler-check tests (#458).
+ *
+ * The check must (a) never mutate scheduling, (b) never fail readiness just
+ * because the host is not real-time, and (c) report the mode HONESTLY — a box
+ * that never applied SCHED_FIFO must say `fallback`, not imply real-time.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createSchedulerCheck } from '../health';
+
+describe('createSchedulerCheck', () => {
+  it('is registered as a non-required check', () => {
+    const check = createSchedulerCheck();
+    expect(check.name).toBe('scheduler');
+    expect(check.required).toBe(false);
+  });
+
+  it('reports healthy + fallback on a host that never opted in', async () => {
+    const result = await createSchedulerCheck().check();
+
+    // Not real-time is a degraded RT posture, not an outage: readiness must
+    // stay green so a dev box or a non-RT edge node is not marked down.
+    expect(result.status).toBe('healthy');
+    expect(result.details).toMatchObject({
+      schedulingMode: 'fallback',
+      policy: 'SCHED_OTHER',
+      priority: 0,
+      applied: false,
+    });
+    expect(typeof result.message).toBe('string');
+    expect(result.message).toBeTruthy();
+  });
+
+  it('never claims realtime without an applied policy', async () => {
+    const result = await createSchedulerCheck().check();
+    const details = result.details as { schedulingMode: string; applied: boolean };
+    if (details.schedulingMode === 'realtime') {
+      expect(details.applied).toBe(true);
+    } else {
+      expect(details.applied).toBe(false);
+    }
+  });
+});

--- a/server/blueprint/__tests__/scheduler-import-safety.test.ts
+++ b/server/blueprint/__tests__/scheduler-import-safety.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Import-safety regression test (#458).
+ *
+ * The first attempt at this issue applied real-time scheduling as a SIDE EFFECT
+ * of importing `server/health`, which pinned the Express/WebSocket process to
+ * SCHED_FIFO on a PREEMPT_RT host, and crashed at import when
+ * `OXSCADA_RT_PRIORITY` was malformed.
+ *
+ * This test locks both properties down at the seam where it would actually
+ * happen: `chrt(1)` is only ever reached through `spawnSync`, so we mock
+ * `node:child_process` and assert the process spawn count across a module load
+ * performed with real-time scheduling fully enabled in the environment.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const { spawnSyncMock } = vi.hoisted(() => ({
+  spawnSyncMock: vi.fn(() => ({
+    status: 0,
+    stdout: '',
+    stderr: '',
+    signal: null,
+    pid: 1,
+    output: [],
+  })),
+}));
+
+vi.mock('node:child_process', () => ({ spawnSync: spawnSyncMock }));
+
+const ENV_KEYS = ['OXSCADA_RT_ENABLED', 'OXSCADA_RT_PRIORITY', 'OXSCADA_RT_POLICY'] as const;
+const saved = new Map<string, string | undefined>();
+
+function setEnv(values: Record<string, string | undefined>): void {
+  for (const key of ENV_KEYS) {
+    if (!saved.has(key)) saved.set(key, process.env[key]);
+    const value = values[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  for (const [key, value] of saved) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  saved.clear();
+  spawnSyncMock.mockClear();
+  vi.resetModules();
+});
+
+describe('server/blueprint import safety (#458)', () => {
+  it('importing the barrel with real-time ENABLED spawns no process', async () => {
+    setEnv({
+      OXSCADA_RT_ENABLED: 'true',
+      OXSCADA_RT_PRIORITY: '50',
+      OXSCADA_RT_POLICY: 'SCHED_FIFO',
+    });
+    vi.resetModules();
+
+    const mod = await import('../index');
+
+    // The whole point: loading the module graph must not touch scheduling.
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    // The spawn assertion alone is host-dependent — on a non-PREEMPT_RT test box
+    // an import-time apply() would fall back before reaching chrt and would slip
+    // through. `status()` is the host-independent discriminator: it throws until
+    // apply() has recorded a decision, so this fails on ANY host the moment an
+    // import-time apply() is reintroduced.
+    expect(() => mod.getScheduler().status()).toThrow(/before apply\(\)/);
+    // …and the shared scheduler must still report the honest, unapplied state.
+    expect(mod.getScheduler().healthSummary().schedulingMode).toBe('fallback');
+    expect(mod.getScheduler().healthSummary().applied).toBe(false);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('the spawn seam is genuinely observable (non-vacuous control)', async () => {
+    setEnv({ OXSCADA_RT_ENABLED: 'true', OXSCADA_RT_PRIORITY: '50' });
+    vi.resetModules();
+
+    const mod = await import('../index');
+    const err = mod.chrtSyscall.apply(4343, 'SCHED_FIFO', 50);
+
+    expect(err).toBeNull();
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'chrt',
+      ['-f', '-p', '50', '4343'],
+      expect.objectContaining({ encoding: 'utf8' }),
+    );
+  });
+
+  it('importing with a MALFORMED priority does not throw', async () => {
+    setEnv({ OXSCADA_RT_ENABLED: 'true', OXSCADA_RT_PRIORITY: 'not-a-number' });
+    vi.resetModules();
+
+    await expect(import('../index')).resolves.toBeDefined();
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('a malformed priority also cannot crash the first getScheduler() call', async () => {
+    setEnv({ OXSCADA_RT_ENABLED: 'true', OXSCADA_RT_PRIORITY: '9999' });
+    vi.resetModules();
+
+    const mod = await import('../index');
+    const freshLogger = await import('../../logger');
+    const warnSpy = vi.spyOn(freshLogger, 'logWarn').mockImplementation(() => {});
+
+    expect(() => mod.getScheduler()).not.toThrow();
+    expect(mod.getScheduler().healthSummary().schedulingMode).toBe('fallback');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/server/blueprint/__tests__/scheduler.test.ts
+++ b/server/blueprint/__tests__/scheduler.test.ts
@@ -1,0 +1,600 @@
+/**
+ * Tick-Aware Scheduler tests (#458)
+ *
+ * Covers capability detection, the realtime-apply path, every fallback branch,
+ * the single-startup-warning guarantee, and — the regression this issue was
+ * reopened for — that malformed `OXSCADA_RT_*` configuration NEVER throws and
+ * always degrades to normal scheduling.
+ *
+ * All host interaction is injected via a fake HostProbe so these run on any
+ * platform with no real kernel and no child process.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  TickScheduler,
+  detectRtCapability,
+  normalizeConfig,
+  configFromEnv,
+  DEFAULT_PRIORITY,
+  DEFAULT_SCHEDULER_CONFIG,
+  ENV_RT_ENABLED,
+  ENV_RT_POLICY,
+  ENV_RT_PRIORITY,
+  PREEMPTION_SYSFS,
+  type HostProbe,
+  type SchedPolicy,
+  type SchedulerConfig,
+} from '../scheduler';
+
+// Spy on the logger so we can assert the "single startup warning" requirement.
+import * as logger from '../../logger';
+
+interface FakeProbeOptions {
+  platform?: NodeJS.Platform;
+  files?: Record<string, string>;
+  existing?: string[];
+  release?: string;
+  version?: string;
+  applyResult?: string | null;
+  applyImpl?: (pid: number, policy: SchedPolicy, priority: number) => string | null;
+}
+
+const DEDICATED_TARGET = {
+  kind: 'dedicated-control-process' as const,
+  pid: 4343,
+};
+
+/** An opted-in config — the tests that exercise the RT path need this. */
+const OPTED_IN: Partial<SchedulerConfig> = { forceFallback: false };
+
+interface FakeProbe {
+  probe: HostProbe;
+  /** Counts every host observation, so "did we probe at all?" is assertable. */
+  probeCalls: () => number;
+}
+
+function makeProbe(opts: FakeProbeOptions = {}): FakeProbe {
+  const files = opts.files ?? {};
+  const existing = new Set(opts.existing ?? []);
+  let calls = 0;
+  const count = <T>(value: T): T => {
+    calls += 1;
+    return value;
+  };
+  const probe: HostProbe = {
+    platform: () => count(opts.platform ?? 'linux'),
+    readFile: (p) => count(p in files ? files[p] : null),
+    fileExists: (p) => count(existing.has(p)),
+    unameRelease: () => count(opts.release ?? '6.1.0-generic'),
+    unameVersion: () => count(opts.version ?? '#1 SMP Debian'),
+    pid: () => 4242,
+    applyRtPolicy: (pid, policy, priority) => {
+      calls += 1;
+      if (opts.applyImpl) return opts.applyImpl(pid, policy, priority);
+      return opts.applyResult ?? null;
+    },
+  };
+  return { probe, probeCalls: () => calls };
+}
+
+const CHRT = '/usr/bin/chrt';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('detectRtCapability', () => {
+  it('reports non-Linux platforms as not RT-capable', () => {
+    const { probe } = makeProbe({ platform: 'win32' });
+    const cap = detectRtCapability(probe);
+    expect(cap.isPreemptRt).toBe(false);
+    expect(cap.hasSyscallPath).toBe(false);
+    expect(cap.reason).toMatch(/non-Linux/);
+  });
+
+  it('detects PREEMPT_RT via /sys/kernel/realtime == 1', () => {
+    const { probe } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1\n' },
+      existing: [CHRT],
+    });
+    const cap = detectRtCapability(probe);
+    expect(cap.isPreemptRt).toBe(true);
+    expect(cap.hasSyscallPath).toBe(true);
+    expect(cap.reason).toContain(PREEMPTION_SYSFS);
+  });
+
+  it('detects PREEMPT_RT via uname version string', () => {
+    const { probe } = makeProbe({
+      version: '#1 SMP PREEMPT_RT Tue ...',
+      existing: [CHRT],
+    });
+    const cap = detectRtCapability(probe);
+    expect(cap.isPreemptRt).toBe(true);
+    expect(cap.reason).toMatch(/uname/);
+  });
+
+  it('detects legacy -rtN kernels via uname release', () => {
+    const { probe } = makeProbe({ release: '5.15.0-rt17-amd64', existing: [CHRT] });
+    const cap = detectRtCapability(probe);
+    expect(cap.isPreemptRt).toBe(true);
+  });
+
+  it('detects RT via debugfs preempt model', () => {
+    const { probe } = makeProbe({
+      files: { '/sys/kernel/debug/sched/preempt': 'none voluntary full (rt)' },
+      existing: [CHRT],
+    });
+    const cap = detectRtCapability(probe);
+    expect(cap.isPreemptRt).toBe(true);
+  });
+
+  it('reports a stock kernel as not RT but still notes chrt availability', () => {
+    const { probe } = makeProbe({ existing: [CHRT] });
+    const cap = detectRtCapability(probe);
+    expect(cap.isPreemptRt).toBe(false);
+    expect(cap.hasSyscallPath).toBe(true);
+    expect(cap.reason).toMatch(/stock/);
+  });
+});
+
+describe('TickScheduler.apply — realtime path', () => {
+  it('applies SCHED_FIFO at the configured priority on an RT kernel', () => {
+    const infoSpy = vi.spyOn(logger, 'logInfo').mockImplementation(() => {});
+    const { probe } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1' },
+      existing: [CHRT],
+    });
+    const sched = new TickScheduler({ ...OPTED_IN, priority: 70 }, probe);
+    const status = sched.apply(DEDICATED_TARGET);
+
+    expect(status.mode).toBe('realtime');
+    expect(status.applied).toBe(true);
+    expect(status.requested).toBe(true);
+    expect(status.policy).toBe('SCHED_FIFO');
+    expect(status.priority).toBe(70);
+    expect(sched.mode).toBe('realtime');
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the configured pid/policy/priority to the syscall', () => {
+    vi.spyOn(logger, 'logInfo').mockImplementation(() => {});
+    const apply = vi.fn().mockReturnValue(null);
+    const { probe } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1' },
+      existing: [CHRT],
+      applyImpl: apply,
+    });
+    new TickScheduler({ ...OPTED_IN, priority: 55, policy: 'SCHED_FIFO' }, probe)
+      .apply(DEDICATED_TARGET);
+    expect(apply).toHaveBeenCalledWith(4343, 'SCHED_FIFO', 55);
+  });
+});
+
+describe('TickScheduler.apply — opt-in gating', () => {
+  it('holds in fallback by DEFAULT and never touches the host', () => {
+    const warnSpy = vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const apply = vi.fn();
+    const { probe, probeCalls } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1' },
+      existing: [CHRT],
+      applyImpl: apply,
+    });
+
+    // No config at all → the opt-in default (forceFallback) must win even on a
+    // fully RT-capable host with a valid dedicated target.
+    const status = new TickScheduler(undefined, probe).apply(DEDICATED_TARGET);
+
+    expect(status.mode).toBe('fallback');
+    expect(status.applied).toBe(false);
+    expect(status.requested).toBe(false);
+    expect(status.error).toMatch(new RegExp(ENV_RT_ENABLED));
+    expect(apply).not.toHaveBeenCalled();
+    expect(probeCalls()).toBe(0); // not even kernel detection ran
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('DEFAULT_SCHEDULER_CONFIG is fail-safe (held, priority 50, SCHED_FIFO)', () => {
+    expect(DEFAULT_SCHEDULER_CONFIG.forceFallback).toBe(true);
+    expect(DEFAULT_SCHEDULER_CONFIG.priority).toBe(DEFAULT_PRIORITY);
+    expect(DEFAULT_SCHEDULER_CONFIG.policy).toBe('SCHED_FIFO');
+  });
+});
+
+describe('TickScheduler.apply — fallback paths', () => {
+  it('falls back on a stock kernel and warns exactly once', () => {
+    const warnSpy = vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const { probe } = makeProbe({ existing: [CHRT] });
+    const sched = new TickScheduler(OPTED_IN, probe);
+
+    const status = sched.apply(DEDICATED_TARGET);
+    expect(status.mode).toBe('fallback');
+    expect(status.applied).toBe(false);
+    expect(status.requested).toBe(true);
+    expect(status.policy).toBe('SCHED_OTHER');
+
+    // Idempotent: repeated apply() must not re-warn or change the decision.
+    sched.apply(DEDICATED_TARGET);
+    sched.apply(DEDICATED_TARGET);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back on non-Linux without invoking the syscall', () => {
+    vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const apply = vi.fn();
+    const { probe } = makeProbe({ platform: 'win32', applyImpl: apply });
+    const status = new TickScheduler(OPTED_IN, probe).apply(DEDICATED_TARGET);
+    expect(status.mode).toBe('fallback');
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('falls back when RT kernel but chrt is missing', () => {
+    vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const apply = vi.fn();
+    const { probe } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1' },
+      existing: [], // no chrt
+      applyImpl: apply,
+    });
+    const status = new TickScheduler(OPTED_IN, probe).apply(DEDICATED_TARGET);
+    expect(status.mode).toBe('fallback');
+    expect(status.error).toMatch(/chrt/);
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('falls back (not crash) when the syscall reports an error', () => {
+    const warnSpy = vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const { probe } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1' },
+      existing: [CHRT],
+      applyResult: 'Operation not permitted',
+    });
+    const status = new TickScheduler(OPTED_IN, probe).apply(DEDICATED_TARGET);
+    expect(status.mode).toBe('fallback');
+    expect(status.applied).toBe(false);
+    expect(status.error).toMatch(/Operation not permitted/);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back (not crash) when the syscall throws', () => {
+    vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const { probe } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1' },
+      existing: [CHRT],
+      applyImpl: () => {
+        throw new Error('chrt: command not found');
+      },
+    });
+    const status = new TickScheduler(OPTED_IN, probe).apply(DEDICATED_TARGET);
+    expect(status.mode).toBe('fallback');
+    expect(status.error).toMatch(/command not found/);
+  });
+
+  it('refuses to apply RT scheduling without a dedicated process target', () => {
+    vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const apply = vi.fn();
+    const { probe } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1' },
+      existing: [CHRT],
+      applyImpl: apply,
+    });
+
+    const status = new TickScheduler(OPTED_IN, probe).apply();
+
+    expect(status.mode).toBe('fallback');
+    expect(status.error).toMatch(/no dedicated control process/i);
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('refuses to target the calling (API server) process pid', () => {
+    vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const apply = vi.fn();
+    const { probe } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1' },
+      existing: [CHRT],
+      applyImpl: apply,
+    });
+
+    const status = new TickScheduler(OPTED_IN, probe).apply({
+      kind: 'dedicated-control-process',
+      pid: 4242, // === probe.pid()
+    });
+
+    expect(status.mode).toBe('fallback');
+    expect(status.error).toMatch(/calling \(API server\) process/i);
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('refuses a nonsensical pid', () => {
+    vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const apply = vi.fn();
+    const { probe } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1' },
+      existing: [CHRT],
+      applyImpl: apply,
+    });
+    const status = new TickScheduler(OPTED_IN, probe).apply({
+      kind: 'dedicated-control-process',
+      pid: -1,
+    });
+    expect(status.mode).toBe('fallback');
+    expect(status.error).toMatch(/invalid dedicated control process pid/i);
+    expect(apply).not.toHaveBeenCalled();
+  });
+});
+
+describe('TickScheduler.healthSummary', () => {
+  it('exposes schedulingMode realtime after a successful apply', () => {
+    vi.spyOn(logger, 'logInfo').mockImplementation(() => {});
+    const { probe } = makeProbe({ files: { [PREEMPTION_SYSFS]: '1' }, existing: [CHRT] });
+    const sched = new TickScheduler(OPTED_IN, probe);
+    sched.apply(DEDICATED_TARGET);
+    const summary = sched.healthSummary();
+    expect(summary.schedulingMode).toBe('realtime');
+    expect(summary.policy).toBe('SCHED_FIFO');
+    expect(summary.priority).toBe(DEFAULT_PRIORITY);
+    expect(summary.applied).toBe(true);
+    expect(summary.requested).toBe(true);
+    expect(summary.realtimeKernel).toBe(true);
+  });
+
+  it('reports fallback before apply() is called', () => {
+    const { probe } = makeProbe();
+    const summary = new TickScheduler(OPTED_IN, probe).healthSummary();
+    expect(summary.schedulingMode).toBe('fallback');
+    expect(summary.applied).toBe(false);
+  });
+
+  it('never implies realtime when the apply failed on an RT kernel', () => {
+    vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const { probe } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1' },
+      existing: [CHRT],
+      applyResult: 'Operation not permitted',
+    });
+    const sched = new TickScheduler(OPTED_IN, probe);
+    sched.apply(DEDICATED_TARGET);
+    const summary = sched.healthSummary();
+    // The kernel IS realtime, but we did not get the policy — say so.
+    expect(summary.realtimeKernel).toBe(true);
+    expect(summary.schedulingMode).toBe('fallback');
+    expect(summary.applied).toBe(false);
+    expect(summary.policy).toBe('SCHED_OTHER');
+    expect(summary.priority).toBe(0);
+  });
+});
+
+describe('normalizeConfig', () => {
+  it('defaults priority to 50 and policy to SCHED_FIFO', () => {
+    const cfg = normalizeConfig();
+    expect(cfg.priority).toBe(DEFAULT_PRIORITY);
+    expect(cfg.policy).toBe('SCHED_FIFO');
+  });
+
+  it('rejects out-of-range priority', () => {
+    expect(() => normalizeConfig({ priority: 0 })).toThrow(/priority/);
+    expect(() => normalizeConfig({ priority: 100 })).toThrow(/priority/);
+    expect(() => normalizeConfig({ priority: 3.5 })).toThrow(/priority/);
+    expect(() => normalizeConfig({ priority: Number.NaN })).toThrow(/priority/);
+  });
+
+  it('rejects an unknown policy', () => {
+    expect(() => normalizeConfig({ policy: 'SCHED_DEADLINE' as SchedPolicy })).toThrow(/policy/);
+  });
+});
+
+describe('configFromEnv — opt-in and malformed-value handling (#458 regression)', () => {
+  it('is OFF by default: an empty environment holds in fallback', () => {
+    const { config, warnings } = configFromEnv({} as NodeJS.ProcessEnv);
+    expect(config.forceFallback).toBe(true);
+    expect(config.holdReason).toMatch(/opt-in/i);
+    expect(warnings).toEqual([]); // "not enabled" is not an error
+  });
+
+  it('enables real-time only for an explicit true/1', () => {
+    for (const raw of ['true', 'TRUE', ' true ', '1']) {
+      const { config, warnings } = configFromEnv({
+        [ENV_RT_ENABLED]: raw,
+      } as NodeJS.ProcessEnv);
+      expect(config.forceFallback, raw).toBe(false);
+      expect(warnings, raw).toEqual([]);
+    }
+    for (const raw of ['false', '0', '']) {
+      const { config } = configFromEnv({ [ENV_RT_ENABLED]: raw } as NodeJS.ProcessEnv);
+      expect(config.forceFallback, raw).toBe(true);
+    }
+  });
+
+  it('reads a valid priority and policy', () => {
+    const { config, warnings } = configFromEnv({
+      [ENV_RT_ENABLED]: 'true',
+      [ENV_RT_PRIORITY]: '80',
+      [ENV_RT_POLICY]: 'SCHED_RR',
+    } as NodeJS.ProcessEnv);
+    expect(config.priority).toBe(80);
+    expect(config.policy).toBe('SCHED_RR');
+    expect(config.forceFallback).toBe(false);
+    expect(warnings).toEqual([]);
+  });
+
+  // This is the exact defect the maintainer rejected the first attempt for:
+  // a malformed OXSCADA_RT_PRIORITY crashed the server at import. It must not
+  // throw, must warn clearly, and must degrade to normal scheduling.
+  const MALFORMED_PRIORITIES = [
+    'not-an-integer',
+    '', // empty
+    '   ', // whitespace only
+    '0', // below the SCHED_FIFO range
+    '100', // above the SCHED_FIFO range
+    '-5', // negative
+    '3.5', // non-integer
+    'NaN',
+    'Infinity',
+    '1e2', // Number() would make this 100 — out of range, and not an integer literal
+    '0x40', // Number() would make this a plausible-looking 64; still rejected
+    '50; rm -rf /', // injection-shaped
+  ];
+
+  it.each(MALFORMED_PRIORITIES)(
+    'never throws for OXSCADA_RT_PRIORITY=%j and falls back to normal scheduling',
+    (raw) => {
+      const env = {
+        [ENV_RT_ENABLED]: 'true',
+        [ENV_RT_PRIORITY]: raw,
+      } as NodeJS.ProcessEnv;
+
+      expect(() => configFromEnv(env)).not.toThrow();
+
+      const { config, warnings } = configFromEnv(env);
+      expect(config.forceFallback).toBe(true);
+      expect(config.priority).toBe(DEFAULT_PRIORITY);
+      expect(config.holdReason).toContain(ENV_RT_PRIORITY);
+      expect(warnings.length).toBeGreaterThan(0);
+      expect(warnings[0]).toContain(ENV_RT_PRIORITY);
+    },
+  );
+
+  it('never throws for a malformed OXSCADA_RT_POLICY', () => {
+    const env = {
+      [ENV_RT_ENABLED]: 'true',
+      [ENV_RT_POLICY]: 'SCHED_DEADLINE',
+    } as NodeJS.ProcessEnv;
+    expect(() => configFromEnv(env)).not.toThrow();
+    const { config, warnings } = configFromEnv(env);
+    expect(config.forceFallback).toBe(true);
+    expect(warnings[0]).toContain(ENV_RT_POLICY);
+  });
+
+  it('treats a non-boolean OXSCADA_RT_ENABLED as disabled and reports it', () => {
+    const { config, warnings } = configFromEnv({
+      [ENV_RT_ENABLED]: 'yes-please',
+    } as NodeJS.ProcessEnv);
+    expect(config.forceFallback).toBe(true);
+    expect(warnings[0]).toContain(ENV_RT_ENABLED);
+  });
+
+  it('does not log — callers decide when to warn (so health probes stay quiet)', () => {
+    const warnSpy = vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    configFromEnv({
+      [ENV_RT_ENABLED]: 'true',
+      [ENV_RT_PRIORITY]: 'garbage',
+    } as NodeJS.ProcessEnv);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('TickScheduler constructor — never throws on bad config (#458 regression)', () => {
+  it('degrades an out-of-range priority instead of throwing', () => {
+    vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const { probe, probeCalls } = makeProbe({
+      files: { [PREEMPTION_SYSFS]: '1' },
+      existing: [CHRT],
+    });
+
+    let sched!: TickScheduler;
+    expect(() => {
+      sched = new TickScheduler({ priority: 999, forceFallback: false }, probe);
+    }).not.toThrow();
+
+    const summary = sched.healthSummary();
+    expect(summary.schedulingMode).toBe('fallback');
+    expect(summary.reason).toMatch(/invalid real-time scheduler configuration/i);
+
+    const status = sched.apply(DEDICATED_TARGET);
+    expect(status.mode).toBe('fallback');
+    expect(status.applied).toBe(false);
+    expect(probeCalls()).toBe(0);
+  });
+
+  it('degrades an unknown policy instead of throwing', () => {
+    vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+    const { probe } = makeProbe();
+    expect(
+      () => new TickScheduler({ policy: 'SCHED_DEADLINE' as SchedPolicy }, probe),
+    ).not.toThrow();
+  });
+});
+
+describe('getScheduler — lazy singleton, warns once, never throws', () => {
+  const ENV_KEYS = [ENV_RT_ENABLED, ENV_RT_PRIORITY, ENV_RT_POLICY] as const;
+
+  /** Load a pristine copy of the scheduler module under a given environment. */
+  async function loadWithEnv(env: Record<string, string | undefined>) {
+    const saved = new Map<string, string | undefined>();
+    for (const key of ENV_KEYS) {
+      saved.set(key, process.env[key]);
+      const value = env[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    vi.resetModules();
+    const freshLogger = await import('../../logger');
+    const warnSpy = vi.spyOn(freshLogger, 'logWarn').mockImplementation(() => {});
+    const mod = await import('../scheduler');
+    const restore = (): void => {
+      for (const [key, value] of saved) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      vi.restoreAllMocks();
+      vi.resetModules();
+    };
+    return { mod, warnSpy, restore };
+  }
+
+  it('does not throw and warns exactly once on a malformed priority', async () => {
+    const { mod, warnSpy, restore } = await loadWithEnv({
+      [ENV_RT_ENABLED]: 'true',
+      [ENV_RT_PRIORITY]: 'definitely-not-a-number',
+      [ENV_RT_POLICY]: undefined,
+    });
+    try {
+      expect(() => mod.getScheduler()).not.toThrow();
+      // Memoised: repeated access must not re-warn.
+      mod.getScheduler();
+      mod.getScheduler();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain(ENV_RT_PRIORITY);
+
+      const summary = mod.getScheduler().healthSummary();
+      expect(summary.schedulingMode).toBe('fallback');
+      expect(summary.applied).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it('is silent and held when real-time scheduling is simply not enabled', async () => {
+    const { mod, warnSpy, restore } = await loadWithEnv({
+      [ENV_RT_ENABLED]: undefined,
+      [ENV_RT_PRIORITY]: undefined,
+      [ENV_RT_POLICY]: undefined,
+    });
+    try {
+      const summary = mod.getScheduler().healthSummary();
+      expect(summary.schedulingMode).toBe('fallback');
+      expect(summary.requested).toBe(false);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it('applyScheduler refuses the calling process even when opted in', async () => {
+    const { mod, restore } = await loadWithEnv({
+      [ENV_RT_ENABLED]: 'true',
+      [ENV_RT_PRIORITY]: '50',
+      [ENV_RT_POLICY]: undefined,
+    });
+    try {
+      const status = mod.applyScheduler({
+        kind: 'dedicated-control-process',
+        pid: process.pid,
+      });
+      expect(status.mode).toBe('fallback');
+      expect(status.applied).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/server/blueprint/__tests__/tick-loop.test.ts
+++ b/server/blueprint/__tests__/tick-loop.test.ts
@@ -1,0 +1,236 @@
+/**
+ * BlueprintTickLoop tests (#458)
+ *
+ * Drives the control loop deterministically with an injected nanosecond clock
+ * and an injected scheduler backed by a fake host probe, verifying scheduler
+ * integration, tick accounting, throwing-tick resilience, and the /health
+ * snapshot shape.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BlueprintTickLoop } from '../tick-loop';
+import { TickScheduler, type HostProbe } from '../scheduler';
+import { resetBlueprintMetrics } from '../../metrics/blueprint';
+import * as logger from '../../logger';
+
+/** Stock-kernel probe: forces the scheduler into fallback mode. */
+function stockProbe(): HostProbe {
+  return {
+    platform: () => 'linux',
+    readFile: () => null,
+    fileExists: () => false,
+    unameRelease: () => '6.1.0-generic',
+    unameVersion: () => '#1 SMP Debian',
+    pid: () => 1,
+    applyRtPolicy: () => null,
+  };
+}
+
+/** PREEMPT_RT probe with chrt present, so the RT path can be exercised. */
+function rtProbe(applyRtPolicy: HostProbe['applyRtPolicy'] = () => null): HostProbe {
+  return {
+    platform: () => 'linux',
+    readFile: (p) => (p === '/sys/kernel/realtime' ? '1' : null),
+    fileExists: (p) => p === '/usr/bin/chrt',
+    unameRelease: () => '6.12.0-rt1',
+    unameVersion: () => '#1 SMP PREEMPT_RT',
+    pid: () => 1,
+    applyRtPolicy,
+  };
+}
+
+/** An opted-in scheduler over the given probe (tests bypass the env parser). */
+function optedInScheduler(probe: HostProbe): TickScheduler {
+  return new TickScheduler({ forceFallback: false }, probe);
+}
+
+/**
+ * Scripted monotonic clock. Each call returns the next value (ns). Build the
+ * sequence as alternating tick-start / tick-end timestamps.
+ */
+function scriptedClock(valuesNs: number[]): () => bigint {
+  let i = 0;
+  return () => {
+    const v = valuesNs[Math.min(i, valuesNs.length - 1)];
+    i += 1;
+    return BigInt(v);
+  };
+}
+
+const MS = 1_000_000;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(logger, 'logInfo').mockImplementation(() => {});
+  vi.spyOn(logger, 'logWarn').mockImplementation(() => {});
+  vi.spyOn(logger, 'logError').mockImplementation(() => {});
+  resetBlueprintMetrics();
+});
+
+describe('BlueprintTickLoop', () => {
+  it('starts in fallback mode on a stock kernel', () => {
+    const loop = new BlueprintTickLoop({
+      blueprintId: 'bp1',
+      periodMs: 10,
+      scheduler: optedInScheduler(stockProbe()),
+      schedulerTarget: { kind: 'dedicated-control-process', pid: 4343 },
+      nowNs: scriptedClock([0, 1 * MS]),
+    });
+    loop.setTickFn(() => {});
+    const status = loop.start();
+    expect(status.mode).toBe('fallback');
+    expect(loop.schedulingMode).toBe('fallback');
+    loop.stop();
+  });
+
+  it('never elevates scheduling when no dedicated target is supplied', () => {
+    const applyRt = vi.fn().mockReturnValue(null);
+    const loop = new BlueprintTickLoop({
+      blueprintId: 'bp-in-process',
+      periodMs: 10,
+      // RT-capable host, opted in — but the loop runs in the API server process
+      // and therefore supplies no dedicated target.
+      scheduler: optedInScheduler(rtProbe(applyRt)),
+      nowNs: scriptedClock([0, 1 * MS]),
+    });
+    loop.setTickFn(() => {});
+    const status = loop.start();
+
+    expect(status.mode).toBe('fallback');
+    expect(status.applied).toBe(false);
+    expect(status.error).toMatch(/no dedicated control process/i);
+    expect(applyRt).not.toHaveBeenCalled();
+    loop.stop();
+  });
+
+  it('applies SCHED_FIFO when a dedicated control process is supplied', () => {
+    const applyRt = vi.fn().mockReturnValue(null);
+    const loop = new BlueprintTickLoop({
+      blueprintId: 'bp-dedicated',
+      periodMs: 10,
+      scheduler: optedInScheduler(rtProbe(applyRt)),
+      schedulerTarget: { kind: 'dedicated-control-process', pid: 9001 },
+      nowNs: scriptedClock([0, 1 * MS]),
+    });
+    loop.setTickFn(() => {});
+    const status = loop.start();
+
+    expect(status.mode).toBe('realtime');
+    expect(status.applied).toBe(true);
+    expect(applyRt).toHaveBeenCalledWith(9001, 'SCHED_FIFO', 50);
+    loop.stop();
+  });
+
+  it('measures tick duration and period jitter across ticks', () => {
+    // Clock script: [start0, end0, start1, end1, start2, end2]
+    //  tick0: dur 1ms              (no period yet)
+    //  tick1: start +10ms, dur 2ms (period 10ms → jitter 0)
+    //  tick2: start +13ms, dur 1ms (period 13ms → jitter +3ms)
+    const clock = scriptedClock([0, 1 * MS, 10 * MS, 12 * MS, 23 * MS, 24 * MS]);
+    const loop = new BlueprintTickLoop({
+      blueprintId: 'bp2',
+      periodMs: 10,
+      scheduler: optedInScheduler(stockProbe()),
+      nowNs: clock,
+    });
+    const ran: number[] = [];
+    loop.setTickFn((idx) => ran.push(idx));
+    loop.start();
+
+    const s0 = loop.runOneTick();
+    expect(s0.lastJitterNs).toBe(0);
+
+    const s1 = loop.runOneTick();
+    expect(s1.lastJitterNs).toBe(0); // period exactly 10ms
+
+    const s2 = loop.runOneTick();
+    expect(s2.lastJitterNs).toBe(3 * MS); // 13ms period vs 10ms target
+    expect(s2.totalTicks).toBe(3);
+    expect(ran).toEqual([0, 1, 2]);
+    loop.stop();
+  });
+
+  it('counts a missed deadline when a tick overruns its budget', () => {
+    // period 10ms, default deadline = 10ms. Tick body runs 15ms.
+    const clock = scriptedClock([0, 15 * MS]);
+    const loop = new BlueprintTickLoop({
+      blueprintId: 'bp3',
+      periodMs: 10,
+      scheduler: optedInScheduler(stockProbe()),
+      nowNs: clock,
+    });
+    loop.setTickFn(() => {});
+    loop.start();
+    const stats = loop.runOneTick();
+    expect(stats.missedDeadlines).toBe(1);
+    loop.stop();
+  });
+
+  it('does not crash the loop when a tick body throws', () => {
+    const clock = scriptedClock([0, 1 * MS, 2 * MS, 3 * MS]);
+    const loop = new BlueprintTickLoop({
+      blueprintId: 'bp4',
+      periodMs: 10,
+      scheduler: optedInScheduler(stockProbe()),
+      nowNs: clock,
+    });
+    loop.setTickFn((idx) => {
+      if (idx === 0) throw new Error('boom');
+    });
+    loop.start();
+    expect(() => loop.runOneTick()).not.toThrow();
+    const stats = loop.runOneTick();
+    expect(stats.totalTicks).toBe(2);
+    loop.stop();
+  });
+
+  it('exposes a health snapshot with schedulingMode and tick stats', () => {
+    const loop = new BlueprintTickLoop({
+      blueprintId: 'bp5',
+      periodMs: 5,
+      scheduler: optedInScheduler(stockProbe()),
+      nowNs: scriptedClock([0, 1 * MS]),
+    });
+    loop.setTickFn(() => {});
+    loop.start();
+    loop.runOneTick();
+    const h = loop.health();
+    expect(h.blueprintId).toBe('bp5');
+    expect(h.running).toBe(true);
+    expect(h.schedulingMode).toBe('fallback');
+    expect(h.scheduler.schedulingMode).toBe('fallback');
+    expect(h.scheduler.applied).toBe(false);
+    expect(h.targetPeriodMs).toBe(5);
+    expect(h.tick.totalTicks).toBe(1);
+    loop.stop();
+    expect(loop.health().running).toBe(false);
+  });
+
+  it('rejects invalid construction', () => {
+    expect(
+      () =>
+        new BlueprintTickLoop({
+          blueprintId: '',
+          periodMs: 10,
+          scheduler: optedInScheduler(stockProbe()),
+        }),
+    ).toThrow();
+    expect(
+      () =>
+        new BlueprintTickLoop({
+          blueprintId: 'x',
+          periodMs: 0,
+          scheduler: optedInScheduler(stockProbe()),
+        }),
+    ).toThrow();
+  });
+
+  it('requires a tick function before start', () => {
+    const loop = new BlueprintTickLoop({
+      blueprintId: 'x',
+      periodMs: 10,
+      scheduler: optedInScheduler(stockProbe()),
+    });
+    expect(() => loop.start()).toThrow(/setTickFn/);
+  });
+});

--- a/server/blueprint/health.ts
+++ b/server/blueprint/health.ts
@@ -1,0 +1,48 @@
+/**
+ * Blueprint scheduler → `/health` adapter (#458)
+ *
+ * Surfaces `schedulingMode` in the `/health` payload without giving the health
+ * module any power to *change* scheduling: this file only reads
+ * {@link TickScheduler.healthSummary}, which never probes the host and never
+ * makes a privileged call.
+ *
+ * @module server/blueprint/health
+ */
+
+import type { HealthCheck, ServiceCheckResult } from '../health/health-manager.js';
+import { getScheduler } from './scheduler.js';
+
+/**
+ * Health check reporting the real scheduling posture.
+ *
+ * Always `healthy` and non-required: running without real-time scheduling is a
+ * degraded real-time posture, NOT a service outage, and must not flip readiness
+ * to "not ready" on a dev box or on any host that simply did not opt in.
+ *
+ * The details are reported honestly — `schedulingMode` is `'realtime'` only when
+ * `SCHED_FIFO` was actually applied; `applied` and `requested` let an operator
+ * tell "we never asked" apart from "we asked and it failed".
+ */
+export function createSchedulerCheck(): HealthCheck {
+  return {
+    name: 'scheduler',
+    required: false,
+    check: async (): Promise<ServiceCheckResult> => {
+      const summary = getScheduler().healthSummary();
+      return {
+        name: 'scheduler',
+        status: 'healthy',
+        lastCheck: new Date(),
+        message: summary.reason,
+        details: {
+          schedulingMode: summary.schedulingMode,
+          policy: summary.policy,
+          priority: summary.priority,
+          applied: summary.applied,
+          requested: summary.requested,
+          realtimeKernel: summary.realtimeKernel,
+        },
+      };
+    },
+  };
+}

--- a/server/blueprint/index.ts
+++ b/server/blueprint/index.ts
@@ -1,24 +1,37 @@
 /**
- * Deterministic Blueprint Runtime + Watchdog / Safe-State — public surface.
+ * Blueprint control-plane module — public surface.
  *
- * Issue #457: [wave:2b] Deterministic Blueprint Runtime
- * Issue #459: [wave:2b] Watchdog & Safe-State Fallback
+ * Three concerns live behind this barrel:
  *
- * This barrel is the single import point for the rest of the server. Consumers
- * should import from `server/blueprint` rather than reaching into individual
- * files, so the internal SoA layout can evolve without churning call sites.
+ *  - **Deterministic execution (#457)** — the compiler, the SoA program layout,
+ *    {@link BlueprintRuntime} (whose `tickFast()` is the bounded-allocation hot
+ *    loop), the `.strict()` definition schema and the gated production host
+ *    {@link BlueprintControlLoop}.
+ *  - **Watchdog & safe-state (#459)** — {@link Watchdog} (per-blueprint
+ *    tick-budget monitor + trip logic), {@link SafeStateController} (applies /
+ *    clears the declared safe state, anchors CRITICAL transitions, audits them),
+ *    {@link WatchdogRegistry} (one watchdog per running blueprint, status for the
+ *    operator UI), {@link BlueprintRuntimeActuator} (the real
+ *    {@link SafeStateActuator} used in production; drives the runtime tag store)
+ *    and {@link BlueprintSafetyHost} (composition root that constructs runtimes,
+ *    registers watchdogs and drives ticks).
+ *  - **Tick-aware scheduling & telemetry (#458)** — PREEMPT_RT detection with
+ *    graceful fallback ({@link TickScheduler}), the fixed-period
+ *    {@link BlueprintTickLoop} that measures jitter / deadline misses / WCET,
+ *    and the `/health` adapter that reports the real scheduling mode.
  *
- * Safe-state pieces:
- * - {@link Watchdog}                : per-blueprint tick-budget monitor + trip logic.
- * - {@link SafeStateController}     : applies / clears the declared safe state,
- *                                     anchors CRITICAL transitions, audits them.
- * - {@link WatchdogRegistry}        : tracks one watchdog per running blueprint and
- *                                     exposes status for the operator UI.
- * - {@link BlueprintRuntimeActuator}: the real {@link SafeStateActuator} used in
- *                                     production; drives the runtime tag store.
- * - {@link BlueprintSafetyHost}     : composition root that constructs runtimes,
- *                                     registers watchdogs and drives ticks.
+ * Consumers should import from `server/blueprint` rather than reaching into
+ * individual files, so the internal layout can evolve without churning call
+ * sites.
+ *
+ * IMPORTING THIS MODULE HAS NO SIDE EFFECTS. In particular it never probes the
+ * kernel and never applies a real-time scheduling policy — see
+ * `./scheduler.ts` for why that matters.
+ *
+ * @module server/blueprint
  */
+
+// ── Deterministic runtime (#457) ─────────────────────────────────────────────
 
 export {
   type TagDirection,
@@ -92,3 +105,55 @@ export {
   getBlueprintProductionSafetyStatus,
   type BlueprintProductionSafetyStatus,
 } from "./production-safety";
+
+// ── Tick-aware scheduler (#458) ──────────────────────────────────────────────
+
+export {
+  TickScheduler,
+  detectRtCapability,
+  normalizeConfig,
+  configFromEnv,
+  getScheduler,
+  applyScheduler,
+  createDefaultHostProbe,
+  chrtSyscall,
+  DEFAULT_PRIORITY,
+  MIN_PRIORITY,
+  MAX_PRIORITY,
+  DEFAULT_SCHEDULER_CONFIG,
+  ENV_RT_ENABLED,
+  ENV_RT_PRIORITY,
+  ENV_RT_POLICY,
+  PREEMPTION_SYSFS,
+  type SchedulingMode,
+  type SchedPolicy,
+  type SchedulerConfig,
+  type SchedulerEnvConfig,
+  type SchedulerStatus,
+  type SchedulerHealthSummary,
+  type DedicatedSchedulerTarget,
+  type RtCapability,
+  type HostProbe,
+  type RtSyscall,
+} from "./scheduler.js";
+
+export {
+  BlueprintTickLoop,
+  type TickFn,
+  type TickLoopOptions,
+  type TickLoopHealth,
+} from "./tick-loop.js";
+
+export { createSchedulerCheck } from "./health.js";
+
+// ── Tick telemetry (#458) ────────────────────────────────────────────────────
+
+export {
+  exposeBlueprintMetrics,
+  resetBlueprintMetrics,
+  TickAccountant,
+  publishTickStats,
+  type TickStats,
+  type TickSample,
+  type TickAccountantOptions,
+} from "../metrics/blueprint.js";

--- a/server/blueprint/scheduler.ts
+++ b/server/blueprint/scheduler.ts
@@ -1,0 +1,696 @@
+/**
+ * Tick-Aware Scheduler (issue #458)
+ *
+ * Detects a PREEMPT_RT host and — **only when an operator has explicitly opted
+ * in and named a dedicated control process** — pins that process to `SCHED_FIFO`.
+ * Everywhere else it degrades to normal (best-effort) scheduling and says so.
+ *
+ * ## Safety posture (why this module has no import-time side effects)
+ * `SCHED_FIFO` is a starvation-capable policy: a runaway FIFO task at priority
+ * 50 preempts almost everything else on the box. Applying it to the process that
+ * serves HTTP/WebSocket traffic can wedge the whole node. Therefore:
+ *
+ *   - Importing this module (or anything that re-exports it) performs **no**
+ *     probing, no logging and no privileged call. Everything is lazy.
+ *   - Real-time scheduling is **off by default** and requires
+ *     `OXSCADA_RT_ENABLED=true` (repo convention: `<FEATURE>_ENABLED`).
+ *   - {@link TickScheduler.apply} refuses to elevate the calling process, so an
+ *     in-process control loop can never drag the API server into `SCHED_FIFO`.
+ *   - Malformed configuration never throws: it is reported as a warning and
+ *     resolves to fallback (fail-safe direction — no RT, no crash).
+ *
+ * ## Why `chrt` and not a native binding
+ * `SCHED_FIFO` requires the `sched_setscheduler(2)` syscall, which Node.js does
+ * not expose. The two realistic options are (a) ship a compiled N-API addon, or
+ * (b) shell out to `chrt(1)` from `util-linux` (present on every PREEMPT_RT
+ * target). We choose (b): it adds no native build step, no `node-gyp`, and no
+ * new runtime dependency, while remaining fully real on a real RT kernel. The
+ * call is isolated behind {@link RtSyscall} so a native binding can be dropped
+ * in later without touching callers.
+ *
+ * All probing is injectable so the decision logic is unit-testable with no real
+ * kernel, filesystem, or child process.
+ *
+ * @module server/blueprint/scheduler
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import * as os from 'node:os';
+
+import { logWarn, logInfo, logError } from '../logger.js';
+
+// ============================================================================
+// PUBLIC TYPES
+// ============================================================================
+
+export type SchedulingMode = 'realtime' | 'fallback';
+
+/** Linux real-time scheduling policy applied to the control process. */
+export type SchedPolicy = 'SCHED_FIFO' | 'SCHED_RR' | 'SCHED_OTHER';
+
+export interface SchedulerConfig {
+  /** RT priority for SCHED_FIFO (1-99). Default 50, per the acceptance criteria. */
+  priority: number;
+  /** Scheduling policy to request on a capable kernel. Default 'SCHED_FIFO'. */
+  policy: SchedPolicy;
+  /**
+   * Hold in fallback regardless of kernel capability. This is the DEFAULT: the
+   * feature is opt-in, so anything that does not explicitly enable it stays
+   * here.
+   */
+  forceFallback: boolean;
+  /** Operator-visible explanation of why real-time scheduling is being held. */
+  holdReason?: string;
+}
+
+export const DEFAULT_PRIORITY = 50;
+export const MIN_PRIORITY = 1;
+export const MAX_PRIORITY = 99;
+
+/** Env var names, exported so docs/tests cannot drift from the implementation. */
+export const ENV_RT_ENABLED = 'OXSCADA_RT_ENABLED';
+export const ENV_RT_PRIORITY = 'OXSCADA_RT_PRIORITY';
+export const ENV_RT_POLICY = 'OXSCADA_RT_POLICY';
+
+/**
+ * Safe default: fallback. Constructing a scheduler with no arguments must never
+ * result in a privileged call.
+ */
+export const DEFAULT_SCHEDULER_CONFIG: SchedulerConfig = {
+  priority: DEFAULT_PRIORITY,
+  policy: 'SCHED_FIFO',
+  forceFallback: true,
+  holdReason: `real-time scheduling is opt-in; set ${ENV_RT_ENABLED}=true to enable it`,
+};
+
+/** Result of probing the host for real-time scheduling capability. */
+export interface RtCapability {
+  /** True when the running kernel is PREEMPT_RT (fully preemptible). */
+  isPreemptRt: boolean;
+  /** True when we have a usable mechanism to apply SCHED_FIFO (e.g. `chrt`). */
+  hasSyscallPath: boolean;
+  /** Raw uname strings we inspected (for diagnostics / `/health`). */
+  kernelVersion: string;
+  /** Human-readable reason, surfaced in the startup warning + `/health`. */
+  reason: string;
+}
+
+/** Outcome of attempting to apply the real-time policy. */
+export interface SchedulerStatus {
+  mode: SchedulingMode;
+  policy: SchedPolicy;
+  priority: number;
+  /** True iff the privileged scheduler call was actually applied successfully. */
+  applied: boolean;
+  /** True iff the operator opted in — i.e. real-time was actually attempted. */
+  requested: boolean;
+  capability: RtCapability;
+  /** Populated whenever we are in fallback, so the reason is never implicit. */
+  error?: string;
+  pid: number;
+}
+
+/**
+ * Explicit target accepted by {@link TickScheduler.apply}.
+ *
+ * The PID must belong to a process OTHER than the caller. `chrt` re-schedules a
+ * whole process, so allowing `pid === process.pid` from inside the API server
+ * would pin Express/WebSocket to `SCHED_FIFO` — precisely the failure mode this
+ * module exists to prevent.
+ */
+export interface DedicatedSchedulerTarget {
+  kind: 'dedicated-control-process';
+  pid: number;
+}
+
+// ============================================================================
+// INJECTABLE PROBES (enable unit testing without a real kernel)
+// ============================================================================
+
+/**
+ * Abstraction over the host facilities the scheduler needs. Every method is
+ * synchronous and side-effect-localised so tests can stub them. The default
+ * implementation talks to the real Linux host.
+ */
+export interface HostProbe {
+  platform(): NodeJS.Platform;
+  /** Read a sysfs/procfs file; return null if absent or unreadable. */
+  readFile(path: string): string | null;
+  fileExists(path: string): boolean;
+  /** Uname release string, e.g. '6.1.0-rt7-amd64'. */
+  unameRelease(): string;
+  /** Uname version string, e.g. '#1 SMP PREEMPT_RT ...'. */
+  unameVersion(): string;
+  pid(): number;
+  /** Apply SCHED_FIFO to the given pid. Returns null on success, else an error. */
+  applyRtPolicy(pid: number, policy: SchedPolicy, priority: number): string | null;
+}
+
+/** Single-source abstraction for the privileged syscall path (`chrt`). */
+export interface RtSyscall {
+  apply(pid: number, policy: SchedPolicy, priority: number): string | null;
+}
+
+const CHRT_POLICY_FLAG: Record<SchedPolicy, string> = {
+  SCHED_FIFO: '-f',
+  SCHED_RR: '-r',
+  SCHED_OTHER: '-o',
+};
+
+/** Default RT syscall path: shell out to `chrt(1)`. */
+export const chrtSyscall: RtSyscall = {
+  apply(pid: number, policy: SchedPolicy, priority: number): string | null {
+    const flag = CHRT_POLICY_FLAG[policy];
+    // chrt -f -p <prio> <pid>  → set policy SCHED_FIFO with priority on a pid.
+    const res = spawnSync('chrt', [flag, '-p', String(priority), String(pid)], {
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+    if (res.error) {
+      return res.error.message;
+    }
+    if (typeof res.status === 'number' && res.status !== 0) {
+      return (res.stderr || `chrt exited with status ${res.status}`).trim();
+    }
+    return null;
+  },
+};
+
+/** Default host probe backed by the real OS. */
+export function createDefaultHostProbe(syscall: RtSyscall = chrtSyscall): HostProbe {
+  return {
+    platform: () => process.platform,
+    readFile: (p: string) => {
+      try {
+        return readFileSync(p, 'utf8');
+      } catch {
+        return null;
+      }
+    },
+    fileExists: (p: string) => {
+      try {
+        return existsSync(p);
+      } catch {
+        return false;
+      }
+    },
+    unameRelease: () => os.release(),
+    unameVersion: () => {
+      // os.version() exists on Node >= 13.11 and returns the kernel version
+      // string (the part where '#1 SMP PREEMPT_RT' lives on Linux).
+      try {
+        return os.version();
+      } catch {
+        return '';
+      }
+    },
+    pid: () => process.pid,
+    applyRtPolicy: (pid, policy, priority) => syscall.apply(pid, policy, priority),
+  };
+}
+
+// ============================================================================
+// CAPABILITY DETECTION (pure given a HostProbe)
+// ============================================================================
+
+/** sysfs file present on PREEMPT_RT kernels; reads `1` when RT is active. */
+export const PREEMPTION_SYSFS = '/sys/kernel/realtime';
+const PREEMPTION_DEBUG = '/sys/kernel/debug/sched/preempt';
+
+/**
+ * Detect whether the host can run a control process under SCHED_FIFO.
+ *
+ * Detection order (cheapest / most authoritative first):
+ *  1. Non-Linux platform → never RT-capable.
+ *  2. `/sys/kernel/realtime` == '1' → authoritative PREEMPT_RT flag.
+ *  3. uname version/release contains 'PREEMPT_RT' (or legacy '-rtN' tag).
+ *  4. `/sys/kernel/debug/sched/preempt` active model is '(rt)'.
+ *
+ * `hasSyscallPath` is reported separately so we can distinguish "RT kernel but
+ * no `chrt`" (still falls back) from "stock kernel".
+ */
+export function detectRtCapability(probe: HostProbe): RtCapability {
+  const platform = probe.platform();
+  const kernelVersion = `${probe.unameRelease()} ${probe.unameVersion()}`.trim();
+  const hasSyscallPath = probe.fileExists('/usr/bin/chrt') || probe.fileExists('/bin/chrt');
+
+  if (platform !== 'linux') {
+    return {
+      isPreemptRt: false,
+      hasSyscallPath: false,
+      kernelVersion,
+      reason: `non-Linux platform '${platform}'; SCHED_FIFO unavailable`,
+    };
+  }
+
+  // (2) Authoritative sysfs flag.
+  const realtimeFlag = probe.readFile(PREEMPTION_SYSFS);
+  if (realtimeFlag !== null && realtimeFlag.trim() === '1') {
+    return {
+      isPreemptRt: true,
+      hasSyscallPath,
+      kernelVersion,
+      reason: `${PREEMPTION_SYSFS} reports realtime kernel`,
+    };
+  }
+
+  // (3) uname markers.
+  if (/PREEMPT_RT/i.test(kernelVersion) || /-rt\d/i.test(kernelVersion)) {
+    return {
+      isPreemptRt: true,
+      hasSyscallPath,
+      kernelVersion,
+      reason: 'uname reports PREEMPT_RT kernel',
+    };
+  }
+
+  // (4) debugfs active preemption model.
+  const preemptModel = probe.readFile(PREEMPTION_DEBUG);
+  if (preemptModel !== null && /\(rt\)/i.test(preemptModel)) {
+    return {
+      isPreemptRt: true,
+      hasSyscallPath,
+      kernelVersion,
+      reason: `${PREEMPTION_DEBUG} active model is realtime`,
+    };
+  }
+
+  return {
+    isPreemptRt: false,
+    hasSyscallPath,
+    kernelVersion: kernelVersion || 'unknown',
+    reason: 'stock (non-PREEMPT_RT) kernel detected',
+  };
+}
+
+// ============================================================================
+// CONFIG VALIDATION
+// ============================================================================
+
+/**
+ * Strict validator. THROWS on invalid input — it is the single definition of
+ * "valid", used by {@link configFromEnv} and by the {@link TickScheduler}
+ * constructor, both of which catch and degrade rather than propagate.
+ */
+export function normalizeConfig(partial?: Partial<SchedulerConfig>): SchedulerConfig {
+  const cfg: SchedulerConfig = { ...DEFAULT_SCHEDULER_CONFIG, ...partial };
+  if (
+    !Number.isInteger(cfg.priority)
+    || cfg.priority < MIN_PRIORITY
+    || cfg.priority > MAX_PRIORITY
+  ) {
+    throw new Error(
+      `scheduler priority must be an integer in [${MIN_PRIORITY}, ${MAX_PRIORITY}], `
+        + `got ${String(cfg.priority)}`,
+    );
+  }
+  if (cfg.policy !== 'SCHED_FIFO' && cfg.policy !== 'SCHED_RR' && cfg.policy !== 'SCHED_OTHER') {
+    throw new Error(`unknown scheduling policy '${String(cfg.policy)}'`);
+  }
+  return cfg;
+}
+
+/** Parsed environment configuration plus any operator-facing problems found. */
+export interface SchedulerEnvConfig {
+  config: SchedulerConfig;
+  /**
+   * Problems found while parsing. Empty when the environment is clean. Callers
+   * log these ONCE (see {@link getScheduler}); this function never logs and
+   * never throws, so it is safe to call from anywhere — including a health probe.
+   */
+  warnings: string[];
+}
+
+const TRUTHY = new Set(['1', 'true']);
+const FALSY = new Set(['', '0', 'false']);
+
+/**
+ * Parse the opt-in flag. Unknown values are treated as DISABLED (fail-safe) and
+ * reported, rather than being coerced into "enabled".
+ */
+function parseEnabled(raw: string | undefined, warnings: string[]): boolean {
+  if (raw === undefined) return false;
+  const value = raw.trim().toLowerCase();
+  if (TRUTHY.has(value)) return true;
+  if (FALSY.has(value)) return false;
+  warnings.push(
+    `${ENV_RT_ENABLED}='${raw}' is not a boolean ('true'/'1' or 'false'/'0'); `
+      + `real-time scheduling stays disabled`,
+  );
+  return false;
+}
+
+/**
+ * Parse the RT priority. Deliberately stricter than `Number()`: `''`, `'  '`,
+ * `'1e2'`, `'0x40'` and `'3.5'` are all rejected rather than silently coerced
+ * into a plausible-looking priority.
+ *
+ * Returns `null` when the value is unusable; the caller then holds in fallback.
+ */
+function parsePriority(raw: string | undefined, warnings: string[]): number | null {
+  if (raw === undefined) return DEFAULT_PRIORITY;
+  const value = raw.trim();
+  if (!/^\d+$/.test(value)) {
+    warnings.push(
+      `${ENV_RT_PRIORITY}='${raw}' is not an integer in `
+        + `[${MIN_PRIORITY}, ${MAX_PRIORITY}]; falling back to normal scheduling`,
+    );
+    return null;
+  }
+  const parsed = Number(value);
+  if (parsed < MIN_PRIORITY || parsed > MAX_PRIORITY) {
+    warnings.push(
+      `${ENV_RT_PRIORITY}='${raw}' is outside the valid SCHED_FIFO range `
+        + `[${MIN_PRIORITY}, ${MAX_PRIORITY}]; falling back to normal scheduling`,
+    );
+    return null;
+  }
+  return parsed;
+}
+
+/** Parse the requested policy; `null` means "unusable, hold in fallback". */
+function parsePolicy(raw: string | undefined, warnings: string[]): SchedPolicy | null {
+  if (raw === undefined) return 'SCHED_FIFO';
+  const value = raw.trim().toUpperCase();
+  if (value === 'SCHED_FIFO' || value === 'SCHED_RR' || value === 'SCHED_OTHER') {
+    return value;
+  }
+  warnings.push(
+    `${ENV_RT_POLICY}='${raw}' is not one of SCHED_FIFO / SCHED_RR / SCHED_OTHER; `
+      + `falling back to normal scheduling`,
+  );
+  return null;
+}
+
+/**
+ * Build a scheduler config from environment variables.
+ *
+ * PURE: no logging, no throwing, no host access. Real-time scheduling is opt-in
+ * (`OXSCADA_RT_ENABLED=true`); every other outcome — unset, disabled, or
+ * malformed — resolves to a held `forceFallback` config carrying a
+ * human-readable `holdReason`. A malformed value therefore can never abort
+ * startup.
+ */
+export function configFromEnv(env: NodeJS.ProcessEnv = process.env): SchedulerEnvConfig {
+  const warnings: string[] = [];
+  const enabled = parseEnabled(env[ENV_RT_ENABLED], warnings);
+  const priority = parsePriority(env[ENV_RT_PRIORITY], warnings);
+  const policy = parsePolicy(env[ENV_RT_POLICY], warnings);
+
+  const held = (holdReason: string): SchedulerEnvConfig => ({
+    config: { ...DEFAULT_SCHEDULER_CONFIG, forceFallback: true, holdReason },
+    warnings,
+  });
+
+  if (warnings.length > 0) {
+    return held(`invalid real-time scheduler configuration: ${warnings.join('; ')}`);
+  }
+  if (!enabled) {
+    return held(`real-time scheduling is opt-in and ${ENV_RT_ENABLED} is not set to 'true'`);
+  }
+  // `priority`/`policy` are non-null here: anything that produced null also
+  // pushed a warning, which was handled above.
+  return {
+    config: {
+      priority: priority ?? DEFAULT_PRIORITY,
+      policy: policy ?? 'SCHED_FIFO',
+      forceFallback: false,
+    },
+    warnings,
+  };
+}
+
+// ============================================================================
+// SCHEDULER
+// ============================================================================
+
+/**
+ * Tick-aware scheduler. Construct at a control-process composition root, call
+ * {@link apply} with a dedicated process target, then surface
+ * {@link healthSummary} in `/health`.
+ *
+ * Idempotent: repeated `apply()` calls do not re-warn and do not re-invoke the
+ * syscall once a decision has been reached (the "single startup warning"
+ * requirement is enforced here, not at the call site).
+ */
+export class TickScheduler {
+  private readonly config: SchedulerConfig;
+  private readonly probe: HostProbe;
+  private readonly configError: string | null;
+  private statusValue: SchedulerStatus | null = null;
+  private warned = false;
+
+  /**
+   * Never throws. An invalid config degrades to a held fallback config and is
+   * reported through {@link healthSummary} and the single `apply()` warning.
+   */
+  constructor(config?: Partial<SchedulerConfig>, probe?: HostProbe) {
+    let resolved: SchedulerConfig;
+    let configError: string | null = null;
+    try {
+      resolved = normalizeConfig(config);
+    } catch (err) {
+      configError =
+        `invalid real-time scheduler configuration, holding in fallback: `
+        + `${err instanceof Error ? err.message : String(err)}`;
+      resolved = { ...DEFAULT_SCHEDULER_CONFIG, forceFallback: true, holdReason: configError };
+    }
+    this.config = resolved;
+    this.configError = configError;
+    this.probe = probe ?? createDefaultHostProbe();
+  }
+
+  /** Current scheduling mode; `'fallback'` until a successful realtime apply. */
+  get mode(): SchedulingMode {
+    return this.statusValue?.mode ?? 'fallback';
+  }
+
+  /**
+   * Decide capability, attempt the SCHED_FIFO pin if (and only if) the operator
+   * opted in AND a valid dedicated control-process target was supplied, and
+   * record the resulting status. Safe to call multiple times; the warning is
+   * emitted at most once.
+   *
+   * This is the ONLY place a privileged scheduling call can happen, and nothing
+   * calls it at import time.
+   */
+  apply(target?: DedicatedSchedulerTarget): SchedulerStatus {
+    if (this.statusValue) return this.statusValue;
+
+    // A held configuration short-circuits BEFORE touching the host at all, so an
+    // opted-out or malformed deployment does no probing and no syscall.
+    if (this.config.forceFallback) {
+      return this.recordFallback(
+        {
+          isPreemptRt: false,
+          hasSyscallPath: false,
+          kernelVersion: 'not probed (real-time scheduling not requested)',
+          reason: 'real-time scheduling not requested',
+        },
+        target?.pid ?? this.probe.pid(),
+        this.configError ?? this.config.holdReason ?? 'real-time scheduling explicitly held',
+        /* requested */ false,
+      );
+    }
+
+    const capability = detectRtCapability(this.probe);
+    const callerPid = this.probe.pid();
+    const targetIsValid =
+      target?.kind === 'dedicated-control-process'
+      && Number.isSafeInteger(target.pid)
+      && target.pid > 0
+      && target.pid !== callerPid;
+    const pid = targetIsValid ? target.pid : callerPid;
+
+    const targetHoldReason = !target
+      ? 'no dedicated control process target was supplied'
+      : !Number.isSafeInteger(target.pid) || target.pid <= 0
+        ? `invalid dedicated control process pid ${String(target.pid)}`
+        : target.pid === callerPid
+          ? 'refusing to apply a process-wide real-time policy to the calling (API server) process'
+          : null;
+
+    // Unsafe/missing target or no RT kernel → fallback. No privileged syscall is
+    // attempted in any of these branches.
+    if (!targetIsValid || !capability.isPreemptRt || !capability.hasSyscallPath) {
+      const reason =
+        targetHoldReason
+        ?? (!capability.isPreemptRt
+          ? capability.reason
+          : 'PREEMPT_RT kernel detected but no chrt(1) available to apply SCHED_FIFO');
+      return this.recordFallback(capability, pid, reason, /* requested */ true);
+    }
+
+    // Capable kernel → attempt the privileged scheduler call.
+    let applyError: string | null = null;
+    try {
+      applyError = this.probe.applyRtPolicy(pid, this.config.policy, this.config.priority);
+    } catch (err) {
+      applyError = err instanceof Error ? err.message : String(err);
+    }
+
+    if (applyError) {
+      // RT kernel present but apply failed (e.g. missing CAP_SYS_NICE). Fall back
+      // rather than crash the control plane — but make it loud, once.
+      return this.recordFallback(
+        capability,
+        pid,
+        `failed to apply ${this.config.policy}: ${applyError}`,
+        /* requested */ true,
+        `[scheduler] PREEMPT_RT kernel detected but could not apply ${this.config.policy} `
+          + `priority ${this.config.priority} (need CAP_SYS_NICE / sufficient rtprio): `
+          + `${applyError}. Falling back to best-effort scheduling.`,
+      );
+    }
+
+    this.statusValue = {
+      mode: 'realtime',
+      policy: this.config.policy,
+      priority: this.config.priority,
+      applied: true,
+      requested: true,
+      capability,
+      pid,
+    };
+    logInfo(
+      `[scheduler] real-time mode active: dedicated control process ${pid} pinned to `
+        + `${this.config.policy} priority ${this.config.priority} (${capability.reason})`,
+    );
+    return this.statusValue;
+  }
+
+  /** Full status object (for diagnostics). Throws if {@link apply} not called. */
+  status(): SchedulerStatus {
+    if (!this.statusValue) {
+      throw new Error('TickScheduler.status() called before apply()');
+    }
+    return this.statusValue;
+  }
+
+  /**
+   * Compact health summary suitable for embedding in the `/health` payload.
+   *
+   * Reports the truth and nothing more: `schedulingMode` is `'realtime'` only
+   * after the privileged call actually succeeded. Before {@link apply} runs, or
+   * after any fallback, it reports `'fallback'` together with the reason.
+   */
+  healthSummary(): SchedulerHealthSummary {
+    const s = this.statusValue;
+    if (!s) {
+      return {
+        schedulingMode: 'fallback',
+        policy: 'SCHED_OTHER',
+        priority: 0,
+        applied: false,
+        requested: false,
+        realtimeKernel: false,
+        reason:
+          this.configError
+          ?? this.config.holdReason
+          ?? 'scheduler not applied: no dedicated control process target has been supplied',
+      };
+    }
+    return {
+      schedulingMode: s.mode,
+      policy: s.policy,
+      priority: s.priority,
+      applied: s.applied,
+      requested: s.requested,
+      realtimeKernel: s.capability.isPreemptRt,
+      reason: s.error ?? s.capability.reason,
+    };
+  }
+
+  /** Record a fallback decision and emit the single startup warning. */
+  private recordFallback(
+    capability: RtCapability,
+    pid: number,
+    reason: string,
+    requested: boolean,
+    warning?: string,
+  ): SchedulerStatus {
+    this.statusValue = {
+      mode: 'fallback',
+      policy: 'SCHED_OTHER',
+      priority: 0,
+      applied: false,
+      requested,
+      capability,
+      error: reason,
+      pid,
+    };
+    this.warnOnce(
+      warning
+        ?? `[scheduler] running in FALLBACK mode (no real-time guarantees): ${reason}. `
+          + `Tick jitter is still reported, but no process is pinned to SCHED_FIFO.`,
+    );
+    return this.statusValue;
+  }
+
+  private warnOnce(message: string): void {
+    if (this.warned) return;
+    this.warned = true;
+    try {
+      logWarn(message);
+    } catch (err) {
+      // Never let logging take down the control plane.
+      logError(err, 'failed to emit scheduler warning');
+    }
+  }
+}
+
+/** Shape embedded in `/health` under the `scheduler` service. */
+export interface SchedulerHealthSummary {
+  schedulingMode: SchedulingMode;
+  policy: SchedPolicy;
+  priority: number;
+  /** True iff the privileged call succeeded. Never inferred from the kernel. */
+  applied: boolean;
+  /** True iff the operator opted in and real-time was actually attempted. */
+  requested: boolean;
+  realtimeKernel: boolean;
+  reason: string;
+}
+
+// ============================================================================
+// PROCESS-WIDE SINGLETON (lazy — nothing runs at import)
+// ============================================================================
+
+let sharedScheduler: TickScheduler | null = null;
+
+/**
+ * Process-wide scheduler, built from the environment on FIRST USE.
+ *
+ * Constructing it performs no host probing and no privileged call — that only
+ * happens inside {@link TickScheduler.apply}. Because the instance is memoised,
+ * any environment-configuration warnings are logged exactly once per process.
+ */
+export function getScheduler(): TickScheduler {
+  if (!sharedScheduler) {
+    const { config, warnings } = configFromEnv();
+    for (const warning of warnings) {
+      logWarn(`[scheduler] ${warning}`);
+    }
+    sharedScheduler = new TickScheduler(config);
+  }
+  return sharedScheduler;
+}
+
+/**
+ * Explicitly apply real-time scheduling to a dedicated control process.
+ *
+ * Requiring an explicit target is what keeps this out of import graphs: no
+ * module can elevate the API server as a side effect of being loaded, and the
+ * scheduler refuses `pid === process.pid` outright.
+ */
+export function applyScheduler(target: DedicatedSchedulerTarget): SchedulerStatus {
+  return getScheduler().apply(target);
+}
+
+// TODO(#458 follow-up): target a single OS thread instead of the whole process.
+// `chrt -p <pid>` applies to a whole process; to pin ONLY a control thread we
+// need either (a) a worker_thread that calls
+// `sched_setscheduler(SCHED_FIFO, gettid(), …)` via an N-API addon, or (b)
+// `chrt` against the control thread's TID once the loop runs on its own thread.
+// Tracked separately; the RtSyscall seam is the injection point.

--- a/server/blueprint/tick-loop.ts
+++ b/server/blueprint/tick-loop.ts
@@ -1,0 +1,223 @@
+/**
+ * Blueprint Tick Loop — scheduler + tick-telemetry integration (#458)
+ *
+ * Drives a fixed-period control tick and measures jitter / execution duration /
+ * deadline misses per tick, mirroring them onto the Prometheus metrics in
+ * `server/metrics/blueprint.ts`.
+ *
+ * ## Relationship to the deterministic runtime (#457) and its host
+ * `server/blueprint/runtime.ts` owns the deterministic, bounded-allocation
+ * blueprint *execution* (`BlueprintRuntime.tickFast()`), and
+ * `server/blueprint/control-loop.ts` is its gated production host — the thing
+ * composed into `server/index.ts` that loads a definition, compiles it and arms
+ * a `setInterval`. This file is neither: it owns only the *timing* measurement
+ * and the real-time scheduling posture, and deliberately imports neither the
+ * runtime nor the host, so the three land and evolve independently. The seam is
+ * the one-line {@link TickFn}:
+ *
+ * ```ts
+ * const loop = new BlueprintTickLoop({ blueprintId: bp.id, periodMs: 10 });
+ * loop.setTickFn(() => runtime.tickFast());
+ * loop.start();
+ * ```
+ *
+ * ## Scheduling
+ * The loop does NOT elevate anything by itself. It asks the scheduler for a
+ * decision at {@link BlueprintTickLoop.start} time, passing through whatever
+ * {@link TickLoopOptions.schedulerTarget} the composition root supplied. When
+ * the loop runs inside the API server process (the current deployment shape) no
+ * target is available, the scheduler stays in `fallback`, and Express/WebSocket
+ * are never pinned to `SCHED_FIFO`. Telemetry is emitted either way.
+ *
+ * @module server/blueprint/tick-loop
+ */
+
+import {
+  TickScheduler,
+  getScheduler,
+  type DedicatedSchedulerTarget,
+  type SchedulerHealthSummary,
+  type SchedulerStatus,
+  type SchedulingMode,
+} from './scheduler.js';
+import { TickAccountant, publishTickStats, type TickStats } from '../metrics/blueprint.js';
+import { logInfo, logError } from '../logger.js';
+
+/**
+ * One tick of blueprint control logic. Synchronous by contract: a real-time
+ * control tick MUST NOT await — Promise micro-tasks defeat the determinism the
+ * scheduler is trying to protect.
+ */
+export type TickFn = (tickIndex: number) => void;
+
+export interface TickLoopOptions {
+  /** Stable id for the blueprint, used as the metric label. */
+  blueprintId: string;
+  /** Target tick period in milliseconds (the control-loop budget). */
+  periodMs: number;
+  /**
+   * Deadline budget in milliseconds. A tick whose body runs longer counts as a
+   * missed deadline. Defaults to `periodMs` (a tick must finish within its own
+   * period).
+   */
+  deadlineMs?: number;
+  /** Rolling window (tick count) over which WCET is computed. Default 1000. */
+  wcetWindow?: number;
+  /**
+   * Scheduler instance to consult. Defaults to the lazily-constructed
+   * process-wide singleton, which is off unless `OXSCADA_RT_ENABLED=true`.
+   * Injectable so tests (and a future dedicated control process) can supply
+   * their own configuration and host probe.
+   */
+  scheduler?: TickScheduler;
+  /**
+   * Dedicated control-process target handed to the scheduler at `start()`.
+   * Omitted by default — without it the scheduler stays in `fallback` and no
+   * privileged call is made. Only a composition root that genuinely runs the
+   * control loop in its own process should supply this.
+   */
+  schedulerTarget?: DedicatedSchedulerTarget;
+  /**
+   * Injectable monotonic clock returning nanoseconds. Defaults to
+   * `process.hrtime.bigint()`. Lets tests drive deterministic timing.
+   */
+  nowNs?: () => bigint;
+}
+
+export interface TickLoopHealth {
+  blueprintId: string;
+  running: boolean;
+  schedulingMode: SchedulingMode;
+  scheduler: SchedulerHealthSummary;
+  tick: TickStats;
+  targetPeriodMs: number;
+}
+
+const MS_TO_NS = 1_000_000;
+
+export class BlueprintTickLoop {
+  private readonly blueprintId: string;
+  private readonly periodMs: number;
+  private readonly deadlineMs: number;
+  private readonly schedulerTarget: DedicatedSchedulerTarget | undefined;
+  private readonly scheduler: TickScheduler;
+  private readonly accountant: TickAccountant;
+  private readonly nowNs: () => bigint;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private tickFn: TickFn | null = null;
+  private tickIndex = 0;
+  private lastTickStartNs: bigint | null = null;
+  private running = false;
+  private lastStats: TickStats;
+
+  constructor(options: TickLoopOptions) {
+    if (!options.blueprintId) throw new Error('blueprintId is required');
+    if (!(options.periodMs > 0)) throw new Error('periodMs must be > 0');
+
+    this.blueprintId = options.blueprintId;
+    this.periodMs = options.periodMs;
+    this.deadlineMs = options.deadlineMs ?? options.periodMs;
+    this.schedulerTarget = options.schedulerTarget;
+    this.nowNs = options.nowNs ?? (() => process.hrtime.bigint());
+
+    // Constructing the loop must not probe the host or touch scheduling policy;
+    // `getScheduler()` is lazy and `apply()` only runs from `start()`.
+    this.scheduler = options.scheduler ?? getScheduler();
+    this.accountant = new TickAccountant({
+      targetPeriodNs: this.periodMs * MS_TO_NS,
+      deadlineNs: this.deadlineMs * MS_TO_NS,
+      windowSize: options.wcetWindow ?? 1000,
+    });
+    this.lastStats = this.accountant.stats();
+  }
+
+  /** Register the per-tick control body. Must be called before {@link start}. */
+  setTickFn(fn: TickFn): void {
+    this.tickFn = fn;
+  }
+
+  /**
+   * Resolve the scheduler posture and begin ticking.
+   *
+   * Returns the scheduler status so the caller can log/assert the mode it
+   * actually got — which is `fallback` unless the deployment opted in AND
+   * supplied a dedicated control-process target.
+   */
+  start(): SchedulerStatus {
+    if (this.running) return this.scheduler.status();
+    if (!this.tickFn) throw new Error('setTickFn() must be called before start()');
+
+    const status = this.scheduler.apply(this.schedulerTarget);
+    logInfo(
+      `[tick-loop] blueprint '${this.blueprintId}' starting in ${status.mode} mode `
+        + `(period ${this.periodMs}ms, deadline ${this.deadlineMs}ms)`,
+    );
+
+    this.running = true;
+    this.timer = setInterval(() => this.runOneTick(), this.periodMs);
+    // Don't keep the process alive solely for the control loop in dev/test.
+    if (typeof this.timer === 'object' && this.timer && 'unref' in this.timer) {
+      (this.timer as { unref: () => void }).unref();
+    }
+    return status;
+  }
+
+  /** Stop the control loop. Idempotent. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.running = false;
+  }
+
+  /**
+   * Execute exactly one tick: measure period jitter and execution duration, run
+   * the registered control body, and publish telemetry. Exposed (not just as the
+   * interval callback) so a deterministic driver or test can step the loop.
+   */
+  runOneTick(): TickStats {
+    const fn = this.tickFn;
+    if (!fn) throw new Error('no tick function registered');
+
+    const startNs = this.nowNs();
+    const periodNs =
+      this.lastTickStartNs === null ? undefined : Number(startNs - this.lastTickStartNs);
+    this.lastTickStartNs = startNs;
+
+    try {
+      fn(this.tickIndex);
+    } catch (err) {
+      // A throwing control body must not crash the loop; surface and continue.
+      logError(err, `[tick-loop] tick ${this.tickIndex} of '${this.blueprintId}' threw`);
+    }
+
+    const durationNs = Number(this.nowNs() - startNs);
+    this.tickIndex += 1;
+
+    this.lastStats = publishTickStats(
+      this.accountant,
+      { durationNs, periodNs },
+      { blueprint: this.blueprintId },
+    );
+    return this.lastStats;
+  }
+
+  /** Current scheduling mode (mirrors the scheduler). */
+  get schedulingMode(): SchedulingMode {
+    return this.scheduler.mode;
+  }
+
+  /** Health snapshot for embedding in the `/health` endpoint payload. */
+  health(): TickLoopHealth {
+    return {
+      blueprintId: this.blueprintId,
+      running: this.running,
+      schedulingMode: this.scheduler.mode,
+      scheduler: this.scheduler.healthSummary(),
+      tick: this.lastStats,
+      targetPeriodMs: this.periodMs,
+    };
+  }
+}

--- a/server/health/index.ts
+++ b/server/health/index.ts
@@ -11,13 +11,23 @@
 import { HealthManager, createDatabaseCheck, createBlockchainCheck, createGatewayCheck } from './health-manager';
 import { storage } from '../storage';
 import { blockchainService } from '../blockchain';
-import { registry, metricsHandler } from '../metrics';
+import { registry, collectProcessMetrics } from '../metrics';
 import { fieldSimulator } from '../simulator';
 import { storeAndForwardService } from '../gateway/store-and-forward';
 import { getBridgeHealthStatus } from '../bridge';
 import { describeBlueprintControlLoopHealth, getBlueprintControlLoop } from '../blueprint/control-loop';
 import { publishControlLoopProbeStatus } from '../integrity/latency-probe';
 import { getBlueprintProductionSafetyStatus } from '../blueprint/production-safety';
+import type { Response } from 'express';
+// Tick-aware scheduler (#458): surface schedulingMode in /health and append
+// blueprint tick telemetry to /metrics.
+//
+// This module only READS the scheduling posture. Applying real-time scheduling
+// is deliberately NOT a health-module import side effect: pinning the process
+// that serves Express/WebSocket to SCHED_FIFO can starve the box. Scheduling is
+// applied only by an explicit `applyScheduler()` call from a composition root
+// that owns a dedicated control process (see server/blueprint/scheduler.ts).
+import { createSchedulerCheck, exposeBlueprintMetrics } from '../blueprint';
 
 // Control-loop latency telemetry (#460): publish the sentinel probe's liveness
 // gauge as part of normal server composition so `scada_control_loop_probe_up`
@@ -188,6 +198,11 @@ healthManager.register({
     };
   },
 });
+// 11. Tick-aware scheduler (#458) — REPORTS schedulingMode (realtime|fallback).
+//     Read-only by construction: the check calls healthSummary(), which never
+//     probes the kernel and never applies a policy. Real-time scheduling stays
+//     off unless a dedicated control process opts in via OXSCADA_RT_ENABLED.
+healthManager.register(createSchedulerCheck());
 
 // ── Sync health → Prometheus after each check cycle ──────────────────────────
 healthManager.onCheckComplete((result) => {
@@ -203,5 +218,13 @@ healthManager.onCheckComplete((result) => {
 // ── Export the pre-built router ──────────────────────────────────────────────
 export const healthRouter = healthManager.createRouter();
 
-// Expose Prometheus metrics alongside health routes so /metrics works
-healthRouter.get('/metrics', metricsHandler);
+// Expose Prometheus metrics alongside health routes so /metrics works.
+// Blueprint tick telemetry (#458) is appended to the same scrape: the shared
+// metrics use the `scada_` prefix while the blueprint tick gauges/histogram
+// carry their authoritative un-prefixed / `oxscada_` names, so both coexist in
+// one exposition document.
+healthRouter.get('/metrics', (_req, res: Response) => {
+  collectProcessMetrics();
+  res.setHeader('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+  res.send(`${registry.metrics()}\n${exposeBlueprintMetrics()}`);
+});

--- a/server/metrics/__tests__/blueprint.test.ts
+++ b/server/metrics/__tests__/blueprint.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Blueprint tick-metrics & TickAccountant tests (#458)
+ *
+ * Exercises the pure jitter / deadline / WCET accounting and the Prometheus
+ * exposition for the exact metric names mandated by the acceptance criteria.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  TickAccountant,
+  publishTickStats,
+  exposeBlueprintMetrics,
+  resetBlueprintMetrics,
+  blueprintTickMissedDeadlinesTotal,
+  blueprintTickJitterNs,
+  blueprintTickWcetNs,
+  METRIC_TICK_JITTER_NS,
+  METRIC_TICK_MISSED_DEADLINES,
+  METRIC_TICK_WCET_NS,
+  METRIC_TICK_DURATION_SECONDS,
+} from '../blueprint';
+
+const MS = 1_000_000; // ns per ms
+
+describe('TickAccountant', () => {
+  it('computes signed period jitter against the target period', () => {
+    const acc = new TickAccountant({ targetPeriodNs: 10 * MS });
+    // First sample has no period (no prior tick) → jitter stays 0.
+    let stats = acc.record({ durationNs: 1 * MS });
+    expect(stats.lastJitterNs).toBe(0);
+
+    // Tick arrived 2ms late.
+    stats = acc.record({ durationNs: 1 * MS, periodNs: 12 * MS });
+    expect(stats.lastJitterNs).toBe(2 * MS);
+
+    // Tick arrived 3ms early.
+    stats = acc.record({ durationNs: 1 * MS, periodNs: 7 * MS });
+    expect(stats.lastJitterNs).toBe(-3 * MS);
+  });
+
+  it('counts a missed deadline only when duration exceeds the budget', () => {
+    const acc = new TickAccountant({ targetPeriodNs: 10 * MS, deadlineNs: 8 * MS });
+    acc.record({ durationNs: 5 * MS }); // under budget
+    acc.record({ durationNs: 8 * MS }); // exactly at budget → NOT missed
+    let stats = acc.record({ durationNs: 9 * MS }); // over budget → missed
+    expect(stats.missedDeadlines).toBe(1);
+    stats = acc.record({ durationNs: 100 * MS }); // way over → missed
+    expect(stats.missedDeadlines).toBe(2);
+    expect(stats.totalTicks).toBe(4);
+  });
+
+  it('defaults the deadline to the target period', () => {
+    const acc = new TickAccountant({ targetPeriodNs: 5 * MS });
+    const stats = acc.record({ durationNs: 6 * MS });
+    expect(stats.missedDeadlines).toBe(1);
+  });
+
+  it('tracks worst-case execution time within the rolling window', () => {
+    const acc = new TickAccountant({ targetPeriodNs: 10 * MS, windowSize: 3 });
+    acc.record({ durationNs: 2 * MS });
+    acc.record({ durationNs: 9 * MS });
+    let stats = acc.record({ durationNs: 4 * MS });
+    expect(stats.wcetNs).toBe(9 * MS); // window = [2,9,4]
+
+    // Window slides; the 9ms peak ages out and WCET drops.
+    acc.record({ durationNs: 3 * MS }); // window = [9,4,3] → still 9
+    acc.record({ durationNs: 1 * MS }); // window = [4,3,1] → 4
+    stats = acc.record({ durationNs: 2 * MS }); // window = [3,1,2] → 3
+    expect(stats.wcetNs).toBe(3 * MS);
+  });
+
+  it('rejects invalid construction and samples', () => {
+    expect(() => new TickAccountant({ targetPeriodNs: 0 })).toThrow();
+    const acc = new TickAccountant({ targetPeriodNs: 10 * MS });
+    expect(() => acc.record({ durationNs: -1 })).toThrow();
+    expect(() => acc.record({ durationNs: 1, periodNs: -5 })).toThrow();
+  });
+});
+
+describe('blueprint metrics exposition', () => {
+  beforeEach(() => resetBlueprintMetrics());
+
+  it('exposes all four metrics under their exact mandated names', () => {
+    const out = exposeBlueprintMetrics();
+    expect(out).toContain(`# TYPE ${METRIC_TICK_JITTER_NS} gauge`);
+    expect(out).toContain(`# TYPE ${METRIC_TICK_MISSED_DEADLINES} counter`);
+    expect(out).toContain(`# TYPE ${METRIC_TICK_WCET_NS} gauge`);
+    expect(out).toContain(`# TYPE ${METRIC_TICK_DURATION_SECONDS} histogram`);
+
+    // Sanity: the exact strings from the acceptance criteria.
+    expect(METRIC_TICK_JITTER_NS).toBe('blueprint_tick_jitter_ns');
+    expect(METRIC_TICK_MISSED_DEADLINES).toBe('blueprint_tick_missed_deadlines_total');
+    expect(METRIC_TICK_WCET_NS).toBe('blueprint_tick_wcet_ns');
+    expect(METRIC_TICK_DURATION_SECONDS).toBe('oxscada_blueprint_tick_duration_seconds');
+  });
+
+  it('publishTickStats mirrors accountant stats onto the metrics', () => {
+    const acc = new TickAccountant({ targetPeriodNs: 10 * MS, deadlineNs: 8 * MS });
+    const labels = { blueprint: 'reactor-1' };
+
+    publishTickStats(acc, { durationNs: 4 * MS, periodNs: 12 * MS }, labels);
+    expect(blueprintTickJitterNs.get(labels)).toBe(2 * MS);
+    expect(blueprintTickWcetNs.get(labels)).toBe(4 * MS);
+    expect(blueprintTickMissedDeadlinesTotal.get(labels)).toBe(0);
+
+    // Over-budget tick increments the missed-deadline counter exactly once.
+    publishTickStats(acc, { durationNs: 9 * MS, periodNs: 10 * MS }, labels);
+    expect(blueprintTickMissedDeadlinesTotal.get(labels)).toBe(1);
+    expect(blueprintTickWcetNs.get(labels)).toBe(9 * MS);
+  });
+
+  it('renders a histogram with buckets, sum and count in seconds', () => {
+    const acc = new TickAccountant({ targetPeriodNs: 10 * MS });
+    publishTickStats(acc, { durationNs: 0.5 * MS }, { blueprint: 'bp' }); // 0.0005 s
+    const out = exposeBlueprintMetrics();
+    expect(out).toContain(`${METRIC_TICK_DURATION_SECONDS}_bucket`);
+    expect(out).toContain('le="+Inf"');
+    expect(out).toContain(`${METRIC_TICK_DURATION_SECONDS}_sum{blueprint="bp"} 0.0005`);
+    expect(out).toContain(`${METRIC_TICK_DURATION_SECONDS}_count{blueprint="bp"} 1`);
+  });
+
+  it('isolates metric series by blueprint label', () => {
+    const acc1 = new TickAccountant({ targetPeriodNs: 10 * MS });
+    const acc2 = new TickAccountant({ targetPeriodNs: 10 * MS });
+    publishTickStats(acc1, { durationNs: 1 * MS, periodNs: 11 * MS }, { blueprint: 'a' });
+    publishTickStats(acc2, { durationNs: 1 * MS, periodNs: 9 * MS }, { blueprint: 'b' });
+    expect(blueprintTickJitterNs.get({ blueprint: 'a' })).toBe(1 * MS);
+    expect(blueprintTickJitterNs.get({ blueprint: 'b' })).toBe(-1 * MS);
+  });
+});

--- a/server/metrics/blueprint.ts
+++ b/server/metrics/blueprint.ts
@@ -1,0 +1,435 @@
+/**
+ * Blueprint Tick Metrics (issue #458 — Tick-Aware Scheduler)
+ *
+ * Real-time scheduling telemetry for the deterministic blueprint control loop.
+ * These metrics expose how well the control thread is meeting its tick budget
+ * so operators can trust (or distrust) the real-time guarantees of the fabric.
+ *
+ * The acceptance criteria pin the EXACT metric names (no `scada_` prefix on the
+ * gauges, `oxscada_` prefix on the histogram), so this module ships its own
+ * tiny self-contained collector rather than going through the shared
+ * `scada_`-prefixed registry in `prometheus.ts`. The exposition format matches
+ * `prometheus.ts` exactly so a single `/metrics` scrape can concatenate both.
+ *
+ * Core jitter / deadline / WCET accounting is implemented as pure logic in the
+ * `TickAccountant` class so it can be unit-tested without Prometheus or a clock.
+ *
+ * @module server/metrics/blueprint
+ */
+
+// ============================================================================
+// EXACT METRIC NAMES (acceptance criteria)
+// ============================================================================
+
+export const METRIC_TICK_JITTER_NS = 'blueprint_tick_jitter_ns';
+export const METRIC_TICK_MISSED_DEADLINES = 'blueprint_tick_missed_deadlines_total';
+export const METRIC_TICK_WCET_NS = 'blueprint_tick_wcet_ns';
+export const METRIC_TICK_DURATION_SECONDS = 'oxscada_blueprint_tick_duration_seconds';
+
+// Default histogram buckets for tick duration, in SECONDS.
+// Tuned for a sub-millisecond control loop (target < 1 ms p99) with headroom up
+// to 50 ms so we still capture pathological GC pauses / scheduling stalls.
+export const DEFAULT_TICK_DURATION_BUCKETS: readonly number[] = [
+  0.000_05, // 50 µs
+  0.000_1, // 100 µs
+  0.000_25, // 250 µs
+  0.000_5, // 500 µs
+  0.001, // 1 ms
+  0.002_5, // 2.5 ms
+  0.005, // 5 ms
+  0.01, // 10 ms
+  0.025, // 25 ms
+  0.05, // 50 ms
+];
+
+// ============================================================================
+// LABEL HANDLING (mirrors prometheus.ts so exposition is byte-compatible)
+// ============================================================================
+
+export type MetricLabels = Record<string, string>;
+
+function labelsToKey(labelNames: string[], labels: MetricLabels): string {
+  return labelNames.map((name) => labels[name] ?? '').join('|');
+}
+
+function keyToLabels(labelNames: string[], key: string): MetricLabels {
+  const values = key.split('|');
+  const labels: MetricLabels = {};
+  labelNames.forEach((name, i) => {
+    if (values[i]) labels[name] = values[i];
+  });
+  return labels;
+}
+
+function escapeLabel(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}
+
+function formatLabels(labels: MetricLabels): string {
+  const entries = Object.entries(labels);
+  if (entries.length === 0) return '';
+  const formatted = entries.map(([k, v]) => `${k}="${escapeLabel(v)}"`).join(',');
+  return `{${formatted}}`;
+}
+
+// ============================================================================
+// MINIMAL METRIC PRIMITIVES (un-prefixed; names are authoritative as given)
+// ============================================================================
+
+class BareGauge {
+  private values = new Map<string, number>();
+
+  constructor(
+    public readonly name: string,
+    public readonly help: string,
+    public readonly labelNames: string[] = [],
+  ) {}
+
+  set(value: number, labels: MetricLabels = {}): void {
+    this.values.set(labelsToKey(this.labelNames, labels), value);
+  }
+
+  get(labels: MetricLabels = {}): number {
+    return this.values.get(labelsToKey(this.labelNames, labels)) ?? 0;
+  }
+
+  reset(): void {
+    this.values.clear();
+  }
+
+  expose(): string {
+    const lines: string[] = [
+      `# HELP ${this.name} ${this.help}`,
+      `# TYPE ${this.name} gauge`,
+    ];
+    for (const [key, value] of this.values) {
+      lines.push(`${this.name}${formatLabels(keyToLabels(this.labelNames, key))} ${value}`);
+    }
+    return lines.join('\n');
+  }
+}
+
+class BareCounter {
+  private values = new Map<string, number>();
+
+  constructor(
+    public readonly name: string,
+    public readonly help: string,
+    public readonly labelNames: string[] = [],
+  ) {}
+
+  inc(labels: MetricLabels = {}, value = 1): void {
+    if (value < 0) throw new Error('Counter cannot decrease');
+    const key = labelsToKey(this.labelNames, labels);
+    this.values.set(key, (this.values.get(key) ?? 0) + value);
+  }
+
+  get(labels: MetricLabels = {}): number {
+    return this.values.get(labelsToKey(this.labelNames, labels)) ?? 0;
+  }
+
+  reset(): void {
+    this.values.clear();
+  }
+
+  expose(): string {
+    const lines: string[] = [
+      `# HELP ${this.name} ${this.help}`,
+      `# TYPE ${this.name} counter`,
+    ];
+    for (const [key, value] of this.values) {
+      lines.push(`${this.name}${formatLabels(keyToLabels(this.labelNames, key))} ${value}`);
+    }
+    return lines.join('\n');
+  }
+}
+
+class BareHistogram {
+  private buckets = new Map<string, Map<number, number>>();
+  private sums = new Map<string, number>();
+  private counts = new Map<string, number>();
+  /**
+   * Boundaries including `+Inf`, precomputed once. `observe()` runs once per
+   * control-loop tick, so it must not allocate a fresh array per observation.
+   */
+  private readonly allBoundaries: readonly number[];
+
+  constructor(
+    public readonly name: string,
+    public readonly help: string,
+    public readonly labelNames: string[] = [],
+    public readonly bucketBoundaries: readonly number[] = DEFAULT_TICK_DURATION_BUCKETS,
+  ) {
+    this.allBoundaries = [...bucketBoundaries, Infinity];
+  }
+
+  observe(value: number, labels: MetricLabels = {}): void {
+    const key = labelsToKey(this.labelNames, labels);
+    if (!this.buckets.has(key)) {
+      const bucketMap = new Map<number, number>();
+      for (const b of this.allBoundaries) bucketMap.set(b, 0);
+      this.buckets.set(key, bucketMap);
+      this.sums.set(key, 0);
+      this.counts.set(key, 0);
+    }
+    const bucketMap = this.buckets.get(key)!;
+    for (const boundary of this.allBoundaries) {
+      if (value <= boundary) bucketMap.set(boundary, (bucketMap.get(boundary) ?? 0) + 1);
+    }
+    this.sums.set(key, (this.sums.get(key) ?? 0) + value);
+    this.counts.set(key, (this.counts.get(key) ?? 0) + 1);
+  }
+
+  count(labels: MetricLabels = {}): number {
+    return this.counts.get(labelsToKey(this.labelNames, labels)) ?? 0;
+  }
+
+  sum(labels: MetricLabels = {}): number {
+    return this.sums.get(labelsToKey(this.labelNames, labels)) ?? 0;
+  }
+
+  reset(): void {
+    this.buckets.clear();
+    this.sums.clear();
+    this.counts.clear();
+  }
+
+  expose(): string {
+    const lines: string[] = [
+      `# HELP ${this.name} ${this.help}`,
+      `# TYPE ${this.name} histogram`,
+    ];
+    for (const [key, buckets] of this.buckets) {
+      const labels = keyToLabels(this.labelNames, key);
+      for (const [le, bucketCount] of buckets) {
+        const leLabel = le === Infinity ? '+Inf' : le.toString();
+        lines.push(`${this.name}_bucket${formatLabels({ ...labels, le: leLabel })} ${bucketCount}`);
+      }
+      lines.push(`${this.name}_sum${formatLabels(labels)} ${this.sums.get(key) ?? 0}`);
+      lines.push(`${this.name}_count${formatLabels(labels)} ${this.counts.get(key) ?? 0}`);
+    }
+    return lines.join('\n');
+  }
+}
+
+// ============================================================================
+// METRIC INSTANCES
+// ============================================================================
+
+const LABELS = ['blueprint'] as const;
+
+/** Most-recent observed tick jitter (deviation from the target period), ns. */
+export const blueprintTickJitterNs = new BareGauge(
+  METRIC_TICK_JITTER_NS,
+  'Most recent blueprint control-loop tick jitter (deviation of actual period from target), in nanoseconds',
+  [...LABELS],
+);
+
+/** Monotonic count of ticks whose duration exceeded the configured deadline. */
+export const blueprintTickMissedDeadlinesTotal = new BareCounter(
+  METRIC_TICK_MISSED_DEADLINES,
+  'Total number of blueprint control-loop ticks that exceeded their deadline budget',
+  [...LABELS],
+);
+
+/** Worst-case execution time observed within the rolling window, ns. */
+export const blueprintTickWcetNs = new BareGauge(
+  METRIC_TICK_WCET_NS,
+  'Worst-case blueprint tick execution time observed within the rolling window, in nanoseconds',
+  [...LABELS],
+);
+
+/** Distribution of tick execution durations, in seconds. */
+export const blueprintTickDurationSeconds = new BareHistogram(
+  METRIC_TICK_DURATION_SECONDS,
+  'Distribution of blueprint control-loop tick execution durations, in seconds',
+  [...LABELS],
+  DEFAULT_TICK_DURATION_BUCKETS,
+);
+
+/**
+ * Render all blueprint tick metrics in Prometheus exposition format.
+ * Returned string carries no trailing newline (matches `prometheus.ts`).
+ */
+export function exposeBlueprintMetrics(): string {
+  return [
+    blueprintTickJitterNs.expose(),
+    blueprintTickMissedDeadlinesTotal.expose(),
+    blueprintTickWcetNs.expose(),
+    blueprintTickDurationSeconds.expose(),
+  ].join('\n');
+}
+
+/** Reset all blueprint metric values (primarily for tests). */
+export function resetBlueprintMetrics(): void {
+  blueprintTickJitterNs.reset();
+  blueprintTickMissedDeadlinesTotal.reset();
+  blueprintTickWcetNs.reset();
+  blueprintTickDurationSeconds.reset();
+}
+
+// ============================================================================
+// TICK ACCOUNTANT — pure jitter / deadline / WCET accounting (unit-testable)
+// ============================================================================
+
+export interface TickSample {
+  /** Tick execution duration in nanoseconds (how long the tick body ran). */
+  durationNs: number;
+  /**
+   * Actual elapsed wall time since the previous tick START, in nanoseconds.
+   * Used to compute period jitter against the target period. Omit for the
+   * first sample (no previous tick to measure a period against).
+   */
+  periodNs?: number;
+}
+
+export interface TickStats {
+  /** Total ticks accounted for since construction. */
+  totalTicks: number;
+  /** Ticks that exceeded the deadline budget. */
+  missedDeadlines: number;
+  /** Most recent period jitter (signed) in nanoseconds. */
+  lastJitterNs: number;
+  /** Worst-case execution time within the current rolling window, in ns. */
+  wcetNs: number;
+  /** Number of duration samples currently retained in the window. */
+  windowSize: number;
+}
+
+export interface TickAccountantOptions {
+  /**
+   * Target tick period in nanoseconds. Jitter is measured as the absolute
+   * deviation of the observed period from this value.
+   */
+  targetPeriodNs: number;
+  /**
+   * Deadline budget in nanoseconds. A tick whose execution duration exceeds
+   * this budget counts as a missed deadline. Defaults to `targetPeriodNs`.
+   */
+  deadlineNs?: number;
+  /**
+   * Rolling window size (number of recent ticks) over which WCET is computed.
+   * WCET is "worst-case in window" per the acceptance criteria. Default 1000.
+   */
+  windowSize?: number;
+}
+
+/**
+ * Pure accounting for control-loop tick health.
+ *
+ * Tracks period jitter, deadline misses, and a windowed worst-case execution
+ * time. Holds no clock and no metric handles — callers feed it samples and read
+ * back stats, then mirror those onto Prometheus gauges. This separation keeps
+ * the math deterministically testable.
+ */
+export class TickAccountant {
+  private readonly targetPeriodNs: number;
+  private readonly deadlineNs: number;
+  private readonly windowCapacity: number;
+
+  // Ring buffer of recent durations for windowed WCET.
+  private readonly window: number[] = [];
+  private windowHead = 0;
+
+  private totalTicks = 0;
+  private missedDeadlines = 0;
+  private lastJitterNs = 0;
+
+  constructor(options: TickAccountantOptions) {
+    if (options.targetPeriodNs <= 0) {
+      throw new Error('targetPeriodNs must be > 0');
+    }
+    this.targetPeriodNs = options.targetPeriodNs;
+    this.deadlineNs = options.deadlineNs ?? options.targetPeriodNs;
+    if (this.deadlineNs <= 0) {
+      throw new Error('deadlineNs must be > 0');
+    }
+    this.windowCapacity = Math.max(1, Math.floor(options.windowSize ?? 1000));
+  }
+
+  /**
+   * Record one tick. Returns the period jitter (signed, ns) for this tick.
+   * Jitter is `periodNs - targetPeriodNs`; positive means the tick ran late.
+   */
+  record(sample: TickSample): TickStats {
+    if (sample.durationNs < 0 || !Number.isFinite(sample.durationNs)) {
+      throw new Error('durationNs must be a finite, non-negative number');
+    }
+
+    this.totalTicks += 1;
+
+    if (sample.durationNs > this.deadlineNs) {
+      this.missedDeadlines += 1;
+    }
+
+    if (sample.periodNs !== undefined) {
+      if (!Number.isFinite(sample.periodNs) || sample.periodNs < 0) {
+        throw new Error('periodNs must be a finite, non-negative number');
+      }
+      this.lastJitterNs = sample.periodNs - this.targetPeriodNs;
+    }
+
+    // Push duration into the rolling window (ring buffer to bound memory).
+    if (this.window.length < this.windowCapacity) {
+      this.window.push(sample.durationNs);
+    } else {
+      this.window[this.windowHead] = sample.durationNs;
+      this.windowHead = (this.windowHead + 1) % this.windowCapacity;
+    }
+
+    return this.stats();
+  }
+
+  /** Current accounting snapshot (does not mutate state). */
+  stats(): TickStats {
+    return {
+      totalTicks: this.totalTicks,
+      missedDeadlines: this.missedDeadlines,
+      lastJitterNs: this.lastJitterNs,
+      wcetNs: this.wcet(),
+      windowSize: this.window.length,
+    };
+  }
+
+  /** Worst-case execution time across the retained window, in nanoseconds. */
+  wcet(): number {
+    let max = 0;
+    for (const d of this.window) {
+      if (d > max) max = d;
+    }
+    return max;
+  }
+
+  /** Clear the rolling window without resetting cumulative counters. */
+  resetWindow(): void {
+    this.window.length = 0;
+    this.windowHead = 0;
+  }
+}
+
+/**
+ * Convenience: record a tick on a `TickAccountant` and mirror the resulting
+ * stats onto the Prometheus metric handles for the given blueprint id.
+ *
+ * Kept here (not inside `TickAccountant`) so the accountant stays metric-free
+ * and unit-testable. The missed-deadline counter is advanced by the DELTA in
+ * the accountant's cumulative `missedDeadlines`, so the counter and the
+ * accountant never drift even if a tick is recorded out-of-band elsewhere.
+ */
+export function publishTickStats(
+  accountant: TickAccountant,
+  sample: TickSample,
+  labels: MetricLabels = {},
+): TickStats {
+  const before = accountant.stats().missedDeadlines;
+  const stats = accountant.record(sample);
+  const missedDelta = stats.missedDeadlines - before;
+
+  blueprintTickJitterNs.set(stats.lastJitterNs, labels);
+  blueprintTickWcetNs.set(stats.wcetNs, labels);
+  if (missedDelta > 0) {
+    blueprintTickMissedDeadlinesTotal.inc(labels, missedDelta);
+  }
+  blueprintTickDurationSeconds.observe(sample.durationNs / 1e9, labels);
+  return stats;
+}

--- a/server/metrics/index.ts
+++ b/server/metrics/index.ts
@@ -27,7 +27,8 @@ export {
   // Express integration
   metricsMiddleware,
   metricsHandler,
-  
+  collectProcessMetrics,
+
   // HTTP metrics
   httpRequestsTotal,
   httpRequestDuration,

--- a/server/metrics/prometheus.ts
+++ b/server/metrics/prometheus.ts
@@ -468,7 +468,7 @@ export const processCpuUsage = registry.gauge(
 /**
  * Collect process metrics
  */
-function collectProcessMetrics(): void {
+export function collectProcessMetrics(): void {
   processUptime.set(process.uptime());
   
   const memUsage = process.memoryUsage();


### PR DESCRIPTION
> Supersedes the stale draft #531, which was opened against a `main` that has since moved 73 commits and is now conflicting. This branch is built on current `main` and fixes the defect that draft left open.

Closes #458.

Rebuild of the tick-aware scheduler slice on current `main`, rewired so the mechanism cannot harm the box it runs on.

## Why this was rejected before

> the tick-aware scheduler detection/fallback logic is real and injection-safe, but the only production effect is `applyScheduler()` running at import time in `server/health`, which pins the Express/WebSocket server to SCHED_FIFO on a PREEMPT_RT host while no control loop exists to benefit (see #457). A malformed `OXSCADA_RT_PRIORITY` env var also crashes the server at import. Net-negative as wired; should be explicit opt-in.

Both are fixed, each with a regression test that was verified by injecting the defect and watching the test fail.

## 1. No import-time side effect

`server/blueprint/scheduler.ts` is fully lazy. Capability detection moved *inside* `apply()`, behind the opt-in short-circuit, so an opted-out or misconfigured deployment does not even read `/sys`. The process-wide instance is built on first use by `getScheduler()`. The single privileged path — `spawnSync('chrt', …)` — is reachable only from `TickScheduler.apply()`, which is reachable only from an explicit `applyScheduler(target)` call. `grep` for non-test call sites finds exactly three, all inside function bodies; none at module scope.

`server/health` now only *reads* the posture via `healthSummary()`.

`server/blueprint/__tests__/scheduler-import-safety.test.ts` mocks `node:child_process`, imports the whole barrel with real-time fully enabled in the environment, and asserts zero spawns. Because a spawn assertion alone is host-dependent — on a non-PREEMPT_RT CI box an import-time `apply()` would fall back before reaching `chrt` and slip through — the test also asserts the host-independent discriminator `getScheduler().status()` still throws `'called before apply()'`. That fails on any host the moment an import-time apply is reintroduced. A separate non-vacuous control asserts the same mock *is* hit when `chrtSyscall.apply()` is called directly, so the seam stays observable.

## 2. Explicit opt-in, default off

`OXSCADA_RT_ENABLED=true`. `DEFAULT_SCHEDULER_CONFIG` is `forceFallback: true`, so a default-constructed scheduler makes no privileged call even on a fully RT-capable host with a valid dedicated target — it does not run kernel detection at all. The slice's redundant `OXSCADA_RT_DISABLE` is gone. A non-boolean value for the flag is treated as *disabled* and reported, never coerced to enabled.

The scheduler additionally refuses `target.pid === process.pid`, so an in-process control loop can never drag the API server into `SCHED_FIFO`.

## 3. Fail soft on bad config

`configFromEnv()` is pure — no logging, no throwing, no host access — and returns `{ config, warnings }`. Priority parsing is strict: a plain decimal integer in `[1, 99]`. `''`, `'   '`, `'0'`, `'100'`, `'-5'`, `'3.5'`, `'NaN'`, `'Infinity'`, `'1e2'`, `'0x40'` and `'50; rm -rf /'` are all **rejected** rather than coerced — `Number()` would have turned `'1e2'` into 100 and `'0x40'` into a plausible-looking 64. The `TickScheduler` constructor also catches an invalid *programmatic* config instead of throwing. `getScheduler()` logs the warnings exactly once per process (the instance is memoised) and holds in fallback.

Regression coverage: a table-driven `it.each` over every malformed priority form asserting no throw + fallback + default priority + a warning naming the variable; equivalents for a bad policy and a bad enable flag; module-reload tests asserting `getScheduler()` neither throws nor re-warns; and an import-safety test asserting `import('../index')` resolves with a malformed priority set.

## 4. Honest `/health`

`SchedulerStatus` / `healthSummary()` gained `applied` (true only when the privileged call actually succeeded) and `requested` (true only when the operator opted in), so "we never asked" is distinguishable from "we asked and it failed". A PREEMPT_RT kernel where `chrt` fails reports `realtimeKernel: true` but `schedulingMode: 'fallback'`, `policy: 'SCHED_OTHER'`, `priority: 0`, `applied: false`. The check stays `healthy` / non-required, so a fallback posture never flips readiness on a dev box or a non-RT edge node.

## Kept from the original slice

PREEMPT_RT detection (sysfs → uname → debugfs), graceful fallback on every branch, the single startup warning (`TickScheduler.warnOnce`), `schedulingMode` in `/health`, and the four mandated metrics: `blueprint_tick_jitter_ns`, `blueprint_tick_missed_deadlines_total`, `blueprint_tick_wcet_ns`, `oxscada_blueprint_tick_duration_seconds`. These are appended to the `/api/metrics` scrape by a plain handler now — `collectProcessMetrics` was exported from `server/metrics/prometheus.ts` instead of monkeypatching `res.send`.

## Forward-port notes

`#457`'s deterministic `BlueprintRuntime` landed on `main` while this slice was in flight, and the slice defined a class of the same name in the same file. Resolution:

- `server/blueprint/runtime.ts` and `__tests__/runtime.test.ts` are restored to `main` verbatim (both are absent from `git diff origin/main...HEAD`).
- The slice's timing/telemetry loop moved to `server/blueprint/control-loop.ts` as `BlueprintControlLoop`.
- `server/blueprint/index.ts` is a merged barrel exporting both concerns.
- `server/health/index.ts` keeps main's simulator / store-and-forward / bridge checks and adds the scheduler check.
- The `/health` adapter lives in `server/blueprint/health.ts` so the barrel stays free of health-manager coupling.

## Scope, stated plainly

**This PR ships the mechanism, the telemetry and the reporting — not a production caller.** The consumer that would actually benefit is the blueprint control loop from **#457**, which is being landed separately. To avoid a hard dependency, `BlueprintControlLoop` takes the scheduler target as an option and exposes a one-line `TickFn` seam (`loop.setTickFn(() => runtime.tickFast())`) rather than importing the deterministic runtime. Until a dedicated control process exists, the real-time path is unreachable in production, the four tick metrics carry no samples, and `/health` reports `fallback` — which is the correct answer, and `docs/operations/preempt-rt.md` says so explicitly (including that `dist/control-process.js` does not exist yet) instead of implying otherwise.

No migration and no new HTTP route are added; the only route change replaces the handler on the pre-existing `GET /api/metrics`.

## Known follow-ups

- `chrt(1)` is a process-wide policy change. Pinning only the control thread needs an N-API `sched_setscheduler` binding or `chrt` against the thread's TID — left as `TODO(#458 follow-up)` at the `RtSyscall` seam, which is the injection point.
- There is no import-safety test over `server/health/index.ts` itself; the guard is at the `server/blueprint` barrel.
- `.env.example` does not yet list the `OXSCADA_RT_*` variables.
- The opt-in flag is `OXSCADA_RT_ENABLED` (not the slice's `OXSCADA_RT_ENABLE`), chosen for the `<FEATURE>_ENABLED` shape; docs and tests are consistent with the new name.

## Verification

- `npx tsc --noEmit` — exits 0.
- `npx vitest run` — `Test Files 100 passed | 2 skipped (102)`, `Tests 2096 passed | 5 skipped (2101)`. Baseline on `main` was 95 files / 2024 passing; this adds 5 test files and 72 tests with no regression.
- Non-vacuity checked by injection: reintroducing a module-scope `applyScheduler()` fails 3 tests; flipping `forceFallback` to `false` fails the opt-in gating tests; loosening priority parsing back to `Number()` coercion fails the malformed-value table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
