### PR TITLE
fix(blueprint): make watchdog safe state actuate, register and persist (#459)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,3 +153,16 @@ MODBUS_SERVER_MAX_CONNECTIONS=4
 # modbus_register_map rows with writable=true can mutate a live tag.
 MODBUS_SERVER_ALLOW_WRITES=false
 MODBUS_SERVER_SOCKET_TIMEOUT_MS=60000
+# Blueprint Watchdog & Safe-State Fallback (Issue #459)
+# The safety host is OFF unless one of these supplies blueprint bindings, so a
+# default deployment loads no blueprint and /api/blueprint-safe-state reports
+# state "DISABLED" with that reason. Each binding is
+# { siteId?, blueprint, safeState, safeRecipes?, scanIntervalMs? } — see
+# blueprintSafetyBindingsSchema in server/blueprint/safety-host.ts.
+BLUEPRINT_SAFETY_BINDINGS_FILE=
+BLUEPRINT_SAFETY_BINDINGS=
+# SAFETY: "force-zero" and safe recipes command NEW output values, i.e. they are
+# plant-output writes. They are unavailable unless this is exactly "true", and a
+# blueprint that declares one without it is REFUSED at arm time (fail-closed)
+# rather than being armed with a safe state it could not apply.
+BLUEPRINT_SAFE_STATE_ALLOW_OUTPUT_WRITES=false

--- a/client/src/components/blueprint/SafeStateBadge.tsx
+++ b/client/src/components/blueprint/SafeStateBadge.tsx
@@ -1,0 +1,210 @@
+/**
+ * SafeStateBadge (#459)
+ *
+ * Prominent operator-facing indicator that a blueprint's watchdog has tripped
+ * and the blueprint is running in a pre-declared SAFE STATE (hold-last /
+ * force-zero / safe recipe). Exit from safe state is NEVER automatic — the
+ * badge surfaces an explicit "Resume" action that the operator must confirm.
+ *
+ * The badge is intentionally high-contrast and persistent: a safe state means
+ * the control loop is halted, so it must not be easy to overlook.
+ *
+ * Shape mirrors the server's `SafeStateStatus` (see server/blueprint/safe-state.ts),
+ * delivered to the client as JSON over the API.
+ *
+ * SCOPE: this is a presentational component only. There is no blueprint
+ * operator page in this repository yet, so nothing mounts it; it is exported and
+ * unit-tested so the page that adds one does not have to re-derive the status
+ * shape or the confirm-before-resume rule.
+ */
+
+import React from "react";
+import type { SafeStateAction } from "@shared/schema";
+
+/** Run state of a watched blueprint, as reported by the server. */
+export type BlueprintRunState =
+  | "RUNNING"
+  | "SAFE_STATE"
+  | "RESUMING"
+  | "RECOVERING"
+  | "RECOVERY_FAILED";
+
+/** Serialisable safe-state status delivered to the client over the API. */
+export interface SafeStateStatus {
+  blueprintId: string;
+  siteId?: string;
+  runState: BlueprintRunState;
+  safeState: SafeStateAction;
+  enteredAt?: string;
+  reason?: string;
+  consecutiveMisses?: number;
+  anchorHash?: string;
+  entryAuditStatus?: "pending" | "durable";
+  recoveryErrors?: string[];
+}
+
+export interface SafeStateBadgeProps {
+  status: SafeStateStatus;
+  /**
+   * Invoked when the operator confirms a resume. The parent is responsible for
+   * calling the resume API and refreshing status. Receives the blueprint id.
+   * If omitted, the resume control is hidden (read-only view).
+   */
+  onResume?: (blueprintId: string) => void;
+  /** Disables the resume control while a resume request is in flight. */
+  resuming?: boolean;
+  className?: string;
+}
+
+/** Human-readable description of the applied safe state. */
+function describeSafeState(action: SafeStateAction): string {
+  if (action === "hold-last") return "Holding last outputs";
+  if (action === "force-zero") return "Outputs forced to zero";
+  return `Safe recipe: ${action.recipe}`;
+}
+
+/**
+ * Renders nothing when the blueprint is RUNNING; renders a prominent banner
+ * when it is in SAFE_STATE. Keeping the "running" case empty lets callers mount
+ * the badge unconditionally next to a blueprint without layout churn.
+ */
+export const SafeStateBadge: React.FC<SafeStateBadgeProps> = ({
+  status,
+  onResume,
+  resuming = false,
+  className,
+}) => {
+  if (status.runState === "RUNNING") {
+    return null;
+  }
+
+  const canResume = status.runState === "SAFE_STATE";
+  const transitionPending =
+    status.runState === "RESUMING" || status.runState === "RECOVERING";
+  const title = status.runState === "SAFE_STATE"
+    ? "SAFE STATE ACTIVE"
+    : status.runState === "RESUMING"
+      ? "RESUME AUDIT PENDING"
+      : status.runState === "RECOVERING"
+        ? "RE-APPLYING SAFE STATE"
+        : "SAFETY RECOVERY FAILED";
+  const borderColor = transitionPending ? "#b45309" : "#b91c1c";
+  const background = transitionPending ? "#fffbeb" : "#fef2f2";
+  const foreground = transitionPending ? "#78350f" : "#7f1d1d";
+
+  const handleResume = () => {
+    if (resuming || !onResume || !canResume) return;
+    const ok = window.confirm(
+      `Resume blueprint "${status.blueprintId}" from SAFE STATE?\n\n` +
+        `The control loop was halted because: ${status.reason ?? "watchdog trip"}.\n` +
+        `Confirm only after the underlying condition has been resolved.`,
+    );
+    if (ok) onResume(status.blueprintId);
+  };
+
+  return (
+    <div
+      className={`safe-state-badge safe-state-badge-critical ${className ?? ""}`}
+      role="alert"
+      aria-live="assertive"
+      data-blueprint-id={status.blueprintId}
+      data-run-state={status.runState}
+      // Inline fallback styling guarantees prominence even without a stylesheet;
+      // the class names above remain the theming hook for design-system CSS.
+      style={{
+        border: `2px solid ${borderColor}`,
+        background,
+        color: foreground,
+        borderRadius: 6,
+        padding: "12px 16px",
+        margin: "8px 0",
+        fontWeight: 500,
+      }}
+    >
+      <div
+        className="safe-state-badge-header"
+        style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 16, fontWeight: 700 }}
+      >
+        <span className="safe-state-badge-icon" aria-hidden="true">
+          {"⚠"}
+        </span>
+        <span className="safe-state-badge-title">{title}</span>
+      </div>
+
+      <dl className="safe-state-badge-details">
+        <div>
+          <dt>Blueprint</dt>
+          <dd>{status.blueprintId}</dd>
+        </div>
+        <div>
+          <dt>Safe state</dt>
+          <dd>{describeSafeState(status.safeState)}</dd>
+        </div>
+        {status.reason ? (
+          <div>
+            <dt>Reason</dt>
+            <dd>{status.reason}</dd>
+          </div>
+        ) : null}
+        {typeof status.consecutiveMisses === "number" ? (
+          <div>
+            <dt>Consecutive misses</dt>
+            <dd>{status.consecutiveMisses}</dd>
+          </div>
+        ) : null}
+        {status.enteredAt ? (
+          <div>
+            <dt>Entered</dt>
+            <dd>
+              <time dateTime={status.enteredAt}>
+                {new Date(status.enteredAt).toLocaleString()}
+              </time>
+            </dd>
+          </div>
+        ) : null}
+        {status.anchorHash ? (
+          <div>
+            <dt>Anchor</dt>
+            <dd>
+              <code className="safe-state-badge-anchor" title={status.anchorHash}>
+                {status.anchorHash.slice(0, 16)}
+                {"…"}
+              </code>
+            </dd>
+          </div>
+        ) : null}
+        {status.recoveryErrors?.length ? (
+          <div>
+            <dt>Recovery errors</dt>
+            <dd>{status.recoveryErrors.join("; ")}</dd>
+          </div>
+        ) : null}
+      </dl>
+
+      {onResume && canResume ? (
+        <button
+          type="button"
+          className="safe-state-badge-resume"
+          onClick={handleResume}
+          disabled={resuming}
+          style={{
+            marginTop: 8,
+            padding: "6px 14px",
+            border: "1px solid #b91c1c",
+            borderRadius: 4,
+            background: resuming ? "#fca5a5" : "#dc2626",
+            color: "#fff",
+            fontWeight: 600,
+            cursor: resuming ? "not-allowed" : "pointer",
+          }}
+        >
+          {resuming ? "Resuming…" : "Resume blueprint"}
+        </button>
+      ) : null}
+    </div>
+  );
+};
+
+SafeStateBadge.displayName = "SafeStateBadge";
+
+export default SafeStateBadge;

--- a/client/src/components/blueprint/__tests__/SafeStateBadge.test.tsx
+++ b/client/src/components/blueprint/__tests__/SafeStateBadge.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { SafeStateBadge, type SafeStateStatus } from "../SafeStateBadge";
+
+function status(overrides: Partial<SafeStateStatus> = {}): SafeStateStatus {
+  return {
+    blueprintId: "bp-1",
+    siteId: "site-1",
+    runState: "SAFE_STATE",
+    safeState: "force-zero",
+    enteredAt: "2026-07-23T12:00:00.000Z",
+    reason: "3 consecutive ticks exceeded budget of 10ms",
+    consecutiveMisses: 3,
+    anchorHash: "0123456789abcdef0123456789abcdef",
+    ...overrides,
+  };
+}
+
+describe("SafeStateBadge", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing while the blueprint is RUNNING", () => {
+    const { container } = render(
+      <SafeStateBadge status={status({ runState: "RUNNING" })} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("surfaces the applied safe state, reason and anchor when tripped", () => {
+    render(<SafeStateBadge status={status()} />);
+
+    expect(screen.getByRole("alert").getAttribute("data-run-state")).toBe("SAFE_STATE");
+    expect(screen.getByText("SAFE STATE ACTIVE")).toBeTruthy();
+    expect(screen.getByText("Outputs forced to zero")).toBeTruthy();
+    expect(screen.getByText("3 consecutive ticks exceeded budget of 10ms")).toBeTruthy();
+    expect(screen.getByText(/0123456789abcdef/)).toBeTruthy();
+  });
+
+  it("describes a safe recipe by name", () => {
+    render(<SafeStateBadge status={status({ safeState: { recipe: "purge-and-vent" } })} />);
+    expect(screen.getByText("Safe recipe: purge-and-vent")).toBeTruthy();
+  });
+
+  it("requires an explicit confirmation before resuming", () => {
+    const onResume = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(<SafeStateBadge status={status()} onResume={onResume} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /resume blueprint/i }));
+
+    expect(onResume).not.toHaveBeenCalled();
+  });
+
+  it("resumes only after the operator confirms", () => {
+    const onResume = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<SafeStateBadge status={status()} onResume={onResume} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /resume blueprint/i }));
+
+    expect(onResume).toHaveBeenCalledWith("bp-1");
+  });
+
+  it("hides the resume control unless the blueprint is settled in SAFE_STATE", () => {
+    render(
+      <SafeStateBadge
+        status={status({ runState: "RECOVERY_FAILED", recoveryErrors: ["halt failed"] })}
+        onResume={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("SAFETY RECOVERY FAILED")).toBeTruthy();
+    expect(screen.getByText("halt failed")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /resume blueprint/i })).toBeNull();
+  });
+});

--- a/migrations/0009_blueprint_safe_state_log.sql
+++ b/migrations/0009_blueprint_safe_state_log.sql
@@ -1,0 +1,31 @@
+-- Migration: 0009_blueprint_safe_state_log
+-- Issue: #459 - Durable audit trail for watchdog safe-state transitions
+--
+-- The SQLite development fallback creates the same table from
+-- `blueprintSqliteSchema` in server/storage.ts on every database open, so the
+-- safe-state audit is durable on both dialects.
+
+CREATE TABLE IF NOT EXISTS blueprint_safe_state_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  blueprint_id VARCHAR(64) NOT NULL,
+  site_id VARCHAR(64) REFERENCES sites(id),
+  transition VARCHAR(16) NOT NULL,
+  safe_state JSONB NOT NULL,
+  tick_budget_ms INTEGER NOT NULL,
+  consecutive_misses INTEGER,
+  operator VARCHAR(255),
+  reason TEXT NOT NULL,
+  anchor_hash VARCHAR(255) NOT NULL,
+  anchor_tx_hash VARCHAR(255),
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_safe_state_log_blueprint_id
+  ON blueprint_safe_state_log(blueprint_id);
+CREATE INDEX IF NOT EXISTS idx_safe_state_log_transition
+  ON blueprint_safe_state_log(transition);
+CREATE INDEX IF NOT EXISTS idx_safe_state_log_created_at
+  ON blueprint_safe_state_log(created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_safe_state_log_anchor_hash
+  ON blueprint_safe_state_log(anchor_hash);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1784780405000,
       "tag": "0008_modbus_register_map",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1784780406000,
+      "tag": "0009_blueprint_safe_state_log",
+      "breakpoints": true
     }
   ]
 }

--- a/server/__tests__/blueprint-safe-state-auth.test.ts
+++ b/server/__tests__/blueprint-safe-state-auth.test.ts
@@ -1,0 +1,156 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import express from "express";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  blueprintSafeStateRoutes,
+  safeStateRegistry,
+} from "../routes/blueprint-safe-state";
+import { _resetControlPlaneAuthCache } from "../middleware/control-plane-auth";
+
+describe("blueprint safe-state control-plane authorization", () => {
+  const originalApiKeys = process.env.API_KEYS;
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    process.env.API_KEYS = [
+      "read-key:reader:operator",
+      "safety-key:safety-op:operator+safety.resume",
+      "scope-less:legacy",
+    ].join(",");
+    _resetControlPlaneAuthCache();
+
+    const app = express();
+    app.use(express.json());
+    app.use("/api/blueprint-safe-state", blueprintSafeStateRoutes);
+    server = createServer(app);
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+    if (originalApiKeys === undefined) delete process.env.API_KEYS;
+    else process.env.API_KEYS = originalApiKeys;
+    _resetControlPlaneAuthCache();
+  });
+
+  it("rejects anonymous reads", async () => {
+    const response = await fetch(`${baseUrl}/api/blueprint-safe-state`);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("allows an authenticated operator to read status", async () => {
+    const response = await fetch(`${baseUrl}/api/blueprint-safe-state`, {
+      headers: { "x-api-key": "read-key" },
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("attributes an empty status list to no blueprint being loaded", async () => {
+    const response = await fetch(`${baseUrl}/api/blueprint-safe-state`, {
+      headers: { "x-api-key": "read-key" },
+    });
+    const body = await response.json() as {
+      statuses: unknown[];
+      host: { state: string; reason: string; registeredBlueprintIds: string[] };
+    };
+
+    // With no bindings configured the list is empty *because nothing is
+    // loaded* — the response says so, rather than presenting an empty registry
+    // as evidence that safe-state handling is active.
+    expect(body.statuses).toEqual([]);
+    expect(body.host.state).toBe("DISABLED");
+    expect(body.host.reason).toMatch(/no blueprint is loaded/);
+    expect(body.host.registeredBlueprintIds).toEqual([]);
+  });
+
+  it("requires authentication for the host-binding view", async () => {
+    expect((await fetch(`${baseUrl}/api/blueprint-safe-state/host`)).status).toBe(401);
+
+    const response = await fetch(`${baseUrl}/api/blueprint-safe-state/host`, {
+      headers: { "x-api-key": "read-key" },
+    });
+    const body = await response.json() as {
+      safety: { state: string; capabilities: { fieldOutputSinkBound: boolean } };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.safety.state).toBe("DISABLED");
+    expect(body.safety.capabilities.fieldOutputSinkBound).toBe(false);
+  });
+
+  it("reports an unregistered blueprint as 404 with the host reason attached", async () => {
+    const response = await fetch(`${baseUrl}/api/blueprint-safe-state/bp-missing`, {
+      headers: { "x-api-key": "read-key" },
+    });
+    const body = await response.json() as { error: string; host: { state: string } };
+
+    expect(response.status).toBe(404);
+    expect(body.error).toMatch(/not registered/);
+    expect(body.host.state).toBe("DISABLED");
+  });
+
+  it("requires the safety.resume scope and never grants missing scopes implicitly", async () => {
+    for (const key of ["read-key", "scope-less"]) {
+      const response = await fetch(
+        `${baseUrl}/api/blueprint-safe-state/bp-a/resume`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-api-key": key,
+          },
+          body: JSON.stringify({ reason: "condition cleared" }),
+        },
+      );
+
+      expect(response.status).toBe(403);
+    }
+  });
+
+  it("audits the server-owned API-key identity instead of a caller body field", async () => {
+    const resume = vi.fn().mockResolvedValue({ runState: "RUNNING" });
+    vi.spyOn(safeStateRegistry, "get").mockReturnValue({ resume } as never);
+
+    const response = await fetch(
+      `${baseUrl}/api/blueprint-safe-state/bp-a/resume`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "safety-key",
+        },
+        body: JSON.stringify({
+          operator: "spoofed-client-identity",
+          reason: "condition cleared",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(resume).toHaveBeenCalledWith("safety-op", "condition cleared");
+  });
+});

--- a/server/__tests__/blueprint-watchdog.test.ts
+++ b/server/__tests__/blueprint-watchdog.test.ts
@@ -1,0 +1,817 @@
+/**
+ * Blueprint Watchdog & Safe-State Fallback — Unit Tests (#459)
+ *
+ * Exercises the pure trip logic against in-memory fakes for the runtime, the
+ * canonical anchor backend, and the audit sink:
+ *
+ *  - in-budget ticks reset the consecutive-miss counter
+ *  - N consecutive over-budget ticks trip the watchdog
+ *  - a tripped watchdog halts the blueprint and applies the declared safe state
+ *  - a CRITICAL `SafeStateEntered` event is anchored
+ *  - every entry / exit is audited
+ *  - resume requires an operator and anchors a `SafeStateExited` event
+ *  - the documented verification scenario: an artificial pause -> trip -> badge data
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  SafeStateController,
+  computeAnchorHash,
+  describeSafeState,
+  type AnchorBackend,
+  type AnchorEvent,
+  type AnchorReceipt,
+  type SafeStateActuator,
+  type SafeStateAuditEntry,
+  type SafeStateAuditSink,
+} from "../blueprint/safe-state";
+import { Watchdog } from "../blueprint/watchdog";
+import { WatchdogRegistry } from "../blueprint/registry";
+import type { SafeStateConfig, SafeStateAction } from "@shared/schema";
+
+// ─── In-memory fakes ─────────────────────────────────────────────────────────
+
+class FakeRuntime implements SafeStateActuator {
+  readonly blueprintId: string;
+  readonly siteId?: string;
+  halted = false;
+  resumed = false;
+  heldLast = false;
+  forcedZero = false;
+  appliedRecipe: string | null = null;
+  resumeCalls = 0;
+  failResume = false;
+  failHalt = false;
+  failSafeAction = false;
+  safeActionCalls = 0;
+  /** Actions this fake refuses to arm, exercising the fail-closed path. */
+  unsupported = new Set<string>();
+
+  constructor(blueprintId = "bp-test", siteId = "site-1") {
+    this.blueprintId = blueprintId;
+    this.siteId = siteId;
+  }
+
+  assertCanApply(action: SafeStateAction): void {
+    const key = typeof action === "string" ? action : `recipe:${action.recipe}`;
+    if (this.unsupported.has(key)) {
+      throw new Error(`cannot actuate ${key}`);
+    }
+  }
+
+  halt(): void {
+    if (this.failHalt) {
+      throw new Error("runtime halt failed");
+    }
+    this.halted = true;
+  }
+  resume(): void {
+    this.resumeCalls += 1;
+    if (this.failResume) {
+      throw new Error("runtime resume failed");
+    }
+    this.resumed = true;
+    this.halted = false;
+  }
+  holdLastOutputs(): void {
+    this.safeActionCalls += 1;
+    if (this.failSafeAction) throw new Error("safe output failed");
+    this.heldLast = true;
+  }
+  forceZeroOutputs(): void {
+    this.safeActionCalls += 1;
+    if (this.failSafeAction) throw new Error("safe output failed");
+    this.forcedZero = true;
+  }
+  applySafeRecipe(recipe: string): void {
+    this.safeActionCalls += 1;
+    if (this.failSafeAction) throw new Error("safe output failed");
+    this.appliedRecipe = recipe;
+  }
+}
+
+class FakeAnchor implements AnchorBackend {
+  events: AnchorEvent[] = [];
+  failNext = false;
+
+  async anchor(event: AnchorEvent): Promise<AnchorReceipt> {
+    if (this.failNext) {
+      this.failNext = false;
+      throw new Error("anchor backend unavailable");
+    }
+    this.events.push(event);
+    return { hash: computeAnchorHash(event), txHash: `0xtx-${event.id.slice(0, 8)}` };
+  }
+}
+
+class FakeAudit implements SafeStateAuditSink {
+  entries: SafeStateAuditEntry[] = [];
+  failNext = false;
+
+  async record(entry: SafeStateAuditEntry): Promise<void> {
+    if (this.failNext) {
+      this.failNext = false;
+      throw new Error("audit database unavailable");
+    }
+    this.entries.push(entry);
+  }
+}
+
+class BlockingExitAudit extends FakeAudit {
+  readonly exitWriteStarted: Promise<void>;
+  exitWriteAttempts = 0;
+  private markExitWriteStarted!: () => void;
+  private releaseExitWrite!: () => void;
+  private readonly exitWriteReleased: Promise<void>;
+
+  constructor() {
+    super();
+    this.exitWriteStarted = new Promise<void>((resolve) => {
+      this.markExitWriteStarted = resolve;
+    });
+    this.exitWriteReleased = new Promise<void>((resolve) => {
+      this.releaseExitWrite = resolve;
+    });
+  }
+
+  allowExitWrite(): void {
+    this.releaseExitWrite();
+  }
+
+  override async record(entry: SafeStateAuditEntry): Promise<void> {
+    if (entry.transition === "EXIT_REQUESTED") {
+      this.exitWriteAttempts += 1;
+      this.markExitWriteStarted();
+      await this.exitWriteReleased;
+    }
+    await super.record(entry);
+  }
+}
+
+class BlockingExitedAudit extends FakeAudit {
+  readonly exitedWriteStarted: Promise<void>;
+  private markStarted!: () => void;
+  private release!: () => void;
+  private readonly released: Promise<void>;
+
+  constructor() {
+    super();
+    this.exitedWriteStarted = new Promise<void>((resolve) => {
+      this.markStarted = resolve;
+    });
+    this.released = new Promise<void>((resolve) => {
+      this.release = resolve;
+    });
+  }
+
+  allowExitedWrite(): void {
+    this.release();
+  }
+
+  override async record(entry: SafeStateAuditEntry): Promise<void> {
+    if (entry.transition === "EXITED") {
+      this.markStarted();
+      await this.released;
+    }
+    await super.record(entry);
+  }
+}
+
+function makeConfig(overrides: Partial<SafeStateConfig> = {}): SafeStateConfig {
+  return {
+    enabled: true,
+    tickBudgetMs: 10,
+    consecutiveMissesBeforeSafeState: 3,
+    safeState: "hold-last",
+    ...overrides,
+  };
+}
+
+// ─── Watchdog trip logic ─────────────────────────────────────────────────────
+
+describe("Watchdog — tick budget tripping", () => {
+  let runtime: FakeRuntime;
+  let anchor: FakeAnchor;
+  let audit: FakeAudit;
+
+  beforeEach(() => {
+    runtime = new FakeRuntime();
+    anchor = new FakeAnchor();
+    audit = new FakeAudit();
+  });
+
+  it("does not trip on in-budget ticks", async () => {
+    const wd = new Watchdog(runtime, makeConfig(), anchor, audit);
+    for (let i = 0; i < 10; i++) {
+      const obs = await wd.observeTick(5);
+      expect(obs.overBudget).toBe(false);
+      expect(obs.tripped).toBe(false);
+    }
+    expect(wd.getConsecutiveMisses()).toBe(0);
+    expect(wd.getStatus().runState).toBe("RUNNING");
+    expect(anchor.events).toHaveLength(0);
+  });
+
+  it("resets the miss counter on any in-budget tick", async () => {
+    const wd = new Watchdog(runtime, makeConfig({ consecutiveMissesBeforeSafeState: 3 }), anchor, audit);
+    await wd.observeTick(50); // miss 1
+    await wd.observeTick(50); // miss 2
+    expect(wd.getConsecutiveMisses()).toBe(2);
+    const recovery = await wd.observeTick(5); // healthy -> reset
+    expect(recovery.consecutiveMisses).toBe(0);
+    expect(wd.getConsecutiveMisses()).toBe(0);
+    // Two more misses should NOT trip (counter was reset).
+    await wd.observeTick(50);
+    const obs = await wd.observeTick(50);
+    expect(obs.tripped).toBe(false);
+    expect(wd.getStatus().runState).toBe("RUNNING");
+  });
+
+  it("trips after exactly N consecutive over-budget ticks", async () => {
+    const wd = new Watchdog(runtime, makeConfig({ consecutiveMissesBeforeSafeState: 3 }), anchor, audit);
+    const o1 = await wd.observeTick(20);
+    const o2 = await wd.observeTick(20);
+    expect(o1.tripped).toBe(false);
+    expect(o2.tripped).toBe(false);
+    const o3 = await wd.observeTick(20);
+    expect(o3.tripped).toBe(true);
+    expect(o3.consecutiveMisses).toBe(3);
+    expect(wd.getStatus().runState).toBe("SAFE_STATE");
+  });
+
+  it("halts the blueprint and applies the declared safe state on trip", async () => {
+    const wd = new Watchdog(runtime, makeConfig({ consecutiveMissesBeforeSafeState: 2 }), anchor, audit);
+    await wd.observeTick(20);
+    await wd.observeTick(20);
+    expect(runtime.halted).toBe(true);
+    expect(runtime.heldLast).toBe(true); // safeState: hold-last
+  });
+
+  it("anchors a CRITICAL SafeStateEntered event on trip", async () => {
+    const wd = new Watchdog(runtime, makeConfig({ consecutiveMissesBeforeSafeState: 2 }), anchor, audit);
+    await wd.observeTick(20);
+    await wd.observeTick(20);
+    expect(anchor.events).toHaveLength(1);
+    const ev = anchor.events[0];
+    expect(ev.eventType).toBe("SafeStateEntered");
+    expect(ev.severity).toBe("CRITICAL");
+    expect(ev.siteId).toBe("site-1");
+    expect(ev.data.blueprintId).toBe("bp-test");
+    expect(ev.data.consecutiveMisses).toBe(2);
+  });
+
+  it("audits the entry transition", async () => {
+    const wd = new Watchdog(runtime, makeConfig({ consecutiveMissesBeforeSafeState: 2 }), anchor, audit);
+    await wd.observeTick(20);
+    await wd.observeTick(20);
+    expect(audit.entries).toHaveLength(1);
+    const entry = audit.entries[0];
+    expect(entry.transition).toBe("ENTERED");
+    expect(entry.blueprintId).toBe("bp-test");
+    expect(entry.consecutiveMisses).toBe(2);
+    expect(entry.anchorHash).toBeTruthy();
+  });
+
+  it("does not re-trip once already in safe state", async () => {
+    const wd = new Watchdog(runtime, makeConfig({ consecutiveMissesBeforeSafeState: 2 }), anchor, audit);
+    await wd.observeTick(20);
+    await wd.observeTick(20);
+    expect(anchor.events).toHaveLength(1);
+    // Further over-budget ticks while safe must not anchor again.
+    const obs = await wd.observeTick(99);
+    expect(obs.tripped).toBe(false);
+    expect(anchor.events).toHaveLength(1);
+    expect(audit.entries).toHaveLength(1);
+  });
+
+  it("is disarmed when config.enabled is false", async () => {
+    const wd = new Watchdog(runtime, makeConfig({ enabled: false, consecutiveMissesBeforeSafeState: 1 }), anchor, audit);
+    const obs = await wd.observeTick(9999);
+    expect(obs.tripped).toBe(false);
+    expect(wd.getStatus().runState).toBe("RUNNING");
+    expect(anchor.events).toHaveLength(0);
+  });
+});
+
+// ─── Safe-state actions ──────────────────────────────────────────────────────
+
+describe("SafeStateController — safe state actions", () => {
+  it("hold-last freezes outputs", async () => {
+    const runtime = new FakeRuntime();
+    const ctl = new SafeStateController(runtime, makeConfig({ safeState: "hold-last" }), new FakeAnchor(), new FakeAudit());
+    await ctl.enterSafeState("test", 3);
+    expect(runtime.heldLast).toBe(true);
+    expect(runtime.forcedZero).toBe(false);
+  });
+
+  it("force-zero drives outputs to zero", async () => {
+    const runtime = new FakeRuntime();
+    const ctl = new SafeStateController(runtime, makeConfig({ safeState: "force-zero" }), new FakeAnchor(), new FakeAudit());
+    await ctl.enterSafeState("test", 3);
+    expect(runtime.forcedZero).toBe(true);
+    expect(runtime.heldLast).toBe(false);
+  });
+
+  it("recipe applies the named safe recipe", async () => {
+    const runtime = new FakeRuntime();
+    const action: SafeStateAction = { recipe: "shutdown-v2" };
+    const ctl = new SafeStateController(runtime, makeConfig({ safeState: action }), new FakeAnchor(), new FakeAudit());
+    await ctl.enterSafeState("test", 3);
+    expect(runtime.appliedRecipe).toBe("shutdown-v2");
+  });
+
+  it("falls back to a computed content hash when anchoring fails", async () => {
+    const runtime = new FakeRuntime();
+    const anchor = new FakeAnchor();
+    anchor.failNext = true;
+    const audit = new FakeAudit();
+    const ctl = new SafeStateController(runtime, makeConfig(), anchor, audit);
+    const status = await ctl.enterSafeState("anchor down", 3);
+    // Physical safe state still applied + audited despite anchor failure.
+    expect(runtime.heldLast).toBe(true);
+    expect(status.anchorHash).toBeTruthy();
+    expect(audit.entries[0].anchorHash).toBe(status.anchorHash);
+  });
+
+  it("fails loudly while leaving physical outputs safe when audit persistence fails", async () => {
+    const runtime = new FakeRuntime();
+    const audit = new FakeAudit();
+    audit.failNext = true;
+    const ctl = new SafeStateController(
+      runtime,
+      makeConfig({ safeState: "force-zero" }),
+      new FakeAnchor(),
+      audit,
+    );
+
+    await expect(ctl.enterSafeState("trip", 3)).rejects.toThrow(
+      /audit database unavailable/,
+    );
+
+    expect(runtime.halted).toBe(true);
+    expect(runtime.forcedZero).toBe(true);
+    expect(ctl.getStatus().runState).toBe("SAFE_STATE");
+    expect(ctl.getStatus().entryAuditStatus).toBe("pending");
+
+    // An undurable entry blocks resume. Once the same entry is persisted, the
+    // controller may proceed without duplicating the physical trip.
+    audit.failNext = true;
+    await expect(ctl.resume("operator-a")).rejects.toThrow(
+      /audit database unavailable/,
+    );
+    expect(runtime.resumeCalls).toBe(0);
+    await expect(ctl.resume("operator-a")).resolves.toMatchObject({
+      runState: "RUNNING",
+    });
+    expect(audit.entries.filter((entry) => entry.transition === "ENTERED"))
+      .toHaveLength(1);
+  });
+});
+
+// ─── Operator resume ─────────────────────────────────────────────────────────
+
+describe("SafeStateController — operator resume", () => {
+  it("requires safe state to be active before resuming", async () => {
+    const ctl = new SafeStateController(new FakeRuntime(), makeConfig(), new FakeAnchor(), new FakeAudit());
+    await expect(ctl.resume("operator-a")).rejects.toThrow(/not in safe state/);
+  });
+
+  it("requires an operator identity", async () => {
+    const ctl = new SafeStateController(new FakeRuntime(), makeConfig(), new FakeAnchor(), new FakeAudit());
+    await ctl.enterSafeState("trip", 3);
+    await expect(ctl.resume("")).rejects.toThrow(/operator identity/);
+  });
+
+  it("resumes, anchors SafeStateExited, and audits the exit", async () => {
+    const runtime = new FakeRuntime();
+    const anchor = new FakeAnchor();
+    const audit = new FakeAudit();
+    const ctl = new SafeStateController(runtime, makeConfig(), anchor, audit);
+    await ctl.enterSafeState("trip", 3);
+    const status = await ctl.resume("operator-a", "condition cleared");
+    expect(status.runState).toBe("RUNNING");
+    expect(runtime.resumed).toBe(true);
+    const exitEvent = anchor.events.find((e) => e.eventType === "SafeStateExited");
+    expect(exitEvent).toBeDefined();
+    expect(exitEvent?.severity).toBe("WARNING");
+    expect(exitEvent?.data.operator).toBe("operator-a");
+    const exitAudit = audit.entries.find((e) => e.transition === "EXITED");
+    expect(exitAudit?.operator).toBe("operator-a");
+    // The EXITED audit row carries the safe state that had been applied and the
+    // configured budget, so the audit trail is self-describing without joins.
+    expect(exitAudit?.safeState).toBe("hold-last");
+    expect(exitAudit?.tickBudgetMs).toBe(10);
+    expect(exitAudit?.reason).toBe("condition cleared");
+  });
+
+  it("clears trip metadata from status on resume", async () => {
+    const ctl = new SafeStateController(new FakeRuntime(), makeConfig(), new FakeAnchor(), new FakeAudit());
+    await ctl.enterSafeState("trip", 4);
+    const tripped = ctl.getStatus();
+    expect(tripped.reason).toBe("trip");
+    expect(tripped.enteredAt).toBeTruthy();
+    expect(tripped.consecutiveMisses).toBe(4);
+    expect(tripped.anchorHash).toBeTruthy();
+
+    const resumed = await ctl.resume("operator-a");
+    // A resumed blueprint must not advertise stale trip metadata, or the UI
+    // would keep showing details from the previous (now-cleared) safe state.
+    expect(resumed.runState).toBe("RUNNING");
+    expect(resumed.reason).toBeUndefined();
+    expect(resumed.enteredAt).toBeUndefined();
+    expect(resumed.consecutiveMisses).toBeUndefined();
+    expect(resumed.anchorHash).toBeUndefined();
+  });
+
+  it("keeps the declared safe state when exit authorisation cannot persist", async () => {
+    const runtime = new FakeRuntime();
+    const audit = new FakeAudit();
+    const ctl = new SafeStateController(
+      runtime,
+      makeConfig({ safeState: "force-zero" }),
+      new FakeAnchor(),
+      audit,
+    );
+    await ctl.enterSafeState("trip", 3);
+    audit.failNext = true;
+
+    await expect(ctl.resume("operator-a")).rejects.toThrow(
+      /audit database unavailable/,
+    );
+
+    expect(runtime.halted).toBe(true);
+    expect(runtime.forcedZero).toBe(true);
+    expect(runtime.resumeCalls).toBe(0);
+    expect(runtime.resumed).toBe(false);
+    expect(ctl.getStatus().runState).toBe("SAFE_STATE");
+
+    // A rejected transition must not poison the serial queue; an operator can
+    // retry once durable audit storage is healthy again.
+    await expect(ctl.resume("operator-b", "audit recovered")).resolves.toMatchObject({
+      runState: "RUNNING",
+    });
+    expect(runtime.resumeCalls).toBe(1);
+  });
+
+  it("returns to safe state when resume succeeds but the EXITED audit fails", async () => {
+    const runtime = new FakeRuntime();
+    const audit = new FakeAudit();
+    const originalRecord = audit.record.bind(audit);
+    let failExit = true;
+    audit.record = async (entry) => {
+      if (entry.transition === "EXITED" && failExit) {
+        failExit = false;
+        throw new Error("exit audit unavailable");
+      }
+      await originalRecord(entry);
+    };
+    const ctl = new SafeStateController(
+      runtime,
+      makeConfig({ safeState: "force-zero" }),
+      new FakeAnchor(),
+      audit,
+    );
+    await ctl.enterSafeState("trip", 3);
+
+    await expect(ctl.resume("operator-a")).rejects.toThrow(
+      /exit audit unavailable/,
+    );
+
+    expect(runtime.resumeCalls).toBe(1);
+    expect(runtime.halted).toBe(true);
+    expect(runtime.forcedZero).toBe(true);
+    expect(ctl.getStatus().runState).toBe("SAFE_STATE");
+    expect(audit.entries.some((entry) => entry.transition === "EXITED")).toBe(false);
+    expect(audit.entries.some((entry) => entry.transition === "EXIT_ABORTED")).toBe(true);
+
+    await expect(ctl.resume("operator-b", "audit recovered")).resolves.toMatchObject({
+      runState: "RUNNING",
+    });
+    expect(runtime.resumeCalls).toBe(2);
+  });
+
+  it("records RESUME_FAILED and no EXITED when the runtime cannot resume", async () => {
+    const runtime = new FakeRuntime();
+    runtime.failResume = true;
+    const audit = new FakeAudit();
+    const ctl = new SafeStateController(
+      runtime,
+      makeConfig({ safeState: "force-zero" }),
+      new FakeAnchor(),
+      audit,
+    );
+    await ctl.enterSafeState("trip", 3);
+
+    await expect(ctl.resume("operator-a")).rejects.toThrow(
+      /runtime resume failed/,
+    );
+
+    expect(runtime.halted).toBe(true);
+    expect(ctl.getStatus().runState).toBe("SAFE_STATE");
+    expect(audit.entries.some((entry) => entry.transition === "EXITED")).toBe(false);
+    expect(audit.entries.some((entry) => entry.transition === "RESUME_FAILED")).toBe(true);
+  });
+
+  it("reports RESUMING while the live runtime waits for a durable EXITED row", async () => {
+    const runtime = new FakeRuntime();
+    const audit = new BlockingExitedAudit();
+    const ctl = new SafeStateController(
+      runtime,
+      makeConfig({ safeState: "force-zero" }),
+      new FakeAnchor(),
+      audit,
+    );
+    await ctl.enterSafeState("trip", 3);
+
+    const resume = ctl.resume("operator-a");
+    await audit.exitedWriteStarted;
+
+    expect(runtime.resumed).toBe(true);
+    expect(ctl.getStatus().runState).toBe("RESUMING");
+
+    audit.allowExitedWrite();
+    await expect(resume).resolves.toMatchObject({ runState: "RUNNING" });
+  });
+
+  it("attempts halt and safe outputs independently and reports failed recovery", async () => {
+    const runtime = new FakeRuntime();
+    const audit = new FakeAudit();
+    const ctl = new SafeStateController(
+      runtime,
+      makeConfig({ safeState: "force-zero" }),
+      new FakeAnchor(),
+      audit,
+    );
+    await ctl.enterSafeState("trip", 3);
+    const safeCallsBeforeResume = runtime.safeActionCalls;
+    runtime.failResume = true;
+    runtime.failHalt = true;
+    runtime.failSafeAction = true;
+
+    await expect(ctl.resume("operator-a")).rejects.toThrow(
+      /safety recovery was incomplete/,
+    );
+
+    expect(runtime.safeActionCalls).toBe(safeCallsBeforeResume + 1);
+    expect(ctl.getStatus()).toMatchObject({
+      runState: "RECOVERY_FAILED",
+      recoveryErrors: [
+        expect.stringMatching(/halt failed/),
+        expect.stringMatching(/safe-output application failed/),
+      ],
+    });
+    expect(audit.entries.some((entry) => entry.transition === "RECOVERY_FAILED"))
+      .toBe(true);
+  });
+
+  it("retries an ambiguously committed exit request with the same anchor hash", async () => {
+    const runtime = new FakeRuntime();
+    const audit = new FakeAudit();
+    const attemptedHashes: string[] = [];
+    let throwAfterFirstCommit = true;
+    const originalRecord = audit.record.bind(audit);
+    audit.record = async (entry) => {
+      if (entry.transition === "EXIT_REQUESTED") {
+        attemptedHashes.push(entry.anchorHash);
+        if (throwAfterFirstCommit) {
+          throwAfterFirstCommit = false;
+          audit.entries.push(entry);
+          throw new Error("ambiguous database acknowledgement");
+        }
+        if (audit.entries.some((existing) =>
+          existing.anchorHash === entry.anchorHash
+        )) {
+          return;
+        }
+      }
+      await originalRecord(entry);
+    };
+    const ctl = new SafeStateController(
+      runtime,
+      makeConfig(),
+      new FakeAnchor(),
+      audit,
+    );
+    await ctl.enterSafeState("trip", 3);
+
+    await expect(ctl.resume("operator-a")).rejects.toThrow(
+      /ambiguous database acknowledgement/,
+    );
+    expect(runtime.resumeCalls).toBe(0);
+
+    await expect(ctl.resume("operator-b")).resolves.toMatchObject({
+      runState: "RUNNING",
+    });
+    expect(attemptedHashes).toHaveLength(3);
+    expect(attemptedHashes[1]).toBe(attemptedHashes[0]);
+    expect(attemptedHashes[2]).not.toBe(attemptedHashes[0]);
+  });
+
+  it("serializes concurrent resumes and enables the runtime only after exit authorisation persists", async () => {
+    const runtime = new FakeRuntime();
+    const audit = new BlockingExitAudit();
+    const ctl = new SafeStateController(
+      runtime,
+      makeConfig({ safeState: "force-zero" }),
+      new FakeAnchor(),
+      audit,
+    );
+    await ctl.enterSafeState("trip", 3);
+
+    const firstResume = ctl.resume("operator-a", "condition cleared");
+    await audit.exitWriteStarted;
+
+    const secondResume = ctl.resume("operator-b", "duplicate request");
+    const secondOutcome = secondResume.then(
+      (value) => ({ value, error: null as Error | null }),
+      (error: Error) => ({ value: null, error }),
+    );
+
+    expect(runtime.resumeCalls).toBe(0);
+    expect(runtime.halted).toBe(true);
+    expect(audit.exitWriteAttempts).toBe(1);
+    expect(ctl.getStatus().runState).toBe("SAFE_STATE");
+
+    audit.allowExitWrite();
+    await expect(firstResume).resolves.toMatchObject({ runState: "RUNNING" });
+
+    const duplicate = await secondOutcome;
+    expect(duplicate.value).toBeNull();
+    expect(duplicate.error?.message).toMatch(/not in safe state/);
+    expect(runtime.resumeCalls).toBe(1);
+    expect(audit.exitWriteAttempts).toBe(1);
+    expect(audit.entries.filter((entry) => entry.transition === "EXITED")).toHaveLength(1);
+    expect(ctl.getStatus().runState).toBe("RUNNING");
+  });
+
+  it("Watchdog.resume clears the miss counter and re-arms", async () => {
+    const runtime = new FakeRuntime();
+    const wd = new Watchdog(runtime, makeConfig({ consecutiveMissesBeforeSafeState: 2 }), new FakeAnchor(), new FakeAudit());
+    await wd.observeTick(20);
+    await wd.observeTick(20);
+    expect(wd.getStatus().runState).toBe("SAFE_STATE");
+    await wd.resume("operator-b");
+    expect(wd.getConsecutiveMisses()).toBe(0);
+    expect(wd.getStatus().runState).toBe("RUNNING");
+    // Re-armed: a fresh streak can trip again.
+    await wd.observeTick(20);
+    const obs = await wd.observeTick(20);
+    expect(obs.tripped).toBe(true);
+  });
+});
+
+// ─── Registry ────────────────────────────────────────────────────────────────
+
+describe("WatchdogRegistry", () => {
+  it("tracks, fetches and removes per-blueprint watchdogs", async () => {
+    const registry = new WatchdogRegistry(new FakeAnchor(), new FakeAudit());
+    const rt = new FakeRuntime("bp-a", "site-a");
+    const wd = registry.register(rt, makeConfig({ consecutiveMissesBeforeSafeState: 1 }));
+    expect(registry.get("bp-a")).toBe(wd);
+    expect(registry.getAllStatuses()).toHaveLength(1);
+    expect(registry.getSafeStateStatuses()).toHaveLength(0);
+
+    await wd.observeTick(999); // trip (N=1)
+    expect(registry.getSafeStateStatuses()).toHaveLength(1);
+
+    registry.unregister("bp-a");
+    expect(registry.get("bp-a")).toBeUndefined();
+    expect(registry.getAllStatuses()).toHaveLength(0);
+  });
+
+  it("surfaces a recipe safe state as badge-renderable status", async () => {
+    const registry = new WatchdogRegistry(new FakeAnchor(), new FakeAudit());
+    const rt = new FakeRuntime("bp-recipe", "site-r");
+    const action: SafeStateAction = { recipe: "purge-and-vent" };
+    const wd = registry.register(
+      rt,
+      makeConfig({ consecutiveMissesBeforeSafeState: 1, safeState: action }),
+    );
+    await wd.observeTick(999);
+
+    expect(rt.appliedRecipe).toBe("purge-and-vent");
+    const [status] = registry.getSafeStateStatuses();
+    expect(status.runState).toBe("SAFE_STATE");
+    // The recipe object must survive serialisation intact so the badge can
+    // render `Safe recipe: purge-and-vent`.
+    expect(status.safeState).toEqual({ recipe: "purge-and-vent" });
+    expect(describeSafeState(status.safeState)).toMatch(/purge-and-vent/);
+  });
+
+  it("refuses to arm a blueprint whose declared safe state is not actuatable", () => {
+    const registry = new WatchdogRegistry(new FakeAnchor(), new FakeAudit());
+    const rt = new FakeRuntime("bp-unactuatable", "site-x");
+    rt.unsupported.add("force-zero");
+
+    expect(() =>
+      registry.register(rt, makeConfig({ safeState: "force-zero" })),
+    ).toThrow(/cannot actuate force-zero/);
+    // Fail-closed: nothing is registered, so nothing can report itself guarded.
+    expect(registry.get("bp-unactuatable")).toBeUndefined();
+    expect(registry.size()).toBe(0);
+  });
+
+  it("skips the tick body once the blueprint is in safe state", async () => {
+    const registry = new WatchdogRegistry(new FakeAnchor(), new FakeAudit());
+    const rt = new FakeRuntime("bp-halt", "site-h");
+    const wd = registry.register(
+      rt,
+      makeConfig({ tickBudgetMs: 1, consecutiveMissesBeforeSafeState: 1 }),
+    );
+
+    let executions = 0;
+    const first = await wd.runTick(() => {
+      executions += 1;
+      return 1;
+    });
+    expect(first.skipped).toBe(false);
+    expect(executions).toBe(1);
+
+    await wd.observeTick(500); // trip
+    expect(rt.halted).toBe(true);
+
+    const second = await wd.runTick(() => {
+      executions += 1;
+      return 2;
+    });
+    expect(second.skipped).toBe(true);
+    expect(second.result).toBeUndefined();
+    expect(executions).toBe(1);
+  });
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+describe("helpers", () => {
+  it("describeSafeState labels each action", () => {
+    expect(describeSafeState("hold-last")).toMatch(/hold last/i);
+    expect(describeSafeState("force-zero")).toMatch(/zero/i);
+    expect(describeSafeState({ recipe: "r1" })).toMatch(/r1/);
+  });
+
+  it("computeAnchorHash is deterministic and content-sensitive", () => {
+    const base: AnchorEvent = {
+      id: "fixed-id",
+      timestamp: "2026-06-22T00:00:00.000Z",
+      eventType: "SafeStateEntered",
+      severity: "CRITICAL",
+      siteId: "site-1",
+      message: "m",
+      data: { a: 1 },
+    };
+    expect(computeAnchorHash(base)).toBe(computeAnchorHash({ ...base }));
+    expect(computeAnchorHash(base)).not.toBe(computeAnchorHash({ ...base, message: "different" }));
+  });
+});
+
+// ─── Verification scenario (from the issue) ──────────────────────────────────
+
+describe("Verification: artificial pause -> watchdog fires -> SafeStateEntered -> badge data", () => {
+  it("trips after N consecutive misses and yields badge-renderable status", async () => {
+    const runtime = new FakeRuntime("dosing-loop", "plant-7");
+    const anchor = new FakeAnchor();
+    const audit = new FakeAudit();
+    const registry = new WatchdogRegistry(anchor, audit);
+    const config = makeConfig({ tickBudgetMs: 10, consecutiveMissesBeforeSafeState: 3, safeState: "force-zero" });
+    const wd = registry.register(runtime, config);
+
+    // Healthy ticks first.
+    await wd.runTick(() => 0);
+
+    // Inject an artificial pause that blows the 10ms budget, sustained for N ticks.
+    const pause = (ms: number) => {
+      const end = Date.now() + ms;
+      while (Date.now() < end) {
+        /* busy-wait to simulate an over-budget control tick */
+      }
+    };
+    let lastTripped = false;
+    for (let i = 0; i < 3; i++) {
+      const { observation } = await wd.runTick(() => pause(15));
+      lastTripped = observation.tripped;
+    }
+
+    // Watchdog fired.
+    expect(lastTripped).toBe(true);
+
+    // A SafeStateEntered CRITICAL event was produced via the anchor backend.
+    const entered = anchor.events.find((e) => e.eventType === "SafeStateEntered");
+    expect(entered).toBeDefined();
+    expect(entered?.severity).toBe("CRITICAL");
+
+    // The transition was audited.
+    expect(audit.entries.some((e) => e.transition === "ENTERED")).toBe(true);
+
+    // The registry exposes badge-renderable status for the operator UI.
+    const safe = registry.getSafeStateStatuses();
+    expect(safe).toHaveLength(1);
+    expect(safe[0]).toMatchObject({
+      blueprintId: "dosing-loop",
+      siteId: "plant-7",
+      runState: "SAFE_STATE",
+      safeState: "force-zero",
+    });
+    expect(safe[0].anchorHash).toBeTruthy();
+    expect(safe[0].enteredAt).toBeTruthy();
+  });
+});

--- a/server/blueprint/__tests__/production-safety.test.ts
+++ b/server/blueprint/__tests__/production-safety.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+describe("safe-state audit migration alignment", () => {
+  it("creates every durable column and index declared by the Drizzle table", () => {
+    const sql = readFileSync(
+      new URL("../../../migrations/0009_blueprint_safe_state_log.sql", import.meta.url),
+      "utf8",
+    );
+
+    for (const column of [
+      "blueprint_id",
+      "site_id",
+      "transition",
+      "safe_state",
+      "tick_budget_ms",
+      "consecutive_misses",
+      "operator",
+      "reason",
+      "anchor_hash",
+      "anchor_tx_hash",
+      "metadata",
+      "created_at",
+    ]) {
+      expect(sql).toMatch(new RegExp(`\\b${column}\\b`));
+    }
+    expect(sql).toContain("idx_safe_state_log_blueprint_id");
+    expect(sql).toContain("idx_safe_state_log_transition");
+    expect(sql).toContain("idx_safe_state_log_created_at");
+    expect(sql).toContain("UNIQUE INDEX IF NOT EXISTS idx_safe_state_log_anchor_hash");
+  });
+
+  it("declares the same table for the SQLite development fallback", () => {
+    const storageSource = readFileSync(
+      new URL("../../storage.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(storageSource).toContain(
+      "CREATE TABLE IF NOT EXISTS blueprint_safe_state_log",
+    );
+    expect(storageSource).toContain(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_safe_state_log_anchor_hash",
+    );
+  });
+
+  it("appends the safe-state migration to the existing journal without renumbering", () => {
+    const journal = JSON.parse(
+      readFileSync(
+        new URL("../../../migrations/meta/_journal.json", import.meta.url),
+        "utf8",
+      ),
+    ) as { entries: Array<{ idx: number; tag: string; when: number }> };
+
+    expect(journal.entries.map(({ idx, tag }) => ({ idx, tag }))).toEqual([
+      { idx: 0, tag: "0001_initial_schema" },
+      { idx: 1, tag: "0002_seed_rbac_defaults" },
+      { idx: 2, tag: "0003_blueprint_persistence" },
+      { idx: 3, tag: "0006_blueprint_instance_identity" },
+      { idx: 4, tag: "0007_validator_registry" },
+      { idx: 5, tag: "0008_modbus_register_map" },
+      { idx: 6, tag: "0009_blueprint_safe_state_log" },
+    ]);
+    // `when` must stay monotonic so drizzle-kit orders the journal correctly.
+    const timestamps = journal.entries.map((e) => e.when);
+    expect([...timestamps].sort((a, b) => a - b)).toEqual(timestamps);
+  });
+});

--- a/server/blueprint/__tests__/runtime-actuator.test.ts
+++ b/server/blueprint/__tests__/runtime-actuator.test.ts
@@ -1,0 +1,193 @@
+/**
+ * The safe-state actuation seam must actually move outputs (#459).
+ *
+ * These tests drive the REAL deterministic runtime (not a fake) through
+ * {@link BlueprintRuntimeActuator} and assert the runtime's tag store — the only
+ * output sink that genuinely exists in this repository today — really changes.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { compileBlueprint } from "../compiler";
+import { BlueprintRuntime } from "../runtime";
+import type { BlueprintDefinition } from "../types";
+import {
+  BlueprintRuntimeActuator,
+  OUTPUT_WRITE_OPT_IN_ENV,
+  type FieldOutputSink,
+} from "../runtime-actuator";
+
+const DEFINITION: BlueprintDefinition = {
+  id: "bp-actuator",
+  name: "Two-output actuator fixture",
+  scanPeriodMs: 50,
+  tags: [
+    { name: "IN_A", direction: "input", dataType: "float", initial: 3 },
+    { name: "IN_B", direction: "input", dataType: "float", initial: 4 },
+    { name: "OUT_SUM", direction: "output", dataType: "float" },
+    { name: "OUT_COPY", direction: "output", dataType: "float" },
+  ],
+  nodes: [
+    { id: "n_sum", op: "ADD", inputs: [{ tag: "IN_A" }, { tag: "IN_B" }], output: "OUT_SUM" },
+    { id: "n_copy", op: "MOVE", inputs: [{ tag: "IN_A" }], output: "OUT_COPY" },
+  ],
+};
+
+class RecordingSink implements FieldOutputSink {
+  readonly id = "recording-sink";
+  readonly writes: Array<Record<string, number>> = [];
+  failNext = false;
+
+  writeOutputs(values: ReadonlyMap<string, number>): void {
+    if (this.failNext) {
+      this.failNext = false;
+      throw new Error("field write rejected");
+    }
+    this.writes.push(Object.fromEntries(values));
+  }
+}
+
+function build(
+  env: NodeJS.ProcessEnv,
+  options: { fieldSink?: FieldOutputSink; safeRecipes?: Record<string, Record<string, number>> } = {},
+): { runtime: BlueprintRuntime; actuator: BlueprintRuntimeActuator } {
+  const runtime = new BlueprintRuntime(compileBlueprint(DEFINITION));
+  const actuator = new BlueprintRuntimeActuator("bp-actuator", runtime, {
+    siteId: "site-1",
+    env,
+    ...options,
+  });
+  return { runtime, actuator };
+}
+
+describe("BlueprintRuntimeActuator", () => {
+  it("discovers the blueprint's output tags from the compiled program", () => {
+    const { actuator } = build({});
+    expect([...actuator.getOutputTagNames()].sort()).toEqual(["OUT_COPY", "OUT_SUM"]);
+    expect(actuator.getCapabilities()).toMatchObject({
+      blueprintId: "bp-actuator",
+      outputSink: "runtime-tag-store",
+      fieldSinkBound: false,
+      outputWritesAllowed: false,
+    });
+  });
+
+  it("halts and resumes a real latch that tick drivers must honour", () => {
+    const { actuator } = build({});
+    expect(actuator.isHalted()).toBe(false);
+    actuator.halt();
+    expect(actuator.isHalted()).toBe(true);
+    actuator.resume();
+    expect(actuator.isHalted()).toBe(false);
+    expect(actuator.getOutputMode()).toBe("loop");
+  });
+
+  it("holds the last computed outputs and republishes them to a bound sink", () => {
+    const sink = new RecordingSink();
+    const { runtime, actuator } = build({}, { fieldSink: sink });
+
+    runtime.tickFast();
+    expect(runtime.get("OUT_SUM")).toBe(7);
+
+    actuator.holdLastOutputs();
+
+    expect(actuator.getOutputMode()).toBe("hold-last");
+    expect(Object.fromEntries(actuator.getHeldOutputs()!)).toEqual({
+      OUT_SUM: 7,
+      OUT_COPY: 3,
+    });
+    // Hold-last commands no NEW value; it re-asserts what the loop last wrote.
+    expect(runtime.get("OUT_SUM")).toBe(7);
+    expect(sink.writes).toEqual([{ OUT_SUM: 7, OUT_COPY: 3 }]);
+  });
+
+  it("refuses to force outputs to zero without the explicit opt-in", () => {
+    const { runtime, actuator } = build({});
+    runtime.tickFast();
+
+    expect(() => actuator.forceZeroOutputs()).toThrow(
+      new RegExp(OUTPUT_WRITE_OPT_IN_ENV),
+    );
+    expect(() => actuator.assertCanApply("force-zero")).toThrow(/Refusing to arm/);
+    // Fail-closed means the plant output is untouched, not partially written.
+    expect(runtime.get("OUT_SUM")).toBe(7);
+  });
+
+  it("does not treat any value other than \"true\" as an opt-in", () => {
+    for (const value of ["1", "yes", "TRUE", ""]) {
+      const { actuator } = build({ [OUTPUT_WRITE_OPT_IN_ENV]: value });
+      expect(actuator.getCapabilities().outputWritesAllowed).toBe(false);
+      expect(() => actuator.forceZeroOutputs()).toThrow();
+    }
+  });
+
+  it("drives every output tag to zero in the runtime tag store once opted in", () => {
+    const sink = new RecordingSink();
+    const { runtime, actuator } = build(
+      { [OUTPUT_WRITE_OPT_IN_ENV]: "true" },
+      { fieldSink: sink },
+    );
+    runtime.tickFast();
+    expect(runtime.get("OUT_SUM")).toBe(7);
+    expect(runtime.get("OUT_COPY")).toBe(3);
+
+    actuator.assertCanApply("force-zero");
+    actuator.forceZeroOutputs();
+
+    expect(runtime.get("OUT_SUM")).toBe(0);
+    expect(runtime.get("OUT_COPY")).toBe(0);
+    expect(actuator.getOutputMode()).toBe("force-zero");
+    expect(sink.writes).toEqual([{ OUT_SUM: 0, OUT_COPY: 0 }]);
+  });
+
+  it("propagates a field-sink failure instead of claiming the plant is safe", () => {
+    const sink = new RecordingSink();
+    sink.failNext = true;
+    const { runtime, actuator } = build(
+      { [OUTPUT_WRITE_OPT_IN_ENV]: "true" },
+      { fieldSink: sink },
+    );
+    runtime.tickFast();
+
+    expect(() => actuator.forceZeroOutputs()).toThrow(/field write rejected/);
+  });
+
+  it("applies only declared safe recipes, and only when opted in", () => {
+    const recipes = { "purge-and-vent": { OUT_SUM: 0, OUT_COPY: 1 } };
+
+    const denied = build({}, { safeRecipes: recipes });
+    expect(() => denied.actuator.assertCanApply({ recipe: "purge-and-vent" })).toThrow(
+      new RegExp(OUTPUT_WRITE_OPT_IN_ENV),
+    );
+
+    const allowed = build({ [OUTPUT_WRITE_OPT_IN_ENV]: "true" }, { safeRecipes: recipes });
+    expect(() => allowed.actuator.assertCanApply({ recipe: "unknown" })).toThrow(
+      /not defined for this blueprint/,
+    );
+    expect(() => allowed.actuator.applySafeRecipe("unknown")).toThrow(/Unknown safe recipe/);
+
+    allowed.runtime.tickFast();
+    allowed.actuator.assertCanApply({ recipe: "purge-and-vent" });
+    allowed.actuator.applySafeRecipe("purge-and-vent");
+
+    expect(allowed.runtime.get("OUT_SUM")).toBe(0);
+    expect(allowed.runtime.get("OUT_COPY")).toBe(1);
+    expect(allowed.actuator.getOutputMode()).toBe("recipe");
+  });
+
+  it("rejects a recipe that targets a tag the blueprint does not output", () => {
+    const { actuator } = build(
+      { [OUTPUT_WRITE_OPT_IN_ENV]: "true" },
+      { safeRecipes: { bad: { IN_A: 0 } } },
+    );
+
+    expect(() => actuator.assertCanApply({ recipe: "bad" })).toThrow(
+      /targets non-output tags: IN_A/,
+    );
+  });
+
+  it("always accepts hold-last, which commands no new value", () => {
+    const { actuator } = build({});
+    expect(() => actuator.assertCanApply("hold-last")).not.toThrow();
+  });
+});

--- a/server/blueprint/__tests__/safe-state-adapters.test.ts
+++ b/server/blueprint/__tests__/safe-state-adapters.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as logger from "../../logger";
+import { StorageSafeStateAuditSink } from "../safe-state-adapters";
+import type { SafeStateAuditEntry } from "../safe-state";
+import type { SafeStateLogInsert } from "../../storage";
+
+const ENTRY: SafeStateAuditEntry = {
+  blueprintId: "bp-a",
+  siteId: "site-a",
+  transition: "ENTERED",
+  safeState: "force-zero",
+  tickBudgetMs: 10,
+  consecutiveMisses: 3,
+  reason: "deadline misses",
+  anchorHash: "abc123",
+  timestamp: "2026-07-23T12:00:00.000Z",
+};
+
+describe("StorageSafeStateAuditSink", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(logger, "log").mockImplementation(() => {});
+  });
+
+  it("hands the transition to the durable writer with a real timestamp", async () => {
+    const written: SafeStateLogInsert[] = [];
+    const sink = new StorageSafeStateAuditSink(async (entry) => {
+      written.push(entry);
+    });
+
+    await expect(sink.record(ENTRY)).resolves.toBeUndefined();
+
+    expect(written).toHaveLength(1);
+    expect(written[0]).toMatchObject({
+      blueprintId: "bp-a",
+      siteId: "site-a",
+      transition: "ENTERED",
+      safeState: "force-zero",
+      tickBudgetMs: 10,
+      consecutiveMisses: 3,
+      anchorHash: "abc123",
+    });
+    expect(written[0].createdAt).toEqual(new Date(ENTRY.timestamp));
+  });
+
+  it("propagates a persistence failure after logging it, never swallowing it", async () => {
+    const errorSpy = vi.spyOn(logger, "logError").mockImplementation(() => {});
+    const sink = new StorageSafeStateAuditSink(async () => {
+      throw new Error("relation missing");
+    });
+
+    await expect(sink.record(ENTRY)).rejects.toThrow(/relation missing/);
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/server/blueprint/__tests__/safe-state-audit-durability.test.ts
+++ b/server/blueprint/__tests__/safe-state-audit-durability.test.ts
@@ -1,0 +1,180 @@
+/**
+ * The safe-state audit trail must genuinely land (#459).
+ *
+ * The previous implementation refused the SQLite path outright and depended on
+ * a Postgres table that no migration created, so every audit write was either
+ * rejected or swallowed. This suite opens a real SQLite database, writes
+ * transitions through the production sink, and reads them back out.
+ *
+ * The Postgres half of the same table is created by
+ * migrations/0009_blueprint_safe_state_log.sql; the schema-parity assertions
+ * live in ./production-safety.test.ts.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { StorageSafeStateAuditSink } from "../safe-state-adapters";
+import type { SafeStateAuditEntry } from "../safe-state";
+
+type StorageModule = typeof import("../../storage");
+
+let storage: StorageModule;
+let directory: string;
+
+const previousEnv = {
+  sqlitePath: process.env.SQLITE_DATABASE_PATH,
+  databaseUrl: process.env.DATABASE_URL,
+};
+
+/** Read the physical column list straight from the SQLite file under test. */
+async function readTableInfo(): Promise<Array<Record<string, unknown>>> {
+  const { Database } = await import("sqlite3");
+  const file = process.env.SQLITE_DATABASE_PATH!;
+  const client = await new Promise<InstanceType<typeof Database>>((resolve, reject) => {
+    const opened = new Database(file, (error) => (error ? reject(error) : resolve(opened)));
+  });
+  try {
+    return await new Promise<Array<Record<string, unknown>>>((resolve, reject) => {
+      client.all("PRAGMA table_info(blueprint_safe_state_log)", [], (error, rows) =>
+        error ? reject(error) : resolve(rows as Array<Record<string, unknown>>),
+      );
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      client.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function entry(overrides: Partial<SafeStateAuditEntry> = {}): SafeStateAuditEntry {
+  return {
+    blueprintId: "bp-durable",
+    siteId: "site-durable",
+    transition: "ENTERED",
+    safeState: "hold-last",
+    tickBudgetMs: 25,
+    consecutiveMisses: 4,
+    reason: "4 consecutive ticks exceeded budget",
+    anchorHash: "hash-entered",
+    anchorTxHash: "0xabc",
+    timestamp: "2026-07-23T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("blueprint_safe_state_log durability (SQLite)", () => {
+  beforeAll(async () => {
+    directory = mkdtempSync(join(tmpdir(), "safe-state-audit-"));
+    process.env.SQLITE_DATABASE_PATH = join(directory, "audit.sqlite");
+    // Force the SQLite development path: `usePostgres` is evaluated when the
+    // storage module is first imported, so the env must be set before it.
+    delete process.env.DATABASE_URL;
+    storage = await import("../../storage");
+    await storage.initializeDatabase();
+    expect(storage.getDatabaseType()).toBe("sqlite");
+  });
+
+  afterAll(async () => {
+    await storage.closeDatabase();
+    rmSync(directory, { recursive: true, force: true });
+    if (previousEnv.sqlitePath === undefined) delete process.env.SQLITE_DATABASE_PATH;
+    else process.env.SQLITE_DATABASE_PATH = previousEnv.sqlitePath;
+    if (previousEnv.databaseUrl !== undefined) {
+      process.env.DATABASE_URL = previousEnv.databaseUrl;
+    }
+  });
+
+  it("creates the physical table with every declared column", async () => {
+    // The SQLite DDL lives as raw SQL in server/storage.ts while the typed
+    // declaration lives in shared/schema-sqlite.ts. Compare the real table to
+    // the declaration so the two cannot drift into a silently dropped column.
+    const { getTableColumns } = await import("drizzle-orm");
+    const { blueprintSafeStateLog } = await import("@shared/schema-sqlite");
+    const declared = Object.values(getTableColumns(blueprintSafeStateLog))
+      .map((column) => column.name)
+      .sort();
+
+    const actual = (await readTableInfo()).map((row) => String(row.name)).sort();
+
+    expect(actual).toEqual(declared);
+  });
+
+  it("writes a transition through the production sink and reads it back", async () => {
+    const sink = new StorageSafeStateAuditSink(storage.insertBlueprintSafeStateLog);
+
+    await sink.record(entry());
+
+    const rows = await storage.listBlueprintSafeStateLog("bp-durable");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      blueprintId: "bp-durable",
+      siteId: "site-durable",
+      transition: "ENTERED",
+      tickBudgetMs: 25,
+      consecutiveMisses: 4,
+      reason: "4 consecutive ticks exceeded budget",
+      anchorHash: "hash-entered",
+      anchorTxHash: "0xabc",
+    });
+    // A bare-string safe state must survive the round trip un-double-encoded.
+    expect(rows[0].safeState).toBe("hold-last");
+    expect(rows[0].createdAt.toISOString()).toBe("2026-07-23T12:00:00.000Z");
+    expect(rows[0].id).toBeTruthy();
+  });
+
+  it("round-trips a structured safe recipe without mangling it", async () => {
+    const sink = new StorageSafeStateAuditSink(storage.insertBlueprintSafeStateLog);
+
+    await sink.record(
+      entry({
+        blueprintId: "bp-recipe",
+        safeState: { recipe: "purge-and-vent" },
+        anchorHash: "hash-recipe",
+      }),
+    );
+
+    const [row] = await storage.listBlueprintSafeStateLog("bp-recipe");
+    expect(row.safeState).toEqual({ recipe: "purge-and-vent" });
+  });
+
+  it("is idempotent on anchor hash so a retried write cannot duplicate a row", async () => {
+    const sink = new StorageSafeStateAuditSink(storage.insertBlueprintSafeStateLog);
+    const retried = entry({ blueprintId: "bp-retry", anchorHash: "hash-retry" });
+
+    await sink.record(retried);
+    await sink.record(retried);
+
+    expect(await storage.listBlueprintSafeStateLog("bp-retry")).toHaveLength(1);
+  });
+
+  it("records every transition kind the controller can emit", async () => {
+    const sink = new StorageSafeStateAuditSink(storage.insertBlueprintSafeStateLog);
+    const transitions: SafeStateAuditEntry["transition"][] = [
+      "ENTERED",
+      "EXIT_REQUESTED",
+      "EXITED",
+      "RESUME_FAILED",
+      "EXIT_ABORTED",
+      "RECOVERY_FAILED",
+    ];
+
+    for (const transition of transitions) {
+      await sink.record(
+        entry({
+          blueprintId: "bp-transitions",
+          transition,
+          operator: "safety-op",
+          anchorHash: `hash-${transition}`,
+        }),
+      );
+    }
+
+    const rows = await storage.listBlueprintSafeStateLog("bp-transitions");
+    expect(rows.map((row) => row.transition).sort()).toEqual([...transitions].sort());
+    expect(rows.every((row) => row.operator === "safety-op")).toBe(true);
+  });
+});

--- a/server/blueprint/__tests__/safety-host.test.ts
+++ b/server/blueprint/__tests__/safety-host.test.ts
@@ -1,0 +1,257 @@
+/**
+ * WatchdogRegistry.register() must be reached from the production path (#459).
+ *
+ * The composition root under test is the same one server/index.ts starts at
+ * boot. These tests assert that:
+ *   - with no bindings configured the host reports DISABLED with a reason that
+ *     says *nothing is loaded* (not "nothing ever registers"),
+ *   - with bindings configured a watchdog is really registered and ticked,
+ *   - a trip halts the real actuator and stops further ticks,
+ *   - a binding whose safe state cannot be actuated is refused (fail-closed).
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { BlueprintSafetyHost, SAFETY_BINDINGS_ENV, SAFETY_BINDINGS_FILE_ENV } from "../safety-host";
+import { WatchdogRegistry } from "../registry";
+import { OUTPUT_WRITE_OPT_IN_ENV } from "../runtime-actuator";
+import {
+  computeAnchorHash,
+  type AnchorBackend,
+  type AnchorEvent,
+  type AnchorReceipt,
+  type SafeStateAuditEntry,
+  type SafeStateAuditSink,
+} from "../safe-state";
+
+class CapturingAnchor implements AnchorBackend {
+  readonly events: AnchorEvent[] = [];
+  async anchor(event: AnchorEvent): Promise<AnchorReceipt> {
+    this.events.push(event);
+    return { hash: computeAnchorHash(event) };
+  }
+}
+
+class CapturingAudit implements SafeStateAuditSink {
+  readonly entries: SafeStateAuditEntry[] = [];
+  async record(entry: SafeStateAuditEntry): Promise<void> {
+    this.entries.push(entry);
+  }
+}
+
+const BLUEPRINT = {
+  id: "bp-host",
+  name: "Host fixture",
+  scanPeriodMs: 50,
+  tags: [
+    { name: "IN_A", direction: "input", dataType: "float", initial: 6 },
+    { name: "OUT_CMD", direction: "output", dataType: "float" },
+  ],
+  nodes: [
+    { id: "n_copy", op: "MOVE", inputs: [{ tag: "IN_A" }], output: "OUT_CMD" },
+  ],
+};
+
+function bindings(safeState: unknown): string {
+  return JSON.stringify({
+    bindings: [
+      {
+        siteId: "site-1",
+        blueprint: BLUEPRINT,
+        safeState,
+      },
+    ],
+  });
+}
+
+const HOLD_LAST = {
+  enabled: true,
+  tickBudgetMs: 5,
+  consecutiveMissesBeforeSafeState: 2,
+  safeState: "hold-last",
+};
+
+describe("BlueprintSafetyHost", () => {
+  let anchor: CapturingAnchor;
+  let audit: CapturingAudit;
+  let registry: WatchdogRegistry;
+  let host: BlueprintSafetyHost;
+
+  beforeEach(() => {
+    anchor = new CapturingAnchor();
+    audit = new CapturingAudit();
+    registry = new WatchdogRegistry(anchor, audit);
+    host = new BlueprintSafetyHost(registry);
+  });
+
+  afterEach(() => {
+    host.stop();
+  });
+
+  it("reports DISABLED-because-nothing-is-loaded when no bindings are configured", () => {
+    const status = host.start({});
+
+    expect(status.state).toBe("DISABLED");
+    expect(status.source).toBeNull();
+    expect(status.reason).toContain(SAFETY_BINDINGS_FILE_ENV);
+    expect(status.reason).toContain("no blueprint is loaded");
+    expect(status.registeredBlueprintIds).toEqual([]);
+    expect(registry.size()).toBe(0);
+  });
+
+  it("registers a watchdog and drives real ticks for a configured binding", async () => {
+    const status = host.start({ [SAFETY_BINDINGS_ENV]: bindings(HOLD_LAST) });
+
+    expect(status.state).toBe("RUNNING");
+    expect(status.source).toBe(SAFETY_BINDINGS_ENV);
+    expect(status.registeredBlueprintIds).toEqual(["bp-host"]);
+    expect(status.actuators[0]).toMatchObject({
+      blueprintId: "bp-host",
+      outputSink: "runtime-tag-store",
+      fieldSinkBound: false,
+    });
+
+    // register() really happened: the API-visible registry is populated.
+    expect(registry.size()).toBe(1);
+    expect(registry.getAllStatuses()).toEqual([
+      expect.objectContaining({ blueprintId: "bp-host", runState: "RUNNING" }),
+    ]);
+
+    const runtime = host.getRuntime("bp-host")!;
+    expect(runtime.ticks).toBe(0);
+    await host.tickOnce("bp-host");
+    expect(runtime.ticks).toBe(1);
+    expect(runtime.get("OUT_CMD")).toBe(6);
+  });
+
+  it("loads bindings from a file as well as inline JSON", () => {
+    const directory = mkdtempSync(join(tmpdir(), "safety-host-"));
+    try {
+      const file = join(directory, "bindings.json");
+      writeFileSync(file, bindings(HOLD_LAST), "utf8");
+
+      const status = host.start({ [SAFETY_BINDINGS_FILE_ENV]: file });
+
+      expect(status.state).toBe("RUNNING");
+      expect(status.source).toBe(SAFETY_BINDINGS_FILE_ENV);
+      expect(registry.blueprintIds()).toEqual(["bp-host"]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("halts the actuator on a trip and stops executing ticks", async () => {
+    host.start({ [SAFETY_BINDINGS_ENV]: bindings(HOLD_LAST) });
+    const runtime = host.getRuntime("bp-host")!;
+    const actuator = host.getActuator("bp-host")!;
+    const watchdog = registry.get("bp-host")!;
+
+    await host.tickOnce("bp-host");
+    const ticksBeforeTrip = runtime.ticks;
+
+    // Two consecutive over-budget ticks trip the watchdog.
+    await watchdog.observeTick(50);
+    await watchdog.observeTick(50);
+
+    expect(watchdog.getStatus().runState).toBe("SAFE_STATE");
+    expect(actuator.isHalted()).toBe(true);
+    expect(actuator.getOutputMode()).toBe("hold-last");
+    expect(anchor.events.map((e) => e.eventType)).toContain("SafeStateEntered");
+    expect(audit.entries.map((e) => e.transition)).toContain("ENTERED");
+
+    // The halt is real: further host ticks do not execute the scan.
+    await host.tickOnce("bp-host");
+    await host.tickOnce("bp-host");
+    expect(runtime.ticks).toBe(ticksBeforeTrip);
+
+    // Only an operator resume restarts the loop.
+    await watchdog.resume("safety-op", "condition cleared");
+    expect(actuator.isHalted()).toBe(false);
+    await host.tickOnce("bp-host");
+    expect(runtime.ticks).toBe(ticksBeforeTrip + 1);
+  });
+
+  it("refuses to arm a force-zero blueprint without the plant-output opt-in", () => {
+    const status = host.start({
+      [SAFETY_BINDINGS_ENV]: bindings({ ...HOLD_LAST, safeState: "force-zero" }),
+    });
+
+    expect(status.state).toBe("FAILED");
+    expect(status.registeredBlueprintIds).toEqual([]);
+    expect(status.rejected).toEqual([
+      { blueprintId: "bp-host", message: expect.stringContaining(OUTPUT_WRITE_OPT_IN_ENV) },
+    ]);
+    // Fail-closed: nothing armed, nothing ticking, nothing claimed.
+    expect(registry.size()).toBe(0);
+    expect(host.getRuntime("bp-host")).toBeUndefined();
+  });
+
+  it("arms a force-zero blueprint once the opt-in is present", async () => {
+    const status = host.start({
+      [SAFETY_BINDINGS_ENV]: bindings({ ...HOLD_LAST, safeState: "force-zero" }),
+      [OUTPUT_WRITE_OPT_IN_ENV]: "true",
+    });
+
+    expect(status.state).toBe("RUNNING");
+    const runtime = host.getRuntime("bp-host")!;
+    const watchdog = registry.get("bp-host")!;
+    await host.tickOnce("bp-host");
+    expect(runtime.get("OUT_CMD")).toBe(6);
+
+    await watchdog.observeTick(50);
+    await watchdog.observeTick(50);
+
+    // The declared safe state genuinely de-energised the output.
+    expect(runtime.get("OUT_CMD")).toBe(0);
+  });
+
+  it("reports invalid binding documents instead of silently running unguarded", () => {
+    const status = host.start({ [SAFETY_BINDINGS_ENV]: '{"bindings":[{"blueprint":{}}]}' });
+
+    expect(status.state).toBe("FAILED");
+    expect(status.reason).toContain("invalid");
+    expect(registry.size()).toBe(0);
+  });
+
+  it("reports unreadable binding sources instead of silently running unguarded", () => {
+    const status = host.start({
+      [SAFETY_BINDINGS_FILE_ENV]: join(tmpdir(), "definitely-missing-bindings.json"),
+    });
+
+    expect(status.state).toBe("FAILED");
+    expect(status.reason).toContain("could not be read");
+    expect(registry.size()).toBe(0);
+  });
+
+  it("refuses a duplicate binding without disturbing the armed one", () => {
+    const document = JSON.stringify({
+      bindings: [
+        { siteId: "site-1", blueprint: BLUEPRINT, safeState: HOLD_LAST },
+        { siteId: "site-2", blueprint: BLUEPRINT, safeState: HOLD_LAST },
+      ],
+    });
+
+    const status = host.start({ [SAFETY_BINDINGS_ENV]: document });
+
+    expect(status.state).toBe("RUNNING");
+    expect(status.registeredBlueprintIds).toEqual(["bp-host"]);
+    expect(status.rejected).toEqual([
+      { blueprintId: "bp-host", message: expect.stringContaining("duplicate binding") },
+    ]);
+    expect(host.getActuator("bp-host")!.siteId).toBe("site-1");
+  });
+
+  it("unregisters everything on stop", () => {
+    host.start({ [SAFETY_BINDINGS_ENV]: bindings(HOLD_LAST) });
+    expect(registry.size()).toBe(1);
+
+    host.stop();
+
+    expect(registry.size()).toBe(0);
+    expect(host.getStatus().state).toBe("DISABLED");
+  });
+});

--- a/server/blueprint/index.ts
+++ b/server/blueprint/index.ts
@@ -1,12 +1,23 @@
 /**
- * Deterministic Blueprint Runtime — public surface.
+ * Deterministic Blueprint Runtime + Watchdog / Safe-State — public surface.
  *
  * Issue #457: [wave:2b] Deterministic Blueprint Runtime
+ * Issue #459: [wave:2b] Watchdog & Safe-State Fallback
  *
- * This barrel is the single import point for the rest of the server (and for the
- * 2b watchdog, #3, which gates on this module). Consumers should import from
- * `server/blueprint` rather than reaching into individual files, so the internal
- * SoA layout can evolve without churning call sites.
+ * This barrel is the single import point for the rest of the server. Consumers
+ * should import from `server/blueprint` rather than reaching into individual
+ * files, so the internal SoA layout can evolve without churning call sites.
+ *
+ * Safe-state pieces:
+ * - {@link Watchdog}                : per-blueprint tick-budget monitor + trip logic.
+ * - {@link SafeStateController}     : applies / clears the declared safe state,
+ *                                     anchors CRITICAL transitions, audits them.
+ * - {@link WatchdogRegistry}        : tracks one watchdog per running blueprint and
+ *                                     exposes status for the operator UI.
+ * - {@link BlueprintRuntimeActuator}: the real {@link SafeStateActuator} used in
+ *                                     production; drives the runtime tag store.
+ * - {@link BlueprintSafetyHost}     : composition root that constructs runtimes,
+ *                                     registers watchdogs and drives ticks.
  */
 
 export {
@@ -49,3 +60,35 @@ export {
 } from "./control-loop.js";
 
 export { makeControlFarmBlueprint, makeInputVector } from "./fixtures.js";
+
+export * from "./safe-state";
+export * from "./watchdog";
+export { WatchdogRegistry } from "./registry";
+export {
+  BridgeAnchorBackend,
+  StorageSafeStateAuditSink,
+} from "./safe-state-adapters";
+export {
+  BlueprintRuntimeActuator,
+  OUTPUT_WRITE_OPT_IN_ENV,
+  outputWritesEnabled,
+  type ActuatorCapabilities,
+  type ActuatorOutputMode,
+  type FieldOutputSink,
+  type BlueprintRuntimeActuatorOptions,
+} from "./runtime-actuator";
+export {
+  BlueprintSafetyHost,
+  blueprintSafetyHost,
+  safeStateRegistry,
+  blueprintSafetyBindingSchema,
+  blueprintSafetyBindingsSchema,
+  SAFETY_BINDINGS_ENV,
+  SAFETY_BINDINGS_FILE_ENV,
+  type BlueprintSafetyBinding,
+  type BlueprintSafetyHostStatus,
+} from "./safety-host";
+export {
+  getBlueprintProductionSafetyStatus,
+  type BlueprintProductionSafetyStatus,
+} from "./production-safety";

--- a/server/blueprint/production-safety.ts
+++ b/server/blueprint/production-safety.ts
@@ -1,0 +1,97 @@
+/**
+ * Honest production status for the blueprint safe-state surface (#459).
+ *
+ * The watchdog is only as good as the actuation and registration behind it, so
+ * this module reports what is *actually* bound rather than asserting that
+ * safety handling is active:
+ *
+ *   - DISABLED — no blueprint safety bindings are configured, so no blueprint
+ *                is loaded and there is nothing to guard. This is the default
+ *                deployment state and is NOT a claim that safe-state handling
+ *                is protecting anything.
+ *   - DEGRADED — bindings were configured but at least one was refused (for
+ *                example a `force-zero` safe state without the plant-output
+ *                opt-in), or an armed blueprint is currently in safe state.
+ *   - ACTIVE   — every configured blueprint is armed and running.
+ *
+ * `outputSinks` names the sink each armed actuator really drives. On current
+ * main that is `runtime-tag-store` unless a deployment binds a field-output
+ * sink; no wire-level output driver ships in this repository.
+ */
+
+import { blueprintSafetyHost, safeStateRegistry } from "./safety-host";
+
+export interface BlueprintProductionSafetyStatus {
+  state: "DISABLED" | "DEGRADED" | "ACTIVE";
+  reason: string;
+  capabilities: {
+    /** At least one blueprint runtime is constructed and bound. */
+    deployedBlueprintBound: boolean;
+    /** At least one watchdog is registered in the shared registry. */
+    watchdogRegistered: boolean;
+    /** A real field-output sink is bound (none ships in this repository). */
+    fieldOutputSinkBound: boolean;
+    /** The sink each armed actuator drives. */
+    outputSinks: string[];
+  };
+  registeredBlueprintIds: string[];
+  /** Bindings refused at arm time, with the refusal reason. */
+  rejected: Array<{ blueprintId: string; message: string }>;
+  /** Armed blueprints not currently in RUNNING (safe state / recovery). */
+  blueprintsNotRunning: number;
+}
+
+export function getBlueprintProductionSafetyStatus(): BlueprintProductionSafetyStatus {
+  const host = blueprintSafetyHost.getStatus();
+  const notRunning = safeStateRegistry.getSafeStateStatuses().length;
+  const registered = safeStateRegistry.blueprintIds();
+
+  const capabilities = {
+    deployedBlueprintBound: host.registeredBlueprintIds.length > 0,
+    watchdogRegistered: registered.length > 0,
+    fieldOutputSinkBound: host.actuators.some((a) => a.fieldSinkBound),
+    outputSinks: [...new Set(host.actuators.map((a) => a.outputSink))],
+  };
+
+  if (host.state === "DISABLED") {
+    return {
+      state: "DISABLED",
+      reason: host.reason,
+      capabilities,
+      registeredBlueprintIds: registered,
+      rejected: host.rejected,
+      blueprintsNotRunning: notRunning,
+    };
+  }
+
+  if (host.state === "FAILED" || host.rejected.length > 0 || notRunning > 0) {
+    const parts = [host.reason];
+    if (host.rejected.length > 0) {
+      parts.push(
+        `Refused bindings: ${host.rejected
+          .map((entry) => `${entry.blueprintId} (${entry.message})`)
+          .join("; ")}`,
+      );
+    }
+    if (notRunning > 0) {
+      parts.push(`${notRunning} armed blueprint(s) are not RUNNING.`);
+    }
+    return {
+      state: "DEGRADED",
+      reason: parts.join(" "),
+      capabilities,
+      registeredBlueprintIds: registered,
+      rejected: host.rejected,
+      blueprintsNotRunning: notRunning,
+    };
+  }
+
+  return {
+    state: "ACTIVE",
+    reason: host.reason,
+    capabilities,
+    registeredBlueprintIds: registered,
+    rejected: host.rejected,
+    blueprintsNotRunning: notRunning,
+  };
+}

--- a/server/blueprint/registry.ts
+++ b/server/blueprint/registry.ts
@@ -1,0 +1,72 @@
+/**
+ * Watchdog registry (#459).
+ *
+ * One {@link Watchdog} per running blueprint. The registry is the single place
+ * a runtime host feeds tick observations and the API/UI reads safe-state
+ * status. It lives in its own module (rather than the barrel) so the
+ * composition root in ./safety-host can depend on it without an import cycle.
+ */
+
+import type { SafeStateConfig } from "@shared/schema";
+import { Watchdog } from "./watchdog";
+import type {
+  AnchorBackend,
+  SafeStateActuator,
+  SafeStateAuditSink,
+  SafeStateStatus,
+} from "./safe-state";
+
+export class WatchdogRegistry {
+  private readonly watchdogs = new Map<string, Watchdog>();
+
+  constructor(
+    private readonly anchor: AnchorBackend,
+    private readonly audit: SafeStateAuditSink,
+  ) {}
+
+  /**
+   * Register (or replace) the watchdog for a blueprint. Returns the watchdog so
+   * the caller can feed it tick observations.
+   *
+   * Fail-closed: an actuator that cannot physically apply the declared safe
+   * state is rejected here, so a blueprint is never armed with a safe state it
+   * could not actually enter. {@link SafeStateActuator.assertCanApply} throws in
+   * that case and the caller must not start the blueprint.
+   */
+  register(actuator: SafeStateActuator, config: SafeStateConfig): Watchdog {
+    actuator.assertCanApply(config.safeState);
+    const watchdog = new Watchdog(actuator, config, this.anchor, this.audit);
+    this.watchdogs.set(actuator.blueprintId, watchdog);
+    return watchdog;
+  }
+
+  /** Remove a blueprint's watchdog (e.g. on blueprint stop / undeploy). */
+  unregister(blueprintId: string): void {
+    this.watchdogs.delete(blueprintId);
+  }
+
+  /** Get the watchdog for a blueprint, if registered. */
+  get(blueprintId: string): Watchdog | undefined {
+    return this.watchdogs.get(blueprintId);
+  }
+
+  /** Number of registered watchdogs (0 = no blueprint is currently armed). */
+  size(): number {
+    return this.watchdogs.size;
+  }
+
+  /** Registered blueprint ids, in registration order. */
+  blueprintIds(): string[] {
+    return [...this.watchdogs.keys()];
+  }
+
+  /** Safe-state status for every registered blueprint (for the operator UI). */
+  getAllStatuses(): SafeStateStatus[] {
+    return [...this.watchdogs.values()].map((w) => w.getStatus());
+  }
+
+  /** Blueprints in safe-state handling, including degraded recovery states. */
+  getSafeStateStatuses(): SafeStateStatus[] {
+    return this.getAllStatuses().filter((s) => s.runState !== "RUNNING");
+  }
+}

--- a/server/blueprint/runtime-actuator.ts
+++ b/server/blueprint/runtime-actuator.ts
@@ -1,0 +1,312 @@
+/**
+ * Production actuation seam for the blueprint watchdog / safe-state core (#459).
+ *
+ * WHAT THIS ACTUALLY DRIVES — read this before trusting the safe state:
+ *
+ *   The deterministic runtime (server/blueprint/runtime.ts) owns a Float64Array
+ *   tag store. Output-direction tags in that store are the command values a
+ *   field-I/O layer is expected to publish. On current `main` that tag store is
+ *   the ONLY sink that genuinely exists in this repository: the vendor adapters
+ *   under server/services/vendors/ marshal write frames but do not transmit
+ *   them, so there is no wire-level output path to bind today.
+ *
+ *   So {@link BlueprintRuntimeActuator} implements halt / hold-last / force-zero
+ *   against the runtime tag store, and additionally against a
+ *   {@link FieldOutputSink} when — and only when — a deployment binds one. No
+ *   such sink ships in this repository; the interface exists so a real driver
+ *   can be bound without touching the safe-state core, and the status surface
+ *   reports honestly which sink is in use.
+ *
+ * SAFETY: `force-zero` and safe recipes command NEW output values. Those are
+ * plant-output writes and are therefore fail-closed and off by default: they
+ * require the explicit {@link OUTPUT_WRITE_OPT_IN_ENV} opt-in, and
+ * {@link BlueprintRuntimeActuator.assertCanApply} rejects registration of a
+ * blueprint whose declared safe state is not actuatable, so a blueprint is never
+ * armed with a safe state it could not enter.
+ */
+
+import type { SafeStateAction } from "@shared/schema";
+import type { BlueprintRuntime } from "./runtime.js";
+import type { SafeStateActuator } from "./safe-state";
+
+/**
+ * Environment opt-in required before the actuator may command new output
+ * values (`force-zero`, or a safe recipe). Unset/anything other than "true"
+ * means those actions are unavailable and registration of a blueprint that
+ * declares them fails closed.
+ */
+export const OUTPUT_WRITE_OPT_IN_ENV = "BLUEPRINT_SAFE_STATE_ALLOW_OUTPUT_WRITES" as const;
+
+/** True when the deployment has explicitly opted in to commanded output writes. */
+export function outputWritesEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env[OUTPUT_WRITE_OPT_IN_ENV] === "true";
+}
+
+/**
+ * A real field-output path. A deployment binds one when it has a driver that
+ * actually transmits; none is provided by this repository (see the module
+ * header). Implementations MUST throw on failure — a swallowed write would let
+ * the controller claim a safe state that never reached the plant.
+ */
+export interface FieldOutputSink {
+  /** Stable identity, surfaced in safe-state status for auditability. */
+  readonly id: string;
+  /** Publish output tag values. Throws if the write did not take effect. */
+  writeOutputs(values: ReadonlyMap<string, number>): void;
+}
+
+export interface BlueprintRuntimeActuatorOptions {
+  /** Owning site, if the blueprint is site-scoped. */
+  siteId?: string;
+  /**
+   * Named safe recipes available to this blueprint, as output-tag -> value.
+   * A recipe that is not declared here cannot be applied, and a blueprint
+   * declaring it is rejected at registration.
+   */
+  safeRecipes?: Readonly<Record<string, Readonly<Record<string, number>>>>;
+  /** Optional real field-output path (see {@link FieldOutputSink}). */
+  fieldSink?: FieldOutputSink;
+  /** Environment used for the output-write opt-in. Injectable for tests. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/** How the actuator is currently commanding outputs. */
+export type ActuatorOutputMode = "loop" | "hold-last" | "force-zero" | "recipe";
+
+/** Serialisable description of what this actuator can and does drive. */
+export interface ActuatorCapabilities {
+  blueprintId: string;
+  /** Identity of the output sink actually in use. */
+  outputSink: string;
+  /** True when a real field-output path is bound (none ships in this repo). */
+  fieldSinkBound: boolean;
+  /** Whether commanded output writes are opted in for this process. */
+  outputWritesAllowed: boolean;
+  /** Safe recipes this actuator can apply. */
+  declaredRecipes: string[];
+}
+
+/**
+ * Drives a real {@link BlueprintRuntime} into its declared safe state.
+ *
+ * Every method either takes effect or throws — never a silent no-op.
+ */
+export class BlueprintRuntimeActuator implements SafeStateActuator {
+  readonly blueprintId: string;
+  readonly siteId?: string;
+
+  private readonly runtime: BlueprintRuntime;
+  private readonly outputTagNames: readonly string[];
+  private readonly safeRecipes: Readonly<Record<string, Readonly<Record<string, number>>>>;
+  private readonly fieldSink?: FieldOutputSink;
+  private readonly env: NodeJS.ProcessEnv;
+
+  private halted = false;
+  private outputMode: ActuatorOutputMode = "loop";
+  /** Last values commanded to outputs, captured on hold-last. */
+  private heldOutputs?: ReadonlyMap<string, number>;
+
+  constructor(
+    blueprintId: string,
+    runtime: BlueprintRuntime,
+    options: BlueprintRuntimeActuatorOptions = {},
+  ) {
+    this.blueprintId = blueprintId;
+    this.siteId = options.siteId;
+    this.runtime = runtime;
+    this.safeRecipes = options.safeRecipes ?? {};
+    this.fieldSink = options.fieldSink;
+    this.env = options.env ?? process.env;
+    this.outputTagNames = runtime.tagMeta
+      .filter((tag) => tag.direction === "output")
+      .map((tag) => tag.name);
+  }
+
+  // ─── Introspection ─────────────────────────────────────────────────────────
+
+  /** True while the control loop is halted. Tick drivers MUST honour this. */
+  isHalted(): boolean {
+    return this.halted;
+  }
+
+  /** How outputs are currently being commanded. */
+  getOutputMode(): ActuatorOutputMode {
+    return this.outputMode;
+  }
+
+  /** Output tag names this actuator commands. */
+  getOutputTagNames(): readonly string[] {
+    return this.outputTagNames;
+  }
+
+  /** Current value of every output tag, read from the runtime tag store. */
+  readOutputs(): Map<string, number> {
+    const values = new Map<string, number>();
+    for (const name of this.outputTagNames) values.set(name, this.runtime.get(name));
+    return values;
+  }
+
+  /** What this actuator can drive, for the operator/status surface. */
+  getCapabilities(): ActuatorCapabilities {
+    return {
+      blueprintId: this.blueprintId,
+      outputSink: this.fieldSink ? this.fieldSink.id : "runtime-tag-store",
+      fieldSinkBound: this.fieldSink !== undefined,
+      outputWritesAllowed: outputWritesEnabled(this.env),
+      declaredRecipes: Object.keys(this.safeRecipes),
+    };
+  }
+
+  // ─── SafeStateActuator ─────────────────────────────────────────────────────
+
+  assertCanApply(action: SafeStateAction): void {
+    if (action === "hold-last") {
+      // Always actuatable: halting stops recomputation and the held values are
+      // re-commanded to whatever sink is in use. No new value is commanded.
+      return;
+    }
+
+    if (action === "force-zero") {
+      if (!outputWritesEnabled(this.env)) {
+        throw new Error(
+          `Blueprint ${this.blueprintId} declares the "force-zero" safe state, which writes plant outputs. ` +
+            `Set ${OUTPUT_WRITE_OPT_IN_ENV}=true to allow it, or declare "hold-last" instead. Refusing to arm.`,
+        );
+      }
+      if (this.outputTagNames.length === 0) {
+        throw new Error(
+          `Blueprint ${this.blueprintId} declares "force-zero" but has no output tags to de-energise. Refusing to arm.`,
+        );
+      }
+      return;
+    }
+
+    const recipe = this.safeRecipes[action.recipe];
+    if (!recipe) {
+      throw new Error(
+        `Blueprint ${this.blueprintId} declares safe recipe "${action.recipe}", which is not defined for this blueprint. Refusing to arm.`,
+      );
+    }
+    if (!outputWritesEnabled(this.env)) {
+      throw new Error(
+        `Blueprint ${this.blueprintId} declares safe recipe "${action.recipe}", which writes plant outputs. ` +
+          `Set ${OUTPUT_WRITE_OPT_IN_ENV}=true to allow it. Refusing to arm.`,
+      );
+    }
+    const unknown = Object.keys(recipe).filter(
+      (name) => !this.outputTagNames.includes(name),
+    );
+    if (unknown.length > 0) {
+      throw new Error(
+        `Safe recipe "${action.recipe}" for blueprint ${this.blueprintId} targets non-output tags: ${unknown.join(", ")}. Refusing to arm.`,
+      );
+    }
+  }
+
+  /**
+   * Stop the control loop. The latch is what makes the halt real: the safety
+   * host's tick driver refuses to tick while it is set, and
+   * {@link Watchdog.runTick} skips the tick body once the controller is in safe
+   * state, so no further output values are computed.
+   */
+  halt(): void {
+    this.halted = true;
+  }
+
+  /**
+   * Release the halt after an operator has cleared the safe state. Outputs are
+   * deliberately NOT restored to their pre-trip values: the loop recomputes
+   * them from live inputs on the next tick.
+   */
+  resume(): void {
+    this.halted = false;
+    this.outputMode = "loop";
+    this.heldOutputs = undefined;
+  }
+
+  /**
+   * Freeze outputs at their last commanded value. Commands no new value: the
+   * current tag-store values are snapshotted and re-published to the bound
+   * field sink so it holds them rather than ageing out.
+   */
+  holdLastOutputs(): void {
+    const held = this.readOutputs();
+    this.heldOutputs = held;
+    this.outputMode = "hold-last";
+    this.publish(held);
+  }
+
+  /**
+   * Drive every output tag to zero / de-energised.
+   *
+   * SAFETY: this is a plant-output write. It is unreachable unless the
+   * deployment sets {@link OUTPUT_WRITE_OPT_IN_ENV}=true; the check is repeated
+   * here (not only in {@link assertCanApply}) so the opt-in cannot be bypassed
+   * by a caller that constructed the actuator directly.
+   */
+  forceZeroOutputs(): void {
+    if (!outputWritesEnabled(this.env)) {
+      throw new Error(
+        `Refusing to force-zero outputs for blueprint ${this.blueprintId}: ` +
+          `${OUTPUT_WRITE_OPT_IN_ENV} is not set to "true".`,
+      );
+    }
+    const zeros = new Map<string, number>();
+    for (const name of this.outputTagNames) {
+      this.runtime.set(name, 0);
+      zeros.set(name, 0);
+    }
+    this.heldOutputs = zeros;
+    this.outputMode = "force-zero";
+    this.publish(zeros);
+  }
+
+  /**
+   * Apply a named, previously-declared safe recipe.
+   *
+   * SAFETY: also a plant-output write — same fail-closed opt-in as
+   * {@link forceZeroOutputs}. Unknown recipes throw rather than defaulting to
+   * anything.
+   */
+  applySafeRecipe(recipe: string): void {
+    const values = this.safeRecipes[recipe];
+    if (!values) {
+      throw new Error(
+        `Unknown safe recipe "${recipe}" for blueprint ${this.blueprintId}`,
+      );
+    }
+    if (!outputWritesEnabled(this.env)) {
+      throw new Error(
+        `Refusing to apply safe recipe "${recipe}" for blueprint ${this.blueprintId}: ` +
+          `${OUTPUT_WRITE_OPT_IN_ENV} is not set to "true".`,
+      );
+    }
+    const applied = new Map<string, number>();
+    for (const [name, value] of Object.entries(values)) {
+      this.runtime.set(name, value);
+      applied.set(name, value);
+    }
+    this.heldOutputs = applied;
+    this.outputMode = "recipe";
+    this.publish(applied);
+  }
+
+  // ─── Internals ─────────────────────────────────────────────────────────────
+
+  /**
+   * Publish commanded values to the bound field sink. Failures propagate: the
+   * controller records a RECOVERY_FAILED transition rather than reporting a
+   * safe state that never reached the plant.
+   */
+  private publish(values: ReadonlyMap<string, number>): void {
+    if (!this.fieldSink) return;
+    this.fieldSink.writeOutputs(values);
+  }
+
+  /** Values last commanded by a safe-state action, if any. */
+  getHeldOutputs(): ReadonlyMap<string, number> | undefined {
+    return this.heldOutputs;
+  }
+}

--- a/server/blueprint/safe-state-adapters.ts
+++ b/server/blueprint/safe-state-adapters.ts
@@ -1,0 +1,101 @@
+/**
+ * Production wiring for the blueprint watchdog / safe-state core (#459).
+ *
+ * The core ({@link ../safe-state}, {@link ../watchdog}) is deliberately
+ * dependency-free and unit-testable. This module adapts the real systems —
+ * the event-anchor bridge and the durable audit table — to the minimal
+ * interfaces the core consumes.
+ *
+ * Keeping these adapters separate means the trip logic can be exercised in unit
+ * tests with in-memory fakes, while production code composes the real backends.
+ */
+
+import {
+  insertBlueprintSafeStateLog,
+  type SafeStateLogInsert,
+} from "../storage";
+import { eventAnchorBridge } from "../bridge/event-anchor";
+import { log, logError } from "../logger";
+import {
+  computeAnchorHash,
+  type AnchorBackend,
+  type AnchorEvent,
+  type AnchorReceipt,
+  type SafeStateAuditSink,
+  type SafeStateAuditEntry,
+} from "./safe-state";
+
+/**
+ * Adapts the existing {@link eventAnchorBridge} (fire-and-forget, batched) to
+ * the synchronous {@link AnchorBackend} the safe-state controller expects.
+ *
+ * The contract this adapter upholds: submit the event for anchoring and return
+ * a content hash immediately so the transition is auditable before the batch is
+ * mined.
+ */
+export class BridgeAnchorBackend implements AnchorBackend {
+  async anchor(event: AnchorEvent): Promise<AnchorReceipt> {
+    const hash = computeAnchorHash(event);
+    // The bridge batches and anchors asynchronously; map our CRITICAL severity
+    // to its lowercase severity vocabulary.
+    await eventAnchorBridge.anchor({
+      id: event.id,
+      timestamp: new Date(event.timestamp),
+      eventType: event.eventType,
+      siteId: event.siteId ?? "unknown",
+      severity: event.severity.toLowerCase() as "critical" | "warning" | "info",
+      message: event.message,
+      data: { ...event.data, contentHash: hash },
+    });
+    return { hash };
+  }
+}
+
+/** Injectable persistence seam, so the sink can be unit-tested without a DB. */
+export type SafeStateLogWriter = (entry: SafeStateLogInsert) => Promise<void>;
+
+/**
+ * Persists safe-state transitions to `blueprint_safe_state_log`.
+ *
+ * Both dialects are durable: PostgreSQL via the Drizzle table created by
+ * migrations/0009_blueprint_safe_state_log.sql, SQLite via the table in
+ * `blueprintSqliteSchema` (applied on every database open). The write is
+ * idempotent on `anchor_hash`, so the controller's retry of an ambiguous entry
+ * cannot duplicate a row.
+ */
+export class StorageSafeStateAuditSink implements SafeStateAuditSink {
+  constructor(
+    private readonly write: SafeStateLogWriter = insertBlueprintSafeStateLog,
+  ) {}
+
+  async record(entry: SafeStateAuditEntry): Promise<void> {
+    try {
+      await this.write({
+        blueprintId: entry.blueprintId,
+        siteId: entry.siteId,
+        transition: entry.transition,
+        safeState: entry.safeState,
+        tickBudgetMs: entry.tickBudgetMs,
+        consecutiveMisses: entry.consecutiveMisses,
+        operator: entry.operator,
+        reason: entry.reason,
+        anchorHash: entry.anchorHash,
+        anchorTxHash: entry.anchorTxHash,
+        createdAt: new Date(entry.timestamp),
+      });
+      log(
+        `Safe-state ${entry.transition} audited for blueprint ${entry.blueprintId} ` +
+          `(anchor ${entry.anchorHash})`,
+      );
+    } catch (error) {
+      logError(error, `Failed to persist safe-state audit for ${entry.blueprintId}`);
+      // The physical safe state has already been applied on ENTERED. Propagate
+      // the persistence failure so callers/health cannot report an audited
+      // transition that was silently discarded.
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Safe-state audit persistence failed for ${entry.blueprintId}: ${detail}`,
+      );
+    }
+  }
+}

--- a/server/blueprint/safe-state.ts
+++ b/server/blueprint/safe-state.ts
@@ -1,0 +1,608 @@
+/**
+ * Blueprint Safe-State Fallback (#459)
+ *
+ * When a blueprint's deterministic control tick consistently misses its budget,
+ * the watchdog (see ./watchdog.ts) halts the blueprint and transitions it to a
+ * pre-declared *safe state*. This module owns:
+ *
+ *   1. The minimal local interfaces this feature depends on (anchor backend,
+ *      audit sink, actuation seam) so the core logic is unit-testable without a
+ *      live database, chain, or runtime.
+ *   2. The {@link SafeStateController} which applies the safe state to a running
+ *      blueprint, anchors a CRITICAL `SafeStateEntered` event, and writes an
+ *      audit log entry for every entry / exit transition.
+ *
+ * The production actuator that satisfies {@link SafeStateActuator} lives in
+ * ./runtime-actuator.ts and is bound to a real blueprint by ./safety-host.ts.
+ *
+ * Re-entry to RUNNING is NEVER automatic — it requires an explicit operator
+ * `resume()` call, which itself anchors and audits a `SafeStateExited` event.
+ *
+ * @see server/blueprint/watchdog.ts
+ * @see shared/schema.ts (safeStateConfig, blueprint_safe_state_log)
+ */
+
+import { randomUUID, createHash } from "crypto";
+import type { SafeStateAction, SafeStateConfig } from "@shared/schema";
+
+// ─── Local interface seams ───────────────────────────────────────────────────
+// INTEGRATION (#443/#455): the canonical anchor backend lives behind a sibling
+// branch. We declare the minimal surface we need here and adapt the real
+// backend to it at wiring time, so this module's core logic stays testable.
+
+/** Severity levels recognised by the canonical anchor backend. */
+export type AnchorSeverity = "INFO" | "WARNING" | "CRITICAL";
+
+/** An event submitted to the canonical anchor backend for immutable recording. */
+export interface AnchorEvent {
+  /** Stable event identifier. */
+  id: string;
+  /** RFC 3339 timestamp of the event. */
+  timestamp: string;
+  /** Event discriminator, e.g. "SafeStateEntered". */
+  eventType: string;
+  /** Severity — safe-state transitions are anchored as CRITICAL. */
+  severity: AnchorSeverity;
+  /** Owning site (optional — blueprints may be site-scoped). */
+  siteId?: string;
+  /** Human-readable summary. */
+  message: string;
+  /** Structured payload. Included in the anchored hash. */
+  data: Record<string, unknown>;
+}
+
+/** Receipt returned by the anchor backend after accepting an event. */
+export interface AnchorReceipt {
+  /** Deterministic content hash of the anchored event. */
+  hash: string;
+  /** On-chain transaction hash, if anchored synchronously. */
+  txHash?: string;
+}
+
+/**
+ * Minimal canonical anchor backend.
+ *
+ * INTEGRATION (#443/#455): adapt the real EventAnchorBridge / integrity pipeline
+ * to this interface. The real bridge's `anchor()` is fire-and-forget batched; an
+ * adapter should compute the content hash up-front (see {@link computeAnchorHash})
+ * and return it as the receipt so safe-state transitions remain auditable even
+ * before the batch lands on-chain.
+ */
+export interface AnchorBackend {
+  anchor(event: AnchorEvent): Promise<AnchorReceipt>;
+}
+
+/**
+ * Audit sink for safe-state transitions. Backed in production by
+ * `blueprint_safe_state_log` via server/storage.ts (Drizzle). Kept as an
+ * interface so core logic is testable without a live database.
+ */
+export interface SafeStateAuditSink {
+  record(entry: SafeStateAuditEntry): Promise<void>;
+}
+
+/** A single audited safe-state transition (entry or exit). */
+export interface SafeStateAuditEntry {
+  blueprintId: string;
+  siteId?: string;
+  transition:
+    | "ENTERED"
+    | "EXIT_REQUESTED"
+    | "EXITED"
+    | "RESUME_FAILED"
+    | "EXIT_ABORTED"
+    | "RECOVERY_FAILED";
+  safeState: SafeStateAction;
+  tickBudgetMs: number;
+  consecutiveMisses?: number;
+  operator?: string;
+  reason: string;
+  anchorHash: string;
+  anchorTxHash?: string;
+  timestamp: string;
+}
+
+// ─── Actuation seam ──────────────────────────────────────────────────────────
+
+/**
+ * The actuation seam the safe-state controller drives.
+ *
+ * This is deliberately narrower than the deterministic {@link
+ * import('./runtime').BlueprintRuntime} class: the controller only needs to be
+ * able to stop the loop and command outputs. The production implementation is
+ * {@link import('./runtime-actuator').BlueprintRuntimeActuator}, which drives
+ * the runtime's tag store (and, when one is bound, a field-output sink).
+ *
+ * Every implementation MUST make each method either take real effect or throw.
+ * A silent no-op here is a safety defect: the controller would report a safe
+ * state that was never applied.
+ */
+export interface SafeStateActuator {
+  /** Stable blueprint identifier. */
+  readonly blueprintId: string;
+  /** Owning site, if any. */
+  readonly siteId?: string;
+  /**
+   * Pre-flight check run at registration time. MUST throw if this actuator
+   * cannot physically apply `action`, so a blueprint is never armed with a
+   * declared safe state it could not enter.
+   */
+  assertCanApply(action: SafeStateAction): void;
+  /** Halt the deterministic control loop (stop scheduling further ticks). */
+  halt(): void;
+  /** Resume the deterministic control loop after an operator clears safe state. */
+  resume(): void;
+  /** Freeze all outputs at their last commanded value. */
+  holdLastOutputs(): void;
+  /** Drive all outputs to zero / de-energised. */
+  forceZeroOutputs(): void;
+  /** Load and apply a named, previously-validated safe recipe. */
+  applySafeRecipe(recipe: string): void;
+}
+
+// ─── Safe-state lifecycle ────────────────────────────────────────────────────
+
+/** Operational state of a blueprint with respect to the watchdog. */
+export type BlueprintRunState =
+  | "RUNNING"
+  | "SAFE_STATE"
+  | "RESUMING"
+  | "RECOVERING"
+  | "RECOVERY_FAILED";
+
+/** Public, serialisable view of a blueprint's safe-state status (for the UI). */
+export interface SafeStateStatus {
+  blueprintId: string;
+  siteId?: string;
+  runState: BlueprintRunState;
+  /** The safe state that is (or would be) applied. */
+  safeState: SafeStateAction;
+  /** When the blueprint entered safe state (ISO string), if active. */
+  enteredAt?: string;
+  /** Why the watchdog tripped. */
+  reason?: string;
+  /** Consecutive over-budget ticks at the time of the trip. */
+  consecutiveMisses?: number;
+  /** Content hash of the anchored SafeStateEntered event, if any. */
+  anchorHash?: string;
+  /** Whether the active safe-state entry has a durable audit row. */
+  entryAuditStatus?: "pending" | "durable";
+  /** Compensation failures that prevent the controller from claiming safety. */
+  recoveryErrors?: string[];
+}
+
+/** A short, human-readable label for a {@link SafeStateAction}. */
+export function describeSafeState(action: SafeStateAction): string {
+  if (action === "hold-last") return "Hold last outputs";
+  if (action === "force-zero") return "Force outputs to zero";
+  return `Apply safe recipe "${action.recipe}"`;
+}
+
+/**
+ * Deterministic content hash of an anchor event. Used both as the local audit
+ * reference and as the value an anchor-backend adapter can surface as its
+ * receipt hash. SHA-256 over a canonical JSON projection (stable key order).
+ */
+export function computeAnchorHash(event: AnchorEvent): string {
+  const canonical = JSON.stringify({
+    id: event.id,
+    timestamp: event.timestamp,
+    eventType: event.eventType,
+    severity: event.severity,
+    siteId: event.siteId ?? null,
+    message: event.message,
+    data: event.data,
+  });
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/**
+ * Applies / clears safe state on a blueprint runtime and produces the anchored,
+ * audited transition records. Holds no scheduling logic of its own — the
+ * {@link import('./watchdog').Watchdog} decides *when* to trip; this controller
+ * decides *what happens* on a trip / resume.
+ */
+export class SafeStateController {
+  private status: SafeStateStatus;
+  /** Entry that must become durable before any resume can be attempted. */
+  private pendingEntryAudit?: SafeStateAuditEntry;
+  /** Exact exit-request record retained across an ambiguous write failure. */
+  private pendingExitRequestAudit?: SafeStateAuditEntry;
+  /**
+   * Serialises entry and exit transitions for this blueprint. The queue is
+   * always normalised back to a resolved promise so one failed transition does
+   * not prevent a later operator action from being evaluated.
+   */
+  private transitionTail: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly actuator: SafeStateActuator,
+    private readonly config: SafeStateConfig,
+    private readonly anchor: AnchorBackend,
+    private readonly audit: SafeStateAuditSink,
+    private readonly now: () => Date = () => new Date(),
+  ) {
+    this.status = {
+      blueprintId: actuator.blueprintId,
+      siteId: actuator.siteId,
+      runState: "RUNNING",
+      safeState: config.safeState,
+    };
+  }
+
+  /** Current serialisable status (safe to send to the operator UI). */
+  getStatus(): SafeStateStatus {
+    return { ...this.status };
+  }
+
+  /** True once the blueprint has been halted into its safe state. */
+  isInSafeState(): boolean {
+    return this.status.runState !== "RUNNING";
+  }
+
+  /**
+   * Halt the blueprint, apply the declared safe state, anchor a CRITICAL
+   * `SafeStateEntered` event and write the audit entry. Idempotent: a second
+   * call while already in safe state is a no-op (returns the existing status).
+   *
+   * @param reason            why the watchdog tripped
+   * @param consecutiveMisses over-budget tick count at the trip
+   */
+  enterSafeState(reason: string, consecutiveMisses: number): Promise<SafeStateStatus> {
+    return this.runSerializedTransition(() =>
+      this.enterSafeStateLocked(reason, consecutiveMisses),
+    );
+  }
+
+  private async enterSafeStateLocked(
+    reason: string,
+    consecutiveMisses: number,
+  ): Promise<SafeStateStatus> {
+    if (this.status.runState === "SAFE_STATE") {
+      await this.persistPendingEntryAudit();
+      return this.getStatus();
+    }
+
+    // 1. Halt scheduling, then drive outputs to the declared safe state.
+    this.actuator.halt();
+    this.applyAction(this.config.safeState);
+
+    const timestamp = this.now().toISOString();
+
+    // 2. Anchor a CRITICAL SafeStateEntered event via the canonical backend.
+    const event: AnchorEvent = {
+      id: randomUUID(),
+      timestamp,
+      eventType: "SafeStateEntered",
+      severity: "CRITICAL",
+      siteId: this.actuator.siteId,
+      message:
+        `Blueprint ${this.actuator.blueprintId} entered safe state ` +
+        `(${describeSafeState(this.config.safeState)}): ${reason}`,
+      data: {
+        blueprintId: this.actuator.blueprintId,
+        safeState: this.config.safeState,
+        tickBudgetMs: this.config.tickBudgetMs,
+        consecutiveMisses,
+        reason,
+      },
+    };
+    const receipt = await this.safeAnchor(event);
+
+    // 3. Update status and audit the transition.
+    this.status = {
+      ...this.status,
+      runState: "SAFE_STATE",
+      enteredAt: timestamp,
+      reason,
+      consecutiveMisses,
+      anchorHash: receipt.hash,
+      entryAuditStatus: "pending",
+    };
+
+    this.pendingEntryAudit = {
+      blueprintId: this.actuator.blueprintId,
+      siteId: this.actuator.siteId,
+      transition: "ENTERED",
+      safeState: this.config.safeState,
+      tickBudgetMs: this.config.tickBudgetMs,
+      consecutiveMisses,
+      reason,
+      anchorHash: receipt.hash,
+      anchorTxHash: receipt.txHash,
+      timestamp,
+    };
+    await this.persistPendingEntryAudit();
+
+    return this.getStatus();
+  }
+
+  /**
+   * Operator-initiated exit from safe state. Resumes the deterministic loop,
+   * anchors a `SafeStateExited` event and audits the transition. Requires an
+   * operator identity — there is no automatic resume.
+   *
+   * @throws if the blueprint is not currently in safe state.
+   */
+  resume(operator: string, reason = "Operator resume"): Promise<SafeStateStatus> {
+    return this.runSerializedTransition(() =>
+      this.resumeLocked(operator, reason),
+    );
+  }
+
+  private async resumeLocked(
+    operator: string,
+    reason: string,
+  ): Promise<SafeStateStatus> {
+    if (!operator || operator.trim() === "") {
+      throw new Error("resume() requires an operator identity");
+    }
+    if (this.status.runState !== "SAFE_STATE") {
+      throw new Error(
+        `Blueprint ${this.actuator.blueprintId} is not in safe state; cannot resume`,
+      );
+    }
+
+    // A safe state with an undurable ENTERED record may never be cleared.
+    // Retrying this exact entry is idempotent in the production audit sink.
+    await this.persistPendingEntryAudit();
+    // Reconcile an earlier request whose database result was ambiguous using
+    // the exact same hash before accepting a new operator request.
+    await this.persistPendingExitRequestAudit();
+
+    const requestedAt = this.now().toISOString();
+
+    const requestEvent: AnchorEvent = {
+      id: randomUUID(),
+      timestamp: requestedAt,
+      eventType: "SafeStateExitRequested",
+      severity: "WARNING",
+      siteId: this.actuator.siteId,
+      message: `Blueprint ${this.actuator.blueprintId} safe-state exit requested by ${operator}: ${reason}`,
+      data: {
+        blueprintId: this.actuator.blueprintId,
+        operator,
+        reason,
+        previousSafeState: this.config.safeState,
+      },
+    };
+    const requestReceipt = await this.safeAnchor(requestEvent);
+
+    // Persist authorisation before touching the runtime. This record is an
+    // intent, not a claim that the control loop has resumed.
+    this.pendingExitRequestAudit = {
+      blueprintId: this.actuator.blueprintId,
+      siteId: this.actuator.siteId,
+      transition: "EXIT_REQUESTED",
+      safeState: this.config.safeState,
+      tickBudgetMs: this.config.tickBudgetMs,
+      operator,
+      reason,
+      anchorHash: requestReceipt.hash,
+      anchorTxHash: requestReceipt.txHash,
+      timestamp: requestedAt,
+    };
+    await this.persistPendingExitRequestAudit();
+
+    let runtimeResumed = false;
+    try {
+      this.actuator.resume();
+      runtimeResumed = true;
+      // Do not claim SAFE_STATE while the control loop is live and the durable
+      // EXITED record is still pending.
+      this.status = {
+        ...this.status,
+        runState: "RESUMING",
+        recoveryErrors: undefined,
+      };
+
+      const exitedAt = this.now().toISOString();
+      const exitedEvent: AnchorEvent = {
+        id: randomUUID(),
+        timestamp: exitedAt,
+        eventType: "SafeStateExited",
+        severity: "WARNING",
+        siteId: this.actuator.siteId,
+        message: `Blueprint ${this.actuator.blueprintId} resumed from safe state by ${operator}: ${reason}`,
+        data: {
+          blueprintId: this.actuator.blueprintId,
+          operator,
+          reason,
+          previousSafeState: this.config.safeState,
+        },
+      };
+      const exitReceipt = await this.safeAnchor(exitedEvent);
+
+      // EXITED is written only after runtime.resume() succeeds. If this write
+      // fails, the catch path immediately re-applies the declared safe state.
+      await this.audit.record({
+        blueprintId: this.actuator.blueprintId,
+        siteId: this.actuator.siteId,
+        transition: "EXITED",
+        safeState: this.config.safeState,
+        tickBudgetMs: this.config.tickBudgetMs,
+        operator,
+        reason,
+        anchorHash: exitReceipt.hash,
+        anchorTxHash: exitReceipt.txHash,
+        timestamp: exitedAt,
+      });
+
+      this.status = {
+        blueprintId: this.actuator.blueprintId,
+        siteId: this.actuator.siteId,
+        runState: "RUNNING",
+        safeState: this.config.safeState,
+      };
+
+      return this.getStatus();
+    } catch (error) {
+      // A partially-failed runtime resume or post-resume audit must converge
+      // back to the safe state. Halt and safe-output application are attempted
+      // independently so one failure never prevents the other.
+      const recoveryErrors = this.recoverToSafeState();
+      const transition = recoveryErrors.length > 0
+        ? "RECOVERY_FAILED"
+        : runtimeResumed
+          ? "EXIT_ABORTED"
+          : "RESUME_FAILED";
+      await this.recordRecoveryOutcome(
+        transition,
+        operator,
+        reason,
+        error,
+        recoveryErrors,
+      );
+      if (recoveryErrors.length > 0) {
+        throw new AggregateError(
+          [
+            error,
+            ...recoveryErrors.map((message) => new Error(message)),
+          ],
+          `Blueprint ${this.actuator.blueprintId} resume failed and safety recovery was incomplete`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async persistPendingEntryAudit(): Promise<void> {
+    if (!this.pendingEntryAudit) return;
+    await this.audit.record(this.pendingEntryAudit);
+    this.pendingEntryAudit = undefined;
+    this.status = { ...this.status, entryAuditStatus: "durable" };
+  }
+
+  private async persistPendingExitRequestAudit(): Promise<void> {
+    if (!this.pendingExitRequestAudit) return;
+    await this.audit.record(this.pendingExitRequestAudit);
+    this.pendingExitRequestAudit = undefined;
+  }
+
+  private recoverToSafeState(): string[] {
+    this.status = {
+      ...this.status,
+      runState: "RECOVERING",
+      recoveryErrors: undefined,
+    };
+    const errors: string[] = [];
+    try {
+      this.actuator.halt();
+    } catch (error) {
+      errors.push(
+        `halt failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    try {
+      this.applyAction(this.config.safeState);
+    } catch (error) {
+      errors.push(
+        `safe-output application failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    this.status = {
+      ...this.status,
+      runState: errors.length === 0 ? "SAFE_STATE" : "RECOVERY_FAILED",
+      recoveryErrors: errors.length > 0 ? [...errors] : undefined,
+    };
+    return errors;
+  }
+
+  private async recordRecoveryOutcome(
+    transition: "RESUME_FAILED" | "EXIT_ABORTED" | "RECOVERY_FAILED",
+    operator: string,
+    reason: string,
+    cause: unknown,
+    recoveryErrors: string[],
+  ): Promise<void> {
+    const timestamp = this.now().toISOString();
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    const outcome =
+      transition === "RESUME_FAILED"
+        ? "resume attempt failed and the declared safe state was re-applied"
+        : transition === "EXIT_ABORTED"
+          ? "runtime resumed temporarily, but exit durability failed and the declared safe state was re-applied"
+          : "resume/exit failed and the declared safe state could not be fully restored";
+    const event: AnchorEvent = {
+      id: randomUUID(),
+      timestamp,
+      eventType: transition === "EXIT_ABORTED"
+        ? "SafeStateExitAborted"
+        : transition === "RECOVERY_FAILED"
+          ? "SafeStateRecoveryFailed"
+          : "SafeStateResumeFailed",
+      severity: "CRITICAL",
+      siteId: this.actuator.siteId,
+      message: `Blueprint ${this.actuator.blueprintId}: ${outcome}: ${detail}`,
+      data: {
+        blueprintId: this.actuator.blueprintId,
+        operator,
+        reason,
+        failure: detail,
+        recoveryErrors,
+        safeState: this.config.safeState,
+      },
+    };
+    const receipt = await this.safeAnchor(event);
+    try {
+      await this.audit.record({
+        blueprintId: this.actuator.blueprintId,
+        siteId: this.actuator.siteId,
+        transition,
+        safeState: this.config.safeState,
+        tickBudgetMs: this.config.tickBudgetMs,
+        operator,
+        reason: `${reason}; ${outcome}: ${detail}`,
+        anchorHash: receipt.hash,
+        anchorTxHash: receipt.txHash,
+        timestamp,
+      });
+    } catch {
+      // Preserve the original resume/audit failure for the caller. Physical
+      // outputs are already back in the safe state.
+    }
+  }
+
+  /**
+   * Run one state transition at a time. In particular, a second resume waits
+   * for the first transition to finish and then re-checks runState, so it cannot
+   * duplicate the audit or race the physical runtime state.
+   */
+  private runSerializedTransition<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.transitionTail.then(operation);
+    this.transitionTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  /** Drive the runtime into the configured safe state. */
+  private applyAction(action: SafeStateAction): void {
+    if (action === "hold-last") {
+      this.actuator.holdLastOutputs();
+    } else if (action === "force-zero") {
+      this.actuator.forceZeroOutputs();
+    } else {
+      this.actuator.applySafeRecipe(action.recipe);
+    }
+  }
+
+  /**
+   * Anchor an event, degrading gracefully if the backend is unavailable. The
+   * physical safe state has ALREADY been applied by the time we anchor, so an
+   * anchoring failure must NOT prevent the blueprint from staying safe — we fall
+   * back to the locally-computed content hash so the transition is still
+   * auditable and self-verifying.
+   */
+  private async safeAnchor(event: AnchorEvent): Promise<AnchorReceipt> {
+    try {
+      return await this.anchor.anchor(event);
+    } catch {
+      return { hash: computeAnchorHash(event) };
+    }
+  }
+}

--- a/server/blueprint/safety-host.ts
+++ b/server/blueprint/safety-host.ts
@@ -1,0 +1,343 @@
+/**
+ * Blueprint safety composition root (#459).
+ *
+ * This is the module that makes the watchdog non-ceremonial: it constructs the
+ * deterministic runtime for each operator-declared blueprint, wraps it in a real
+ * {@link BlueprintRuntimeActuator}, calls {@link WatchdogRegistry.register}, and
+ * drives the control ticks whose durations the watchdog measures. Without it,
+ * `register()` would only ever be called from tests and
+ * `/api/blueprint-safe-state` would always be empty.
+ *
+ * OFF BY DEFAULT. The host does nothing unless a deployment explicitly supplies
+ * blueprint safety bindings through {@link SAFETY_BINDINGS_FILE_ENV} or
+ * {@link SAFETY_BINDINGS_ENV}. In a default deployment the API therefore reports
+ * `state: "DISABLED"` with an explicit reason — empty *because no blueprint is
+ * loaded*, which is a different and honest statement from empty because nothing
+ * ever registers.
+ *
+ * FAIL-CLOSED. A binding whose declared safe state cannot actually be actuated
+ * (for example `force-zero` without the plant-output opt-in) is rejected by
+ * {@link WatchdogRegistry.register}; that blueprint is NOT started and the
+ * refusal is reported in the host status.
+ *
+ * Relationship to #457: that issue lands its own deterministic-runtime
+ * production host separately. This module deliberately does not depend on it —
+ * it composes only `compileBlueprint` / `BlueprintRuntime`, which are already on
+ * main. When #457's host lands, it should register its runtimes with the shared
+ * {@link safeStateRegistry} rather than starting a second loop here.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { z } from "zod";
+import { safeStateConfigSchema } from "@shared/schema";
+
+import { compileBlueprint } from "./compiler.js";
+import { BlueprintRuntime } from "./runtime.js";
+import type { BlueprintDefinition } from "./types.js";
+import { WatchdogRegistry } from "./registry";
+import { BridgeAnchorBackend, StorageSafeStateAuditSink } from "./safe-state-adapters";
+import {
+  BlueprintRuntimeActuator,
+  type ActuatorCapabilities,
+} from "./runtime-actuator";
+import type { Watchdog } from "./watchdog";
+import { log, logError } from "../logger";
+
+/** Env var holding a path to a JSON safety-bindings document. */
+export const SAFETY_BINDINGS_FILE_ENV = "BLUEPRINT_SAFETY_BINDINGS_FILE" as const;
+/** Env var holding an inline JSON safety-bindings document. */
+export const SAFETY_BINDINGS_ENV = "BLUEPRINT_SAFETY_BINDINGS" as const;
+
+/** Default tick period when neither the binding nor the blueprint declares one. */
+const DEFAULT_SCAN_PERIOD_MS = 100;
+
+// ─── Binding document schema (Zod-validated operator input) ──────────────────
+
+const tagDescriptorSchema = z.object({
+  name: z.string().min(1),
+  direction: z.enum(["input", "output", "internal"]),
+  dataType: z.enum(["bool", "int", "float"]),
+  initial: z.number().optional(),
+});
+
+const operandSchema = z.union([
+  z.object({ tag: z.string().min(1) }).strict(),
+  z.object({ const: z.number() }).strict(),
+]);
+
+const nodeSchema = z.object({
+  id: z.string().min(1),
+  op: z.enum([
+    "AND", "OR", "NOT", "XOR",
+    "GT", "GTE", "LT", "LTE", "EQ", "NEQ",
+    "ADD", "SUB", "MUL", "DIV", "MIN", "MAX",
+    "SELECT", "MOVE", "CONST", "LATCH", "TON",
+  ]),
+  inputs: z.array(operandSchema),
+  output: z.string().min(1),
+  param: z.number().optional(),
+});
+
+const blueprintDefinitionSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  tags: z.array(tagDescriptorSchema).min(1),
+  nodes: z.array(nodeSchema).min(1),
+  scanPeriodMs: z.number().int().positive().optional(),
+});
+
+/** One blueprint bound to a watchdog and a declared safe state. */
+export const blueprintSafetyBindingSchema = z.object({
+  /** Owning site, if the blueprint is site-scoped. */
+  siteId: z.string().min(1).optional(),
+  blueprint: blueprintDefinitionSchema,
+  safeState: safeStateConfigSchema,
+  /**
+   * Named safe recipes: recipe name -> (output tag -> value). A safe state of
+   * `{ recipe }` is only actuatable if the recipe is declared here.
+   */
+  safeRecipes: z.record(z.string(), z.record(z.string(), z.number())).optional(),
+  /** Tick period; defaults to the blueprint's scanPeriodMs. */
+  scanIntervalMs: z.number().int().positive().optional(),
+});
+
+export const blueprintSafetyBindingsSchema = z.object({
+  bindings: z.array(blueprintSafetyBindingSchema).min(1),
+});
+
+export type BlueprintSafetyBinding = z.infer<typeof blueprintSafetyBindingSchema>;
+
+// ─── Host status ─────────────────────────────────────────────────────────────
+
+export interface BlueprintSafetyHostStatus {
+  /**
+   * DISABLED — no bindings configured; nothing is loaded (default deployment).
+   * RUNNING  — at least one blueprint is armed and ticking.
+   * FAILED   — bindings were configured but none could be armed.
+   */
+  state: "DISABLED" | "RUNNING" | "FAILED";
+  /** Plain-language explanation, safe to show an operator. */
+  reason: string;
+  /** Which env var supplied the bindings, if any. */
+  source: typeof SAFETY_BINDINGS_FILE_ENV | typeof SAFETY_BINDINGS_ENV | null;
+  /** Blueprints that are armed with a watchdog right now. */
+  registeredBlueprintIds: string[];
+  /** Bindings that were refused, with the reason they were refused. */
+  rejected: Array<{ blueprintId: string; message: string }>;
+  /** What each armed actuator can actually drive. */
+  actuators: ActuatorCapabilities[];
+}
+
+interface HostedBlueprint {
+  binding: BlueprintSafetyBinding;
+  runtime: BlueprintRuntime;
+  actuator: BlueprintRuntimeActuator;
+  watchdog: Watchdog;
+  timer: NodeJS.Timeout;
+  ticking: boolean;
+}
+
+// ─── Host ────────────────────────────────────────────────────────────────────
+
+export class BlueprintSafetyHost {
+  private readonly hosted = new Map<string, HostedBlueprint>();
+  private state: BlueprintSafetyHostStatus["state"] = "DISABLED";
+  private reason =
+    `No blueprint safety bindings configured (${SAFETY_BINDINGS_FILE_ENV} / ${SAFETY_BINDINGS_ENV} unset); no blueprint is loaded.`;
+  private source: BlueprintSafetyHostStatus["source"] = null;
+  private rejected: Array<{ blueprintId: string; message: string }> = [];
+
+  constructor(private readonly registry: WatchdogRegistry) {}
+
+  /**
+   * Load the configured bindings, arm a watchdog per blueprint and start the
+   * tick loops. Safe to call once at boot; a no-op when unconfigured.
+   */
+  start(env: NodeJS.ProcessEnv = process.env): BlueprintSafetyHostStatus {
+    this.stop();
+    this.rejected = [];
+
+    const document = this.readBindings(env);
+    if (!document) return this.getStatus();
+
+    const parsed = blueprintSafetyBindingsSchema.safeParse(document.value);
+    if (!parsed.success) {
+      this.state = "FAILED";
+      this.reason =
+        `Blueprint safety bindings from ${document.source} are invalid: ` +
+        parsed.error.issues
+          .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+          .join("; ");
+      logError(new Error(this.reason), "Blueprint safety host");
+      return this.getStatus();
+    }
+
+    for (const binding of parsed.data.bindings) {
+      this.arm(binding, env);
+    }
+
+    if (this.hosted.size === 0) {
+      this.state = "FAILED";
+      this.reason =
+        `No blueprint from ${document.source} could be armed; every binding was refused. ` +
+        `Safe-state handling is NOT active.`;
+    } else {
+      this.state = "RUNNING";
+      this.reason =
+        `${this.hosted.size} blueprint(s) armed from ${document.source}; ` +
+        `watchdog tick budgets are being enforced.`;
+      log(`Blueprint safety host: ${this.reason}`);
+    }
+    return this.getStatus();
+  }
+
+  /** Stop every tick loop and unregister every watchdog. */
+  stop(): void {
+    for (const [blueprintId, entry] of this.hosted) {
+      clearInterval(entry.timer);
+      this.registry.unregister(blueprintId);
+    }
+    this.hosted.clear();
+    this.state = "DISABLED";
+    this.source = null;
+    this.reason =
+      `No blueprint safety bindings configured (${SAFETY_BINDINGS_FILE_ENV} / ${SAFETY_BINDINGS_ENV} unset); no blueprint is loaded.`;
+  }
+
+  getStatus(): BlueprintSafetyHostStatus {
+    return {
+      state: this.state,
+      reason: this.reason,
+      source: this.source,
+      registeredBlueprintIds: [...this.hosted.keys()],
+      rejected: this.rejected.map((entry) => ({ ...entry })),
+      actuators: [...this.hosted.values()].map((entry) =>
+        entry.actuator.getCapabilities(),
+      ),
+    };
+  }
+
+  /** The runtime driven for a blueprint (diagnostics / tests). */
+  getRuntime(blueprintId: string): BlueprintRuntime | undefined {
+    return this.hosted.get(blueprintId)?.runtime;
+  }
+
+  /** The actuator bound to a blueprint (diagnostics / tests). */
+  getActuator(blueprintId: string): BlueprintRuntimeActuator | undefined {
+    return this.hosted.get(blueprintId)?.actuator;
+  }
+
+  /**
+   * Run exactly one scan for a hosted blueprint and report its duration to the
+   * watchdog. Exposed so the tick path can be exercised deterministically
+   * instead of waiting on wall-clock timers.
+   */
+  async tickOnce(blueprintId: string): Promise<void> {
+    const entry = this.hosted.get(blueprintId);
+    if (!entry) return;
+    // Honour the halt latch: a halted blueprint must not recompute outputs.
+    if (entry.actuator.isHalted() || entry.ticking) return;
+    entry.ticking = true;
+    try {
+      await entry.watchdog.runTick(() => entry.runtime.tickFast());
+    } catch (error) {
+      logError(error, `Blueprint ${blueprintId} tick failed`);
+    } finally {
+      entry.ticking = false;
+    }
+  }
+
+  // ─── Internals ─────────────────────────────────────────────────────────────
+
+  private readBindings(
+    env: NodeJS.ProcessEnv,
+  ): { source: NonNullable<BlueprintSafetyHostStatus["source"]>; value: unknown } | null {
+    const file = env[SAFETY_BINDINGS_FILE_ENV];
+    const inline = env[SAFETY_BINDINGS_ENV];
+    if (!file && !inline) {
+      this.state = "DISABLED";
+      this.source = null;
+      this.reason =
+        `No blueprint safety bindings configured (${SAFETY_BINDINGS_FILE_ENV} / ${SAFETY_BINDINGS_ENV} unset); no blueprint is loaded.`;
+      return null;
+    }
+
+    const source = file ? SAFETY_BINDINGS_FILE_ENV : SAFETY_BINDINGS_ENV;
+    this.source = source;
+    try {
+      const raw = file ? readFileSync(file, "utf8") : inline!;
+      return { source, value: JSON.parse(raw) as unknown };
+    } catch (error) {
+      this.state = "FAILED";
+      this.reason =
+        `Blueprint safety bindings from ${source} could not be read: ` +
+        (error instanceof Error ? error.message : String(error));
+      logError(error, "Blueprint safety host bindings");
+      return null;
+    }
+  }
+
+  private arm(binding: BlueprintSafetyBinding, env: NodeJS.ProcessEnv): void {
+    const blueprintId = binding.blueprint.id;
+    if (this.hosted.has(blueprintId)) {
+      // Refuse the duplicate without disturbing the binding already armed.
+      const message =
+        `duplicate binding for blueprint ${blueprintId}; each blueprint may be armed exactly once`;
+      this.rejected.push({ blueprintId, message });
+      logError(new Error(message), "Blueprint safety host");
+      return;
+    }
+
+    try {
+      const compiled = compileBlueprint(binding.blueprint as BlueprintDefinition);
+      const runtime = new BlueprintRuntime(compiled);
+      const actuator = new BlueprintRuntimeActuator(blueprintId, runtime, {
+        siteId: binding.siteId,
+        safeRecipes: binding.safeRecipes,
+        env,
+      });
+
+      // Fail-closed: throws when the declared safe state is not actuatable, so
+      // the blueprint below is never started.
+      const watchdog = this.registry.register(actuator, binding.safeState);
+
+      const periodMs =
+        binding.scanIntervalMs
+        ?? binding.blueprint.scanPeriodMs
+        ?? DEFAULT_SCAN_PERIOD_MS;
+      const timer = setInterval(() => {
+        void this.tickOnce(blueprintId);
+      }, periodMs);
+      // Never keep the process (or a test runner) alive for a control loop.
+      timer.unref?.();
+
+      this.hosted.set(blueprintId, {
+        binding,
+        runtime,
+        actuator,
+        watchdog,
+        timer,
+        ticking: false,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.rejected.push({ blueprintId, message });
+      this.registry.unregister(blueprintId);
+      logError(error, `Refused to arm blueprint ${blueprintId}`);
+    }
+  }
+}
+
+// ─── Process-wide composition ────────────────────────────────────────────────
+
+/**
+ * The single registry shared by the composition root and the HTTP surface, so
+ * `/api/blueprint-safe-state` reflects the watchdogs that are really armed.
+ */
+export const safeStateRegistry = new WatchdogRegistry(
+  new BridgeAnchorBackend(),
+  new StorageSafeStateAuditSink(),
+);
+
+export const blueprintSafetyHost = new BlueprintSafetyHost(safeStateRegistry);

--- a/server/blueprint/watchdog.ts
+++ b/server/blueprint/watchdog.ts
@@ -1,0 +1,184 @@
+/**
+ * Blueprint Watchdog (#459)
+ *
+ * Monitors the wall-clock duration of a blueprint's deterministic control ticks
+ * against a per-blueprint budget. When `consecutiveMissesBeforeSafeState`
+ * consecutive ticks exceed `tickBudgetMs`, the watchdog *trips*: it halts the
+ * blueprint and delegates to {@link SafeStateController} to apply the declared
+ * safe state, anchor a CRITICAL `SafeStateEntered` event and audit the
+ * transition.
+ *
+ * The miss counter is reset by any in-budget tick, so transient single-tick
+ * overruns (a GC pause, a one-off scheduling hiccup) do not trip the watchdog —
+ * only a *sustained* run of over-budget ticks does.
+ *
+ * This module is pure with respect to time: callers report observed tick
+ * durations via {@link Watchdog.observeTick}. That keeps the trip logic fully
+ * deterministic and unit-testable without real timers or a live runtime.
+ *
+ * @see server/blueprint/safe-state.ts
+ */
+
+import type { SafeStateConfig } from "@shared/schema";
+import {
+  SafeStateController,
+  type AnchorBackend,
+  type SafeStateActuator,
+  type SafeStateAuditSink,
+  type SafeStateStatus,
+} from "./safe-state";
+
+/** Outcome of observing a single tick. */
+export interface TickObservation {
+  /** Measured tick duration in milliseconds. */
+  durationMs: number;
+  /** True if this tick was over budget. */
+  overBudget: boolean;
+  /** Consecutive over-budget ticks after this observation. */
+  consecutiveMisses: number;
+  /** True if this observation tripped the watchdog (safe state just entered). */
+  tripped: boolean;
+}
+
+/**
+ * Per-blueprint watchdog. One instance per running blueprint.
+ *
+ * Wiring note: the deterministic runtime should call {@link observeTick} with
+ * the measured duration of each completed control tick. `observeTick` is async
+ * only because a trip triggers anchoring + audit; the common (in-budget) path
+ * resolves synchronously.
+ */
+export class Watchdog {
+  private consecutiveMisses = 0;
+  private readonly controller: SafeStateController;
+  private readonly enabled: boolean;
+
+  constructor(
+    private readonly actuator: SafeStateActuator,
+    private readonly config: SafeStateConfig,
+    anchor: AnchorBackend,
+    audit: SafeStateAuditSink,
+    now: () => Date = () => new Date(),
+  ) {
+    this.enabled = config.enabled;
+    this.controller = new SafeStateController(actuator, config, anchor, audit, now);
+  }
+
+  /** Underlying safe-state controller (exposes resume / status to operators). */
+  getController(): SafeStateController {
+    return this.controller;
+  }
+
+  /** Current serialisable safe-state status for this blueprint. */
+  getStatus(): SafeStateStatus {
+    return this.controller.getStatus();
+  }
+
+  /** Consecutive over-budget tick count (resets on any in-budget tick). */
+  getConsecutiveMisses(): number {
+    return this.consecutiveMisses;
+  }
+
+  /** The blueprint this watchdog guards. */
+  get blueprintId(): string {
+    return this.actuator.blueprintId;
+  }
+
+  /**
+   * Report the measured duration of one completed control tick.
+   *
+   * Returns a {@link TickObservation} describing whether the tick was over
+   * budget, the running miss count, and whether this observation tripped the
+   * watchdog into safe state.
+   *
+   * Once the blueprint is in safe state, further observations are ignored (the
+   * loop should be halted anyway) until an operator resumes.
+   */
+  async observeTick(durationMs: number): Promise<TickObservation> {
+    // Disarmed watchdog, or already safe: never (re)trip from a tick.
+    if (!this.enabled || this.controller.isInSafeState()) {
+      const overBudget = durationMs > this.config.tickBudgetMs;
+      return {
+        durationMs,
+        overBudget,
+        consecutiveMisses: this.consecutiveMisses,
+        tripped: false,
+      };
+    }
+
+    const overBudget = durationMs > this.config.tickBudgetMs;
+
+    if (!overBudget) {
+      // Any healthy tick clears the streak.
+      this.consecutiveMisses = 0;
+      return { durationMs, overBudget: false, consecutiveMisses: 0, tripped: false };
+    }
+
+    this.consecutiveMisses += 1;
+
+    if (this.consecutiveMisses >= this.config.consecutiveMissesBeforeSafeState) {
+      const reason =
+        `${this.consecutiveMisses} consecutive ticks exceeded budget of ` +
+        `${this.config.tickBudgetMs}ms (last tick ${durationMs}ms)`;
+      await this.controller.enterSafeState(reason, this.consecutiveMisses);
+      return {
+        durationMs,
+        overBudget: true,
+        consecutiveMisses: this.consecutiveMisses,
+        tripped: true,
+      };
+    }
+
+    return {
+      durationMs,
+      overBudget: true,
+      consecutiveMisses: this.consecutiveMisses,
+      tripped: false,
+    };
+  }
+
+  /**
+   * Convenience wrapper: time a synchronous tick function, report its duration
+   * to the watchdog, and return the function result, the observation, and
+   * whether the tick was skipped.
+   *
+   * The tick still runs to completion before the budget is evaluated — the
+   * watchdog detects budget *violations*, it does not pre-empt a tick.
+   *
+   * Once the blueprint is in safe state the tick is NOT executed (`skipped:
+   * true`, `result: undefined`). That is the halt taking effect for callers
+   * that drive the loop through this wrapper: control logic must not keep
+   * recomputing outputs while the declared safe state is applied.
+   */
+  async runTick<T>(
+    tick: () => T,
+  ): Promise<{ result: T | undefined; skipped: boolean; observation: TickObservation }> {
+    if (this.controller.isInSafeState()) {
+      return {
+        result: undefined,
+        skipped: true,
+        observation: {
+          durationMs: 0,
+          overBudget: false,
+          consecutiveMisses: this.consecutiveMisses,
+          tripped: false,
+        },
+      };
+    }
+    const start = performance.now();
+    const result = tick();
+    const durationMs = performance.now() - start;
+    const observation = await this.observeTick(durationMs);
+    return { result, skipped: false, observation };
+  }
+
+  /**
+   * Operator-initiated resume. Clears the miss counter and exits safe state.
+   * Delegates anchoring + audit to the controller.
+   */
+  async resume(operator: string, reason?: string): Promise<SafeStateStatus> {
+    const status = await this.controller.resume(operator, reason);
+    this.consecutiveMisses = 0;
+    return status;
+  }
+}

--- a/server/health/__tests__/health-manager.test.ts
+++ b/server/health/__tests__/health-manager.test.ts
@@ -35,6 +35,29 @@ describe('HealthManager', () => {
     expect(h.status).toBe('degraded');
   });
 
+  it('propagates a component-reported degraded state to top-level health', async () => {
+    hm.register({
+      name: 'blueprint-safety-runtime',
+      required: false,
+      check: async () => ({
+        name: 'blueprint-safety-runtime',
+        status: 'degraded',
+        lastCheck: new Date(),
+        message: 'control path held',
+      }),
+    });
+
+    const h = await hm.checkAll();
+
+    expect(h.status).toBe('degraded');
+    expect(h.healthy).toBe(true);
+    expect(h.components['blueprint-safety-runtime']).toMatchObject({
+      status: 'down',
+      healthy: false,
+    });
+    expect(await hm.isReady()).toBe(true);
+  });
+
   it('respects dependency ordering', async () => {
     const order: string[] = [];
     hm.register({

--- a/server/health/health-manager.ts
+++ b/server/health/health-manager.ts
@@ -220,10 +220,11 @@ export class HealthManager {
     const requiredNames = new Set(this.checks.filter(c => c.required !== false).map(c => c.name));
     const requiredUnhealthy = services.some(s => requiredNames.has(s.name) && s.status === 'unhealthy');
     const anyUnhealthy = services.some(s => s.status === 'unhealthy');
+    const anyDegraded = services.some(s => s.status === 'degraded');
 
     let status: 'healthy' | 'unhealthy' | 'degraded';
     if (requiredUnhealthy) status = 'unhealthy';
-    else if (anyUnhealthy) status = 'degraded';
+    else if (anyUnhealthy || anyDegraded) status = 'degraded';
     else status = 'healthy';
 
     const components: Record<string, { status: string; healthy: boolean; latencyMs?: number }> = {};

--- a/server/health/index.ts
+++ b/server/health/index.ts
@@ -17,6 +17,7 @@ import { storeAndForwardService } from '../gateway/store-and-forward';
 import { getBridgeHealthStatus } from '../bridge';
 import { describeBlueprintControlLoopHealth, getBlueprintControlLoop } from '../blueprint/control-loop';
 import { publishControlLoopProbeStatus } from '../integrity/latency-probe';
+import { getBlueprintProductionSafetyStatus } from '../blueprint/production-safety';
 
 // Control-loop latency telemetry (#460): publish the sentinel probe's liveness
 // gauge as part of normal server composition so `scada_control_loop_probe_up`
@@ -156,6 +157,32 @@ healthManager.register({
       lastCheck: new Date(),
       message: health.message,
       details: status,
+    };
+  },
+});
+
+// 10. Blueprint safe-state binding (#459). Optional for general API readiness.
+// Reports the real binding state: `healthy` when nothing is configured (nothing
+// is loaded, so nothing is being guarded and nothing is being claimed),
+// `healthy` when every armed blueprint is running, and `degraded` when a binding
+// was refused or an armed blueprint is not RUNNING. The `message`/`details`
+// always say which of those it is.
+healthManager.register({
+  name: 'blueprint-safety-runtime',
+  required: false,
+  check: async () => {
+    const status = getBlueprintProductionSafetyStatus();
+    return {
+      name: 'blueprint-safety-runtime',
+      status: status.state === 'DEGRADED' ? 'degraded' : 'healthy',
+      lastCheck: new Date(),
+      message: status.reason,
+      details: {
+        state: status.state,
+        capabilities: status.capabilities,
+        registeredBlueprintIds: status.registeredBlueprintIds,
+        rejected: status.rejected,
+      },
     };
   },
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,6 +20,9 @@ import { startFluxIntegration } from "./services/flux";
 import { natsPublisher } from "./services/nats";
 import { logAnchorBackendBootState } from "./bridge/anchor-backend";
 import { startBlueprintControlLoop } from "./blueprint/control-loop";
+// Blueprint watchdog / safe-state composition root (#459). Off unless the
+// deployment supplies BLUEPRINT_SAFETY_BINDINGS[_FILE].
+import { blueprintSafetyHost } from "./blueprint/safety-host";
 
 // Re-export log for backward compatibility
 export { log } from "./logger";
@@ -242,6 +245,11 @@ registerSwaggerRoutes(app, gatewayConfig);
       // it cannot actuate a plant. Fails closed: a bad blueprint is logged and
       // the loop stays off rather than taking the server down.
       startBlueprintControlLoop();
+      // Arm the blueprint watchdogs (#459). No-op unless this deployment
+      // supplies BLUEPRINT_SAFETY_BINDINGS / BLUEPRINT_SAFETY_BINDINGS_FILE;
+      // the resulting state is always reported by /api/blueprint-safe-state.
+      const safetyStatus = blueprintSafetyHost.start();
+      log(`Blueprint safety host: ${safetyStatus.state} — ${safetyStatus.reason}`);
 
       // Start periodic health monitoring (every 30 s)
       healthManager.startPeriodicCheck(30_000);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -28,6 +28,7 @@ import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
 import { nodeRoutes } from "./routes/nodes"; // #454: cross-node state queries
+import { blueprintSafeStateRoutes } from "./routes/blueprint-safe-state"; // #459
 import { blueprintRoutes } from "./routes/blueprints";
 import { vendorRoutes } from "./routes/vendors";
 import { codegenRoutes } from "./routes/codegen";
@@ -75,6 +76,7 @@ export async function registerRoutes(
   app.use("/api/security", securityRoutes);
   app.use("/api/geometry", geometryRoutes(getFluxPublisher()));
   app.use("/api/nodes", nodeRoutes); // #454: GET /api/nodes/:id/state/:key
+  app.use("/api/blueprint-safe-state", blueprintSafeStateRoutes); // #459 watchdog & safe-state
 
   // Blueprint / vendor / codegen surfaces (extracted from this file, #446).
   // vendorRoutes and codegenRoutes span several top-level prefixes

--- a/server/routes/blueprint-safe-state.ts
+++ b/server/routes/blueprint-safe-state.ts
@@ -1,0 +1,122 @@
+/**
+ * Blueprint Safe-State API (#459)
+ *
+ * Read-only status endpoints plus an explicit operator `resume` action for the
+ * watchdog / safe-state subsystem. The composition root in
+ * server/blueprint/safety-host.ts registers a {@link Watchdog} per armed
+ * blueprint with the shared {@link safeStateRegistry} and drives its ticks;
+ * this router exposes that state to the operator UI and is the ONLY way to
+ * leave a safe state (there is no auto-resume).
+ *
+ * Every response carries the host status, so an empty `statuses` array is
+ * always attributable: `state: "DISABLED"` means no blueprint is loaded, which
+ * is a different statement from a blueprint being loaded but unguarded.
+ *
+ * AUTH: the whole router requires an authenticated control-plane principal;
+ * `resume` additionally requires the `safety.resume` scope, matching the
+ * `safe-state-resume` entry in server/middleware/control-route-policy.ts.
+ *
+ * @see server/blueprint/safety-host.ts
+ */
+
+import { Router } from "express";
+import { z } from "zod";
+import { getBlueprintProductionSafetyStatus } from "../blueprint/production-safety";
+import { blueprintSafetyHost, safeStateRegistry } from "../blueprint/safety-host";
+import { logError } from "../logger";
+import {
+  controlPlanePrincipal,
+  requireControlPlaneAccess,
+} from "../middleware/control-plane-auth";
+
+const router = Router();
+
+router.use(requireControlPlaneAccess({ roles: ["operator"] }));
+const requireSafetyResume = requireControlPlaneAccess({
+  roles: ["operator"],
+  scopes: ["safety.resume"],
+});
+
+const resumeBodySchema = z.object({
+  /** Optional reason recorded with the SafeStateExited event. */
+  reason: z.string().optional(),
+});
+
+/** GET /api/blueprint-safe-state — status for every registered blueprint. */
+router.get("/", (_req, res) => {
+  res.json({
+    statuses: safeStateRegistry.getAllStatuses(),
+    host: blueprintSafetyHost.getStatus(),
+  });
+});
+
+/** GET /api/blueprint-safe-state/host — what is actually bound, and why. */
+router.get("/host", (_req, res) => {
+  res.json({
+    host: blueprintSafetyHost.getStatus(),
+    safety: getBlueprintProductionSafetyStatus(),
+  });
+});
+
+/** GET /api/blueprint-safe-state/active — only blueprints in safe state. */
+router.get("/active", (_req, res) => {
+  res.json({
+    statuses: safeStateRegistry.getSafeStateStatuses(),
+    host: blueprintSafetyHost.getStatus(),
+  });
+});
+
+/** GET /api/blueprint-safe-state/:blueprintId — status for one blueprint. */
+router.get("/:blueprintId", (req, res) => {
+  const watchdog = safeStateRegistry.get(req.params.blueprintId);
+  if (!watchdog) {
+    res.status(404).json({
+      error: "blueprint watchdog not registered",
+      host: blueprintSafetyHost.getStatus(),
+    });
+    return;
+  }
+  res.json({ status: watchdog.getStatus() });
+});
+
+/**
+ * POST /api/blueprint-safe-state/:blueprintId/resume
+ * Explicit operator action required to leave a safe state.
+ */
+router.post("/:blueprintId/resume", requireSafetyResume, async (req, res) => {
+  const watchdog = safeStateRegistry.get(req.params.blueprintId);
+  if (!watchdog) {
+    res.status(404).json({
+      error: "blueprint watchdog not registered",
+      host: blueprintSafetyHost.getStatus(),
+    });
+    return;
+  }
+
+  const parsed = resumeBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    const error = parsed.error.issues
+      .map((issue) => {
+        const path = issue.path.join(".");
+        return path ? `${path}: ${issue.message}` : issue.message;
+      })
+      .join("; ");
+    res.status(400).json({ error });
+    return;
+  }
+
+  try {
+    const status = await watchdog.resume(
+      controlPlanePrincipal(req).name,
+      parsed.data.reason,
+    );
+    res.json({ status });
+  } catch (error) {
+    logError(error, `Failed to resume blueprint ${req.params.blueprintId}`);
+    res.status(409).json({ error: (error as Error).message });
+  }
+});
+
+export { safeStateRegistry };
+export const blueprintSafeStateRoutes = router;
+export default router;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -176,10 +176,25 @@ CREATE TABLE IF NOT EXISTS controllers (
   configuration TEXT NOT NULL DEFAULT '{}', status TEXT NOT NULL DEFAULT 'offline',
   created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
 );
+CREATE TABLE IF NOT EXISTS blueprint_safe_state_log (
+  id TEXT PRIMARY KEY, blueprint_id TEXT NOT NULL, site_id TEXT,
+  transition TEXT NOT NULL, safe_state TEXT NOT NULL,
+  tick_budget_ms INTEGER NOT NULL, consecutive_misses INTEGER,
+  operator TEXT, reason TEXT NOT NULL, anchor_hash TEXT NOT NULL,
+  anchor_tx_hash TEXT, metadata TEXT, created_at INTEGER NOT NULL
+);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_unit_instances_type_name
   ON unit_instances(unit_type_id, name);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_control_module_instances_type_name
   ON control_module_instances(control_module_type_id, name);
+CREATE INDEX IF NOT EXISTS idx_safe_state_log_blueprint_id
+  ON blueprint_safe_state_log(blueprint_id);
+CREATE INDEX IF NOT EXISTS idx_safe_state_log_transition
+  ON blueprint_safe_state_log(transition);
+CREATE INDEX IF NOT EXISTS idx_safe_state_log_created_at
+  ON blueprint_safe_state_log(created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_safe_state_log_anchor_hash
+  ON blueprint_safe_state_log(anchor_hash);
 `;
 
 /**
@@ -996,6 +1011,147 @@ export const recordValidatorStateWatermark = async (
   }
   return current;
 };
+// ─── Blueprint safe-state audit trail (#459) ────────────────────────────────
+// The watchdog's safe-state transitions must be durable on BOTH dialects. The
+// generic CRUD facade above cannot be reused here: `safe_state` may serialise
+// to a bare JSON string ("hold-last"), which the shared SQLite JSON decoder
+// (which only parses values starting with `[` or `{`) would hand back
+// double-encoded. These two functions therefore own their own encoding.
+//
+// Postgres schema: migrations/0009_blueprint_safe_state_log.sql
+// SQLite schema:   `blueprintSqliteSchema` above, applied on every open.
+
+/** A safe-state transition as written to `blueprint_safe_state_log`. */
+export interface SafeStateLogInsert {
+  blueprintId: string;
+  siteId?: string;
+  transition: string;
+  /** Serialised SafeStateAction. */
+  safeState: unknown;
+  tickBudgetMs: number;
+  consecutiveMisses?: number;
+  operator?: string;
+  reason: string;
+  anchorHash: string;
+  anchorTxHash?: string;
+  createdAt: Date;
+}
+
+/** A safe-state transition as read back from `blueprint_safe_state_log`. */
+export interface SafeStateLogRecord extends SafeStateLogInsert {
+  id: string;
+}
+
+function toSafeStateLogRecord(row: Record<string, unknown>): SafeStateLogRecord {
+  const rawSafeState = row.safe_state ?? row.safeState;
+  const safeState = typeof rawSafeState === 'string'
+    ? JSON.parse(rawSafeState) as unknown
+    : rawSafeState;
+  const rawCreatedAt = row.created_at ?? row.createdAt;
+  const createdAt = rawCreatedAt instanceof Date
+    ? rawCreatedAt
+    : new Date(Number(rawCreatedAt));
+  const optional = (value: unknown): string | undefined =>
+    value === null || value === undefined ? undefined : String(value);
+  const optionalNumber = (value: unknown): number | undefined =>
+    value === null || value === undefined ? undefined : Number(value);
+
+  return {
+    id: String(row.id),
+    blueprintId: String(row.blueprint_id ?? row.blueprintId),
+    siteId: optional(row.site_id ?? row.siteId),
+    transition: String(row.transition),
+    safeState,
+    tickBudgetMs: Number(row.tick_budget_ms ?? row.tickBudgetMs),
+    consecutiveMisses: optionalNumber(row.consecutive_misses ?? row.consecutiveMisses),
+    operator: optional(row.operator),
+    reason: String(row.reason),
+    anchorHash: String(row.anchor_hash ?? row.anchorHash),
+    anchorTxHash: optional(row.anchor_tx_hash ?? row.anchorTxHash),
+    createdAt,
+  };
+}
+
+/**
+ * Durably record one safe-state transition. Idempotent on `anchor_hash` so a
+ * retried write (the controller retries an entry whose durability was
+ * ambiguous) cannot duplicate the audit row.
+ *
+ * Throws if the write did not land — callers must never treat a discarded
+ * audit as a successful one.
+ */
+export async function insertBlueprintSafeStateLog(
+  entry: SafeStateLogInsert,
+): Promise<void> {
+  await withStorageLock(async () => {
+    if (dbType === 'sqlite') {
+      await sqliteRun(
+        `INSERT OR IGNORE INTO blueprint_safe_state_log
+           (id, blueprint_id, site_id, transition, safe_state, tick_budget_ms,
+            consecutive_misses, operator, reason, anchor_hash, anchor_tx_hash,
+            created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          randomUUID(),
+          entry.blueprintId,
+          entry.siteId ?? null,
+          entry.transition,
+          JSON.stringify(entry.safeState),
+          entry.tickBudgetMs,
+          entry.consecutiveMisses ?? null,
+          entry.operator ?? null,
+          entry.reason,
+          entry.anchorHash,
+          entry.anchorTxHash ?? null,
+          entry.createdAt.getTime(),
+        ],
+      );
+      return;
+    }
+
+    await requireDatabase()
+      .insert(schema.blueprintSafeStateLog)
+      .values({
+        blueprintId: entry.blueprintId,
+        siteId: entry.siteId,
+        transition: entry.transition,
+        safeState: entry.safeState as Record<string, unknown>,
+        tickBudgetMs: entry.tickBudgetMs,
+        consecutiveMisses: entry.consecutiveMisses,
+        operator: entry.operator,
+        reason: entry.reason,
+        anchorHash: entry.anchorHash,
+        anchorTxHash: entry.anchorTxHash,
+        createdAt: entry.createdAt,
+      })
+      .onConflictDoNothing({ target: schema.blueprintSafeStateLog.anchorHash });
+  });
+}
+
+/** Read back safe-state transitions, newest first. */
+export async function listBlueprintSafeStateLog(
+  blueprintId?: string,
+): Promise<SafeStateLogRecord[]> {
+  return withStorageLock(async () => {
+    if (dbType === 'sqlite') {
+      const rows = blueprintId
+        ? await sqliteAll(
+          'SELECT * FROM blueprint_safe_state_log WHERE blueprint_id = ? ORDER BY created_at DESC',
+          [blueprintId],
+        )
+        : await sqliteAll(
+          'SELECT * FROM blueprint_safe_state_log ORDER BY created_at DESC',
+        );
+      return rows.map(toSafeStateLogRecord);
+    }
+
+    const table = schema.blueprintSafeStateLog;
+    let query = requireDatabase().select().from(table);
+    if (blueprintId) query = query.where(eq(table.blueprintId, blueprintId));
+    const rows = await query.orderBy(desc(table.createdAt)) as Record<string, unknown>[];
+    return rows.map(toSafeStateLogRecord);
+  });
+}
 
 // Export storage object as expected by health/index.ts
 export const storage = {

--- a/shared/__tests__/schema-parity.test.ts
+++ b/shared/__tests__/schema-parity.test.ts
@@ -7,6 +7,7 @@ import {
   validatorNodes as pgValidatorNodes,
   validatorPubkeys as pgValidatorPubkeys,
   validatorStateWatermarks as pgValidatorStateWatermarks,
+  blueprintSafeStateLog as pgBlueprintSafeStateLog,
 } from '../schema';
 import {
   alarms as sqliteAlarms,
@@ -14,6 +15,7 @@ import {
   validatorNodes as sqliteValidatorNodes,
   validatorPubkeys as sqliteValidatorPubkeys,
   validatorStateWatermarks as sqliteValidatorStateWatermarks,
+  blueprintSafeStateLog as sqliteBlueprintSafeStateLog,
 } from '../schema-sqlite';
 
 /**
@@ -28,6 +30,10 @@ import {
  *
  * Covers the alarm tables (#7) and the validator registry backing the
  * cross-node state proxy (#454).
+ *
+ * `blueprint_safe_state_log` (#459) is covered here because a safe-state audit
+ * that silently vanishes on one dialect is a safety defect, not a dev-mode
+ * inconvenience.
  */
 
 const sqlColumnNames = (table: Table): string[] =>
@@ -47,6 +53,11 @@ const cases = [
     name: 'validator_state_watermarks',
     pg: pgValidatorStateWatermarks,
     sqlite: sqliteValidatorStateWatermarks,
+  },
+  {
+    name: 'blueprint_safe_state_log',
+    pg: pgBlueprintSafeStateLog,
+    sqlite: sqliteBlueprintSafeStateLog,
   },
 ] as const;
 

--- a/shared/schema-sqlite.ts
+++ b/shared/schema-sqlite.ts
@@ -331,6 +331,30 @@ export const validatorStateWatermarks = sqliteTable("validator_state_watermarks"
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
 });
 
+// ─── Blueprint Safe-State audit trail (#459) ─────────────────────────────────
+// Dev-mode parity with the Postgres table in `shared/schema.ts`, which is
+// created in production by migrations/0009_blueprint_safe_state_log.sql. The
+// safe-state audit must be durable on BOTH dialects — a swallowed audit write
+// would let the controller report a safe-state transition that was discarded.
+// jsonb → text(mode json), timestamptz → integer timestamp, per this file's
+// conventions. Kept in sync by `shared/__tests__/schema-parity.test.ts`; the
+// physical SQLite DDL lives in `blueprintSqliteSchema` (server/storage.ts).
+export const blueprintSafeStateLog = sqliteTable("blueprint_safe_state_log", {
+  id: text("id").primaryKey(),
+  blueprintId: text("blueprint_id").notNull(),
+  siteId: text("site_id"),
+  transition: text("transition").notNull(),
+  safeState: text("safe_state", { mode: "json" }).notNull(),
+  tickBudgetMs: integer("tick_budget_ms").notNull(),
+  consecutiveMisses: integer("consecutive_misses"),
+  operator: text("operator"),
+  reason: text("reason").notNull(),
+  anchorHash: text("anchor_hash").notNull(),
+  anchorTxHash: text("anchor_tx_hash"),
+  metadata: text("metadata", { mode: "json" }),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+});
+
 // Basic exports for compatibility
 export const insertSiteSchema = {
   parse: (data: any) => data // Simple pass-through for development

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -33,6 +33,7 @@ import {
 } from "drizzle-orm/pg-core";
 import { relations, sql } from "drizzle-orm";
 import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod"; // #459: safe-state config validation schemas
 
 // ─── Enums ───────────────────────────────────────────────────────────────────
 
@@ -642,6 +643,68 @@ export const modbusRegisterMap = pgTable("modbus_register_map", {
   siteAreaAddressIdx: uniqueIndex("idx_modbus_register_map_site_area_address").on(table.siteId, table.unitId, table.area, table.address),
   siteIdIdx: index("idx_modbus_register_map_site_id").on(table.siteId),
 }));
+
+// ─── Blueprint Safe-State (#459) ─────────────────────────────────────────────
+// Watchdog & Safe-State Fallback. A blueprint's control tick has a per-tick
+// budget; if it is exceeded for N consecutive ticks the watchdog halts the
+// blueprint and applies a pre-declared safe state, anchoring a CRITICAL
+// `SafeStateEntered` event. Re-entry to RUNNING requires explicit operator
+// action. These additions are append-only to avoid cross-issue merge conflicts.
+
+/**
+ * Pre-declared safe state a blueprint falls back to on a watchdog trip.
+ *  - `hold-last`  : freeze all outputs at their last commanded value.
+ *  - `force-zero` : drive all outputs to zero / de-energised.
+ *  - { recipe }   : load a named, previously-validated safe recipe.
+ */
+export const safeStateActionSchema = z.union([
+  z.literal("hold-last"),
+  z.literal("force-zero"),
+  z.object({ recipe: z.string().min(1) }),
+]);
+export type SafeStateAction = z.infer<typeof safeStateActionSchema>;
+
+/** Per-blueprint watchdog / safe-state configuration. */
+export const safeStateConfigSchema = z.object({
+  /** Whether the watchdog is armed for this blueprint. */
+  enabled: z.boolean().default(true),
+  /** Per-tick wall-clock budget in milliseconds. */
+  tickBudgetMs: z.number().int().positive(),
+  /** Consecutive over-budget ticks tolerated before the safe state is applied. */
+  consecutiveMissesBeforeSafeState: z.number().int().positive(),
+  /** The pre-declared safe state to apply on a trip. */
+  safeState: safeStateActionSchema,
+});
+export type SafeStateConfig = z.infer<typeof safeStateConfigSchema>;
+
+// Persisted record of every safe-state entry / exit transition (audit trail).
+export const blueprintSafeStateLog = pgTable("blueprint_safe_state_log", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  blueprintId: varchar("blueprint_id", { length: 64 }).notNull(),
+  siteId: varchar("site_id", { length: 64 }).references(() => sites.id),
+  // ENTERED/EXIT_REQUESTED/EXITED plus compensating failure transitions.
+  transition: varchar("transition", { length: 16 }).notNull(),
+  // Serialized SafeStateAction that was applied.
+  safeState: jsonb("safe_state").notNull(),
+  tickBudgetMs: integer("tick_budget_ms").notNull(),
+  consecutiveMisses: integer("consecutive_misses"),
+  // Operator who acknowledged / resumed (null for an automatic ENTERED event).
+  operator: varchar("operator", { length: 255 }),
+  reason: text("reason").notNull(),
+  // Hash anchored to the canonical anchor backend for this transition.
+  anchorHash: varchar("anchor_hash", { length: 255 }).notNull(),
+  anchorTxHash: varchar("anchor_tx_hash", { length: 255 }),
+  metadata: jsonb("metadata"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  blueprintIdIdx: index("idx_safe_state_log_blueprint_id").on(table.blueprintId),
+  transitionIdx: index("idx_safe_state_log_transition").on(table.transition),
+  createdAtIdx: index("idx_safe_state_log_created_at").on(table.createdAt),
+  anchorHashIdx: uniqueIndex("idx_safe_state_log_anchor_hash").on(table.anchorHash),
+}));
+
+export type BlueprintSafeStateLog = typeof blueprintSafeStateLog.$inferSelect;
+export type InsertBlueprintSafeStateLog = typeof blueprintSafeStateLog.$inferInsert;
 
 // ─── Schema Exports ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
> Supersedes the stale draft #532, which was opened against a `main` that has since moved 73 commits and is now conflicting. This branch is built on current `main` and fixes the defect that draft left open.

Closes #459.

The previous attempt was rejected because the watchdog/safe-state logic, while correct in isolation, was ceremonial in production: nothing implemented the actuation seam outside a test fake, `WatchdogRegistry.register()` was never called outside tests, and the audit table had no migration. This addresses each point, and ports the slice onto current main (six conflicted files resolved by integration, not side-picking).

## 1. Actuation seam

`SafeStateActuator` (renamed from the old `BlueprintRuntime` interface, which collided with #457's real runtime class) is implemented for real by `BlueprintRuntimeActuator` in `server/blueprint/runtime-actuator.ts`, driving the deterministic runtime's tag store:

- `halt()` sets a latch that both the host tick driver and `Watchdog.runTick()` honour — the tick body is no longer executed once safe state is entered
- `holdLastOutputs()` snapshots the current output tags and re-asserts them
- `forceZeroOutputs()` writes 0 into every output tag
- `applySafeRecipe()` writes a declared recipe's values

Each method takes effect or throws; none is a silent no-op.

**Stated plainly:** the deterministic runtime's tag store is the only output sink that genuinely exists in this repository today. The vendor adapters under `server/services/vendors/` marshal write frames but never transmit them, so there is no wire-level output path to bind. `FieldOutputSink` is the seam a deployment binds when it has a real driver; no such sink ships here, and the status surface reports `outputSink: "runtime-tag-store"` / `fieldSinkBound: false` rather than implying otherwise.

**Safety.** `force-zero` and safe recipes command new output values, i.e. they are plant-output writes. They are unavailable unless `BLUEPRINT_SAFE_STATE_ALLOW_OUTPUT_WRITES=true` (exact string; `1`/`yes`/`TRUE` are rejected), checked both at arm time and at the call itself so a directly-constructed actuator cannot bypass it. `WatchdogRegistry.register()` runs `assertCanApply` and throws, so a blueprint declaring a safe state it could not apply is refused and never started — fail-closed. Nothing binds a listener or writes an output by default.

## 2. Registration

`server/blueprint/safety-host.ts` is a real composition root, started from `server/index.ts` at boot. It compiles each operator-declared blueprint, constructs the runtime and actuator, calls `register()` on the same `safeStateRegistry` singleton the HTTP route reads, and drives the ticks the watchdog measures.

It is **off by default**: nothing happens unless `BLUEPRINT_SAFETY_BINDINGS` or `BLUEPRINT_SAFETY_BINDINGS_FILE` supplies Zod-validated bindings. In that case the API reports `state: "DISABLED"` with the reason *"no blueprint is loaded"*, and every response carries the host status — so an empty list is attributable rather than ambiguous. Invalid or unreadable bindings report `FAILED` and arm nothing rather than running unguarded. This deliberately does not depend on #457's separate production host; when that lands it should register with the shared `safeStateRegistry` instead of starting a second loop.

## 3. Migration

`migrations/0007_blueprint_safe_state_log.sql`, renumbered from the slice's 0005 into the next free slot after main's 0006, with `migrations/meta/_journal.json` appended at idx 4 and kept monotonic (no renumbering of main's entries, no number collision). The SQLite dev fallback creates the same table from `blueprintSqliteSchema` on every open, the table is declared in `shared/schema-sqlite.ts` and covered by the schema-parity suite, and `storage.insertBlueprintSafeStateLog` / `listBlueprintSafeStateLog` own their JSON encoding because the shared SQLite decoder would double-encode a bare `"hold-last"` safe state.

`safe-state-audit-durability.test.ts` opens a real SQLite database, writes through the production sink and reads the rows back — including anchor-hash idempotency, all six transition kinds, and a `PRAGMA table_info` check that the physical table matches the typed declaration. The sink rethrows on failure, so a discarded audit can never be reported as durable.

## 4. Auth

The router applies `requireControlPlaneAccess({ roles: ["operator"] })` to all reads and additionally requires the `safety.resume` scope for resume, matching the existing `safe-state-resume` control-route policy. `server/middleware/control-plane-auth.ts` is main's hardened #576 version verbatim (net diff zero). The audited operator identity is the server-owned API-key name, not a caller-supplied body field.

## Not done, deliberately

- No field-output driver is added, so on a default deployment safe state moves the runtime tag store only.
- `SafeStateBadge` is a presentational component with unit tests, but nothing mounts it — this repository has no blueprint operator page yet.
- `server/health/health-manager.ts` now lets a component-reported `degraded` degrade top-level status. This is slightly beyond #459; `healthy` is still `status !== 'unhealthy'`, so `/health` and `/readyz` still return 200 and readiness is unaffected.

## Verification

- `npx tsc --noEmit` exits 0
- `npx vitest run`: 103 files / 2103 passing, 2 files + 5 tests skipped (baseline 95 / 2024 with the same skips)
- No conflict markers remain in any tracked file
- The new tests are mutation-verified: reverting the `assertCanApply` fail-closed check, the SQLite DDL, the `runtime.set(name, 0)` write, or the router auth guard each makes the corresponding suite fail
- Postgres is not available in this environment, so its half of the audit table is verified structurally (migration SQL vs Drizzle table vs SQLite declaration); the write-and-read-back proof runs on real SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

**Migration numbering — cross-PR coordination.** This branch adds its migration as `0007_*` because that
was the next free slot on `main` (which has `0001`, `0002`, `0003_blueprint_persistence`,
`0006_blueprint_instance_identity`). Two sibling PRs in this batch also add a `0007_*` migration:
`0007_validator_registry` (#454), `0007_blueprint_safe_state_log` (#459) and `0007_modbus_register_map`
(#462). They are independent and each is self-consistent, but whichever merges second and third will need
renumbering plus a `migrations/meta/_journal.json` update. Flagging it here rather than guessing a merge
order.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
