### PR TITLE
feat(modbus): ship Modbus TCP Server Mode gated, loopback-bound and fail-closed (#462)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,3 +128,28 @@ CONTROL_LOOP_LATENCY_PROBE=false
 CONTROL_LOOP_LATENCY_PROBE_INTERVAL_MS=1000
 # Names the sentinel blueprint (sentinel/<site>).
 CONTROL_LOOP_LATENCY_PROBE_SITE=local
+# Modbus TCP Server Mode (Issue #462)
+# Lets standard Modbus masters poll 0xSCADA tags. OFF by default.
+#
+# WARNING: Modbus TCP has NO authentication in the protocol — no credential, no
+# handshake. Any peer that can open the socket is a fully privileged master.
+# The controls below are the only ones available; all of them fail closed.
+#
+# Must be exactly "true" to start a listener at all.
+MODBUS_SERVER_ENABLED=false
+# Site whose modbus_register_map rows are served (required when enabled).
+MODBUS_SERVER_SITE_ID=
+MODBUS_SERVER_UNIT_ID=1
+# Bind address. Defaults to loopback; a routable address is a deliberate act
+# and then REQUIRES MODBUS_SERVER_ALLOWED_PEERS below.
+MODBUS_SERVER_BIND_HOST=127.0.0.1
+# Port 502 needs elevated privileges; use 1502 for unprivileged/dev runs.
+MODBUS_SERVER_PORT=502
+# Comma-separated IPs/CIDRs allowed to connect, enforced at accept time.
+# Defaults to loopback only. Wildcards (0.0.0.0/0, ::/0) are rejected.
+MODBUS_SERVER_ALLOWED_PEERS=
+MODBUS_SERVER_MAX_CONNECTIONS=4
+# Separate opt-in before FC05/06/15/16 are served at all. Even when true, only
+# modbus_register_map rows with writable=true can mutate a live tag.
+MODBUS_SERVER_ALLOW_WRITES=false
+MODBUS_SERVER_SOCKET_TIMEOUT_MS=60000

--- a/docs/protocols/modbus-server.md
+++ b/docs/protocols/modbus-server.md
@@ -1,0 +1,243 @@
+# Modbus TCP Server Mode
+
+> Issue #462 — Mirror of OPC-UA Server Mode for the lower-end market. Legacy
+> HMIs and integrators can read (and, with explicit opt-in, write) 0xSCADA tags
+> via standard Modbus TCP.
+
+## Overview
+
+The Modbus TCP server (`server/protocols/modbus-server/`) lets any standard
+Modbus master (pymodbus, ModScan, legacy HMIs, SCADA integrators) poll 0xSCADA
+tags. The Modbus TCP wire protocol (MBAP header + PDU) is implemented **from
+scratch** — it is small, well specified, and avoids a heavy runtime dependency,
+which keeps the protocol logic fully unit-testable.
+
+```
+Modbus master ──TCP──▶ ModbusTcpServer ──▶ handlers ──▶ TagStoreDataModel
+   (pymodbus)          (server.ts)        (handlers.ts)   (tag-store-bridge.ts)
+                            │                                     │
+                     peer allowlist                               ▼
+                     + connection cap                      live tag store
+                     (peer-filter.ts)                     (tagCache / Redis)
+```
+
+## Security model — read this before enabling it
+
+**Modbus TCP has no authentication.** The protocol carries no credential, no
+handshake, and no integrity protection. Any peer that can complete a TCP
+connection to the listener is, as far as the protocol is concerned, a fully
+privileged master. Nothing in this implementation can change that, and nothing
+in it pretends to.
+
+What 0xSCADA does instead is refuse to be exposed by accident. Every control
+below is off or closed by default, and each has to be opened deliberately:
+
+| Control | Default | How it opens |
+|---------|---------|--------------|
+| The listener exists at all | **off** | `MODBUS_SERVER_ENABLED=true` |
+| Bind address | **`127.0.0.1`** | `MODBUS_SERVER_BIND_HOST=<addr>` |
+| Peer allowlist (accept time) | **loopback only** | `MODBUS_SERVER_ALLOWED_PEERS=<ip/cidr,…>` — *mandatory* once the bind address is not loopback |
+| Simultaneous masters | **4** | `MODBUS_SERVER_MAX_CONNECTIONS=<n>` |
+| Write function codes served | **refused (0x01)** | `MODBUS_SERVER_ALLOW_WRITES=true` |
+| A given address is writable | **not writable** | `modbus_register_map.writable = true` for that row |
+
+Additional hard rules, enforced in code:
+
+- A wildcard allowlist (`0.0.0.0/0`, `::/0`) is **rejected** — an allowlist that
+  admits everyone is not an allowlist, and the protocol cannot authenticate the
+  peers it would admit.
+- A non-loopback bind with no `MODBUS_SERVER_ALLOWED_PEERS` is **rejected**.
+- Any invalid value fails closed with a `ModbusServerConfigError`; the process
+  logs it and binds **no** socket. Configuration is never silently defaulted
+  into something more permissive.
+- Peers outside the allowlist and connections past the cap are logged and
+  destroyed at accept time, before a single protocol byte is read.
+
+Enabling writes on a routable interface still means an unauthenticated peer on
+the allowlisted subnet can actuate every address marked `writable`. Keep the
+listener on a segmented control network; the allowlist is a blast-radius
+control, not an authentication mechanism.
+
+## Module layout
+
+| File | Responsibility |
+|------|----------------|
+| `codec.ts` | MBAP header + PDU encode/decode, bit/register packing. Pure, no I/O. |
+| `data-model.ts` | `ModbusDataModel` interface + `InMemoryDataModel`. The four primary tables. |
+| `register-map.ts` | Per-site tag ⇄ address mapping, Zod schema, lookups, value⇄register codec. |
+| `register-map-store.ts` | Loads a site's map from `modbus_register_map`. Fails closed. |
+| `handlers.ts` | Pure request → response processing for all 8 FCs + exception mapping. |
+| `tag-store-bridge.ts` | Binds a `RegisterMap` to the live tag store; writes propagate back. |
+| `peer-filter.ts` | IP/CIDR allowlist parsing + matching (IPv4, IPv6, IPv4-mapped). Pure. |
+| `config.ts` | Zod-validated deployment configuration from the environment. |
+| `server.ts` | `net.Server` listener, admission control, TCP frame reassembly. |
+| `index.ts` | Public exports, `createModbusServerForSite()`, `startModbusServer()`. |
+
+## Supported function codes
+
+| FC | Name | Direction |
+|----|------|-----------|
+| `0x01` | Read Coils | read R/W bits |
+| `0x02` | Read Discrete Inputs | read RO bits |
+| `0x03` | Read Holding Registers | read R/W 16-bit |
+| `0x04` | Read Input Registers | read RO 16-bit |
+| `0x05` | Write Single Coil | write 1 bit |
+| `0x06` | Write Single Register | write 1 register |
+| `0x0F` | Write Multiple Coils | write N bits |
+| `0x10` | Write Multiple Registers | write N registers |
+
+## Exception responses
+
+| Code | Name | When |
+|------|------|------|
+| `0x01` | Illegal Function | function code not in the supported set, **or any write FC on a listener started without `MODBUS_SERVER_ALLOW_WRITES=true`** |
+| `0x02` | Illegal Data Address | the requested address/range is not mapped |
+| `0x03` | Illegal Data Value | quantity/byte-count out of spec range; write to an address not marked `writable`; misaligned or truncated multi-register write |
+| `0x04` | Server Device Failure | the data model / tag store raised an unexpected error |
+
+A multi-address write is validated in full before any tag is touched: if one
+address in the range is not writable, the whole request is rejected and nothing
+is mutated.
+
+## Register map (per-site configuration)
+
+Each site declares which tags are exposed at which Modbus addresses. The runtime
+schema lives in `register-map.ts`; the persisted table is `modbus_register_map`
+(`shared/schema.ts`, migration `0007_modbus_register_map.sql`).
+
+```sql
+INSERT INTO modbus_register_map
+  (site_id, unit_id, area, address, tag_id, data_type, scale, word_order, writable)
+VALUES
+  ('site-1', 1, 'coil',            0, 'pump-01.run',   'bool',    NULL, NULL, true),
+  ('site-1', 1, 'discreteInput',   0, 'alarm.active',  'bool',    NULL, NULL, false),
+  ('site-1', 1, 'holdingRegister', 0, 'tank.level',    'uint16',  NULL, NULL, false),
+  ('site-1', 1, 'holdingRegister', 1, 'flow.rate',     'float32', 1,    NULL, false),
+  ('site-1', 1, 'inputRegister',   5, 'device.serial', 'uint16',  NULL, NULL, false);
+```
+
+### Entry fields
+
+- `tagId` — the 0xSCADA tag exposed at this address.
+- `area` — `coil` | `discreteInput` | `holdingRegister` | `inputRegister`.
+- `address` — zero-based on-the-wire address (NOT 4xxxx notation).
+- `dataType` — `bool` (bit areas) | `uint16` | `int16` | `uint32` | `int32` | `float32`.
+- `scale` — optional linear scale: read value = raw × scale; write raw = value ÷ scale.
+- `wordOrder` — `big` (default) | `little` for 32-bit types.
+- `writable` — **defaults to false.** Exposing a tag for polling never implies a
+  master may actuate it. A write to a non-writable address is rejected with
+  Illegal Data Value even on a listener that has writes enabled.
+
+32-bit types occupy two consecutive registers; the map rejects overlapping or
+duplicate addresses at construction time.
+
+### Backend requirement
+
+`loadModbusRegisterMap()` reads the `modbus_register_map` table over Drizzle and
+therefore **requires the PostgreSQL backend**. The SQLite development fallback
+in `server/storage.ts` does not carry this table (its Drizzle shim resolves
+every select to `[]`), so the loader refuses with a clear error instead of
+opening a listener backed by an empty map. An empty result set from Postgres is
+likewise refused: a socket that answers nothing is pure attack surface.
+
+## Configuration / environment
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `MODBUS_SERVER_ENABLED` | `false` | Must be exactly `true` to start a listener. |
+| `MODBUS_SERVER_SITE_ID` | *(required)* | Site whose register map is served. |
+| `MODBUS_SERVER_UNIT_ID` | `1` | Modbus unit id whose rows are served. |
+| `MODBUS_SERVER_BIND_HOST` | `127.0.0.1` | Bind address. Non-loopback forces an allowlist. |
+| `MODBUS_SERVER_PORT` | `502` | Bind port (use a high port for unprivileged runs). |
+| `MODBUS_SERVER_ALLOWED_PEERS` | loopback (`127.0.0.0/8`, `::1/128`) | Comma-separated IPs/CIDRs allowed to connect. No `/0`. |
+| `MODBUS_SERVER_MAX_CONNECTIONS` | `4` | Simultaneous master connections. |
+| `MODBUS_SERVER_ALLOW_WRITES` | `false` | Must be exactly `true` to serve FC05/06/15/16. |
+| `MODBUS_SERVER_SOCKET_TIMEOUT_MS` | `60000` | Idle socket timeout (`0` disables). |
+
+> Binding to port 502 requires elevated privileges on most operating systems.
+> For local development/conformance testing, set `MODBUS_SERVER_PORT=1502`.
+
+### Example: read-only, loopback (the safe starting point)
+
+```bash
+MODBUS_SERVER_ENABLED=true \
+MODBUS_SERVER_SITE_ID=site-1 \
+MODBUS_SERVER_PORT=1502 \
+npm run start
+```
+
+### Example: exposed to a named control subnet, writes enabled
+
+```bash
+MODBUS_SERVER_ENABLED=true \
+MODBUS_SERVER_SITE_ID=site-1 \
+MODBUS_SERVER_BIND_HOST=10.4.0.10 \
+MODBUS_SERVER_PORT=502 \
+MODBUS_SERVER_ALLOWED_PEERS=10.4.7.0/24,10.4.9.15 \
+MODBUS_SERVER_MAX_CONNECTIONS=8 \
+MODBUS_SERVER_ALLOW_WRITES=true \
+npm run start
+```
+
+Both the write opt-in and the non-loopback bind are logged at `warn` on
+startup, together with how many mapped addresses are writable, so an operator
+can see from the boot log alone what was exposed.
+
+## Server bootstrap / wiring
+
+`server/index.ts` calls `startModbusServer()` after the HTTP server is
+listening, next to the Sparkplug B bridge:
+
+```ts
+try {
+  const { startModbusServer } = await import("./protocols/modbus-server");
+  await startModbusServer();
+} catch (err) {
+  logError(err, "Modbus TCP Server Mode not started (failed closed)");
+}
+```
+
+`startModbusServer()` returns `null` — having done nothing — unless
+`MODBUS_SERVER_ENABLED=true`. When enabled it validates the environment, loads
+the site's register map, and binds the listener. A configuration or register-map
+failure throws; `server/index.ts` logs it and the process continues **without a
+Modbus listener**. There is no fallback path that binds a permissive socket.
+
+## Conformance smoke test (pymodbus)
+
+A runnable pymodbus client lives at
+`server/protocols/modbus-server/__tests__/pymodbus_smoke.py`. It exercises coil
++ register read/write ranges and asserts values round-trip.
+
+```bash
+# 1. Start a loopback server with writes enabled, on a high port
+MODBUS_SERVER_ENABLED=true MODBUS_SERVER_SITE_ID=site-1 \
+MODBUS_SERVER_PORT=1502 MODBUS_SERVER_ALLOW_WRITES=true npm run dev
+
+# 2. In another shell, run the conformance client
+pip install pymodbus
+python server/protocols/modbus-server/__tests__/pymodbus_smoke.py --port 1502
+```
+
+Its write checks require both `MODBUS_SERVER_ALLOW_WRITES=true` and a register
+map whose `--coil` / `--hreg` addresses are marked `writable`; otherwise they
+fail by design (0x01 and 0x03 respectively).
+
+> NOTE: This smoke test requires a running server, a PostgreSQL-backed register
+> map, and Python's `pymodbus`, so it is **not** part of the Node/vitest suite
+> and was **not** executed in the isolated build worktree. The TypeScript
+> request/response path it exercises *is* covered end-to-end by the vitest
+> tests below, including over real TCP sockets.
+
+## Tests
+
+`server/protocols/modbus-server/__tests__/`:
+- `codec.test.ts` — MBAP/PDU encode/decode round-trips, partial/coalesced frames.
+- `handlers.test.ts` — each of the 8 function codes + every exception code.
+- `register-map.test.ts` — lookups, range coverage, value⇄register encoding, scale, word order.
+- `register-map-store.test.ts` — loader fails closed on empty/invalid rows, read errors, and a backend without the table.
+- `tag-store-bridge.test.ts` — reads observe live values; writes propagate; write scoping and all-or-nothing multi-address writes.
+- `peer-filter.test.ts` — IPv4/IPv6/IPv4-mapped parsing, CIDR matching, wildcard rejection, fail-closed defaults.
+- `config.test.ts` — enable flag, loopback default, mandatory allowlist when exposed, every invalid-config rejection.
+- `server.test.ts` — real loopback TCP: framing, reassembly, exception frames, write refusal.
+- `bootstrap.test.ts` — real TCP through `startModbusServer()`: disabled by default, refuses invalid config, binds loopback, drops disallowed peers, caps connections, refuses writes with 0x01, and lands writes only on `writable` addresses once opted in.

--- a/migrations/0008_modbus_register_map.sql
+++ b/migrations/0008_modbus_register_map.sql
@@ -1,0 +1,30 @@
+-- Migration: 0008_modbus_register_map
+-- Issue: #462 - Modbus TCP Server Mode
+-- Description: Persist per-site Modbus register mappings declared in shared/schema.ts
+-- Date: 2026-07-23
+--
+-- SAFETY: `writable` defaults to FALSE. Modbus TCP carries no authentication, so
+-- a mapped address is readable only. Letting a master actuate it is a deliberate
+-- per-address opt-in that additionally requires the listener to have been armed
+-- with MODBUS_SERVER_ALLOW_WRITES=true.
+
+CREATE TABLE IF NOT EXISTS modbus_register_map (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  site_id VARCHAR(64) NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+  unit_id INTEGER NOT NULL DEFAULT 1,
+  area VARCHAR(32) NOT NULL,
+  address INTEGER NOT NULL,
+  tag_id VARCHAR(255) NOT NULL,
+  data_type VARCHAR(16) NOT NULL,
+  scale REAL,
+  word_order VARCHAR(8),
+  writable BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_modbus_register_map_site_area_address
+  ON modbus_register_map(site_id, unit_id, area, address);
+
+CREATE INDEX IF NOT EXISTS idx_modbus_register_map_site_id
+  ON modbus_register_map(site_id);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1784780404000,
       "tag": "0007_validator_registry",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1784780405000,
+      "tag": "0008_modbus_register_map",
+      "breakpoints": true
     }
   ]
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -215,6 +215,19 @@ registerSwaggerRoutes(app, gatewayConfig);
         logError(err, "OPC-UA Server Mode failed to start — not listening");
       }
 
+      // Start Modbus TCP Server Mode (Issue #462) — no-op unless
+      // MODBUS_SERVER_ENABLED=true. The protocol has no authentication, so the
+      // listener defaults to loopback, refuses peers outside its allowlist, and
+      // serves write function codes only when separately opted in. A
+      // configuration or register-map failure is terminal for the listener:
+      // it is logged and no socket is bound, never downgraded to defaults.
+      try {
+        const { startModbusServer } = await import("./protocols/modbus-server");
+        await startModbusServer();
+      } catch (err) {
+        logError(err, "Modbus TCP Server Mode not started (failed closed)");
+      }
+
       // Connect to NATS for SCADA event publishing
       await natsPublisher.connect();
 

--- a/server/protocols/modbus-server/__tests__/bootstrap.test.ts
+++ b/server/protocols/modbus-server/__tests__/bootstrap.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Bootstrap tests (#462): `startModbusServer` is the real, explicitly opt-in
+ * startup path `server/index.ts` calls — this file exercises it end to end over
+ * genuine TCP sockets.
+ *
+ * What is asserted here is exactly the safety contract the maintainer rejected
+ * the first cut for:
+ *   - nothing happens at all unless MODBUS_SERVER_ENABLED=true;
+ *   - invalid configuration refuses to start instead of falling back;
+ *   - the listener binds loopback by default;
+ *   - a peer outside the allowlist is dropped at accept time;
+ *   - writes are answered with exception 0x01 unless writes were opted into;
+ *   - once opted in, only addresses marked `writable` reach the tag store;
+ *   - a plain read still works over a real socket.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import net from "node:net";
+import { startModbusServer, type RegisterMapLoader } from "../index";
+import type { ModbusTcpServer } from "../server";
+import { ModbusServerConfigError } from "../config";
+import { RegisterMap } from "../register-map";
+import { InMemoryTagStore } from "../tag-store-bridge";
+import { EXCEPTION_FLAG, FunctionCode, encodeMbapHeader } from "../codec";
+
+/**
+ * The register map used by these tests. `pump.speed` is deliberately the ONLY
+ * writable address, so "writes land only where the map says" is observable.
+ */
+const registerMap = (): RegisterMap =>
+  RegisterMap.fromConfig({
+    siteId: "site-1",
+    unitId: 1,
+    entries: [
+      {
+        tagId: "tank.level",
+        area: "holdingRegister",
+        address: 0,
+        dataType: "uint16",
+      },
+      {
+        tagId: "pump.speed",
+        area: "holdingRegister",
+        address: 1,
+        dataType: "uint16",
+        writable: true,
+      },
+    ],
+  });
+
+const loadRegisterMap: RegisterMapLoader = async () => registerMap();
+
+/** Reserve a free TCP port so the tests never need privileged port 502. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      if (!address || typeof address !== "object") {
+        probe.close();
+        reject(new Error("could not reserve a port"));
+        return;
+      }
+      const { port } = address;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+function baseEnv(port: number): NodeJS.ProcessEnv {
+  return {
+    MODBUS_SERVER_ENABLED: "true",
+    MODBUS_SERVER_SITE_ID: "site-1",
+    MODBUS_SERVER_PORT: String(port),
+  };
+}
+
+/** Build a request frame on the wire. */
+function frame(txId: number, fc: number, data: Buffer): Buffer {
+  const header = encodeMbapHeader(
+    { transactionId: txId, protocolId: 0, unitId: 1 },
+    1 + data.length,
+  );
+  return Buffer.concat([header, Buffer.from([fc]), data]);
+}
+
+/** Send one frame, resolve with the first `expectedBytes` of response. */
+function exchange(
+  port: number,
+  request: Buffer,
+  expectedBytes: number,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ port, host: "127.0.0.1" });
+    let received = Buffer.alloc(0);
+    socket.on("connect", () => socket.write(request));
+    socket.on("data", (chunk) => {
+      received = Buffer.concat([received, chunk]);
+      if (received.length >= expectedBytes) {
+        socket.end();
+        resolve(received);
+      }
+    });
+    socket.on("error", reject);
+    socket.setTimeout(2000, () => {
+      socket.destroy();
+      reject(new Error("socket timeout"));
+    });
+  });
+}
+
+/** Connect and report whether the peer was served or dropped without a reply. */
+function probeAdmission(
+  port: number,
+  request: Buffer,
+): Promise<{ served: boolean }> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ port, host: "127.0.0.1" });
+    let bytes = 0;
+    socket.on("connect", () => socket.write(request));
+    socket.on("data", (chunk) => {
+      bytes += chunk.length;
+      socket.destroy();
+      resolve({ served: true });
+    });
+    // A refused peer is destroyed at accept time: the connection closes (or
+    // resets) with no protocol bytes ever delivered.
+    socket.on("close", () => resolve({ served: bytes > 0 }));
+    socket.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "ECONNRESET" || err.code === "EPIPE") {
+        resolve({ served: false });
+        return;
+      }
+      reject(err);
+    });
+    socket.setTimeout(2000, () => {
+      socket.destroy();
+      reject(new Error("socket timeout"));
+    });
+  });
+}
+
+const readTankLevel = frame(
+  0x0001,
+  FunctionCode.READ_HOLDING_REGISTERS,
+  Buffer.from([0x00, 0x00, 0x00, 0x01]),
+);
+
+describe("startModbusServer gating", () => {
+  let server: ModbusTcpServer | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+  });
+
+  it("does nothing at all when MODBUS_SERVER_ENABLED is unset", async () => {
+    server = await startModbusServer({ env: {}, loadRegisterMap });
+    expect(server).toBeNull();
+  });
+
+  it("does nothing for a non-'true' enable flag", async () => {
+    server = await startModbusServer({
+      env: { MODBUS_SERVER_ENABLED: "1", MODBUS_SERVER_SITE_ID: "site-1" },
+      loadRegisterMap,
+    });
+    expect(server).toBeNull();
+  });
+
+  it("refuses to start when the site id is missing", async () => {
+    await expect(
+      startModbusServer({
+        env: { MODBUS_SERVER_ENABLED: "true" },
+        loadRegisterMap,
+      }),
+    ).rejects.toBeInstanceOf(ModbusServerConfigError);
+  });
+
+  it("refuses to start when exposed without a peer allowlist", async () => {
+    await expect(
+      startModbusServer({
+        env: {
+          MODBUS_SERVER_ENABLED: "true",
+          MODBUS_SERVER_SITE_ID: "site-1",
+          MODBUS_SERVER_BIND_HOST: "0.0.0.0",
+        },
+        loadRegisterMap,
+      }),
+    ).rejects.toThrow(/MODBUS_SERVER_ALLOWED_PEERS must list/);
+  });
+
+  it("refuses to start on a wildcard peer allowlist", async () => {
+    await expect(
+      startModbusServer({
+        env: {
+          MODBUS_SERVER_ENABLED: "true",
+          MODBUS_SERVER_SITE_ID: "site-1",
+          MODBUS_SERVER_BIND_HOST: "0.0.0.0",
+          MODBUS_SERVER_ALLOWED_PEERS: "0.0.0.0/0",
+        },
+        loadRegisterMap,
+      }),
+    ).rejects.toBeInstanceOf(ModbusServerConfigError);
+  });
+
+  it("propagates a register-map load failure instead of listening", async () => {
+    const port = await freePort();
+    await expect(
+      startModbusServer({
+        env: baseEnv(port),
+        loadRegisterMap: async () => {
+          throw new Error("no rows for site-1");
+        },
+      }),
+    ).rejects.toThrow(/no rows for site-1/);
+
+    // Nothing is holding the port: it can be bound by an unrelated listener.
+    await expect(
+      new Promise<void>((resolve, reject) => {
+        const probe = net.createServer();
+        probe.once("error", reject);
+        probe.listen(port, "127.0.0.1", () => probe.close(() => resolve()));
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("startModbusServer listener", () => {
+  let server: ModbusTcpServer | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+  });
+
+  it("binds loopback by default and serves a read over a real socket", async () => {
+    const port = await freePort();
+    const store = new InMemoryTagStore();
+    store.seed("tank.level", 0xbeef);
+
+    server = await startModbusServer({
+      env: baseEnv(port),
+      loadRegisterMap,
+      tagStore: store,
+    });
+    expect(server).not.toBeNull();
+    expect(server!.isListening).toBe(true);
+    expect(server!.address()!.address).toBe("127.0.0.1");
+    expect(server!.writesAllowed).toBe(false);
+
+    // 7-byte MBAP + FC + byte count + 2 data bytes.
+    const response = await exchange(port, readTankLevel, 11);
+    expect(response.readUInt16BE(0)).toBe(0x0001); // transaction id echoed
+    expect(response.readUInt8(7)).toBe(FunctionCode.READ_HOLDING_REGISTERS);
+    expect(response.readUInt16BE(9)).toBe(0xbeef);
+  });
+
+  it("drops a peer outside the allowlist at accept time", async () => {
+    const port = await freePort();
+    server = await startModbusServer({
+      env: {
+        ...baseEnv(port),
+        // The loopback client used by this test is deliberately NOT in here.
+        MODBUS_SERVER_ALLOWED_PEERS: "10.99.0.1/32",
+      },
+      loadRegisterMap,
+      tagStore: new InMemoryTagStore(),
+    });
+
+    const result = await probeAdmission(port, readTankLevel);
+    expect(result.served).toBe(false);
+    expect(server!.rejectedConnectionCount).toBe(1);
+    expect(server!.connectionCount).toBe(0);
+  });
+
+  it("still serves an allowlisted peer on the same listener config", async () => {
+    const port = await freePort();
+    const store = new InMemoryTagStore();
+    store.seed("tank.level", 7);
+    server = await startModbusServer({
+      env: { ...baseEnv(port), MODBUS_SERVER_ALLOWED_PEERS: "127.0.0.1/32" },
+      loadRegisterMap,
+      tagStore: store,
+    });
+
+    const response = await exchange(port, readTankLevel, 11);
+    expect(response.readUInt16BE(9)).toBe(7);
+    expect(server!.rejectedConnectionCount).toBe(0);
+  });
+
+  it("caps simultaneous master connections", async () => {
+    const port = await freePort();
+    server = await startModbusServer({
+      env: { ...baseEnv(port), MODBUS_SERVER_MAX_CONNECTIONS: "1" },
+      loadRegisterMap,
+      tagStore: new InMemoryTagStore(),
+    });
+
+    const first = net.createConnection({ port, host: "127.0.0.1" });
+    await new Promise<void>((resolve, reject) => {
+      first.once("connect", () => resolve());
+      first.once("error", reject);
+    });
+
+    try {
+      const second = await probeAdmission(port, readTankLevel);
+      expect(second.served).toBe(false);
+      expect(server!.rejectedConnectionCount).toBe(1);
+    } finally {
+      first.destroy();
+    }
+  });
+});
+
+describe("startModbusServer write gating", () => {
+  let server: ModbusTcpServer | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+  });
+
+  /** FC06 write of 0x0064 to holding register 1 (`pump.speed`). */
+  const writePumpSpeed = frame(
+    0x0010,
+    FunctionCode.WRITE_SINGLE_REGISTER,
+    Buffer.from([0x00, 0x01, 0x00, 0x64]),
+  );
+
+  it("answers a write with exception 0x01 and mutates nothing when writes are off", async () => {
+    const port = await freePort();
+    const store = new InMemoryTagStore();
+    server = await startModbusServer({
+      env: baseEnv(port),
+      loadRegisterMap,
+      tagStore: store,
+    });
+
+    // MBAP(7) + (FC|0x80) + exception byte.
+    const response = await exchange(port, writePumpSpeed, 9);
+    expect(response.readUInt8(7)).toBe(
+      FunctionCode.WRITE_SINGLE_REGISTER | EXCEPTION_FLAG,
+    );
+    expect(response.readUInt8(8)).toBe(0x01); // Illegal Function
+    expect(store.peek("pump.speed")).toBeUndefined();
+  });
+
+  it("refuses FC05/FC15/FC16 too, not just FC06", async () => {
+    const port = await freePort();
+    server = await startModbusServer({
+      env: baseEnv(port),
+      loadRegisterMap,
+      tagStore: new InMemoryTagStore(),
+    });
+
+    for (const fc of [
+      FunctionCode.WRITE_SINGLE_COIL,
+      FunctionCode.WRITE_MULTIPLE_COILS,
+      FunctionCode.WRITE_MULTIPLE_REGISTERS,
+    ]) {
+      const response = await exchange(
+        port,
+        frame(0x0011, fc, Buffer.from([0x00, 0x00, 0x00, 0x01, 0x02, 0x00, 0x00])),
+        9,
+      );
+      expect(response.readUInt8(7)).toBe(fc | EXCEPTION_FLAG);
+      expect(response.readUInt8(8)).toBe(0x01);
+    }
+  });
+
+  it("lands a write on an explicitly writable address once writes are opted in", async () => {
+    const port = await freePort();
+    const store = new InMemoryTagStore();
+    server = await startModbusServer({
+      env: { ...baseEnv(port), MODBUS_SERVER_ALLOW_WRITES: "true" },
+      loadRegisterMap,
+      tagStore: store,
+    });
+    expect(server!.writesAllowed).toBe(true);
+
+    // FC06 echoes the request: MBAP(7) + FC + 4 bytes = 12.
+    const response = await exchange(port, writePumpSpeed, 12);
+    expect(response.readUInt8(7)).toBe(FunctionCode.WRITE_SINGLE_REGISTER);
+    expect(store.peek("pump.speed")).toBe(0x0064);
+  });
+
+  it("still refuses a write to a mapped-but-not-writable address when writes are on", async () => {
+    const port = await freePort();
+    const store = new InMemoryTagStore();
+    server = await startModbusServer({
+      env: { ...baseEnv(port), MODBUS_SERVER_ALLOW_WRITES: "true" },
+      loadRegisterMap,
+      tagStore: store,
+    });
+
+    // Holding register 0 is `tank.level`, mapped but never marked writable.
+    const writeTankLevel = frame(
+      0x0012,
+      FunctionCode.WRITE_SINGLE_REGISTER,
+      Buffer.from([0x00, 0x00, 0x00, 0x2a]),
+    );
+    const response = await exchange(port, writeTankLevel, 9);
+    expect(response.readUInt8(7)).toBe(
+      FunctionCode.WRITE_SINGLE_REGISTER | EXCEPTION_FLAG,
+    );
+    expect(response.readUInt8(8)).toBe(0x03); // Illegal Data Value
+    expect(store.peek("tank.level")).toBeUndefined();
+  });
+});

--- a/server/protocols/modbus-server/__tests__/codec.test.ts
+++ b/server/protocols/modbus-server/__tests__/codec.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Codec tests (#462): MBAP/PDU decode + encode round-trips.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  EXCEPTION_FLAG,
+  ExceptionCode,
+  MBAP_HEADER_LENGTH,
+  MODBUS_PROTOCOL_ID,
+  ModbusFrameError,
+  decodeMbapHeader,
+  decodeRequest,
+  encodeExceptionResponse,
+  encodeMbapHeader,
+  encodeResponse,
+  packBits,
+  packRegisters,
+  unpackBits,
+  unpackRegisters,
+} from "../codec";
+
+describe("MBAP header", () => {
+  it("encodes then decodes to the same values (round-trip)", () => {
+    const header = { transactionId: 0x1234, protocolId: 0, unitId: 0x11 };
+    const pduLength = 5; // FC + 4 data bytes
+    const buf = encodeMbapHeader(header, pduLength);
+
+    expect(buf.length).toBe(MBAP_HEADER_LENGTH);
+    const decoded = decodeMbapHeader(buf);
+    expect(decoded.transactionId).toBe(0x1234);
+    expect(decoded.protocolId).toBe(MODBUS_PROTOCOL_ID);
+    expect(decoded.unitId).toBe(0x11);
+    // Length = pduLength + 1 (unit id)
+    expect(decoded.length).toBe(pduLength + 1);
+  });
+
+  it("throws on a too-short buffer", () => {
+    expect(() => decodeMbapHeader(Buffer.alloc(3))).toThrow(ModbusFrameError);
+  });
+});
+
+describe("decodeRequest", () => {
+  function frame(
+    transactionId: number,
+    unitId: number,
+    fc: number,
+    data: Buffer,
+  ): Buffer {
+    const pduLength = 1 + data.length;
+    const header = encodeMbapHeader(
+      { transactionId, protocolId: 0, unitId },
+      pduLength,
+    );
+    return Buffer.concat([header, Buffer.from([fc]), data]);
+  }
+
+  it("decodes a complete FC03 request", () => {
+    const data = Buffer.from([0x00, 0x6b, 0x00, 0x03]); // addr 107, qty 3
+    const buf = frame(0x0001, 0x01, 0x03, data);
+
+    const result = decodeRequest(buf);
+    expect(result).not.toBeNull();
+    expect(result!.bytesConsumed).toBe(buf.length);
+    expect(result!.request.functionCode).toBe(0x03);
+    expect(result!.request.header.transactionId).toBe(1);
+    expect(result!.request.data.equals(data)).toBe(true);
+  });
+
+  it("returns null for an incomplete header", () => {
+    expect(decodeRequest(Buffer.alloc(3))).toBeNull();
+  });
+
+  it("returns null for an incomplete body (partial frame)", () => {
+    const data = Buffer.from([0x00, 0x6b, 0x00, 0x03]);
+    const buf = frame(0x0001, 0x01, 0x03, data);
+    // Drop the last 2 bytes
+    expect(decodeRequest(buf.subarray(0, buf.length - 2))).toBeNull();
+  });
+
+  it("consumes only the first frame when two are coalesced", () => {
+    const a = frame(0x0001, 0x01, 0x03, Buffer.from([0, 0, 0, 1]));
+    const b = frame(0x0002, 0x01, 0x03, Buffer.from([0, 5, 0, 1]));
+    const combined = Buffer.concat([a, b]);
+
+    const first = decodeRequest(combined)!;
+    expect(first.bytesConsumed).toBe(a.length);
+    expect(first.request.header.transactionId).toBe(1);
+
+    const rest = combined.subarray(first.bytesConsumed);
+    const second = decodeRequest(rest)!;
+    expect(second.request.header.transactionId).toBe(2);
+  });
+
+  it("throws on an unexpected protocol id", () => {
+    const buf = frame(0x0001, 0x01, 0x03, Buffer.from([0, 0, 0, 1]));
+    buf.writeUInt16BE(0x0001, 2); // corrupt protocol id
+    expect(() => decodeRequest(buf)).toThrow(ModbusFrameError);
+  });
+
+  it("throws on an MBAP length below the minimum", () => {
+    const buf = frame(0x0001, 0x01, 0x03, Buffer.from([0, 0, 0, 1]));
+    buf.writeUInt16BE(0x0001, 4); // length = 1 (no room for PDU)
+    expect(() => decodeRequest(buf)).toThrow(ModbusFrameError);
+  });
+});
+
+describe("response encoding", () => {
+  it("encodes a normal response and decodes back into a frame", () => {
+    const header = { transactionId: 0x2222, protocolId: 0, unitId: 0x05 };
+    const pdu = Buffer.from([0x02, 0xca, 0xfe]); // byte count + 2 bytes
+    const buf = encodeResponse(header, 0x03, pdu);
+
+    const decoded = decodeRequest(buf)!;
+    expect(decoded.request.functionCode).toBe(0x03);
+    expect(decoded.request.header.transactionId).toBe(0x2222);
+    expect(decoded.request.data.equals(pdu)).toBe(true);
+  });
+
+  it("encodes an exception response with the FC high bit set", () => {
+    const header = { transactionId: 7, protocolId: 0, unitId: 1 };
+    const buf = encodeExceptionResponse(
+      header,
+      0x03,
+      ExceptionCode.ILLEGAL_DATA_ADDRESS,
+    );
+    // FC byte = 0x83, exception byte = 0x02
+    expect(buf.readUInt8(MBAP_HEADER_LENGTH)).toBe(0x03 | EXCEPTION_FLAG);
+    expect(buf.readUInt8(MBAP_HEADER_LENGTH + 1)).toBe(
+      ExceptionCode.ILLEGAL_DATA_ADDRESS,
+    );
+  });
+});
+
+describe("bit packing", () => {
+  it("packs and unpacks bits LSB-first", () => {
+    const bits = [true, false, true, true, false, false, false, false, true];
+    const packed = packBits(bits);
+    expect(packed.length).toBe(2); // 9 bits -> 2 bytes
+    expect(packed[0]).toBe(0b00001101); // bits 0,2,3
+    expect(packed[1]).toBe(0b00000001); // bit 8
+    expect(unpackBits(packed, bits.length)).toEqual(bits);
+  });
+
+  it("round-trips a single byte boundary", () => {
+    const bits = [true, true, true, true, true, true, true, true];
+    expect(unpackBits(packBits(bits), 8)).toEqual(bits);
+  });
+});
+
+describe("register packing", () => {
+  it("packs and unpacks 16-bit registers big-endian", () => {
+    const regs = [0x1234, 0xabcd, 0x0001];
+    const packed = packRegisters(regs);
+    expect(packed.length).toBe(6);
+    expect(packed.readUInt16BE(0)).toBe(0x1234);
+    expect(unpackRegisters(packed, regs.length)).toEqual(regs);
+  });
+});

--- a/server/protocols/modbus-server/__tests__/config.test.ts
+++ b/server/protocols/modbus-server/__tests__/config.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Deployment-configuration tests (#462).
+ *
+ * The listener is off by default, binds loopback by default, refuses to be
+ * exposed without a peer allowlist, and refuses to serve writes unless writes
+ * were separately opted into. Every invalid combination must raise
+ * `ModbusServerConfigError` rather than degrade to a permissive listener.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  describeModbusServerConfig,
+  isModbusServerEnabled,
+  loadModbusServerConfig,
+  ModbusServerConfigError,
+} from "../config";
+
+/** Minimal valid environment: enabled, everything else defaulted. */
+const baseEnv: NodeJS.ProcessEnv = {
+  MODBUS_SERVER_ENABLED: "true",
+  MODBUS_SERVER_SITE_ID: "site-1",
+};
+
+describe("isModbusServerEnabled", () => {
+  it("is off when unset", () => {
+    expect(isModbusServerEnabled({})).toBe(false);
+  });
+
+  it("is off for anything other than the exact string 'true'", () => {
+    expect(isModbusServerEnabled({ MODBUS_SERVER_ENABLED: "1" })).toBe(false);
+    expect(isModbusServerEnabled({ MODBUS_SERVER_ENABLED: "TRUE" })).toBe(false);
+    expect(isModbusServerEnabled({ MODBUS_SERVER_ENABLED: "yes" })).toBe(false);
+  });
+
+  it("is on only for 'true'", () => {
+    expect(isModbusServerEnabled({ MODBUS_SERVER_ENABLED: "true" })).toBe(true);
+  });
+});
+
+describe("loadModbusServerConfig defaults", () => {
+  it("binds loopback and refuses writes by default", () => {
+    const config = loadModbusServerConfig(baseEnv);
+    expect(config.host).toBe("127.0.0.1");
+    expect(config.allowWrites).toBe(false);
+    expect(config.allowedPeers).toEqual(["127.0.0.0/8", "::1/128"]);
+    expect(config.maxConnections).toBeGreaterThan(0);
+    expect(config.port).toBe(502);
+  });
+
+  it("never defaults the bind host to a routable address", () => {
+    expect(loadModbusServerConfig(baseEnv).host).not.toBe("0.0.0.0");
+    expect(loadModbusServerConfig(baseEnv).host).not.toBe("::");
+  });
+
+  it("treats blank template values as unset rather than as failures", () => {
+    // `.env.example` ships these keys with empty values.
+    const config = loadModbusServerConfig({
+      ...baseEnv,
+      MODBUS_SERVER_ALLOWED_PEERS: "",
+      MODBUS_SERVER_BIND_HOST: "",
+      MODBUS_SERVER_PORT: "",
+      MODBUS_SERVER_MAX_CONNECTIONS: "",
+    });
+    expect(config.host).toBe("127.0.0.1");
+    expect(config.allowedPeers).toEqual(["127.0.0.0/8", "::1/128"]);
+    expect(config.port).toBe(502);
+  });
+
+  it("still refuses an exposed bind whose allowlist is blank", () => {
+    expect(() =>
+      loadModbusServerConfig({
+        ...baseEnv,
+        MODBUS_SERVER_BIND_HOST: "0.0.0.0",
+        MODBUS_SERVER_ALLOWED_PEERS: "  ,  ",
+      }),
+    ).toThrow(/MODBUS_SERVER_ALLOWED_PEERS must list/);
+  });
+
+  it("enables writes only on the explicit separate opt-in", () => {
+    expect(
+      loadModbusServerConfig({ ...baseEnv, MODBUS_SERVER_ALLOW_WRITES: "1" })
+        .allowWrites,
+    ).toBe(false);
+    expect(
+      loadModbusServerConfig({ ...baseEnv, MODBUS_SERVER_ALLOW_WRITES: "true" })
+        .allowWrites,
+    ).toBe(true);
+  });
+});
+
+describe("loadModbusServerConfig failure modes", () => {
+  it("refuses to start without a site id", () => {
+    expect(() =>
+      loadModbusServerConfig({ MODBUS_SERVER_ENABLED: "true" }),
+    ).toThrow(ModbusServerConfigError);
+  });
+
+  it("refuses a routable bind with no peer allowlist", () => {
+    expect(() =>
+      loadModbusServerConfig({ ...baseEnv, MODBUS_SERVER_BIND_HOST: "0.0.0.0" }),
+    ).toThrow(/MODBUS_SERVER_ALLOWED_PEERS must list/);
+  });
+
+  it("refuses a wildcard peer allowlist", () => {
+    expect(() =>
+      loadModbusServerConfig({
+        ...baseEnv,
+        MODBUS_SERVER_BIND_HOST: "0.0.0.0",
+        MODBUS_SERVER_ALLOWED_PEERS: "0.0.0.0/0",
+      }),
+    ).toThrow(ModbusServerConfigError);
+  });
+
+  it("refuses an unparseable peer allowlist entry", () => {
+    expect(() =>
+      loadModbusServerConfig({
+        ...baseEnv,
+        MODBUS_SERVER_ALLOWED_PEERS: "10.0.0.0/16, not-an-ip",
+      }),
+    ).toThrow(ModbusServerConfigError);
+  });
+
+  it("refuses an out-of-range port", () => {
+    expect(() =>
+      loadModbusServerConfig({ ...baseEnv, MODBUS_SERVER_PORT: "70000" }),
+    ).toThrow(ModbusServerConfigError);
+    expect(() =>
+      loadModbusServerConfig({ ...baseEnv, MODBUS_SERVER_PORT: "nope" }),
+    ).toThrow(ModbusServerConfigError);
+  });
+
+  it("refuses a non-numeric or zero connection cap", () => {
+    expect(() =>
+      loadModbusServerConfig({ ...baseEnv, MODBUS_SERVER_MAX_CONNECTIONS: "0" }),
+    ).toThrow(ModbusServerConfigError);
+  });
+
+  it("refuses an out-of-range unit id", () => {
+    expect(() =>
+      loadModbusServerConfig({ ...baseEnv, MODBUS_SERVER_UNIT_ID: "256" }),
+    ).toThrow(ModbusServerConfigError);
+  });
+});
+
+describe("loadModbusServerConfig explicit exposure", () => {
+  it("accepts a routable bind when the masters are named", () => {
+    const config = loadModbusServerConfig({
+      ...baseEnv,
+      MODBUS_SERVER_BIND_HOST: "0.0.0.0",
+      MODBUS_SERVER_ALLOWED_PEERS: "10.4.0.0/16, 10.9.9.9",
+      MODBUS_SERVER_PORT: "1502",
+    });
+    expect(config.host).toBe("0.0.0.0");
+    expect(config.allowedPeers).toEqual(["10.4.0.0/16", "10.9.9.9"]);
+    expect(config.port).toBe(1502);
+  });
+});
+
+describe("describeModbusServerConfig", () => {
+  it("makes a writable listener obvious in the boot log", () => {
+    const summary = describeModbusServerConfig(
+      loadModbusServerConfig({ ...baseEnv, MODBUS_SERVER_ALLOW_WRITES: "true" }),
+    );
+    expect(summary).toContain("writes=ENABLED");
+    expect(summary).toContain("bind=127.0.0.1:502");
+  });
+
+  it("reports a read-only listener as such", () => {
+    expect(describeModbusServerConfig(loadModbusServerConfig(baseEnv))).toContain(
+      "writes=disabled",
+    );
+  });
+});

--- a/server/protocols/modbus-server/__tests__/handlers.test.ts
+++ b/server/protocols/modbus-server/__tests__/handlers.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Handler tests (#462): each function-code handler + each exception case.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  EXCEPTION_FLAG,
+  ExceptionCode,
+  FunctionCode,
+  decodeRequest,
+  type ModbusRequest,
+} from "../codec";
+import { processRequest } from "../handlers";
+import { InMemoryDataModel, type ModbusDataModel } from "../data-model";
+
+function makeRequest(fc: number, data: Buffer, unitId = 1): ModbusRequest {
+  return {
+    header: { transactionId: 0x42, protocolId: 0, length: 0, unitId },
+    functionCode: fc,
+    data,
+  };
+}
+
+/** Parse a response frame buffer into { fc, isException, body }. */
+function parseResponse(buf: Buffer): {
+  fc: number;
+  isException: boolean;
+  body: Buffer;
+  transactionId: number;
+} {
+  const decoded = decodeRequest(buf)!;
+  const rawFc = decoded.request.functionCode;
+  return {
+    fc: rawFc & ~EXCEPTION_FLAG,
+    isException: (rawFc & EXCEPTION_FLAG) !== 0,
+    body: decoded.request.data,
+    transactionId: decoded.request.header.transactionId,
+  };
+}
+
+describe("read function codes", () => {
+  let model: InMemoryDataModel;
+
+  beforeEach(() => {
+    model = new InMemoryDataModel({
+      coils: 100,
+      discreteInputs: 100,
+      holdingRegisters: 100,
+      inputRegisters: 100,
+    });
+  });
+
+  it("FC01 Read Coils returns packed coil bits", async () => {
+    await model.writeCoils(0, [true, false, true]); // bits 0,2 set
+    const data = Buffer.from([0x00, 0x00, 0x00, 0x03]); // addr 0, qty 3
+    const resp = parseResponse(
+      await processRequest(makeRequest(FunctionCode.READ_COILS, data), model),
+    );
+    expect(resp.isException).toBe(false);
+    expect(resp.fc).toBe(FunctionCode.READ_COILS);
+    expect(resp.body.readUInt8(0)).toBe(1); // byte count
+    expect(resp.body.readUInt8(1)).toBe(0b00000101);
+    expect(resp.transactionId).toBe(0x42); // echoes request transaction id
+  });
+
+  it("FC02 Read Discrete Inputs returns packed bits", async () => {
+    model.setDiscreteInput(1, true);
+    const data = Buffer.from([0x00, 0x00, 0x00, 0x02]);
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.READ_DISCRETE_INPUTS, data),
+        model,
+      ),
+    );
+    expect(resp.isException).toBe(false);
+    expect(resp.body.readUInt8(1)).toBe(0b00000010); // bit 1 set
+  });
+
+  it("FC03 Read Holding Registers returns big-endian words", async () => {
+    await model.writeHoldingRegisters(10, [0x1234, 0xabcd]);
+    const data = Buffer.from([0x00, 0x0a, 0x00, 0x02]);
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.READ_HOLDING_REGISTERS, data),
+        model,
+      ),
+    );
+    expect(resp.body.readUInt8(0)).toBe(4); // byte count = qty*2
+    expect(resp.body.readUInt16BE(1)).toBe(0x1234);
+    expect(resp.body.readUInt16BE(3)).toBe(0xabcd);
+  });
+
+  it("FC04 Read Input Registers returns values", async () => {
+    model.setInputRegister(5, 0x00ff);
+    const data = Buffer.from([0x00, 0x05, 0x00, 0x01]);
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.READ_INPUT_REGISTERS, data),
+        model,
+      ),
+    );
+    expect(resp.body.readUInt16BE(1)).toBe(0x00ff);
+  });
+});
+
+describe("write function codes", () => {
+  let model: InMemoryDataModel;
+
+  beforeEach(() => {
+    model = new InMemoryDataModel({
+      coils: 100,
+      holdingRegisters: 100,
+    });
+  });
+
+  it("FC05 Write Single Coil ON writes and echoes the request", async () => {
+    const data = Buffer.from([0x00, 0x03, 0xff, 0x00]); // addr 3, ON
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.WRITE_SINGLE_COIL, data),
+        model,
+      ),
+    );
+    expect(resp.isException).toBe(false);
+    expect(resp.body.equals(data)).toBe(true);
+    expect(await model.readCoils(3, 1)).toEqual([true]);
+  });
+
+  it("FC05 rejects an invalid coil value with Illegal Data Value", async () => {
+    const data = Buffer.from([0x00, 0x03, 0x12, 0x34]); // not 0x0000/0xFF00
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.WRITE_SINGLE_COIL, data),
+        model,
+      ),
+    );
+    expect(resp.isException).toBe(true);
+    expect(resp.body.readUInt8(0)).toBe(ExceptionCode.ILLEGAL_DATA_VALUE);
+  });
+
+  it("FC06 Write Single Register writes and echoes", async () => {
+    const data = Buffer.from([0x00, 0x07, 0xbe, 0xef]);
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.WRITE_SINGLE_REGISTER, data),
+        model,
+      ),
+    );
+    expect(resp.body.equals(data)).toBe(true);
+    expect(await model.readHoldingRegisters(7, 1)).toEqual([0xbeef]);
+  });
+
+  it("FC15 Write Multiple Coils writes the bit pattern", async () => {
+    // addr 0, qty 5, byteCount 1, value 0b00010011 (bits 0,1,4)
+    const data = Buffer.from([0x00, 0x00, 0x00, 0x05, 0x01, 0b00010011]);
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.WRITE_MULTIPLE_COILS, data),
+        model,
+      ),
+    );
+    expect(resp.isException).toBe(false);
+    // response = starting address + quantity
+    expect(resp.body.readUInt16BE(0)).toBe(0);
+    expect(resp.body.readUInt16BE(2)).toBe(5);
+    expect(await model.readCoils(0, 5)).toEqual([
+      true,
+      true,
+      false,
+      false,
+      true,
+    ]);
+  });
+
+  it("FC15 rejects a mismatched byte count", async () => {
+    // qty 5 needs ceil(5/8)=1 byte, declare 2
+    const data = Buffer.from([0x00, 0x00, 0x00, 0x05, 0x02, 0x01, 0x00]);
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.WRITE_MULTIPLE_COILS, data),
+        model,
+      ),
+    );
+    expect(resp.isException).toBe(true);
+    expect(resp.body.readUInt8(0)).toBe(ExceptionCode.ILLEGAL_DATA_VALUE);
+  });
+
+  it("FC16 Write Multiple Registers writes the words", async () => {
+    // addr 20, qty 2, byteCount 4, words 0x1111 0x2222
+    const data = Buffer.from([
+      0x00, 0x14, 0x00, 0x02, 0x04, 0x11, 0x11, 0x22, 0x22,
+    ]);
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.WRITE_MULTIPLE_REGISTERS, data),
+        model,
+      ),
+    );
+    expect(resp.body.readUInt16BE(0)).toBe(20);
+    expect(resp.body.readUInt16BE(2)).toBe(2);
+    expect(await model.readHoldingRegisters(20, 2)).toEqual([0x1111, 0x2222]);
+  });
+
+  it("FC16 rejects byteCount != quantity*2", async () => {
+    const data = Buffer.from([0x00, 0x14, 0x00, 0x02, 0x02, 0x11, 0x11]);
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.WRITE_MULTIPLE_REGISTERS, data),
+        model,
+      ),
+    );
+    expect(resp.isException).toBe(true);
+    expect(resp.body.readUInt8(0)).toBe(ExceptionCode.ILLEGAL_DATA_VALUE);
+  });
+});
+
+describe("exception cases", () => {
+  it("returns Illegal Function (0x01) for an unsupported FC", async () => {
+    const model = new InMemoryDataModel();
+    const resp = parseResponse(
+      await processRequest(makeRequest(0x63, Buffer.alloc(4)), model),
+    );
+    expect(resp.isException).toBe(true);
+    expect(resp.fc).toBe(0x63);
+    expect(resp.body.readUInt8(0)).toBe(ExceptionCode.ILLEGAL_FUNCTION);
+  });
+
+  it("returns Illegal Data Address (0x02) for an out-of-range read", async () => {
+    const model = new InMemoryDataModel({ holdingRegisters: 10 });
+    const data = Buffer.from([0x00, 0x09, 0x00, 0x05]); // 9..14 > size 10
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.READ_HOLDING_REGISTERS, data),
+        model,
+      ),
+    );
+    expect(resp.isException).toBe(true);
+    expect(resp.body.readUInt8(0)).toBe(ExceptionCode.ILLEGAL_DATA_ADDRESS);
+  });
+
+  it("returns Illegal Data Value (0x03) for quantity 0", async () => {
+    const model = new InMemoryDataModel({ holdingRegisters: 10 });
+    const data = Buffer.from([0x00, 0x00, 0x00, 0x00]); // qty 0
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.READ_HOLDING_REGISTERS, data),
+        model,
+      ),
+    );
+    expect(resp.isException).toBe(true);
+    expect(resp.body.readUInt8(0)).toBe(ExceptionCode.ILLEGAL_DATA_VALUE);
+  });
+
+  it("returns Illegal Data Value (0x03) for quantity over the cap", async () => {
+    const model = new InMemoryDataModel();
+    const data = Buffer.from([0x00, 0x00, 0x00, 0x7e]); // 126 > 125
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.READ_HOLDING_REGISTERS, data),
+        model,
+      ),
+    );
+    expect(resp.isException).toBe(true);
+    expect(resp.body.readUInt8(0)).toBe(ExceptionCode.ILLEGAL_DATA_VALUE);
+  });
+
+  it("returns Server Device Failure (0x04) when the model throws unexpectedly", async () => {
+    const failing: ModbusDataModel = {
+      readCoils: () => Promise.reject(new Error("boom")),
+      readDiscreteInputs: () => Promise.reject(new Error("boom")),
+      readHoldingRegisters: () => Promise.reject(new Error("boom")),
+      readInputRegisters: () => Promise.reject(new Error("boom")),
+      writeCoils: () => Promise.reject(new Error("boom")),
+      writeHoldingRegisters: () => Promise.reject(new Error("boom")),
+    };
+    const data = Buffer.from([0x00, 0x00, 0x00, 0x01]);
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.READ_HOLDING_REGISTERS, data),
+        failing,
+      ),
+    );
+    expect(resp.isException).toBe(true);
+    expect(resp.body.readUInt8(0)).toBe(ExceptionCode.SERVER_DEVICE_FAILURE);
+  });
+
+  it("returns Illegal Data Value for a truncated PDU", async () => {
+    const model = new InMemoryDataModel();
+    const resp = parseResponse(
+      await processRequest(
+        makeRequest(FunctionCode.READ_HOLDING_REGISTERS, Buffer.from([0x00])),
+        model,
+      ),
+    );
+    expect(resp.isException).toBe(true);
+    expect(resp.body.readUInt8(0)).toBe(ExceptionCode.ILLEGAL_DATA_VALUE);
+  });
+});
+
+describe("response framing", () => {
+  it("preserves transaction id and unit id in the response MBAP header", async () => {
+    const model = new InMemoryDataModel({ holdingRegisters: 10 });
+    const req = makeRequest(
+      FunctionCode.READ_HOLDING_REGISTERS,
+      Buffer.from([0x00, 0x00, 0x00, 0x01]),
+      0x09,
+    );
+    req.header.transactionId = 0xbeef;
+    const buf = await processRequest(req, model);
+    expect(buf.readUInt16BE(0)).toBe(0xbeef); // transaction id
+    expect(buf.readUInt8(6)).toBe(0x09); // unit id
+    expect(buf.readUInt16BE(2)).toBe(0); // protocol id
+  });
+});

--- a/server/protocols/modbus-server/__tests__/index.test.ts
+++ b/server/protocols/modbus-server/__tests__/index.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Factory tests (#462): `createModbusServerForSite` — the public glue that ties
+ * a register map -> tag-store-backed data model -> TCP listener together.
+ *
+ * These tests exercise the construction contract only (parse raw config / accept
+ * a prebuilt map / bind + report an ephemeral port). They deliberately do NOT
+ * drive a tag READ through the returned server, because the factory binds the
+ * data model to the real `tagCache` (server/services/cache/tag-cache.ts), whose
+ * read/write path requires the Redis-backed cache stack that is not present in
+ * the isolated unit-test environment. Read/write propagation against an
+ * in-memory store is covered hermetically in `tag-store-bridge.test.ts`.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { createModbusServerForSite, ModbusTcpServer, RegisterMap } from "../index";
+
+const rawConfig = {
+  siteId: "site-1",
+  unitId: 7,
+  entries: [
+    { tagId: "tank.level", area: "holdingRegister", address: 0, dataType: "uint16" },
+  ],
+};
+
+describe("createModbusServerForSite", () => {
+  let server: ModbusTcpServer | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = undefined;
+    }
+  });
+
+  it("builds a startable server from a raw (Zod-validated) config", async () => {
+    server = createModbusServerForSite(rawConfig, { host: "127.0.0.1", port: 0 });
+    expect(server).toBeInstanceOf(ModbusTcpServer);
+    await server.start();
+    expect(server.isListening).toBe(true);
+    expect(server.address()!.port).toBeGreaterThan(0);
+  });
+
+  it("accepts an already-built RegisterMap without re-parsing", async () => {
+    const map = RegisterMap.fromConfig(rawConfig);
+    server = createModbusServerForSite(map, { host: "127.0.0.1", port: 0 });
+    await server.start();
+    expect(server.isListening).toBe(true);
+  });
+
+  it("propagates an invalid register map as a validation error at construction", () => {
+    expect(() =>
+      createModbusServerForSite({
+        siteId: "s",
+        // bit area with a non-bool dataType is rejected by RegisterMap
+        entries: [{ tagId: "x", area: "coil", address: 0, dataType: "uint16" }],
+      }),
+    ).toThrow();
+  });
+
+  it("defaults the server unit id from the map when not overridden", () => {
+    // unitId 7 comes from the config; the factory threads map.unitId through.
+    const map = RegisterMap.fromConfig(rawConfig);
+    expect(map.unitId).toBe(7);
+    server = createModbusServerForSite(map, { host: "127.0.0.1", port: 0 });
+    expect(server).toBeInstanceOf(ModbusTcpServer);
+  });
+});

--- a/server/protocols/modbus-server/__tests__/peer-filter.test.ts
+++ b/server/protocols/modbus-server/__tests__/peer-filter.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Peer allowlist tests (#462): the accept-time control that compensates for
+ * Modbus TCP having no client authentication.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isLoopbackHost,
+  isPeerAllowed,
+  normalizeAddress,
+  parsePeerRule,
+  parsePeerRules,
+  PeerRuleError,
+} from "../peer-filter";
+
+describe("normalizeAddress", () => {
+  it("parses IPv4", () => {
+    expect(normalizeAddress("192.0.2.7")).toEqual({
+      family: 4,
+      bytes: new Uint8Array([192, 0, 2, 7]),
+    });
+  });
+
+  it("collapses IPv4-mapped IPv6 to IPv4 (what a dual-stack accept reports)", () => {
+    expect(normalizeAddress("::ffff:10.1.2.3")).toEqual({
+      family: 4,
+      bytes: new Uint8Array([10, 1, 2, 3]),
+    });
+  });
+
+  it("expands compressed IPv6", () => {
+    const normalized = normalizeAddress("2001:db8::1");
+    expect(normalized?.family).toBe(6);
+    expect(Array.from(normalized!.bytes)).toEqual([
+      0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    ]);
+  });
+
+  it("strips an IPv6 zone id", () => {
+    expect(normalizeAddress("::1%eth0")).toEqual(normalizeAddress("::1"));
+  });
+
+  it("returns null for junk", () => {
+    expect(normalizeAddress("not-an-ip")).toBeNull();
+    expect(normalizeAddress("")).toBeNull();
+    expect(normalizeAddress("999.1.1.1")).toBeNull();
+  });
+});
+
+describe("parsePeerRule", () => {
+  it("treats a bare address as a host route", () => {
+    expect(parsePeerRule("10.0.0.5")).toMatchObject({ family: 4, prefix: 32 });
+    expect(parsePeerRule("::1")).toMatchObject({ family: 6, prefix: 128 });
+  });
+
+  it("parses CIDR notation", () => {
+    expect(parsePeerRule("10.4.0.0/16")).toMatchObject({ family: 4, prefix: 16 });
+    expect(parsePeerRule("2001:db8::/32")).toMatchObject({ family: 6, prefix: 32 });
+  });
+
+  it("rebases an IPv4-mapped CIDR onto the IPv4 space", () => {
+    expect(parsePeerRule("::ffff:10.4.0.0/112")).toMatchObject({
+      family: 4,
+      prefix: 16,
+    });
+  });
+
+  it("rejects a wildcard rule — an allowlist that allows everything is not one", () => {
+    expect(() => parsePeerRule("0.0.0.0/0")).toThrow(PeerRuleError);
+    expect(() => parsePeerRule("::/0")).toThrow(PeerRuleError);
+  });
+
+  it("rejects malformed entries", () => {
+    expect(() => parsePeerRule("10.0.0.0/33")).toThrow(PeerRuleError);
+    expect(() => parsePeerRule("10.0.0.0/abc")).toThrow(PeerRuleError);
+    expect(() => parsePeerRule("nonsense")).toThrow(PeerRuleError);
+    expect(() => parsePeerRule("   ")).toThrow(PeerRuleError);
+  });
+});
+
+describe("isPeerAllowed", () => {
+  const rules = parsePeerRules(["127.0.0.0/8", "10.4.0.0/16", "2001:db8::/32"]);
+
+  it("admits an address inside an allowed network", () => {
+    expect(isPeerAllowed("127.0.0.1", rules)).toBe(true);
+    expect(isPeerAllowed("10.4.200.9", rules)).toBe(true);
+    expect(isPeerAllowed("2001:db8::dead", rules)).toBe(true);
+  });
+
+  it("admits an IPv4 peer arriving as IPv4-mapped IPv6", () => {
+    expect(isPeerAllowed("::ffff:10.4.0.9", rules)).toBe(true);
+  });
+
+  it("refuses an address outside every allowed network", () => {
+    expect(isPeerAllowed("10.5.0.1", rules)).toBe(false);
+    expect(isPeerAllowed("203.0.113.9", rules)).toBe(false);
+    expect(isPeerAllowed("2001:dbf::1", rules)).toBe(false);
+  });
+
+  it("does not match an IPv6 peer against an IPv4 rule", () => {
+    expect(isPeerAllowed("::1", parsePeerRules(["127.0.0.1"]))).toBe(false);
+  });
+
+  it("fails closed on a missing/unparseable peer or an empty rule set", () => {
+    expect(isPeerAllowed(undefined, rules)).toBe(false);
+    expect(isPeerAllowed("garbage", rules)).toBe(false);
+    expect(isPeerAllowed("127.0.0.1", [])).toBe(false);
+  });
+
+  it("respects sub-byte prefix boundaries", () => {
+    const narrow = parsePeerRules(["192.0.2.128/25"]);
+    expect(isPeerAllowed("192.0.2.129", narrow)).toBe(true);
+    expect(isPeerAllowed("192.0.2.127", narrow)).toBe(false);
+  });
+});
+
+describe("isLoopbackHost", () => {
+  it("recognises loopback binds", () => {
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("127.5.5.5")).toBe(true);
+    expect(isLoopbackHost("::1")).toBe(true);
+    expect(isLoopbackHost("localhost")).toBe(true);
+  });
+
+  it("recognises routable binds", () => {
+    expect(isLoopbackHost("0.0.0.0")).toBe(false);
+    expect(isLoopbackHost("::")).toBe(false);
+    expect(isLoopbackHost("10.0.0.4")).toBe(false);
+  });
+});

--- a/server/protocols/modbus-server/__tests__/pymodbus_smoke.py
+++ b/server/protocols/modbus-server/__tests__/pymodbus_smoke.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Conformance smoke test for the 0xSCADA Modbus TCP server (Issue #462).
+
+This is a REAL, runnable pymodbus client. It is NOT part of the Node/vitest
+suite and was NOT executed in the isolated build worktree (it needs a running
+server and the `pymodbus` package). Run it against a live server:
+
+    pip install pymodbus
+    python pymodbus_smoke.py --host 127.0.0.1 --port 1502 --unit 1
+
+It exercises the acceptance-criteria function codes and asserts that coil and
+register writes round-trip back through reads. Addresses below assume a register
+map similar to the example in docs/protocols/modbus-server.md; adjust with the
+CLI flags if your map differs.
+
+PREREQUISITES (the write checks fail otherwise, by design):
+  * the target server was started with MODBUS_SERVER_ALLOW_WRITES=true —
+    otherwise every write returns exception 0x01 (Illegal Function);
+  * the --coil / --hreg addresses are marked `writable` in the register map —
+    otherwise they return exception 0x03 (Illegal Data Value);
+  * this machine's IP is in MODBUS_SERVER_ALLOWED_PEERS — otherwise the
+    connection is dropped at accept time and connect() fails.
+Run it only against an isolated loopback/test deployment.
+
+Exit code 0 = all checks passed; non-zero = a check failed.
+"""
+
+import argparse
+import sys
+
+try:
+    # pymodbus >= 3.x
+    from pymodbus.client import ModbusTcpClient
+except ImportError:  # pragma: no cover - depends on installed version
+    # pymodbus 2.x fallback
+    from pymodbus.client.sync import ModbusTcpClient  # type: ignore
+
+
+def check(label, condition):
+    status = "PASS" if condition else "FAIL"
+    print(f"  [{status}] {label}")
+    return condition
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=1502)
+    parser.add_argument("--unit", type=int, default=1)
+    parser.add_argument("--coil", type=int, default=0, help="writable coil addr")
+    parser.add_argument(
+        "--hreg", type=int, default=0, help="writable holding register addr"
+    )
+    args = parser.parse_args()
+
+    client = ModbusTcpClient(args.host, port=args.port)
+    if not client.connect():
+        print(f"ERROR: could not connect to {args.host}:{args.port}")
+        return 2
+
+    ok = True
+    try:
+        print("Modbus TCP conformance smoke test")
+        print(f"Target {args.host}:{args.port} unit {args.unit}\n")
+
+        # FC05 + FC01: write a single coil, then read it back.
+        client.write_coil(args.coil, True, slave=args.unit)
+        rr = client.read_coils(args.coil, 1, slave=args.unit)
+        ok &= check("FC05 write coil True -> FC01 read coil",
+                    not rr.isError() and rr.bits[0] is True)
+
+        client.write_coil(args.coil, False, slave=args.unit)
+        rr = client.read_coils(args.coil, 1, slave=args.unit)
+        ok &= check("FC05 write coil False -> FC01 read coil",
+                    not rr.isError() and rr.bits[0] is False)
+
+        # FC06 + FC03: write a single register, read it back.
+        client.write_register(args.hreg, 1337, slave=args.unit)
+        rr = client.read_holding_registers(args.hreg, 1, slave=args.unit)
+        ok &= check("FC06 write register 1337 -> FC03 read register",
+                    not rr.isError() and rr.registers[0] == 1337)
+
+        # FC16 + FC03: write multiple registers (where the map allows it).
+        client.write_registers(args.hreg, [111, 222], slave=args.unit)
+        rr = client.read_holding_registers(args.hreg, 2, slave=args.unit)
+        ok &= check("FC16 write [111,222] -> FC03 read range",
+                    not rr.isError() and list(rr.registers[:2]) == [111, 222])
+
+        # FC15 + FC01: write multiple coils, read back the range.
+        client.write_coils(args.coil, [True, False, True], slave=args.unit)
+        rr = client.read_coils(args.coil, 3, slave=args.unit)
+        ok &= check("FC15 write [T,F,T] -> FC01 read range",
+                    not rr.isError() and list(rr.bits[:3]) == [True, False, True])
+
+        # FC02 / FC04: read-only areas should at least respond without error.
+        rr = client.read_discrete_inputs(0, 1, slave=args.unit)
+        ok &= check("FC02 read discrete inputs responds", rr is not None)
+        rr = client.read_input_registers(5, 1, slave=args.unit)
+        ok &= check("FC04 read input registers responds", rr is not None)
+
+        # Exception: reading an unmapped address must return an exception.
+        rr = client.read_holding_registers(60000, 1, slave=args.unit)
+        ok &= check("FC03 unmapped address -> Modbus exception", rr.isError())
+
+    finally:
+        client.close()
+
+    print("\nRESULT:", "ALL PASS" if ok else "FAILURES PRESENT")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/protocols/modbus-server/__tests__/register-map-store.test.ts
+++ b/server/protocols/modbus-server/__tests__/register-map-store.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Register-map loader tests (#462).
+ *
+ * The loader is the last gate before a socket is bound, so every failure path
+ * has to be terminal: no rows, an invalid row, a read error, or a backend that
+ * does not carry the table must all raise rather than yield a map that would
+ * open a listener serving nothing (or, worse, serving defaults).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getDatabaseType = vi.fn<[], string>();
+const withLockedDatabase = vi.fn();
+
+vi.mock("../../../storage", () => ({
+  getDatabaseType: () => getDatabaseType(),
+  withLockedDatabase: (operation: unknown) => withLockedDatabase(operation),
+}));
+
+import { loadModbusRegisterMap, RegisterMapLoadError } from "../register-map-store";
+
+/** Stand-in for the Drizzle chain the loader drives. */
+function rowsResolvingTo(rows: unknown[]): void {
+  withLockedDatabase.mockImplementation(
+    async (operation: (db: unknown) => Promise<unknown>) =>
+      operation({
+        select: () => ({ from: () => ({ where: async () => rows }) }),
+      }),
+  );
+}
+
+const row = (over: Record<string, unknown> = {}) => ({
+  unitId: 1,
+  area: "holdingRegister",
+  address: 0,
+  tagId: "tank.level",
+  dataType: "uint16",
+  scale: null,
+  wordOrder: null,
+  writable: false,
+  ...over,
+});
+
+describe("loadModbusRegisterMap", () => {
+  beforeEach(() => {
+    getDatabaseType.mockReturnValue("postgres");
+    withLockedDatabase.mockReset();
+  });
+
+  it("builds a validated map from the persisted rows", async () => {
+    rowsResolvingTo([
+      row(),
+      row({ address: 1, tagId: "pump.speed", writable: true }),
+    ]);
+
+    const map = await loadModbusRegisterMap("site-1", 1);
+    expect(map.siteId).toBe("site-1");
+    expect(map.entries).toHaveLength(2);
+    expect(map.entryStartingAt("holdingRegister", 0)?.writable).toBe(false);
+    expect(map.entryStartingAt("holdingRegister", 1)?.writable).toBe(true);
+  });
+
+  it("carries scale and word order through, mapping NULL to undefined", async () => {
+    rowsResolvingTo([
+      row({ dataType: "float32", scale: 0.1, wordOrder: "little" }),
+    ]);
+
+    const entry = (await loadModbusRegisterMap("site-1", 1)).entries[0];
+    expect(entry.scale).toBe(0.1);
+    expect(entry.wordOrder).toBe("little");
+  });
+
+  it("refuses an empty register map rather than opening an empty listener", async () => {
+    rowsResolvingTo([]);
+    await expect(loadModbusRegisterMap("site-1", 1)).rejects.toBeInstanceOf(
+      RegisterMapLoadError,
+    );
+    await expect(loadModbusRegisterMap("site-1", 1)).rejects.toThrow(
+      /empty register map/,
+    );
+  });
+
+  it("refuses a row the runtime schema rejects", async () => {
+    rowsResolvingTo([row({ area: "notAnArea" })]);
+    await expect(loadModbusRegisterMap("site-1", 1)).rejects.toBeInstanceOf(
+      RegisterMapLoadError,
+    );
+  });
+
+  it("refuses a backend that does not carry the table", async () => {
+    getDatabaseType.mockReturnValue("sqlite");
+    await expect(loadModbusRegisterMap("site-1", 1)).rejects.toThrow(
+      /requires the PostgreSQL backend/,
+    );
+    expect(withLockedDatabase).not.toHaveBeenCalled();
+  });
+
+  it("wraps a read failure instead of swallowing it", async () => {
+    withLockedDatabase.mockRejectedValue(new Error("connection terminated"));
+    await expect(loadModbusRegisterMap("site-1", 1)).rejects.toThrow(
+      /connection terminated/,
+    );
+  });
+});

--- a/server/protocols/modbus-server/__tests__/register-map.test.ts
+++ b/server/protocols/modbus-server/__tests__/register-map.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Register-map tests (#462): lookups + value <-> register encoding.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  RegisterMap,
+  decodeRegistersToValue,
+  encodeValueToRegisters,
+  registerWidth,
+  type RegisterMapEntry,
+} from "../register-map";
+
+const baseConfig = {
+  siteId: "site-1",
+  unitId: 1,
+  entries: [
+    { tagId: "pump.run", area: "coil", address: 0, dataType: "bool" },
+    {
+      tagId: "valve.open",
+      area: "discreteInput",
+      address: 0,
+      dataType: "bool",
+    },
+    {
+      tagId: "tank.level",
+      area: "holdingRegister",
+      address: 0,
+      dataType: "uint16",
+    },
+    {
+      tagId: "flow.rate",
+      area: "holdingRegister",
+      address: 1,
+      dataType: "float32",
+    }, // occupies 1 and 2
+    {
+      tagId: "motor.temp",
+      area: "inputRegister",
+      address: 10,
+      dataType: "int16",
+    },
+  ],
+};
+
+describe("RegisterMap.fromConfig", () => {
+  it("validates and indexes entries", () => {
+    const map = RegisterMap.fromConfig(baseConfig);
+    expect(map.siteId).toBe("site-1");
+    expect(map.unitId).toBe(1);
+    expect(map.entriesForArea("holdingRegister").map((e) => e.tagId)).toEqual([
+      "tank.level",
+      "flow.rate",
+    ]);
+  });
+
+  it("looks up the entry starting at an address", () => {
+    const map = RegisterMap.fromConfig(baseConfig);
+    expect(map.entryStartingAt("coil", 0)?.tagId).toBe("pump.run");
+    expect(map.entryStartingAt("coil", 1)).toBeUndefined();
+  });
+
+  it("resolves the entry occupying a secondary register of a 32-bit value", () => {
+    const map = RegisterMap.fromConfig(baseConfig);
+    // flow.rate is float32 at hr1 -> occupies hr1 and hr2
+    expect(map.entryOccupying("holdingRegister", 1)?.tagId).toBe("flow.rate");
+    expect(map.entryOccupying("holdingRegister", 2)?.tagId).toBe("flow.rate");
+    expect(map.entryOccupying("holdingRegister", 3)).toBeUndefined();
+  });
+
+  it("reports range coverage correctly", () => {
+    const map = RegisterMap.fromConfig(baseConfig);
+    expect(map.rangeIsFullyMapped("holdingRegister", 0, 3)).toBe(true); // hr0,1,2
+    expect(map.rangeIsFullyMapped("holdingRegister", 0, 4)).toBe(false); // hr3 unmapped
+  });
+
+  it("rejects a bit area entry with a non-bool dataType", () => {
+    expect(() =>
+      RegisterMap.fromConfig({
+        siteId: "s",
+        entries: [
+          { tagId: "x", area: "coil", address: 0, dataType: "uint16" },
+        ],
+      }),
+    ).toThrow(/must use dataType "bool"/);
+  });
+
+  it("rejects a register area entry using bool", () => {
+    expect(() =>
+      RegisterMap.fromConfig({
+        siteId: "s",
+        entries: [
+          { tagId: "x", area: "holdingRegister", address: 0, dataType: "bool" },
+        ],
+      }),
+    ).toThrow(/cannot use dataType "bool"/);
+  });
+
+  it("rejects duplicate addresses", () => {
+    expect(() =>
+      RegisterMap.fromConfig({
+        siteId: "s",
+        entries: [
+          { tagId: "a", area: "coil", address: 0, dataType: "bool" },
+          { tagId: "b", area: "coil", address: 0, dataType: "bool" },
+        ],
+      }),
+    ).toThrow(/Duplicate/);
+  });
+
+  it("rejects overlapping multi-register entries", () => {
+    expect(() =>
+      RegisterMap.fromConfig({
+        siteId: "s",
+        entries: [
+          {
+            tagId: "a",
+            area: "holdingRegister",
+            address: 0,
+            dataType: "uint32",
+          }, // hr0,1
+          {
+            tagId: "b",
+            area: "holdingRegister",
+            address: 1,
+            dataType: "uint16",
+          }, // collides at hr1
+        ],
+      }),
+    ).toThrow(/Overlapping/);
+  });
+
+  it("defaults unitId to 1 when omitted", () => {
+    const map = RegisterMap.fromConfig({ siteId: "s", entries: [] });
+    expect(map.unitId).toBe(1);
+  });
+});
+
+describe("registerWidth", () => {
+  it("returns the correct word counts", () => {
+    expect(registerWidth("uint16")).toBe(1);
+    expect(registerWidth("int16")).toBe(1);
+    expect(registerWidth("uint32")).toBe(2);
+    expect(registerWidth("int32")).toBe(2);
+    expect(registerWidth("float32")).toBe(2);
+    expect(registerWidth("bool")).toBe(0);
+  });
+});
+
+describe("value <-> register codec", () => {
+  function entry(over: Partial<RegisterMapEntry>): RegisterMapEntry {
+    return {
+      tagId: "t",
+      area: "holdingRegister",
+      address: 0,
+      dataType: "uint16",
+      ...over,
+    } as RegisterMapEntry;
+  }
+
+  it("round-trips uint16", () => {
+    const e = entry({ dataType: "uint16" });
+    const words = encodeValueToRegisters(e, 0x1234);
+    expect(words).toEqual([0x1234]);
+    expect(decodeRegistersToValue(e, words)).toBe(0x1234);
+  });
+
+  it("round-trips negative int16", () => {
+    const e = entry({ dataType: "int16" });
+    const words = encodeValueToRegisters(e, -5);
+    expect(decodeRegistersToValue(e, words)).toBe(-5);
+  });
+
+  it("round-trips uint32 big word order", () => {
+    const e = entry({ dataType: "uint32" });
+    const words = encodeValueToRegisters(e, 0x12345678);
+    expect(words).toEqual([0x1234, 0x5678]);
+    expect(decodeRegistersToValue(e, words)).toBe(0x12345678);
+  });
+
+  it("honours little word order for uint32", () => {
+    const e = entry({ dataType: "uint32", wordOrder: "little" });
+    const words = encodeValueToRegisters(e, 0x12345678);
+    expect(words).toEqual([0x5678, 0x1234]);
+    expect(decodeRegistersToValue(e, words)).toBe(0x12345678);
+  });
+
+  it("round-trips float32 within tolerance", () => {
+    const e = entry({ dataType: "float32" });
+    const words = encodeValueToRegisters(e, 3.14159);
+    expect(decodeRegistersToValue(e, words)).toBeCloseTo(3.14159, 4);
+  });
+
+  it("applies scale on encode and decode", () => {
+    // scale 0.1: tag value 23.5 -> raw 235 -> back to 23.5
+    const e = entry({ dataType: "uint16", scale: 0.1 });
+    const words = encodeValueToRegisters(e, 23.5);
+    expect(words).toEqual([235]);
+    expect(decodeRegistersToValue(e, words)).toBeCloseTo(23.5, 5);
+  });
+});

--- a/server/protocols/modbus-server/__tests__/server.test.ts
+++ b/server/protocols/modbus-server/__tests__/server.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Server transport tests (#462): real loopback TCP socket exercises framing,
+ * partial-frame reassembly, and request/response over the wire.
+ *
+ * Uses only Node's built-in `net` (no external Modbus dependency).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import net from "node:net";
+import { ModbusTcpServer } from "../server";
+import { InMemoryDataModel, type ModbusDataModel } from "../data-model";
+import {
+  EXCEPTION_FLAG,
+  FunctionCode,
+  encodeMbapHeader,
+} from "../codec";
+
+/** Build a request frame on the wire. */
+function frame(txId: number, unitId: number, fc: number, data: Buffer): Buffer {
+  const header = encodeMbapHeader(
+    { transactionId: txId, protocolId: 0, unitId },
+    1 + data.length,
+  );
+  return Buffer.concat([header, Buffer.from([fc]), data]);
+}
+
+/** Connect, send `payload` (possibly in chunks), resolve with first response. */
+function exchange(
+  port: number,
+  chunks: Buffer[],
+  expectedResponseBytes: number,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ port, host: "127.0.0.1" });
+    let received = Buffer.alloc(0);
+    socket.on("connect", () => {
+      for (const chunk of chunks) socket.write(chunk);
+    });
+    socket.on("data", (d) => {
+      received = Buffer.concat([received, d]);
+      if (received.length >= expectedResponseBytes) {
+        socket.end();
+        resolve(received);
+      }
+    });
+    socket.on("error", reject);
+    socket.setTimeout(2000, () => {
+      socket.destroy();
+      reject(new Error("socket timeout"));
+    });
+  });
+}
+
+describe("ModbusTcpServer over loopback TCP", () => {
+  let model: InMemoryDataModel;
+  let server: ModbusTcpServer;
+  let port: number;
+
+  beforeEach(async () => {
+    model = new InMemoryDataModel({
+      coils: 100,
+      holdingRegisters: 100,
+    });
+    // Port 0 => OS assigns a free port; keeps the test unprivileged.
+    server = new ModbusTcpServer(model, { host: "127.0.0.1", port: 0 });
+    await server.start();
+    port = server.address()!.port;
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it("binds to an ephemeral port and reports it", () => {
+    expect(server.isListening).toBe(true);
+    expect(port).toBeGreaterThan(0);
+  });
+
+  it("answers an FC03 read with the correct value", async () => {
+    await model.writeHoldingRegisters(0, [0xcafe]);
+    const req = frame(0x0001, 1, FunctionCode.READ_HOLDING_REGISTERS,
+      Buffer.from([0x00, 0x00, 0x00, 0x01]));
+    // Response: 7-byte MBAP + FC + byteCount + 2 data = 11 bytes
+    const resp = await exchange(port, [req], 11);
+    expect(resp.readUInt16BE(0)).toBe(0x0001); // tx id echoed
+    expect(resp.readUInt8(7)).toBe(FunctionCode.READ_HOLDING_REGISTERS);
+    expect(resp.readUInt8(8)).toBe(2); // byte count
+    expect(resp.readUInt16BE(9)).toBe(0xcafe);
+  });
+
+  it("rejects network writes by default without mutating the model", async () => {
+    const write = frame(
+      0x0002,
+      1,
+      FunctionCode.WRITE_SINGLE_REGISTER,
+      Buffer.from([0x00, 0x05, 0x12, 0x34]),
+    );
+    const resp = await exchange(port, [write], 9);
+    expect(resp.readUInt8(7)).toBe(
+      FunctionCode.WRITE_SINGLE_REGISTER | EXCEPTION_FLAG,
+    );
+    expect(resp.readUInt8(8)).toBe(0x01); // Illegal Function
+    expect(await model.readHoldingRegisters(5, 1)).toEqual([0]);
+  });
+
+  it("write (FC06) then read (FC03) works only with explicit opt-in", async () => {
+    await server.stop();
+    server = new ModbusTcpServer(model, {
+      host: "127.0.0.1",
+      port: 0,
+      allowWrites: true,
+    });
+    await server.start();
+    port = server.address()!.port;
+
+    const write = frame(0x0002, 1, FunctionCode.WRITE_SINGLE_REGISTER,
+      Buffer.from([0x00, 0x05, 0x12, 0x34]));
+    const read = frame(0x0003, 1, FunctionCode.READ_HOLDING_REGISTERS,
+      Buffer.from([0x00, 0x05, 0x00, 0x01]));
+    // FC06 echo response (12) + FC03 read response (11) = 23 bytes
+    const resp = await exchange(port, [write, read], 23);
+    // Second response begins at byte 12
+    const readResp = resp.subarray(12);
+    expect(readResp.readUInt16BE(9)).toBe(0x1234);
+  });
+
+  it("reassembles a frame split across two TCP chunks", async () => {
+    await model.writeHoldingRegisters(0, [0x0042]);
+    const req = frame(0x0004, 1, FunctionCode.READ_HOLDING_REGISTERS,
+      Buffer.from([0x00, 0x00, 0x00, 0x01]));
+    // Split mid-frame: header partial, then the rest.
+    const resp = await exchange(
+      port,
+      [req.subarray(0, 4), req.subarray(4)],
+      11,
+    );
+    expect(resp.readUInt16BE(9)).toBe(0x0042);
+  });
+
+  it("returns an exception frame for an unsupported function code", async () => {
+    const req = frame(0x0005, 1, 0x63, Buffer.from([0x00, 0x00, 0x00, 0x01]));
+    const resp = await exchange(port, [req], 9);
+    expect((resp.readUInt8(7) & EXCEPTION_FLAG) !== 0).toBe(true);
+    expect(resp.readUInt8(8)).toBe(0x01); // Illegal Function
+  });
+});
+
+/**
+ * A model whose reads take real wall-clock time, the way the live tag store
+ * does (Redis round-trip). The earlier tests all use a model that resolves
+ * within a microtask, so a `data` event can never land mid-request there.
+ */
+function slowModel(delayMs: number, value: number): ModbusDataModel {
+  const wait = () => new Promise((resolve) => setTimeout(resolve, delayMs));
+  return {
+    async readCoils(_a, q) {
+      await wait();
+      return new Array<boolean>(q).fill(false);
+    },
+    async readDiscreteInputs(_a, q) {
+      await wait();
+      return new Array<boolean>(q).fill(false);
+    },
+    async readHoldingRegisters(_a, q) {
+      await wait();
+      return new Array<number>(q).fill(value);
+    },
+    async readInputRegisters(_a, q) {
+      await wait();
+      return new Array<number>(q).fill(value);
+    },
+    async writeCoils() {
+      await wait();
+    },
+    async writeHoldingRegisters() {
+      await wait();
+    },
+  };
+}
+
+describe("ModbusTcpServer request pipelining", () => {
+  let server: ModbusTcpServer;
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  // Regression: a master that sends a second request while the first is still
+  // awaiting the data model must still get both answers. Assigning the drain's
+  // return value straight back to the receive buffer discarded every byte that
+  // arrived during the await, silently swallowing the second request.
+  it("answers a request that arrives while the previous one is in flight", async () => {
+    server = new ModbusTcpServer(slowModel(60, 0x0042), {
+      host: "127.0.0.1",
+      port: 0,
+    });
+    await server.start();
+    const port = server.address()!.port;
+
+    const read = (txId: number) =>
+      frame(txId, 1, FunctionCode.READ_HOLDING_REGISTERS,
+        Buffer.from([0x00, 0x00, 0x00, 0x01]));
+
+    const seen = await new Promise<number[]>((resolve, reject) => {
+      const socket = net.createConnection({ port, host: "127.0.0.1" });
+      const txIds: number[] = [];
+      let received = Buffer.alloc(0);
+      const finish = () => {
+        clearTimeout(deadline);
+        socket.destroy();
+        resolve(txIds);
+      };
+      const deadline = setTimeout(finish, 1500);
+      socket.on("connect", () => {
+        socket.write(read(0x0001));
+        // Lands while the first read is still inside the 60 ms model call.
+        setTimeout(() => socket.write(read(0x0002)), 20);
+      });
+      socket.on("data", (chunk) => {
+        received = Buffer.concat([received, chunk]);
+        while (received.length >= 11) {
+          txIds.push(received.readUInt16BE(0));
+          received = received.subarray(11);
+        }
+        if (txIds.length === 2) finish();
+      });
+      socket.on("error", (err) => {
+        clearTimeout(deadline);
+        reject(err);
+      });
+    });
+
+    expect(seen).toEqual([0x0001, 0x0002]);
+  });
+});

--- a/server/protocols/modbus-server/__tests__/tag-store-bridge.test.ts
+++ b/server/protocols/modbus-server/__tests__/tag-store-bridge.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tag-store bridge tests (#462): reads observe live tag values, writes
+ * propagate back into the tag store (the issue's core verification).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { RegisterMap } from "../register-map";
+import { InMemoryTagStore, TagStoreDataModel } from "../tag-store-bridge";
+import { DataModelError } from "../data-model";
+import { processRequest } from "../handlers";
+import {
+  EXCEPTION_FLAG,
+  ExceptionCode,
+  FunctionCode,
+  decodeRequest,
+  type ModbusRequest,
+} from "../codec";
+
+/**
+ * `writable` is opt-in per address: `config.locked` and `device.serial` are
+ * deliberately left at the default (not writable) so the write-scoping rules
+ * are exercised against a map that also contains writable addresses.
+ */
+function makeMap() {
+  return RegisterMap.fromConfig({
+    siteId: "site-1",
+    unitId: 1,
+    entries: [
+      {
+        tagId: "pump.run",
+        area: "coil",
+        address: 0,
+        dataType: "bool",
+        writable: true,
+      },
+      {
+        tagId: "alarm.active",
+        area: "discreteInput",
+        address: 0,
+        dataType: "bool",
+      },
+      {
+        tagId: "tank.level",
+        area: "holdingRegister",
+        address: 0,
+        dataType: "uint16",
+        writable: true,
+      },
+      {
+        tagId: "flow.rate",
+        area: "holdingRegister",
+        address: 1,
+        dataType: "float32",
+        scale: 1,
+        writable: true,
+      },
+      {
+        tagId: "device.serial",
+        area: "inputRegister",
+        address: 5,
+        dataType: "uint16",
+      },
+      {
+        tagId: "config.locked",
+        area: "holdingRegister",
+        address: 10,
+        dataType: "uint16",
+      },
+    ],
+  });
+}
+
+function makeRequest(fc: number, data: Buffer): ModbusRequest {
+  return {
+    header: { transactionId: 1, protocolId: 0, length: 0, unitId: 1 },
+    functionCode: fc,
+    data,
+  };
+}
+
+function isException(buf: Buffer): { exc: boolean; code: number } {
+  const decoded = decodeRequest(buf)!;
+  const fc = decoded.request.functionCode;
+  return {
+    exc: (fc & EXCEPTION_FLAG) !== 0,
+    code: decoded.request.data.readUInt8(0),
+  };
+}
+
+describe("TagStoreDataModel reads", () => {
+  let store: InMemoryTagStore;
+  let model: TagStoreDataModel;
+
+  beforeEach(() => {
+    store = new InMemoryTagStore();
+    model = new TagStoreDataModel(makeMap(), store);
+  });
+
+  it("reads a coil from the live tag value", async () => {
+    store.seed("pump.run", true);
+    expect(await model.readCoils(0, 1)).toEqual([true]);
+  });
+
+  it("reads a holding register from the live tag value", async () => {
+    store.seed("tank.level", 4242);
+    expect(await model.readHoldingRegisters(0, 1)).toEqual([4242]);
+  });
+
+  it("reads a multi-register float32 value spanning two addresses", async () => {
+    store.seed("flow.rate", 12.5);
+    const words = await model.readHoldingRegisters(1, 2);
+    // Recombine the words and confirm the float
+    const buf = Buffer.alloc(4);
+    buf.writeUInt16BE(words[0], 0);
+    buf.writeUInt16BE(words[1], 2);
+    expect(buf.readFloatBE(0)).toBeCloseTo(12.5, 5);
+  });
+
+  it("treats an unknown tag as a default (0 / false)", async () => {
+    expect(await model.readCoils(0, 1)).toEqual([false]);
+    expect(await model.readHoldingRegisters(0, 1)).toEqual([0]);
+  });
+
+  it("throws ILLEGAL_DATA_ADDRESS for an unmapped address", async () => {
+    await expect(model.readHoldingRegisters(99, 1)).rejects.toBeInstanceOf(
+      DataModelError,
+    );
+    await expect(model.readHoldingRegisters(99, 1)).rejects.toMatchObject({
+      kind: "ILLEGAL_DATA_ADDRESS",
+    });
+  });
+});
+
+describe("TagStoreDataModel writes propagate into the tag store", () => {
+  let store: InMemoryTagStore;
+  let model: TagStoreDataModel;
+
+  beforeEach(() => {
+    store = new InMemoryTagStore();
+    model = new TagStoreDataModel(makeMap(), store);
+  });
+
+  it("FC05 coil write reaches the tag store", async () => {
+    await model.writeCoils(0, [true]);
+    expect(store.peek("pump.run")).toBe(true);
+  });
+
+  it("FC06 register write reaches the tag store", async () => {
+    await model.writeHoldingRegisters(0, [777]);
+    expect(store.peek("tank.level")).toBe(777);
+  });
+
+  it("FC16 multi-register write decodes the float and stores it", async () => {
+    const buf = Buffer.alloc(4);
+    buf.writeFloatBE(9.75, 0);
+    const words = [buf.readUInt16BE(0), buf.readUInt16BE(2)];
+    await model.writeHoldingRegisters(1, words);
+    expect(store.peek("flow.rate")).toBeCloseTo(9.75, 5);
+  });
+
+  it("rejects a write to an entry that is not marked writable", async () => {
+    await expect(model.writeHoldingRegisters(10, [1])).rejects.toMatchObject({
+      kind: "ILLEGAL_DATA_VALUE",
+    });
+    expect(store.peek("config.locked")).toBeUndefined();
+  });
+
+  it("defaults a mapped entry to not-writable when `writable` is omitted", async () => {
+    const map = RegisterMap.fromConfig({
+      siteId: "site-1",
+      entries: [
+        {
+          tagId: "silent.setpoint",
+          area: "holdingRegister",
+          address: 0,
+          dataType: "uint16",
+        },
+      ],
+    });
+    const scopedStore = new InMemoryTagStore();
+    const scopedModel = new TagStoreDataModel(map, scopedStore);
+
+    expect(map.entries[0].writable).toBe(false);
+    await expect(scopedModel.writeHoldingRegisters(0, [5])).rejects.toMatchObject(
+      { kind: "ILLEGAL_DATA_VALUE" },
+    );
+    expect(scopedStore.peek("silent.setpoint")).toBeUndefined();
+  });
+
+  it("does not partially apply a multi-coil write that spans a non-writable address", async () => {
+    const map = RegisterMap.fromConfig({
+      siteId: "site-1",
+      entries: [
+        {
+          tagId: "coil.a",
+          area: "coil",
+          address: 0,
+          dataType: "bool",
+          writable: true,
+        },
+        { tagId: "coil.b", area: "coil", address: 1, dataType: "bool" },
+      ],
+    });
+    const scopedStore = new InMemoryTagStore();
+    const scopedModel = new TagStoreDataModel(map, scopedStore);
+
+    await expect(scopedModel.writeCoils(0, [true, true])).rejects.toMatchObject({
+      kind: "ILLEGAL_DATA_VALUE",
+    });
+    // coil.a must not have been mutated before the request was rejected.
+    expect(scopedStore.peek("coil.a")).toBeUndefined();
+    expect(scopedStore.peek("coil.b")).toBeUndefined();
+  });
+
+  it("rejects a write that truncates a multi-register entry", async () => {
+    // Write only 1 word at flow.rate (needs 2)
+    await expect(model.writeHoldingRegisters(1, [0x4120])).rejects.toMatchObject(
+      { kind: "ILLEGAL_DATA_VALUE" },
+    );
+  });
+});
+
+describe("end-to-end through the handler layer", () => {
+  it("FC06 over the wire updates the live tag store", async () => {
+    const store = new InMemoryTagStore();
+    const model = new TagStoreDataModel(makeMap(), store);
+
+    // Write single register at hr0 = 0x0539 (1337)
+    const data = Buffer.from([0x00, 0x00, 0x05, 0x39]);
+    const resp = await processRequest(
+      makeRequest(FunctionCode.WRITE_SINGLE_REGISTER, data),
+      model,
+    );
+    expect(isException(resp).exc).toBe(false);
+    expect(store.peek("tank.level")).toBe(0x0539);
+
+    // Read it back via FC03
+    const readResp = await processRequest(
+      makeRequest(
+        FunctionCode.READ_HOLDING_REGISTERS,
+        Buffer.from([0x00, 0x00, 0x00, 0x01]),
+      ),
+      model,
+    );
+    const body = decodeRequest(readResp)!.request.data;
+    expect(body.readUInt16BE(1)).toBe(0x0539);
+  });
+
+  it("FC03 read of an unmapped range returns Illegal Data Address", async () => {
+    const store = new InMemoryTagStore();
+    const model = new TagStoreDataModel(makeMap(), store);
+    const resp = await processRequest(
+      makeRequest(
+        FunctionCode.READ_HOLDING_REGISTERS,
+        Buffer.from([0x00, 0x32, 0x00, 0x01]), // addr 50, unmapped
+      ),
+      model,
+    );
+    const result = isException(resp);
+    expect(result.exc).toBe(true);
+    expect(result.code).toBe(ExceptionCode.ILLEGAL_DATA_ADDRESS);
+  });
+});

--- a/server/protocols/modbus-server/codec.ts
+++ b/server/protocols/modbus-server/codec.ts
@@ -1,0 +1,254 @@
+/**
+ * Modbus TCP wire codec — MBAP header + PDU encode/decode.
+ *
+ * Issue #462: Modbus TCP Server Mode.
+ *
+ * This module implements the Modbus TCP framing from scratch (no external
+ * dependency) so it is fully unit-testable. It deals ONLY with bytes <-> typed
+ * request/response objects; it has no knowledge of the data model, the tag
+ * store, or sockets. See `handlers.ts` for request processing.
+ *
+ * Frame layout (Modbus Application Protocol / "Modbus Messaging on TCP/IP",
+ * MODBUS Messaging Implementation Guide v1.0b):
+ *
+ *   MBAP header (7 bytes):
+ *     [0..1] Transaction Identifier (echoed back unchanged)
+ *     [2..3] Protocol Identifier     (0x0000 for Modbus)
+ *     [4..5] Length                  (number of following bytes = unitId + PDU)
+ *     [6]    Unit Identifier         (a.k.a. slave / server address)
+ *   PDU:
+ *     [7]    Function code
+ *     [8..]  Function-specific data
+ */
+
+import {
+  MODBUS_EXCEPTION_CODES,
+  MODBUS_FUNCTION_CODES,
+} from "@shared/protocols/modbus-constants";
+
+/**
+ * Standard Modbus function codes supported by this server — the subset of the
+ * shared {@link MODBUS_FUNCTION_CODES} this server implements. Sourcing the
+ * values from the shared module keeps them in lock-step with the vendor-side
+ * `MODBUS_FC` (issue #370 / #462).
+ */
+export const FunctionCode = {
+  READ_COILS: MODBUS_FUNCTION_CODES.READ_COILS,
+  READ_DISCRETE_INPUTS: MODBUS_FUNCTION_CODES.READ_DISCRETE_INPUTS,
+  READ_HOLDING_REGISTERS: MODBUS_FUNCTION_CODES.READ_HOLDING_REGISTERS,
+  READ_INPUT_REGISTERS: MODBUS_FUNCTION_CODES.READ_INPUT_REGISTERS,
+  WRITE_SINGLE_COIL: MODBUS_FUNCTION_CODES.WRITE_SINGLE_COIL,
+  WRITE_SINGLE_REGISTER: MODBUS_FUNCTION_CODES.WRITE_SINGLE_REGISTER,
+  WRITE_MULTIPLE_COILS: MODBUS_FUNCTION_CODES.WRITE_MULTIPLE_COILS,
+  WRITE_MULTIPLE_REGISTERS: MODBUS_FUNCTION_CODES.WRITE_MULTIPLE_REGISTERS,
+} as const;
+
+export type FunctionCode = (typeof FunctionCode)[keyof typeof FunctionCode];
+
+/**
+ * Modbus exception codes this server can return (set in responses with the high
+ * bit of the FC set) — the subset of the shared {@link MODBUS_EXCEPTION_CODES}
+ * it produces.
+ */
+export const ExceptionCode = {
+  ILLEGAL_FUNCTION: MODBUS_EXCEPTION_CODES.ILLEGAL_FUNCTION,
+  ILLEGAL_DATA_ADDRESS: MODBUS_EXCEPTION_CODES.ILLEGAL_DATA_ADDRESS,
+  ILLEGAL_DATA_VALUE: MODBUS_EXCEPTION_CODES.ILLEGAL_DATA_VALUE,
+  SERVER_DEVICE_FAILURE: MODBUS_EXCEPTION_CODES.SERVER_DEVICE_FAILURE,
+} as const;
+
+export type ExceptionCode = (typeof ExceptionCode)[keyof typeof ExceptionCode];
+
+/** Bit set in a response function code to flag an exception (FC | 0x80). */
+export const EXCEPTION_FLAG = 0x80;
+
+export const MBAP_HEADER_LENGTH = 7;
+export const MODBUS_PROTOCOL_ID = 0x0000;
+/** Modbus caps a single read at 0x07D0 (2000) coils/inputs. */
+export const MAX_READ_BITS = 0x07d0;
+/** Modbus caps a single read at 0x007D (125) registers. */
+export const MAX_READ_REGISTERS = 0x007d;
+/** Modbus caps writes at 0x07B0 (1968) coils. */
+export const MAX_WRITE_COILS = 0x07b0;
+/** Modbus caps writes at 0x007B (123) registers. */
+export const MAX_WRITE_REGISTERS = 0x007b;
+
+/** Parsed MBAP header. */
+export interface MbapHeader {
+  transactionId: number;
+  protocolId: number;
+  /** Declared length of (unitId + PDU). */
+  length: number;
+  unitId: number;
+}
+
+/** A fully decoded request: MBAP header + the raw PDU bytes. */
+export interface ModbusRequest {
+  header: MbapHeader;
+  functionCode: number;
+  /** PDU bytes AFTER the function code byte. */
+  data: Buffer;
+}
+
+/** Raised when a buffer cannot be decoded into a Modbus frame. */
+export class ModbusFrameError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ModbusFrameError";
+  }
+}
+
+/**
+ * Decode the 7-byte MBAP header.
+ * @throws {ModbusFrameError} if the buffer is shorter than the header.
+ */
+export function decodeMbapHeader(buf: Buffer): MbapHeader {
+  if (buf.length < MBAP_HEADER_LENGTH) {
+    throw new ModbusFrameError(
+      `MBAP header requires ${MBAP_HEADER_LENGTH} bytes, got ${buf.length}`,
+    );
+  }
+  return {
+    transactionId: buf.readUInt16BE(0),
+    protocolId: buf.readUInt16BE(2),
+    length: buf.readUInt16BE(4),
+    unitId: buf.readUInt8(6),
+  };
+}
+
+/**
+ * Encode an MBAP header. `pduLength` is the length of the PDU (function code +
+ * data); the declared MBAP length field is `pduLength + 1` to include unitId.
+ */
+export function encodeMbapHeader(
+  header: Omit<MbapHeader, "length">,
+  pduLength: number,
+): Buffer {
+  const out = Buffer.alloc(MBAP_HEADER_LENGTH);
+  out.writeUInt16BE(header.transactionId & 0xffff, 0);
+  out.writeUInt16BE(header.protocolId & 0xffff, 2);
+  out.writeUInt16BE((pduLength + 1) & 0xffff, 4); // +1 for unit id
+  out.writeUInt8(header.unitId & 0xff, 6);
+  return out;
+}
+
+/**
+ * Attempt to decode a single complete Modbus TCP frame from `buf`.
+ *
+ * Returns the decoded request plus the number of bytes consumed, or `null` if
+ * the buffer does not yet contain a complete frame (the caller should wait for
+ * more bytes — TCP is a stream and frames may be split or coalesced).
+ *
+ * @throws {ModbusFrameError} for structurally invalid frames (bad protocol id,
+ *   nonsensical length) so the caller can close the connection.
+ */
+export function decodeRequest(
+  buf: Buffer,
+): { request: ModbusRequest; bytesConsumed: number } | null {
+  if (buf.length < MBAP_HEADER_LENGTH) {
+    return null; // need more bytes for the header
+  }
+
+  const header = decodeMbapHeader(buf);
+
+  if (header.protocolId !== MODBUS_PROTOCOL_ID) {
+    throw new ModbusFrameError(
+      `Unexpected protocol id 0x${header.protocolId.toString(16)}`,
+    );
+  }
+  // Length field counts unitId(1) + PDU. PDU must contain at least the FC byte.
+  if (header.length < 2) {
+    throw new ModbusFrameError(`Invalid MBAP length ${header.length}`);
+  }
+
+  const frameLength = MBAP_HEADER_LENGTH - 1 + header.length; // 6 + length
+  if (buf.length < frameLength) {
+    return null; // incomplete — wait for more bytes
+  }
+
+  const functionCode = buf.readUInt8(MBAP_HEADER_LENGTH);
+  const data = buf.subarray(MBAP_HEADER_LENGTH + 1, frameLength);
+
+  return {
+    request: { header, functionCode, data: Buffer.from(data) },
+    bytesConsumed: frameLength,
+  };
+}
+
+/**
+ * Encode a normal (non-exception) response frame.
+ * `responsePdu` is the PDU body AFTER the function code byte.
+ */
+export function encodeResponse(
+  header: Pick<MbapHeader, "transactionId" | "protocolId" | "unitId">,
+  functionCode: number,
+  responsePdu: Buffer,
+): Buffer {
+  const pduLength = 1 + responsePdu.length; // FC + body
+  const mbap = encodeMbapHeader(header, pduLength);
+  const fc = Buffer.from([functionCode & 0xff]);
+  return Buffer.concat([mbap, fc, responsePdu]);
+}
+
+/**
+ * Encode an exception response frame: function code with the high bit set,
+ * followed by a single exception-code byte.
+ */
+export function encodeExceptionResponse(
+  header: Pick<MbapHeader, "transactionId" | "protocolId" | "unitId">,
+  functionCode: number,
+  exceptionCode: ExceptionCode,
+): Buffer {
+  const mbap = encodeMbapHeader(header, 2); // FC + exception byte
+  const body = Buffer.from([
+    (functionCode | EXCEPTION_FLAG) & 0xff,
+    exceptionCode & 0xff,
+  ]);
+  return Buffer.concat([mbap, body]);
+}
+
+/**
+ * Pack an array of booleans into Modbus coil/discrete-input bytes (LSB-first
+ * within each byte, per the spec). Used by FC01/FC02 responses.
+ */
+export function packBits(bits: boolean[]): Buffer {
+  const byteCount = Math.ceil(bits.length / 8);
+  const out = Buffer.alloc(byteCount);
+  for (let i = 0; i < bits.length; i++) {
+    if (bits[i]) {
+      out[Math.floor(i / 8)] |= 1 << i % 8;
+    }
+  }
+  return out;
+}
+
+/**
+ * Unpack `count` booleans from Modbus coil bytes (LSB-first within each byte).
+ * Used to decode FC15 (write multiple coils) request bodies.
+ */
+export function unpackBits(buf: Buffer, count: number): boolean[] {
+  const bits: boolean[] = [];
+  for (let i = 0; i < count; i++) {
+    const byte = buf[Math.floor(i / 8)] ?? 0;
+    bits.push((byte & (1 << i % 8)) !== 0);
+  }
+  return bits;
+}
+
+/** Pack an array of 16-bit register values into a big-endian buffer. */
+export function packRegisters(registers: number[]): Buffer {
+  const out = Buffer.alloc(registers.length * 2);
+  for (let i = 0; i < registers.length; i++) {
+    out.writeUInt16BE(registers[i] & 0xffff, i * 2);
+  }
+  return out;
+}
+
+/** Unpack `count` big-endian 16-bit register values from a buffer. */
+export function unpackRegisters(buf: Buffer, count: number): number[] {
+  const registers: number[] = [];
+  for (let i = 0; i < count; i++) {
+    registers.push(buf.readUInt16BE(i * 2));
+  }
+  return registers;
+}

--- a/server/protocols/modbus-server/config.ts
+++ b/server/protocols/modbus-server/config.ts
@@ -1,0 +1,182 @@
+/**
+ * Modbus TCP Server Mode — deployment configuration.
+ *
+ * Issue #462: Modbus TCP Server Mode.
+ *
+ * The listener is OFF by default and every unsafe choice has to be made
+ * explicitly, because Modbus TCP authenticates nothing: any peer that can open
+ * the socket is a fully privileged master. The gates, from least to most
+ * dangerous:
+ *
+ *   1. `MODBUS_SERVER_ENABLED=true`            — start a listener at all.
+ *   2. `MODBUS_SERVER_BIND_HOST`               — defaults to 127.0.0.1. Leaving
+ *                                                loopback is a deliberate act
+ *                                                and forces gate 3.
+ *   3. `MODBUS_SERVER_ALLOWED_PEERS`           — mandatory (and wildcard-free)
+ *                                                once the bind host is routable.
+ *   4. `MODBUS_SERVER_ALLOW_WRITES=true`       — separate opt-in before FC05 /
+ *                                                FC06 / FC15 / FC16 are served
+ *                                                at all; even then only register
+ *                                                map entries marked `writable`
+ *                                                can be mutated.
+ *
+ * Validation is Zod-based and fails closed: a malformed value raises
+ * `ModbusServerConfigError` and no listener is created.
+ */
+
+import { z } from "zod";
+import {
+  isLoopbackHost,
+  LOOPBACK_PEER_RULES,
+  parsePeerRules,
+  PeerRuleError,
+} from "./peer-filter";
+
+/** Raised when the deployment configuration cannot produce a safe listener. */
+export class ModbusServerConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ModbusServerConfigError";
+  }
+}
+
+/** Environment flag that must be exactly "true" to arm the listener. */
+export const MODBUS_SERVER_ENABLED_ENV = "MODBUS_SERVER_ENABLED";
+
+/**
+ * Treat a blank variable as unset. `.env` templates ship keys with empty values,
+ * and "present but empty" must mean "not configured" rather than "configured to
+ * nothing" — the latter would turn a template into a startup failure.
+ */
+const present = (raw: string | undefined): string | undefined => {
+  const trimmed = raw?.trim();
+  return trimmed === undefined || trimmed === "" ? undefined : trimmed;
+};
+
+/** Parse a comma-separated list; a blank/absent value reads as unset. */
+const csv = (raw: string | undefined): string[] | undefined => {
+  const value = present(raw);
+  if (value === undefined) return undefined;
+  const items = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item !== "");
+  return items.length > 0 ? items : undefined;
+};
+
+const boolFlag = (raw: string | undefined): boolean => raw?.trim() === "true";
+
+export const modbusServerDeploymentConfigSchema = z
+  .object({
+    /** Bind address. Defaults to loopback — never 0.0.0.0. */
+    host: z.string().trim().min(1).default("127.0.0.1"),
+    /** Bind port. 502 is the registered Modbus port and needs privileges. */
+    port: z.coerce.number().int().min(1).max(65535).default(502),
+    /** Site whose register map this listener serves. */
+    siteId: z.string().trim().min(1),
+    /** Modbus unit id whose register-map rows are served. */
+    unitId: z.coerce.number().int().min(0).max(255).default(1),
+    /**
+     * Peer IPs/CIDRs permitted to connect. Enforced at accept time. Wildcard
+     * prefixes (`/0`) are rejected by `parsePeerRules`.
+     */
+    allowedPeers: z.array(z.string().trim().min(1)).min(1),
+    /** Hard cap on simultaneous master connections. */
+    maxConnections: z.coerce.number().int().min(1).max(1024).default(4),
+    /** Serve Modbus write function codes at all. Separate, explicit opt-in. */
+    allowWrites: z.boolean().default(false),
+    /** Idle socket timeout in ms (0 disables). */
+    socketTimeoutMs: z.coerce.number().int().min(0).default(60_000),
+  })
+  .superRefine((config, ctx) => {
+    try {
+      parsePeerRules(config.allowedPeers);
+    } catch (err) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["allowedPeers"],
+        message:
+          err instanceof PeerRuleError
+            ? err.message
+            : `invalid peer allowlist: ${String(err)}`,
+      });
+    }
+  });
+
+export type ModbusServerDeploymentConfig = z.infer<
+  typeof modbusServerDeploymentConfigSchema
+>;
+
+/**
+ * True only when the listener has been explicitly armed. Anything other than
+ * the exact string "true" (including unset) leaves Modbus TCP Server Mode off.
+ */
+export function isModbusServerEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return boolFlag(env[MODBUS_SERVER_ENABLED_ENV]);
+}
+
+/**
+ * Build and validate the listener configuration from the environment.
+ *
+ * @throws {ModbusServerConfigError} with an operator-readable message when the
+ *   configuration cannot produce a safe listener. The caller must not fall back
+ *   to defaults — an unparseable configuration means no listener.
+ */
+export function loadModbusServerConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ModbusServerDeploymentConfig {
+  const host = present(env.MODBUS_SERVER_BIND_HOST) ?? "127.0.0.1";
+  const declaredPeers = csv(env.MODBUS_SERVER_ALLOWED_PEERS);
+
+  // A routable bind must name its masters. Silently inheriting the loopback
+  // default there would produce a listener that is exposed to the network but
+  // rejects everything — confusing, and one edit away from being wide open.
+  if (!isLoopbackHost(host) && declaredPeers === undefined) {
+    throw new ModbusServerConfigError(
+      `MODBUS_SERVER_BIND_HOST="${host}" is not a loopback address, so ` +
+        "MODBUS_SERVER_ALLOWED_PEERS must list the Modbus masters permitted to " +
+        "connect (IP or CIDR, comma-separated). Modbus TCP has no client " +
+        "authentication; the allowlist is the only peer control available.",
+    );
+  }
+
+  const parsed = modbusServerDeploymentConfigSchema.safeParse({
+    host,
+    port: present(env.MODBUS_SERVER_PORT),
+    siteId: present(env.MODBUS_SERVER_SITE_ID),
+    unitId: present(env.MODBUS_SERVER_UNIT_ID),
+    allowedPeers: declaredPeers ?? [...LOOPBACK_PEER_RULES],
+    maxConnections: present(env.MODBUS_SERVER_MAX_CONNECTIONS),
+    allowWrites: boolFlag(env.MODBUS_SERVER_ALLOW_WRITES),
+    socketTimeoutMs: present(env.MODBUS_SERVER_SOCKET_TIMEOUT_MS),
+  });
+
+  if (!parsed.success) {
+    const detail = parsed.error.issues
+      .map((issue) => `${issue.path.join(".") || "config"}: ${issue.message}`)
+      .join("; ");
+    throw new ModbusServerConfigError(
+      `Modbus TCP Server Mode is enabled but its configuration is invalid — ${detail}. ` +
+        "Refusing to start a listener.",
+    );
+  }
+
+  return parsed.data;
+}
+
+/**
+ * A one-line, credential-free summary for the boot log. Operators need to be
+ * able to see from the log alone whether they exposed a writable listener.
+ */
+export function describeModbusServerConfig(
+  config: ModbusServerDeploymentConfig,
+): string {
+  return (
+    `site=${config.siteId} unit=${config.unitId} bind=${config.host}:${config.port} ` +
+    `writes=${config.allowWrites ? "ENABLED" : "disabled"} ` +
+    `maxConnections=${config.maxConnections} ` +
+    `allowedPeers=[${config.allowedPeers.join(", ")}]`
+  );
+}

--- a/server/protocols/modbus-server/data-model.ts
+++ b/server/protocols/modbus-server/data-model.ts
@@ -1,0 +1,194 @@
+/**
+ * Modbus data model — the four classic primary tables.
+ *
+ * Issue #462: Modbus TCP Server Mode.
+ *
+ * Modbus exposes four logically-distinct address spaces:
+ *   - Coils             (FC01 read, FC05/FC15 write) — 1-bit read/write
+ *   - Discrete Inputs   (FC02 read)                   — 1-bit read-only
+ *   - Holding Registers (FC03 read, FC06/FC16 write)  — 16-bit read/write
+ *   - Input Registers   (FC04 read)                   — 16-bit read-only
+ *
+ * This module defines the `ModbusDataModel` interface that the function-code
+ * handlers operate against, plus an `InMemoryDataModel` used for tests and as
+ * the in-process backing for the tag-store bridge. Keeping the handlers behind
+ * this interface is what lets the protocol logic be unit-tested with zero I/O.
+ */
+
+/** One of the four Modbus primary tables. */
+export type RegisterArea =
+  | "coil"
+  | "discreteInput"
+  | "holdingRegister"
+  | "inputRegister";
+
+/**
+ * Reason a data-model access was rejected. Maps onto Modbus exception codes by
+ * the handler layer (see `handlers.ts`):
+ *   ILLEGAL_DATA_ADDRESS -> 0x02
+ *   ILLEGAL_DATA_VALUE   -> 0x03 (e.g. write to a read-only entry, misalignment)
+ *   SERVER_FAILURE       -> 0x04
+ */
+export type DataModelErrorKind =
+  | "ILLEGAL_DATA_ADDRESS"
+  | "ILLEGAL_DATA_VALUE"
+  | "SERVER_FAILURE";
+
+/** Thrown by data-model implementations to signal a typed failure. */
+export class DataModelError extends Error {
+  constructor(
+    public readonly kind: DataModelErrorKind,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DataModelError";
+  }
+}
+
+/**
+ * Backing store for Modbus addresses. Implementations decide whether an address
+ * is mapped (throwing `ILLEGAL_DATA_ADDRESS` if not) and how reads/writes
+ * propagate to the underlying tag store.
+ *
+ * Reads/writes are async because a real backing store (the live tag store /
+ * Redis cache) is async; the in-memory implementation resolves synchronously.
+ */
+export interface ModbusDataModel {
+  /** Read `quantity` coils starting at `address`. */
+  readCoils(address: number, quantity: number): Promise<boolean[]>;
+  /** Read `quantity` discrete inputs starting at `address`. */
+  readDiscreteInputs(address: number, quantity: number): Promise<boolean[]>;
+  /** Read `quantity` holding registers (16-bit) starting at `address`. */
+  readHoldingRegisters(address: number, quantity: number): Promise<number[]>;
+  /** Read `quantity` input registers (16-bit) starting at `address`. */
+  readInputRegisters(address: number, quantity: number): Promise<number[]>;
+  /** Write coils starting at `address`. */
+  writeCoils(address: number, values: boolean[]): Promise<void>;
+  /** Write holding registers (16-bit) starting at `address`. */
+  writeHoldingRegisters(address: number, values: number[]): Promise<void>;
+}
+
+/**
+ * Simple in-memory data model. Addresses are "mapped" if they fall inside the
+ * configured size of each area; otherwise reads/writes throw
+ * `ILLEGAL_DATA_ADDRESS`. This mirrors how a real PLC rejects out-of-range
+ * accesses and is the default backing used by unit tests.
+ */
+export class InMemoryDataModel implements ModbusDataModel {
+  private coils: boolean[];
+  private discreteInputs: boolean[];
+  private holdingRegisters: number[];
+  private inputRegisters: number[];
+
+  constructor(
+    size: {
+      coils?: number;
+      discreteInputs?: number;
+      holdingRegisters?: number;
+      inputRegisters?: number;
+    } = {},
+  ) {
+    this.coils = new Array<boolean>(size.coils ?? 0x10000).fill(false);
+    this.discreteInputs = new Array<boolean>(
+      size.discreteInputs ?? 0x10000,
+    ).fill(false);
+    this.holdingRegisters = new Array<number>(
+      size.holdingRegisters ?? 0x10000,
+    ).fill(0);
+    this.inputRegisters = new Array<number>(size.inputRegisters ?? 0x10000).fill(
+      0,
+    );
+  }
+
+  private static assertRange(
+    area: RegisterArea,
+    backing: { length: number },
+    address: number,
+    quantity: number,
+  ): void {
+    if (address < 0 || quantity < 0 || address + quantity > backing.length) {
+      throw new DataModelError(
+        "ILLEGAL_DATA_ADDRESS",
+        `${area} access [${address}, ${address + quantity}) out of range (size ${backing.length})`,
+      );
+    }
+  }
+
+  async readCoils(address: number, quantity: number): Promise<boolean[]> {
+    InMemoryDataModel.assertRange("coil", this.coils, address, quantity);
+    return this.coils.slice(address, address + quantity);
+  }
+
+  async readDiscreteInputs(
+    address: number,
+    quantity: number,
+  ): Promise<boolean[]> {
+    InMemoryDataModel.assertRange(
+      "discreteInput",
+      this.discreteInputs,
+      address,
+      quantity,
+    );
+    return this.discreteInputs.slice(address, address + quantity);
+  }
+
+  async readHoldingRegisters(
+    address: number,
+    quantity: number,
+  ): Promise<number[]> {
+    InMemoryDataModel.assertRange(
+      "holdingRegister",
+      this.holdingRegisters,
+      address,
+      quantity,
+    );
+    return this.holdingRegisters.slice(address, address + quantity);
+  }
+
+  async readInputRegisters(
+    address: number,
+    quantity: number,
+  ): Promise<number[]> {
+    InMemoryDataModel.assertRange(
+      "inputRegister",
+      this.inputRegisters,
+      address,
+      quantity,
+    );
+    return this.inputRegisters.slice(address, address + quantity);
+  }
+
+  async writeCoils(address: number, values: boolean[]): Promise<void> {
+    InMemoryDataModel.assertRange("coil", this.coils, address, values.length);
+    for (let i = 0; i < values.length; i++) {
+      this.coils[address + i] = values[i];
+    }
+  }
+
+  async writeHoldingRegisters(
+    address: number,
+    values: number[],
+  ): Promise<void> {
+    InMemoryDataModel.assertRange(
+      "holdingRegister",
+      this.holdingRegisters,
+      address,
+      values.length,
+    );
+    for (let i = 0; i < values.length; i++) {
+      this.holdingRegisters[address + i] = values[i] & 0xffff;
+    }
+  }
+
+  // ── Test/seed helpers (not part of the ModbusDataModel interface) ──────────
+
+  /** Directly seed a discrete-input value (read-only over Modbus). */
+  setDiscreteInput(address: number, value: boolean): void {
+    this.discreteInputs[address] = value;
+  }
+
+  /** Directly seed an input-register value (read-only over Modbus). */
+  setInputRegister(address: number, value: number): void {
+    this.inputRegisters[address] = value & 0xffff;
+  }
+}

--- a/server/protocols/modbus-server/handlers.ts
+++ b/server/protocols/modbus-server/handlers.ts
@@ -1,0 +1,270 @@
+/**
+ * Modbus function-code handlers — pure request -> response processing.
+ *
+ * Issue #462: Modbus TCP Server Mode.
+ *
+ * Given a decoded `ModbusRequest` and a `ModbusDataModel`, `processRequest`
+ * produces the response frame bytes (normal or exception). It has no socket
+ * dependency, so every function code and every exception path is unit-testable.
+ *
+ * Supported function codes:
+ *   0x01 Read Coils
+ *   0x02 Read Discrete Inputs
+ *   0x03 Read Holding Registers
+ *   0x04 Read Input Registers
+ *   0x05 Write Single Coil
+ *   0x06 Write Single Register
+ *   0x0F Write Multiple Coils
+ *   0x10 Write Multiple Registers
+ *
+ * Exception codes returned:
+ *   0x01 Illegal Function      — unsupported function code
+ *   0x02 Illegal Data Address  — address/range not mapped
+ *   0x03 Illegal Data Value    — quantity / byte-count / value out of spec range
+ *   0x04 Server Device Failure — data model raised an unexpected error
+ */
+
+import {
+  ExceptionCode,
+  FunctionCode,
+  MAX_READ_BITS,
+  MAX_READ_REGISTERS,
+  MAX_WRITE_COILS,
+  MAX_WRITE_REGISTERS,
+  encodeExceptionResponse,
+  encodeResponse,
+  packBits,
+  packRegisters,
+  unpackBits,
+  unpackRegisters,
+  type ModbusRequest,
+} from "./codec";
+import { DataModelError, type ModbusDataModel } from "./data-model";
+
+const COIL_ON = 0xff00;
+const COIL_OFF = 0x0000;
+
+/** A typed error a handler can throw to short-circuit to an exception response. */
+class ModbusException extends Error {
+  constructor(public readonly code: ExceptionCode) {
+    super(`Modbus exception 0x${code.toString(16)}`);
+    this.name = "ModbusException";
+  }
+}
+
+/**
+ * Process one decoded request against the data model and return the encoded
+ * response frame. Never throws — all failures become exception responses.
+ */
+export async function processRequest(
+  request: ModbusRequest,
+  model: ModbusDataModel,
+): Promise<Buffer> {
+  const { header, functionCode, data } = request;
+
+  try {
+    const responsePdu = await dispatch(functionCode, data, model);
+    return encodeResponse(header, functionCode, responsePdu);
+  } catch (err) {
+    const code = toExceptionCode(err);
+    return encodeExceptionResponse(header, functionCode, code);
+  }
+}
+
+/** Map a thrown error to the appropriate Modbus exception code. */
+function toExceptionCode(err: unknown): ExceptionCode {
+  if (err instanceof ModbusException) {
+    return err.code;
+  }
+  if (err instanceof DataModelError) {
+    switch (err.kind) {
+      case "ILLEGAL_DATA_ADDRESS":
+        return ExceptionCode.ILLEGAL_DATA_ADDRESS;
+      case "ILLEGAL_DATA_VALUE":
+        return ExceptionCode.ILLEGAL_DATA_VALUE;
+      case "SERVER_FAILURE":
+        return ExceptionCode.SERVER_DEVICE_FAILURE;
+    }
+  }
+  // Unexpected: treat as a server-side failure rather than leaking details.
+  return ExceptionCode.SERVER_DEVICE_FAILURE;
+}
+
+/** Dispatch to the per-function-code handler; returns the response PDU body. */
+async function dispatch(
+  functionCode: number,
+  data: Buffer,
+  model: ModbusDataModel,
+): Promise<Buffer> {
+  switch (functionCode) {
+    case FunctionCode.READ_COILS:
+      return readBits(data, MAX_READ_BITS, (addr, qty) =>
+        model.readCoils(addr, qty),
+      );
+    case FunctionCode.READ_DISCRETE_INPUTS:
+      return readBits(data, MAX_READ_BITS, (addr, qty) =>
+        model.readDiscreteInputs(addr, qty),
+      );
+    case FunctionCode.READ_HOLDING_REGISTERS:
+      return readRegisters(data, (addr, qty) =>
+        model.readHoldingRegisters(addr, qty),
+      );
+    case FunctionCode.READ_INPUT_REGISTERS:
+      return readRegisters(data, (addr, qty) =>
+        model.readInputRegisters(addr, qty),
+      );
+    case FunctionCode.WRITE_SINGLE_COIL:
+      return writeSingleCoil(data, model);
+    case FunctionCode.WRITE_SINGLE_REGISTER:
+      return writeSingleRegister(data, model);
+    case FunctionCode.WRITE_MULTIPLE_COILS:
+      return writeMultipleCoils(data, model);
+    case FunctionCode.WRITE_MULTIPLE_REGISTERS:
+      return writeMultipleRegisters(data, model);
+    default:
+      throw new ModbusException(ExceptionCode.ILLEGAL_FUNCTION);
+  }
+}
+
+/** Require that the request PDU body has at least `n` bytes. */
+function requireBytes(data: Buffer, n: number): void {
+  if (data.length < n) {
+    // A truncated PDU is structurally invalid data.
+    throw new ModbusException(ExceptionCode.ILLEGAL_DATA_VALUE);
+  }
+}
+
+// ── FC01 / FC02: read bits ──────────────────────────────────────────────────
+
+async function readBits(
+  data: Buffer,
+  maxQuantity: number,
+  read: (address: number, quantity: number) => Promise<boolean[]>,
+): Promise<Buffer> {
+  requireBytes(data, 4);
+  const address = data.readUInt16BE(0);
+  const quantity = data.readUInt16BE(2);
+
+  if (quantity < 1 || quantity > maxQuantity) {
+    throw new ModbusException(ExceptionCode.ILLEGAL_DATA_VALUE);
+  }
+
+  const bits = await read(address, quantity);
+  const packed = packBits(bits);
+  const out = Buffer.alloc(1 + packed.length);
+  out.writeUInt8(packed.length, 0); // byte count
+  packed.copy(out, 1);
+  return out;
+}
+
+// ── FC03 / FC04: read registers ───────────────────────────────────────────
+
+async function readRegisters(
+  data: Buffer,
+  read: (address: number, quantity: number) => Promise<number[]>,
+): Promise<Buffer> {
+  requireBytes(data, 4);
+  const address = data.readUInt16BE(0);
+  const quantity = data.readUInt16BE(2);
+
+  if (quantity < 1 || quantity > MAX_READ_REGISTERS) {
+    throw new ModbusException(ExceptionCode.ILLEGAL_DATA_VALUE);
+  }
+
+  const registers = await read(address, quantity);
+  const packed = packRegisters(registers);
+  const out = Buffer.alloc(1 + packed.length);
+  out.writeUInt8(packed.length, 0); // byte count = quantity * 2
+  packed.copy(out, 1);
+  return out;
+}
+
+// ── FC05: write single coil ──────────────────────────────────────────────────
+
+async function writeSingleCoil(
+  data: Buffer,
+  model: ModbusDataModel,
+): Promise<Buffer> {
+  requireBytes(data, 4);
+  const address = data.readUInt16BE(0);
+  const raw = data.readUInt16BE(2);
+
+  if (raw !== COIL_ON && raw !== COIL_OFF) {
+    throw new ModbusException(ExceptionCode.ILLEGAL_DATA_VALUE);
+  }
+
+  await model.writeCoils(address, [raw === COIL_ON]);
+  // Echo the request back as the response.
+  return Buffer.from(data.subarray(0, 4));
+}
+
+// ── FC06: write single register ──────────────────────────────────────────────
+
+async function writeSingleRegister(
+  data: Buffer,
+  model: ModbusDataModel,
+): Promise<Buffer> {
+  requireBytes(data, 4);
+  const address = data.readUInt16BE(0);
+  const value = data.readUInt16BE(2);
+
+  await model.writeHoldingRegisters(address, [value]);
+  // Echo the request back as the response.
+  return Buffer.from(data.subarray(0, 4));
+}
+
+// ── FC15: write multiple coils ───────────────────────────────────────────────
+
+async function writeMultipleCoils(
+  data: Buffer,
+  model: ModbusDataModel,
+): Promise<Buffer> {
+  requireBytes(data, 5);
+  const address = data.readUInt16BE(0);
+  const quantity = data.readUInt16BE(2);
+  const byteCount = data.readUInt8(4);
+
+  if (quantity < 1 || quantity > MAX_WRITE_COILS) {
+    throw new ModbusException(ExceptionCode.ILLEGAL_DATA_VALUE);
+  }
+  if (byteCount !== Math.ceil(quantity / 8) || data.length < 5 + byteCount) {
+    throw new ModbusException(ExceptionCode.ILLEGAL_DATA_VALUE);
+  }
+
+  const values = unpackBits(data.subarray(5, 5 + byteCount), quantity);
+  await model.writeCoils(address, values);
+
+  // Response: starting address + quantity of coils written.
+  const out = Buffer.alloc(4);
+  out.writeUInt16BE(address, 0);
+  out.writeUInt16BE(quantity, 2);
+  return out;
+}
+
+// ── FC16: write multiple registers ───────────────────────────────────────────
+
+async function writeMultipleRegisters(
+  data: Buffer,
+  model: ModbusDataModel,
+): Promise<Buffer> {
+  requireBytes(data, 5);
+  const address = data.readUInt16BE(0);
+  const quantity = data.readUInt16BE(2);
+  const byteCount = data.readUInt8(4);
+
+  if (quantity < 1 || quantity > MAX_WRITE_REGISTERS) {
+    throw new ModbusException(ExceptionCode.ILLEGAL_DATA_VALUE);
+  }
+  if (byteCount !== quantity * 2 || data.length < 5 + byteCount) {
+    throw new ModbusException(ExceptionCode.ILLEGAL_DATA_VALUE);
+  }
+
+  const values = unpackRegisters(data.subarray(5, 5 + byteCount), quantity);
+  await model.writeHoldingRegisters(address, values);
+
+  // Response: starting address + quantity of registers written.
+  const out = Buffer.alloc(4);
+  out.writeUInt16BE(address, 0);
+  out.writeUInt16BE(quantity, 2);
+  return out;
+}

--- a/server/protocols/modbus-server/index.ts
+++ b/server/protocols/modbus-server/index.ts
@@ -1,0 +1,161 @@
+/**
+ * Modbus TCP Server Mode — public surface and startup path.
+ *
+ * Issue #462: standard Modbus masters can poll 0xSCADA.
+ *
+ * Mirrors OPC-UA Server Mode for the lower-end market: legacy HMIs and
+ * integrators read/write 0xSCADA tags over standard Modbus TCP. This barrel
+ * re-exports the building blocks, provides `createModbusServerForSite` (the
+ * one-call factory that wires a register map to the live tag store), and owns
+ * `startModbusServer`, the bootstrap `server/index.ts` calls at boot.
+ *
+ * SAFETY POSTURE. Modbus TCP has no authentication in the protocol — no
+ * credential, no handshake, no integrity protection. There is no way to make it
+ * safe on the wire, so the compensations live at the deployment boundary and
+ * every one of them is off by default:
+ *
+ *   - the listener does not exist unless MODBUS_SERVER_ENABLED=true;
+ *   - it binds 127.0.0.1 unless a routable MODBUS_SERVER_BIND_HOST is set;
+ *   - a routable bind additionally requires a wildcard-free
+ *     MODBUS_SERVER_ALLOWED_PEERS allowlist, enforced at accept time;
+ *   - concurrent masters are capped;
+ *   - write function codes return exception 0x01 unless
+ *     MODBUS_SERVER_ALLOW_WRITES=true, and even then only register-map entries
+ *     explicitly marked `writable` can mutate a live tag.
+ *
+ * Invalid configuration throws. It never degrades into a permissive listener.
+ */
+
+import { RegisterMap, type RegisterMapConfig } from "./register-map";
+import {
+  TagStoreDataModel,
+  createTagStorePort,
+  type TagStorePort,
+} from "./tag-store-bridge";
+import { ModbusTcpServer, type ModbusServerConfig } from "./server";
+import {
+  describeModbusServerConfig,
+  isModbusServerEnabled,
+  loadModbusServerConfig,
+} from "./config";
+import { isLoopbackHost } from "./peer-filter";
+import { loadModbusRegisterMap } from "./register-map-store";
+import { log, logWarn } from "../../logger";
+
+export * from "./codec";
+export * from "./data-model";
+export * from "./register-map";
+export * from "./handlers";
+export * from "./tag-store-bridge";
+export * from "./peer-filter";
+export * from "./config";
+export { loadModbusRegisterMap, RegisterMapLoadError } from "./register-map-store";
+export { ModbusTcpServer, type ModbusServerConfig } from "./server";
+
+const LOG_SCOPE = "modbus-server";
+
+/**
+ * Build a Modbus TCP server for a site: parse + index the register map, bind it
+ * to the live tag store, and construct the listener. Call `.start()` to listen.
+ *
+ * Transport defaults are the safe ones (`server.ts`): loopback bind, loopback
+ * peer allowlist, writes off.
+ *
+ * @param rawMap   Raw register-map config (validated with Zod) or a built map.
+ * @param config   Transport overrides (host/port/peers/writes).
+ */
+export function createModbusServerForSite(
+  rawMap: RegisterMapConfig | RegisterMap | unknown,
+  config: ModbusServerConfig = {},
+): ModbusTcpServer {
+  const map =
+    rawMap instanceof RegisterMap ? rawMap : RegisterMap.fromConfig(rawMap);
+  const store = createTagStorePort(map.siteId);
+  const model = new TagStoreDataModel(map, store);
+
+  return new ModbusTcpServer(model, {
+    ...config,
+    unitId: config.unitId ?? map.unitId,
+  });
+}
+
+/** Loader seam so the bootstrap can be tested without a database. */
+export type RegisterMapLoader = (
+  siteId: string,
+  unitId: number,
+) => Promise<RegisterMap>;
+
+export interface StartModbusServerOptions {
+  /** Environment to read configuration from. Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Register-map source. Defaults to the `modbus_register_map` table. */
+  loadRegisterMap?: RegisterMapLoader;
+  /** Tag backing store. Defaults to the live `tagCache` for the site. */
+  tagStore?: TagStorePort;
+}
+
+/**
+ * Start Modbus TCP Server Mode from validated configuration.
+ *
+ * Returns `null` — having done nothing at all — when the feature is not
+ * explicitly enabled. That is the default for every deployment.
+ *
+ * @throws {ModbusServerConfigError} when enabled with configuration that cannot
+ *   produce a safe listener.
+ * @throws {RegisterMapLoadError} when the site's register map cannot be loaded.
+ *   In both cases no socket is bound: the failure is terminal for the listener,
+ *   never a fallback to permissive defaults.
+ */
+export async function startModbusServer(
+  options: StartModbusServerOptions = {},
+): Promise<ModbusTcpServer | null> {
+  const env = options.env ?? process.env;
+
+  if (!isModbusServerEnabled(env)) {
+    return null;
+  }
+
+  const config = loadModbusServerConfig(env);
+  const loadRegisterMap = options.loadRegisterMap ?? loadModbusRegisterMap;
+  const map = await loadRegisterMap(config.siteId, config.unitId);
+
+  if (config.allowWrites) {
+    const writable = map.entries.filter((entry) => entry.writable);
+    // Say plainly what an unauthenticated peer will be able to actuate.
+    logWarn(
+      `Modbus TCP Server Mode has WRITES ENABLED: ${writable.length} of ` +
+        `${map.entries.length} mapped addresses are writable by any allowlisted ` +
+        "peer. Modbus TCP does not authenticate clients — the peer allowlist and " +
+        "network segmentation are the only controls in front of these tags.",
+      LOG_SCOPE,
+    );
+  }
+  if (!isLoopbackHost(config.host)) {
+    logWarn(
+      `Modbus TCP Server Mode is bound to the non-loopback address ` +
+        `${config.host}. Peers are restricted to ` +
+        `[${config.allowedPeers.join(", ")}], but the protocol itself provides ` +
+        "no authentication; keep this listener on a segmented control network.",
+      LOG_SCOPE,
+    );
+  }
+
+  const store = options.tagStore ?? createTagStorePort(config.siteId);
+  const server = new ModbusTcpServer(new TagStoreDataModel(map, store), {
+    host: config.host,
+    port: config.port,
+    unitId: config.unitId,
+    allowedPeers: config.allowedPeers,
+    maxConnections: config.maxConnections,
+    socketTimeoutMs: config.socketTimeoutMs,
+    allowWrites: config.allowWrites,
+  });
+
+  await server.start();
+  log(
+    `Modbus TCP Server Mode started — ${describeModbusServerConfig(config)}, ` +
+      `${map.entries.length} mapped addresses`,
+    LOG_SCOPE,
+  );
+  return server;
+}

--- a/server/protocols/modbus-server/peer-filter.ts
+++ b/server/protocols/modbus-server/peer-filter.ts
@@ -1,0 +1,246 @@
+/**
+ * Peer allowlist for the Modbus TCP listener.
+ *
+ * Issue #462: Modbus TCP Server Mode.
+ *
+ * Modbus TCP has NO authentication in the protocol itself — there is no
+ * credential, no handshake, and no integrity protection on the wire. Anything
+ * that can open a TCP connection to the listener is, protocol-wise, a fully
+ * privileged master. The only place 0xSCADA can compensate is the deployment
+ * boundary, so the listener refuses connections from any peer that is not
+ * explicitly allowlisted by IP or CIDR, checked at accept time before a single
+ * byte is read.
+ *
+ * This module is pure (no sockets, no I/O) so every parsing and matching rule
+ * is unit-testable. IPv4, IPv6, and IPv4-mapped IPv6 (`::ffff:10.0.0.1`, which
+ * is what a dual-stack listener reports for an IPv4 client) all normalise to
+ * the same comparison form.
+ */
+
+import net from "node:net";
+
+/** Address family of a normalised address or rule. */
+export type IpFamily = 4 | 6;
+
+/** A parsed, normalised address. */
+export interface NormalizedAddress {
+  family: IpFamily;
+  /** 4 bytes for IPv4, 16 for IPv6. */
+  bytes: Uint8Array;
+}
+
+/** A parsed allowlist rule: a network address plus a prefix length. */
+export interface PeerRule extends NormalizedAddress {
+  /** Prefix length in bits (1..32 for IPv4, 1..128 for IPv6). */
+  prefix: number;
+  /** The literal the rule was parsed from, for logging. */
+  source: string;
+}
+
+/** Raised when an allowlist entry cannot be parsed into a usable rule. */
+export class PeerRuleError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PeerRuleError";
+  }
+}
+
+function ipv4ToBytes(addr: string): Uint8Array | null {
+  if (!net.isIPv4(addr)) return null;
+  const parts = addr.split(".");
+  const bytes = new Uint8Array(4);
+  for (let i = 0; i < 4; i++) {
+    bytes[i] = Number(parts[i]) & 0xff;
+  }
+  return bytes;
+}
+
+function ipv6ToBytes(addr: string): Uint8Array | null {
+  if (!net.isIPv6(addr)) return null;
+
+  const doubleColon = addr.indexOf("::");
+  const head =
+    doubleColon >= 0
+      ? addr.slice(0, doubleColon).split(":").filter((g) => g !== "")
+      : addr.split(":");
+  const tail =
+    doubleColon >= 0
+      ? addr.slice(doubleColon + 2).split(":").filter((g) => g !== "")
+      : [];
+
+  const expand = (groups: string[]): number[] | null => {
+    const words: number[] = [];
+    for (const group of groups) {
+      if (group.includes(".")) {
+        // Embedded IPv4 form, e.g. ::ffff:192.0.2.1 — occupies two words.
+        const v4 = ipv4ToBytes(group);
+        if (!v4) return null;
+        words.push((v4[0] << 8) | v4[1], (v4[2] << 8) | v4[3]);
+        continue;
+      }
+      const word = Number.parseInt(group, 16);
+      if (!Number.isFinite(word) || word < 0 || word > 0xffff) return null;
+      words.push(word);
+    }
+    return words;
+  };
+
+  const headWords = expand(head);
+  const tailWords = expand(tail);
+  if (!headWords || !tailWords) return null;
+
+  const missing = 8 - headWords.length - tailWords.length;
+  if (missing < 0) return null;
+  if (doubleColon < 0 && missing !== 0) return null;
+
+  const words = [...headWords, ...new Array<number>(missing).fill(0), ...tailWords];
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 8; i++) {
+    bytes[i * 2] = (words[i] >> 8) & 0xff;
+    bytes[i * 2 + 1] = words[i] & 0xff;
+  }
+  return bytes;
+}
+
+/** True if 16 bytes encode an IPv4-mapped IPv6 address (::ffff:a.b.c.d). */
+function isV4Mapped(bytes: Uint8Array): boolean {
+  if (bytes.length !== 16) return false;
+  for (let i = 0; i < 10; i++) {
+    if (bytes[i] !== 0x00) return false;
+  }
+  return bytes[10] === 0xff && bytes[11] === 0xff;
+}
+
+/**
+ * Parse an address literal into its normalised comparison form.
+ *
+ * A trailing IPv6 zone id (`fe80::1%eth0`) is stripped, and IPv4-mapped IPv6
+ * collapses to plain IPv4 so a `10.0.0.0/8` rule matches a dual-stack socket
+ * that reports `::ffff:10.0.0.1`. Returns `null` for anything unparseable —
+ * callers must treat that as "not allowed".
+ */
+export function normalizeAddress(input: string): NormalizedAddress | null {
+  const addr = input.split("%")[0].trim();
+  if (addr === "") return null;
+
+  const v4 = ipv4ToBytes(addr);
+  if (v4) return { family: 4, bytes: v4 };
+
+  const v6 = ipv6ToBytes(addr);
+  if (!v6) return null;
+  if (isV4Mapped(v6)) {
+    return { family: 4, bytes: v6.slice(12) };
+  }
+  return { family: 6, bytes: v6 };
+}
+
+/**
+ * Parse one allowlist entry: a bare address (`127.0.0.1`, treated as a host
+ * route) or CIDR notation (`10.4.0.0/16`).
+ *
+ * A prefix length of 0 is rejected on purpose: `0.0.0.0/0` and `::/0` allow
+ * every peer on the internet, which is not an allowlist. Modbus TCP cannot
+ * authenticate the peers such a rule would admit, so it fails closed here
+ * rather than silently degrading to "anyone may write to the plant".
+ *
+ * @throws {PeerRuleError} when the entry is not a usable rule.
+ */
+export function parsePeerRule(entry: string): PeerRule {
+  const source = entry.trim();
+  if (source === "") {
+    throw new PeerRuleError("empty allowlist entry");
+  }
+
+  const slash = source.lastIndexOf("/");
+  const addrPart = slash >= 0 ? source.slice(0, slash) : source;
+  const prefixPart = slash >= 0 ? source.slice(slash + 1) : undefined;
+
+  const normalized = normalizeAddress(addrPart);
+  if (!normalized) {
+    throw new PeerRuleError(`"${source}" is not a valid IPv4/IPv6 address or CIDR`);
+  }
+
+  const maxPrefix = normalized.family === 4 ? 32 : 128;
+  let prefix = maxPrefix;
+
+  if (prefixPart !== undefined) {
+    if (!/^\d{1,3}$/.test(prefixPart)) {
+      throw new PeerRuleError(`"${source}" has a non-numeric prefix length`);
+    }
+    prefix = Number.parseInt(prefixPart, 10);
+
+    // `::ffff:10.0.0.0/104` was normalised to IPv4; rebase its prefix onto the
+    // 32-bit IPv4 space so the two notations mean the same network.
+    if (normalized.family === 4 && net.isIPv6(addrPart.split("%")[0].trim())) {
+      if (prefix < 96) {
+        throw new PeerRuleError(
+          `"${source}" maps into the IPv4 space; its prefix must be >= 96`,
+        );
+      }
+      prefix -= 96;
+    }
+
+    if (prefix > maxPrefix) {
+      throw new PeerRuleError(
+        `"${source}" prefix length ${prefixPart} exceeds /${maxPrefix}`,
+      );
+    }
+  }
+
+  if (prefix === 0) {
+    throw new PeerRuleError(
+      `"${source}" allows every peer. Modbus TCP has no client authentication, ` +
+        "so a wildcard allowlist is refused; list the specific master IPs or subnets.",
+    );
+  }
+
+  return { ...normalized, prefix, source };
+}
+
+/** Parse a whole allowlist. Throws on the first unusable entry. */
+export function parsePeerRules(entries: readonly string[]): PeerRule[] {
+  return entries.map(parsePeerRule);
+}
+
+/** True if `addr` falls inside `rule`'s network. */
+function matches(addr: NormalizedAddress, rule: PeerRule): boolean {
+  if (addr.family !== rule.family) return false;
+
+  const fullBytes = rule.prefix >> 3;
+  for (let i = 0; i < fullBytes; i++) {
+    if ((addr.bytes[i] ^ rule.bytes[i]) !== 0) return false;
+  }
+  const remainingBits = rule.prefix & 7;
+  if (remainingBits === 0) return true;
+  const mask = (0xff << (8 - remainingBits)) & 0xff;
+  return ((addr.bytes[fullBytes] ^ rule.bytes[fullBytes]) & mask) === 0;
+}
+
+/**
+ * Decide whether a connecting peer is allowed.
+ *
+ * Fails closed: an absent, empty, or unparseable `remoteAddress`, or an empty
+ * rule set, all deny.
+ */
+export function isPeerAllowed(
+  remoteAddress: string | undefined,
+  rules: readonly PeerRule[],
+): boolean {
+  if (!remoteAddress || rules.length === 0) return false;
+  const addr = normalizeAddress(remoteAddress);
+  if (!addr) return false;
+  return rules.some((rule) => matches(addr, rule));
+}
+
+/** Loopback rules used as the default allowlist for a loopback bind. */
+export const LOOPBACK_PEER_RULES: readonly string[] = ["127.0.0.0/8", "::1/128"];
+
+/** True if a bind host is a loopback address (or the loopback hostname). */
+export function isLoopbackHost(host: string): boolean {
+  if (host === "localhost") return true;
+  const addr = normalizeAddress(host);
+  if (!addr) return false;
+  if (addr.family === 4) return addr.bytes[0] === 127;
+  // ::1
+  return addr.bytes.every((b, i) => (i === 15 ? b === 1 : b === 0));
+}

--- a/server/protocols/modbus-server/register-map-store.ts
+++ b/server/protocols/modbus-server/register-map-store.ts
@@ -1,0 +1,134 @@
+/**
+ * Load a site's Modbus register map from the `modbus_register_map` table.
+ *
+ * Issue #462: Modbus TCP Server Mode.
+ *
+ * This is the seam between the persisted configuration (migration
+ * `0007_modbus_register_map.sql`, table declared in `shared/schema.ts`) and the
+ * in-memory `RegisterMap` the protocol layer serves. The storage module is
+ * imported dynamically so the pure protocol layer — and its unit tests — never
+ * pull in the pg/sqlite driver stack.
+ *
+ * Every failure mode here is fail-closed: the loader throws and the caller does
+ * not start a listener. An empty map in particular is treated as an error
+ * rather than as "a listener that answers nothing", because a socket that
+ * exists but serves no data is pure attack surface.
+ */
+
+import { and, eq, type SQL } from "drizzle-orm";
+import { modbusRegisterMap } from "@shared/schema";
+import { RegisterMap } from "./register-map";
+
+/** Raised when a usable register map cannot be loaded. */
+export class RegisterMapLoadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RegisterMapLoadError";
+  }
+}
+
+/**
+ * The narrow slice of the Drizzle handle this loader uses. `withLockedDatabase`
+ * hands back the repository's shared, loosely-typed connection; declaring the
+ * shape we need keeps this module free of `any`.
+ */
+interface RegisterMapQueryHandle {
+  select(): {
+    from(table: typeof modbusRegisterMap): {
+      where(condition: SQL | undefined): Promise<ModbusRegisterMapRecord[]>;
+    };
+  };
+}
+
+/** One persisted register-map row, as selected. */
+interface ModbusRegisterMapRecord {
+  unitId: number;
+  area: string;
+  address: number;
+  tagId: string;
+  dataType: string;
+  scale: number | null;
+  wordOrder: string | null;
+  writable: boolean;
+}
+
+/**
+ * Read the register map for `siteId` / `unitId` and build the validated runtime
+ * map the protocol layer serves.
+ *
+ * `RegisterMap.fromConfig` owns the Zod schema, so a row with a bogus `area` or
+ * `dataType` surfaces as one consistent validation error regardless of whether
+ * the map came from the database or from a caller.
+ *
+ * @throws {RegisterMapLoadError} when the map cannot be read, is empty, or does
+ *   not validate.
+ */
+export async function loadModbusRegisterMap(
+  siteId: string,
+  unitId: number,
+): Promise<RegisterMap> {
+  const { getDatabaseType, withLockedDatabase } = await import("../../storage");
+
+  if (getDatabaseType() !== "postgres") {
+    // The SQLite development fallback does not carry the modbus_register_map
+    // table, and its Drizzle shim resolves every select to []. Starting a
+    // listener from that would silently expose an empty map instead of the
+    // operator's configuration, so refuse instead of pretending.
+    throw new RegisterMapLoadError(
+      "Modbus TCP Server Mode requires the PostgreSQL backend: the " +
+        "modbus_register_map table is created by migration " +
+        "0007_modbus_register_map.sql and is not present in the SQLite " +
+        "development fallback.",
+    );
+  }
+
+  let rows: ModbusRegisterMapRecord[];
+  try {
+    rows = await withLockedDatabase((database: RegisterMapQueryHandle) =>
+      database
+        .select()
+        .from(modbusRegisterMap)
+        .where(
+          and(
+            eq(modbusRegisterMap.siteId, siteId),
+            eq(modbusRegisterMap.unitId, unitId),
+          ),
+        ),
+    );
+  } catch (err) {
+    throw new RegisterMapLoadError(
+      `Failed to read modbus_register_map for site "${siteId}" unit ${unitId}: ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+  }
+
+  if (rows.length === 0) {
+    throw new RegisterMapLoadError(
+      `No modbus_register_map rows for site "${siteId}" unit ${unitId}. ` +
+        "Refusing to open a Modbus listener with an empty register map.",
+    );
+  }
+
+  const raw: unknown = {
+    siteId,
+    unitId,
+    entries: rows.map((row) => ({
+      tagId: row.tagId,
+      area: row.area,
+      address: row.address,
+      dataType: row.dataType,
+      scale: row.scale ?? undefined,
+      wordOrder: row.wordOrder ?? undefined,
+      writable: row.writable,
+    })),
+  };
+
+  try {
+    return RegisterMap.fromConfig(raw);
+  } catch (err) {
+    throw new RegisterMapLoadError(
+      `modbus_register_map rows for site "${siteId}" unit ${unitId} are not a ` +
+        `valid register map: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/server/protocols/modbus-server/register-map.ts
+++ b/server/protocols/modbus-server/register-map.ts
@@ -1,0 +1,319 @@
+/**
+ * Modbus register map — configurable per-site tag <-> Modbus-address mapping.
+ *
+ * Issue #462: Modbus TCP Server Mode.
+ *
+ * A site administrator declares which 0xSCADA tags are exposed at which Modbus
+ * addresses, and in which area (coil / discrete input / holding register /
+ * input register). Standard Modbus masters then poll those addresses. This
+ * module owns:
+ *   - the Zod schema for a register-map entry / a full map,
+ *   - efficient address -> entry lookup for a contiguous read/write range,
+ *   - encoding/decoding between a JS tag value and its 16-bit register
+ *     representation according to the entry's `dataType`.
+ *
+ * The map itself is pure data and is fully unit-testable. Persistence lives in
+ * `shared/schema.ts` (table `modbusRegisterMap`); see `tag-store-bridge.ts` for
+ * how a loaded map is bound to the live tag store.
+ */
+
+import { z } from "zod";
+import type { RegisterArea } from "./data-model";
+
+/**
+ * How a tag value is encoded into Modbus registers. Coils/discrete inputs are
+ * always single-bit and ignore `dataType`.
+ *
+ *   - bool   : single coil / discrete input (1 bit)
+ *   - uint16 : 1 register, unsigned
+ *   - int16  : 1 register, signed (two's complement)
+ *   - uint32 : 2 registers, unsigned
+ *   - int32  : 2 registers, signed
+ *   - float32: 2 registers, IEEE-754 single precision
+ */
+export const ModbusDataType = {
+  BOOL: "bool",
+  UINT16: "uint16",
+  INT16: "int16",
+  UINT32: "uint32",
+  INT32: "int32",
+  FLOAT32: "float32",
+} as const;
+
+export type ModbusDataType = (typeof ModbusDataType)[keyof typeof ModbusDataType];
+
+/** Word order for multi-register (32-bit) values. */
+export type WordOrder = "big" | "little";
+
+/** Zod schema for a single register-map entry. */
+export const registerMapEntrySchema = z.object({
+  /** 0xSCADA tag identifier this entry exposes. */
+  tagId: z.string().min(1),
+  /** Which Modbus primary table this address lives in. */
+  area: z.enum([
+    "coil",
+    "discreteInput",
+    "holdingRegister",
+    "inputRegister",
+  ]) satisfies z.ZodType<RegisterArea>,
+  /** Zero-based Modbus address (the on-the-wire address, not 4xxxx notation). */
+  address: z.number().int().min(0).max(0xffff),
+  /** Value encoding. Must be `bool` for coil/discreteInput areas. */
+  dataType: z.enum(["bool", "uint16", "int16", "uint32", "int32", "float32"]),
+  /** Optional linear scale applied on read (value * scale) and inverse on write. */
+  scale: z.number().optional(),
+  /** Word order for 32-bit types. Defaults to big-endian word order. */
+  wordOrder: z.enum(["big", "little"]).optional(),
+  /**
+   * Whether a Modbus master may write this address.
+   *
+   * Defaults to FALSE: exposing a tag for polling must never imply that an
+   * unauthenticated master may actuate it. Writable addresses are opted into
+   * one at a time, and only take effect at all when the listener itself was
+   * started with writes enabled. A write to a non-writable address is rejected
+   * with exception 0x03 (Illegal Data Value).
+   */
+  writable: z.boolean().default(false),
+});
+
+export type RegisterMapEntry = z.infer<typeof registerMapEntrySchema>;
+
+/** Zod schema for a full per-site register map. */
+export const registerMapSchema = z.object({
+  siteId: z.string().min(1),
+  /** Modbus unit id this map answers for (default 1). */
+  unitId: z.number().int().min(0).max(255).default(1),
+  entries: z.array(registerMapEntrySchema),
+});
+
+export type RegisterMapConfig = z.infer<typeof registerMapSchema>;
+
+/** Number of 16-bit registers a data type occupies. */
+export function registerWidth(dataType: ModbusDataType): number {
+  switch (dataType) {
+    case "bool":
+      return 0; // bit area, not register-addressed
+    case "uint16":
+    case "int16":
+      return 1;
+    case "uint32":
+    case "int32":
+    case "float32":
+      return 2;
+  }
+}
+
+/** Areas that are bit-addressed rather than register-addressed. */
+function isBitArea(area: RegisterArea): boolean {
+  return area === "coil" || area === "discreteInput";
+}
+
+/**
+ * Indexed, validated view over a register map. Provides O(1) lookup of the
+ * entry owning a given (area, address) and range-coverage checks for a
+ * contiguous read/write. Construct via `RegisterMap.fromConfig`.
+ */
+export class RegisterMap {
+  /** key = `${area}:${address}` -> entry that *starts* there. */
+  private readonly byStart = new Map<string, RegisterMapEntry>();
+  /** key = `${area}:${address}` -> entry that *occupies* that address. */
+  private readonly byOccupied = new Map<string, RegisterMapEntry>();
+
+  readonly siteId: string;
+  readonly unitId: number;
+  readonly entries: RegisterMapEntry[];
+
+  private constructor(config: RegisterMapConfig) {
+    this.siteId = config.siteId;
+    this.unitId = config.unitId;
+    this.entries = config.entries;
+
+    for (const entry of config.entries) {
+      this.assertEntryConsistent(entry);
+      const startKey = RegisterMap.key(entry.area, entry.address);
+      if (this.byStart.has(startKey)) {
+        throw new Error(
+          `Duplicate Modbus entry at ${entry.area}:${entry.address}`,
+        );
+      }
+      this.byStart.set(startKey, entry);
+
+      const width = isBitArea(entry.area)
+        ? 1
+        : registerWidth(entry.dataType);
+      for (let i = 0; i < width; i++) {
+        const occKey = RegisterMap.key(entry.area, entry.address + i);
+        if (this.byOccupied.has(occKey)) {
+          throw new Error(
+            `Overlapping Modbus entries at ${entry.area}:${entry.address + i}`,
+          );
+        }
+        this.byOccupied.set(occKey, entry);
+      }
+    }
+  }
+
+  /** Validate raw config with Zod and build the indexed map. */
+  static fromConfig(raw: unknown): RegisterMap {
+    const config = registerMapSchema.parse(raw);
+    return new RegisterMap(config);
+  }
+
+  private assertEntryConsistent(entry: RegisterMapEntry): void {
+    if (isBitArea(entry.area) && entry.dataType !== "bool") {
+      throw new Error(
+        `Entry ${entry.area}:${entry.address} must use dataType "bool"`,
+      );
+    }
+    if (!isBitArea(entry.area) && entry.dataType === "bool") {
+      throw new Error(
+        `Entry ${entry.area}:${entry.address} (register area) cannot use dataType "bool"`,
+      );
+    }
+  }
+
+  private static key(area: RegisterArea, address: number): string {
+    return `${area}:${address}`;
+  }
+
+  /** The entry that starts exactly at (area, address), if any. */
+  entryStartingAt(
+    area: RegisterArea,
+    address: number,
+  ): RegisterMapEntry | undefined {
+    return this.byStart.get(RegisterMap.key(area, address));
+  }
+
+  /** The entry occupying (area, address), if any (covers multi-register types). */
+  entryOccupying(
+    area: RegisterArea,
+    address: number,
+  ): RegisterMapEntry | undefined {
+    return this.byOccupied.get(RegisterMap.key(area, address));
+  }
+
+  /** True if every address in [address, address+quantity) is mapped. */
+  rangeIsFullyMapped(
+    area: RegisterArea,
+    address: number,
+    quantity: number,
+  ): boolean {
+    for (let i = 0; i < quantity; i++) {
+      if (!this.byOccupied.has(RegisterMap.key(area, address + i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** All entries for an area, sorted by address. */
+  entriesForArea(area: RegisterArea): RegisterMapEntry[] {
+    return this.entries
+      .filter((e) => e.area === area)
+      .sort((a, b) => a.address - b.address);
+  }
+}
+
+// ── Value <-> register encoding ────────────────────────────────────────────
+
+/**
+ * Encode a JS numeric value into the register words it occupies, honouring the
+ * entry's data type, scale, and word order. Returns one or two 16-bit words.
+ */
+export function encodeValueToRegisters(
+  entry: RegisterMapEntry,
+  value: number,
+): number[] {
+  const scaled = entry.scale ? value / entry.scale : value;
+  const wordOrder: WordOrder = entry.wordOrder ?? "big";
+
+  switch (entry.dataType) {
+    case "uint16":
+      return [Math.round(scaled) & 0xffff];
+    case "int16": {
+      const buf = Buffer.alloc(2);
+      buf.writeInt16BE(clampInt(Math.round(scaled), -0x8000, 0x7fff), 0);
+      return [buf.readUInt16BE(0)];
+    }
+    case "uint32": {
+      const buf = Buffer.alloc(4);
+      buf.writeUInt32BE(Math.round(scaled) >>> 0, 0);
+      return splitWords(buf, wordOrder);
+    }
+    case "int32": {
+      const buf = Buffer.alloc(4);
+      buf.writeInt32BE(clampInt(Math.round(scaled), -0x80000000, 0x7fffffff), 0);
+      return splitWords(buf, wordOrder);
+    }
+    case "float32": {
+      const buf = Buffer.alloc(4);
+      buf.writeFloatBE(scaled, 0);
+      return splitWords(buf, wordOrder);
+    }
+    case "bool":
+      throw new Error("encodeValueToRegisters called on bool entry");
+  }
+}
+
+/**
+ * Decode the register words occupied by an entry back into a JS number,
+ * honouring data type, scale, and word order.
+ */
+export function decodeRegistersToValue(
+  entry: RegisterMapEntry,
+  words: number[],
+): number {
+  const wordOrder: WordOrder = entry.wordOrder ?? "big";
+  let raw: number;
+
+  switch (entry.dataType) {
+    case "uint16":
+      raw = words[0] & 0xffff;
+      break;
+    case "int16": {
+      const buf = Buffer.alloc(2);
+      buf.writeUInt16BE(words[0] & 0xffff, 0);
+      raw = buf.readInt16BE(0);
+      break;
+    }
+    case "uint32": {
+      const buf = joinWords(words, wordOrder);
+      raw = buf.readUInt32BE(0);
+      break;
+    }
+    case "int32": {
+      const buf = joinWords(words, wordOrder);
+      raw = buf.readInt32BE(0);
+      break;
+    }
+    case "float32": {
+      const buf = joinWords(words, wordOrder);
+      raw = buf.readFloatBE(0);
+      break;
+    }
+    case "bool":
+      throw new Error("decodeRegistersToValue called on bool entry");
+  }
+
+  return entry.scale ? raw * entry.scale : raw;
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/** Split a 4-byte buffer into two 16-bit words in the given word order. */
+function splitWords(buf: Buffer, wordOrder: WordOrder): number[] {
+  const hi = buf.readUInt16BE(0);
+  const lo = buf.readUInt16BE(2);
+  return wordOrder === "big" ? [hi, lo] : [lo, hi];
+}
+
+/** Join two 16-bit words into a 4-byte buffer in the given word order. */
+function joinWords(words: number[], wordOrder: WordOrder): Buffer {
+  const buf = Buffer.alloc(4);
+  const [hi, lo] = wordOrder === "big" ? [words[0], words[1]] : [words[1], words[0]];
+  buf.writeUInt16BE((hi ?? 0) & 0xffff, 0);
+  buf.writeUInt16BE((lo ?? 0) & 0xffff, 2);
+  return buf;
+}

--- a/server/protocols/modbus-server/server.ts
+++ b/server/protocols/modbus-server/server.ts
@@ -1,0 +1,358 @@
+/**
+ * Modbus TCP server — `net.Server` listener wiring.
+ *
+ * Issue #462: Modbus TCP Server Mode.
+ *
+ * Standard Modbus masters (pymodbus, legacy HMIs, integrators) connect over TCP
+ * and poll 0xSCADA tags. This module owns ONLY the transport concerns:
+ *   - listening on a configurable host/port (default 127.0.0.1:502),
+ *   - refusing connections from peers outside the allowlist, at accept time,
+ *   - capping the number of simultaneous masters,
+ *   - reassembling TCP byte streams into complete Modbus frames,
+ *   - delegating each frame to the pure handler layer,
+ *   - writing the response back.
+ *
+ * All protocol/data logic lives in `codec.ts`, `handlers.ts`, and the data
+ * model, so this file is intentionally thin. Note: binding to port 502 requires
+ * elevated privileges on most OSes; configure a high port (e.g. 1502) for
+ * unprivileged/dev runs via `MODBUS_SERVER_PORT`.
+ *
+ * SAFETY. Modbus TCP carries no authentication whatsoever — no credential, no
+ * handshake, no integrity check. This class therefore fails closed on both axes
+ * it can control:
+ *   - the default bind host is loopback, never 0.0.0.0, and there is no
+ *     "allow everyone" peer rule (see `peer-filter.ts`);
+ *   - write function codes are refused with exception 0x01 (Illegal Function)
+ *     unless `allowWrites` was explicitly turned on, and even then only entries
+ *     the register map marks `writable` can mutate a live tag.
+ */
+
+import net from "node:net";
+import {
+  decodeRequest,
+  encodeExceptionResponse,
+  ExceptionCode,
+  FunctionCode,
+  ModbusFrameError,
+} from "./codec";
+import type { ModbusDataModel } from "./data-model";
+import { processRequest } from "./handlers";
+import {
+  isPeerAllowed,
+  LOOPBACK_PEER_RULES,
+  parsePeerRules,
+  type PeerRule,
+} from "./peer-filter";
+import { log, logError, logWarn } from "../../logger";
+
+export interface ModbusServerConfig {
+  /** Bind host. Default 127.0.0.1 — exposing the listener is deliberate. */
+  host?: string;
+  /** Bind port. Default 502 (override for unprivileged runs). */
+  port?: number;
+  /**
+   * Modbus unit id this server answers for. Requests for a different unit id
+   * are still processed (single-server model); set for documentation/routing.
+   */
+  unitId?: number;
+  /**
+   * Peer IPs/CIDRs permitted to connect, enforced at accept time. Defaults to
+   * loopback only. `/0` wildcards are rejected — see `peer-filter.ts`.
+   */
+  allowedPeers?: readonly string[];
+  /** Hard cap on simultaneous master connections. Default 4. */
+  maxConnections?: number;
+  /** Max bytes buffered per connection before the connection is dropped. */
+  maxBufferBytes?: number;
+  /** Idle socket timeout in ms (0 disables). Default 60_000. */
+  socketTimeoutMs?: number;
+  /**
+   * Permit network clients to use Modbus write function codes.
+   *
+   * Defaults to false. This is a fail-closed capability gate, not client
+   * authentication; deployments must still supply an explicit network/access
+   * control policy before enabling it.
+   */
+  allowWrites?: boolean;
+}
+
+const DEFAULT_PORT = 502;
+/**
+ * Loopback, deliberately. Binding a protocol with no authentication to every
+ * interface must never be something a deployment gets by omission.
+ */
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_MAX_BUFFER = 64 * 1024;
+const DEFAULT_SOCKET_TIMEOUT = 60_000;
+const DEFAULT_MAX_CONNECTIONS = 4;
+const WRITE_FUNCTION_CODES = new Set<number>([
+  FunctionCode.WRITE_SINGLE_COIL,
+  FunctionCode.WRITE_SINGLE_REGISTER,
+  FunctionCode.WRITE_MULTIPLE_COILS,
+  FunctionCode.WRITE_MULTIPLE_REGISTERS,
+]);
+
+/**
+ * A running (or runnable) Modbus TCP server backed by a `ModbusDataModel`.
+ * The data model is injected so the same server class works against the live
+ * tag-store bridge in production and an in-memory model in tests.
+ */
+export class ModbusTcpServer {
+  private readonly server: net.Server;
+  private readonly host: string;
+  private readonly port: number;
+  private readonly maxBufferBytes: number;
+  private readonly socketTimeoutMs: number;
+  private readonly allowWrites: boolean;
+  private readonly maxConnections: number;
+  private readonly peerRules: PeerRule[];
+  private readonly sockets = new Set<net.Socket>();
+  private listening = false;
+  private rejectedConnections = 0;
+
+  /**
+   * @throws {PeerRuleError} if any allowlist entry is unusable. Construction
+   *   failing is intentional: there is no safe fallback for "the operator's
+   *   peer allowlist did not parse".
+   */
+  constructor(
+    private readonly model: ModbusDataModel,
+    config: ModbusServerConfig = {},
+  ) {
+    this.host = config.host ?? DEFAULT_HOST;
+    this.port = config.port ?? DEFAULT_PORT;
+    this.maxBufferBytes = config.maxBufferBytes ?? DEFAULT_MAX_BUFFER;
+    this.socketTimeoutMs = config.socketTimeoutMs ?? DEFAULT_SOCKET_TIMEOUT;
+    this.allowWrites = config.allowWrites ?? false;
+    this.maxConnections = config.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
+    this.peerRules = parsePeerRules(config.allowedPeers ?? LOOPBACK_PEER_RULES);
+    this.server = net.createServer((socket) => this.onConnection(socket));
+    this.server.on("error", (err) =>
+      logError(err, "Modbus TCP server socket error"),
+    );
+  }
+
+  /** Start listening. Resolves once the listen socket is bound. */
+  start(): Promise<void> {
+    if (this.listening) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const onError = (err: Error) => {
+        this.server.off("listening", onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        this.server.off("error", onError);
+        this.listening = true;
+        log(
+          `🔌 Modbus TCP server listening on ${this.host}:${this.port} ` +
+            `(writes ${this.allowWrites ? "ENABLED" : "disabled"}, ` +
+            `peers [${this.peerRules.map((r) => r.source).join(", ")}], ` +
+            `max ${this.maxConnections} connections)`,
+          "modbus-server",
+        );
+        resolve();
+      };
+      this.server.once("error", onError);
+      this.server.once("listening", onListening);
+      this.server.listen(this.port, this.host);
+    });
+  }
+
+  /** Stop listening and forcibly close all open connections. */
+  stop(): Promise<void> {
+    if (!this.listening) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      for (const socket of this.sockets) {
+        socket.destroy();
+      }
+      this.sockets.clear();
+      this.server.close(() => {
+        this.listening = false;
+        log("⏸️  Modbus TCP server stopped", "modbus-server");
+        resolve();
+      });
+    });
+  }
+
+  /** The actual bound address (useful in tests with port 0). */
+  address(): net.AddressInfo | null {
+    const addr = this.server.address();
+    return addr && typeof addr === "object" ? addr : null;
+  }
+
+  get isListening(): boolean {
+    return this.listening;
+  }
+
+  /** Whether write function codes are served on this listener. */
+  get writesAllowed(): boolean {
+    return this.allowWrites;
+  }
+
+  /** Current number of accepted, still-open master connections. */
+  get connectionCount(): number {
+    return this.sockets.size;
+  }
+
+  /** Connections refused since start (allowlist misses + cap overflow). */
+  get rejectedConnectionCount(): number {
+    return this.rejectedConnections;
+  }
+
+  /**
+   * Accept-time admission control, before a single protocol byte is read:
+   * unauthorised peers and connections beyond the cap are logged and dropped.
+   * Returns false when the socket has been destroyed.
+   */
+  private admit(socket: net.Socket): boolean {
+    const peer = socket.remoteAddress;
+
+    if (!isPeerAllowed(peer, this.peerRules)) {
+      this.rejectedConnections++;
+      logWarn(
+        `Modbus TCP connection refused: peer ${peer ?? "<unknown>"} is not in ` +
+          `the allowlist [${this.peerRules.map((r) => r.source).join(", ")}]`,
+        "modbus-server",
+      );
+      socket.destroy();
+      return false;
+    }
+
+    if (this.sockets.size >= this.maxConnections) {
+      this.rejectedConnections++;
+      logWarn(
+        `Modbus TCP connection refused: peer ${peer} exceeds the ` +
+          `${this.maxConnections}-connection limit`,
+        "modbus-server",
+      );
+      socket.destroy();
+      return false;
+    }
+
+    return true;
+  }
+
+  private onConnection(socket: net.Socket): void {
+    if (!this.admit(socket)) return;
+
+    this.sockets.add(socket);
+    if (this.socketTimeoutMs > 0) {
+      socket.setTimeout(this.socketTimeoutMs);
+    }
+    log(
+      `Modbus client connected: ${socket.remoteAddress}:${socket.remotePort}`,
+      "modbus-server",
+    );
+
+    // Per-connection receive buffer; TCP may split or coalesce frames.
+    let buffer: Buffer = Buffer.alloc(0);
+    // Serialize draining so overlapping `data` events don't reorder responses
+    // or race on `buffer`.
+    let draining: Promise<void> = Promise.resolve();
+
+    socket.on("data", (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+
+      if (buffer.length > this.maxBufferBytes) {
+        logWarn(
+          `Modbus client ${socket.remoteAddress} exceeded buffer limit; closing`,
+          "modbus-server",
+        );
+        socket.destroy();
+        return;
+      }
+
+      // Drain as many complete frames as the buffer currently holds, chaining
+      // onto any in-flight drain so frames are answered strictly in order.
+      //
+      // The buffer is taken and cleared before the (awaiting) drain, and the
+      // unconsumed remainder is put back in FRONT of whatever arrived while it
+      // ran. Assigning the drain's return value straight back to `buffer` would
+      // discard every byte a pipelining master sent during the await — the
+      // second request would be silently swallowed and never answered.
+      draining = draining.then(async () => {
+        const pending = buffer;
+        buffer = Buffer.alloc(0);
+        const remainder = await this.drain(socket, pending);
+        buffer = remainder.length > 0 ? Buffer.concat([remainder, buffer]) : buffer;
+      });
+    });
+
+    socket.on("timeout", () => {
+      log(`Modbus client idle timeout: ${socket.remoteAddress}`, "modbus-server");
+      socket.destroy();
+    });
+
+    socket.on("error", (err) => {
+      logWarn(`Modbus client socket error: ${err.message}`, "modbus-server");
+    });
+
+    socket.on("close", () => {
+      this.sockets.delete(socket);
+      log(`Modbus client disconnected: ${socket.remoteAddress}`, "modbus-server");
+    });
+  }
+
+  /**
+   * Pull complete frames out of `buffer` and respond to each, returning the
+   * unconsumed remainder. Frames are processed sequentially to preserve
+   * response ordering and to avoid interleaving model writes from one client.
+   */
+  private async drain(socket: net.Socket, buffer: Buffer): Promise<Buffer> {
+    while (buffer.length > 0 && !socket.destroyed) {
+      let decoded;
+      try {
+        decoded = decodeRequest(buffer);
+      } catch (err) {
+        if (err instanceof ModbusFrameError) {
+          // Unrecoverable framing error — drop the connection.
+          logWarn(
+            `Malformed Modbus frame from ${socket.remoteAddress}: ${err.message}`,
+            "modbus-server",
+          );
+          socket.destroy();
+          return Buffer.alloc(0);
+        }
+        throw err;
+      }
+
+      if (!decoded) {
+        break; // incomplete frame — wait for more bytes
+      }
+
+      buffer = buffer.subarray(decoded.bytesConsumed);
+
+      const writeRefused =
+        !this.allowWrites &&
+        WRITE_FUNCTION_CODES.has(decoded.request.functionCode);
+      if (writeRefused) {
+        // A read-only listener must not silently accept a write. Answering with
+        // 0x01 Illegal Function is the spec-correct way to tell the master the
+        // function is not implemented here.
+        logWarn(
+          `Modbus write FC 0x${decoded.request.functionCode.toString(16)} from ` +
+            `${socket.remoteAddress} refused: this listener is read-only ` +
+            "(set MODBUS_SERVER_ALLOW_WRITES=true to serve writes)",
+          "modbus-server",
+        );
+      }
+
+      try {
+        const response = writeRefused
+          ? encodeExceptionResponse(
+              decoded.request.header,
+              decoded.request.functionCode,
+              ExceptionCode.ILLEGAL_FUNCTION,
+            )
+          : await processRequest(decoded.request, this.model);
+        if (!socket.destroyed) {
+          socket.write(response);
+        }
+      } catch (err) {
+        // processRequest never throws, but guard the socket write regardless.
+        logError(err, "Modbus request processing failed");
+      }
+    }
+    return buffer;
+  }
+}

--- a/server/protocols/modbus-server/tag-store-bridge.ts
+++ b/server/protocols/modbus-server/tag-store-bridge.ts
@@ -1,0 +1,297 @@
+/**
+ * Tag-store bridge — binds a per-site register map to the live tag store so
+ * Modbus reads observe live tag values and Modbus writes propagate back.
+ *
+ * Issue #462: Modbus TCP Server Mode.
+ *
+ * This is the integration seam between the protocol layer (which only knows the
+ * `ModbusDataModel` interface) and 0xSCADA's live tag store. To keep the bridge
+ * unit-testable without Redis, the underlying store is abstracted behind the
+ * minimal `TagStorePort`. `createTagStorePort()` adapts the real `tagCache`
+ * (server/services/cache/tag-cache.ts) to that port.
+ */
+
+import {
+  DataModelError,
+  type ModbusDataModel,
+  type RegisterArea,
+} from "./data-model";
+import {
+  decodeRegistersToValue,
+  encodeValueToRegisters,
+  registerWidth,
+  type RegisterMap,
+  type RegisterMapEntry,
+} from "./register-map";
+
+/**
+ * Minimal async key/value port over the live tag store. Values are the raw JS
+ * tag values (number | boolean). Implementations may be Redis-backed or
+ * in-memory. Reads return `undefined` for an unknown tag.
+ */
+export interface TagStorePort {
+  read(tagId: string): Promise<number | boolean | undefined>;
+  write(tagId: string, value: number | boolean): Promise<void>;
+}
+
+/** Simple in-memory `TagStorePort` for tests and offline/dev usage. */
+export class InMemoryTagStore implements TagStorePort {
+  private values = new Map<string, number | boolean>();
+
+  async read(tagId: string): Promise<number | boolean | undefined> {
+    return this.values.get(tagId);
+  }
+
+  async write(tagId: string, value: number | boolean): Promise<void> {
+    this.values.set(tagId, value);
+  }
+
+  /** Test helper to seed a value directly. */
+  seed(tagId: string, value: number | boolean): void {
+    this.values.set(tagId, value);
+  }
+
+  /** Test helper to read back the current value. */
+  peek(tagId: string): number | boolean | undefined {
+    return this.values.get(tagId);
+  }
+}
+
+/**
+ * A `ModbusDataModel` whose addresses are resolved through a `RegisterMap` and
+ * whose reads/writes hit a `TagStorePort`. Unmapped addresses raise
+ * `ILLEGAL_DATA_ADDRESS`; writes to read-only entries raise a dedicated error
+ * that the handler maps to `ILLEGAL_DATA_VALUE`.
+ */
+export class TagStoreDataModel implements ModbusDataModel {
+  constructor(
+    private readonly map: RegisterMap,
+    private readonly store: TagStorePort,
+  ) {}
+
+  // ── Reads ──────────────────────────────────────────────────────────────────
+
+  async readCoils(address: number, quantity: number): Promise<boolean[]> {
+    return this.readBitArea("coil", address, quantity);
+  }
+
+  async readDiscreteInputs(
+    address: number,
+    quantity: number,
+  ): Promise<boolean[]> {
+    return this.readBitArea("discreteInput", address, quantity);
+  }
+
+  async readHoldingRegisters(
+    address: number,
+    quantity: number,
+  ): Promise<number[]> {
+    return this.readRegisterArea("holdingRegister", address, quantity);
+  }
+
+  async readInputRegisters(
+    address: number,
+    quantity: number,
+  ): Promise<number[]> {
+    return this.readRegisterArea("inputRegister", address, quantity);
+  }
+
+  private async readBitArea(
+    area: RegisterArea,
+    address: number,
+    quantity: number,
+  ): Promise<boolean[]> {
+    if (!this.map.rangeIsFullyMapped(area, address, quantity)) {
+      throw new DataModelError(
+        "ILLEGAL_DATA_ADDRESS",
+        `${area} read [${address}, ${address + quantity}) contains unmapped address`,
+      );
+    }
+    const bits: boolean[] = [];
+    for (let i = 0; i < quantity; i++) {
+      const entry = this.map.entryStartingAt(area, address + i)!;
+      const value = await this.store.read(entry.tagId);
+      bits.push(toBool(value));
+    }
+    return bits;
+  }
+
+  private async readRegisterArea(
+    area: RegisterArea,
+    address: number,
+    quantity: number,
+  ): Promise<number[]> {
+    if (!this.map.rangeIsFullyMapped(area, address, quantity)) {
+      throw new DataModelError(
+        "ILLEGAL_DATA_ADDRESS",
+        `${area} read [${address}, ${address + quantity}) contains unmapped address`,
+      );
+    }
+
+    // Cache decoded words per entry so multi-register entries are only read
+    // from the store once even when the request spans several of their words.
+    const wordCache = new Map<string, number[]>();
+    const out: number[] = [];
+
+    for (let i = 0; i < quantity; i++) {
+      const addr = address + i;
+      const entry = this.map.entryOccupying(area, addr)!;
+      const words = await this.resolveEntryWords(entry, wordCache);
+      const offset = addr - entry.address;
+      out.push(words[offset] ?? 0);
+    }
+    return out;
+  }
+
+  private async resolveEntryWords(
+    entry: RegisterMapEntry,
+    cache: Map<string, number[]>,
+  ): Promise<number[]> {
+    const cacheKey = `${entry.area}:${entry.address}`;
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const raw = await this.store.read(entry.tagId);
+    const numeric = toNumber(raw);
+    const words = encodeValueToRegisters(entry, numeric);
+    cache.set(cacheKey, words);
+    return words;
+  }
+
+  // ── Writes ──────────────────────────────────────────────────────────────────
+
+  async writeCoils(address: number, values: boolean[]): Promise<void> {
+    if (!this.map.rangeIsFullyMapped("coil", address, values.length)) {
+      throw new DataModelError(
+        "ILLEGAL_DATA_ADDRESS",
+        `coil write [${address}, ${address + values.length}) contains unmapped address`,
+      );
+    }
+    // Validate the whole request before mutating anything: a multi-coil write
+    // that touches one non-writable address must be rejected outright, not
+    // applied halfway and then refused.
+    const plan: Array<{ tagId: string; value: boolean }> = [];
+    for (let i = 0; i < values.length; i++) {
+      const entry = this.map.entryStartingAt("coil", address + i)!;
+      this.assertWritable(entry);
+      plan.push({ tagId: entry.tagId, value: values[i] });
+    }
+    for (const item of plan) {
+      await this.store.write(item.tagId, item.value);
+    }
+  }
+
+  async writeHoldingRegisters(
+    address: number,
+    values: number[],
+  ): Promise<void> {
+    if (
+      !this.map.rangeIsFullyMapped("holdingRegister", address, values.length)
+    ) {
+      throw new DataModelError(
+        "ILLEGAL_DATA_ADDRESS",
+        `holdingRegister write [${address}, ${address + values.length}) contains unmapped address`,
+      );
+    }
+
+    // Group incoming words by the entry they belong to, then decode + write
+    // each entry exactly once (so a 32-bit value is written atomically). A
+    // partial write that does not cover all words of a multi-register entry is
+    // rejected as an illegal data value.
+    // Plan first, commit second — the request is rejected as a whole if any
+    // part of it is misaligned, truncated, or not writable.
+    const plan: Array<{ tagId: string; value: number }> = [];
+    const start = address;
+    let i = 0;
+    while (i < values.length) {
+      const addr = start + i;
+      const entry = this.map.entryOccupying("holdingRegister", addr)!;
+      if (addr !== entry.address) {
+        // Write started mid-entry — not aligned to the value boundary.
+        throw new DataModelError(
+          "ILLEGAL_DATA_VALUE",
+          `holdingRegister write not aligned to entry boundary at ${addr}`,
+        );
+      }
+      const width = registerWidth(entry.dataType);
+      if (i + width > values.length) {
+        throw new DataModelError(
+          "ILLEGAL_DATA_VALUE",
+          `holdingRegister write truncates multi-register entry at ${addr}`,
+        );
+      }
+      this.assertWritable(entry);
+      const words = values.slice(i, i + width);
+      plan.push({ tagId: entry.tagId, value: decodeRegistersToValue(entry, words) });
+      i += width;
+    }
+    for (const item of plan) {
+      await this.store.write(item.tagId, item.value);
+    }
+  }
+
+  /**
+   * Writes are scoped to addresses the register map explicitly opted in.
+   *
+   * Being mapped only makes a tag readable. Actuating plant output from an
+   * unauthenticated protocol requires the site administrator to have marked
+   * that specific address `writable`, so the blast radius of enabling writes on
+   * a listener is exactly the set of addresses somebody deliberately listed.
+   */
+  private assertWritable(entry: RegisterMapEntry): void {
+    if (!entry.writable) {
+      throw new DataModelError(
+        "ILLEGAL_DATA_VALUE",
+        `Modbus ${entry.area}:${entry.address} (tag ${entry.tagId}) is not writable`,
+      );
+    }
+  }
+}
+
+function toBool(value: number | boolean | undefined): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  return false;
+}
+
+function toNumber(value: number | boolean | undefined): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "boolean") return value ? 1 : 0;
+  return 0;
+}
+
+// ── Real tag-store adapter ──────────────────────────────────────────────────
+
+/**
+ * Adapt the live `tagCache` (server/services/cache/tag-cache.ts) to a
+ * `TagStorePort` for a given site. Reads pull the latest cached `TagValue`;
+ * writes publish a new `TagValue` with GOOD quality and current timestamp.
+ *
+ * The import is dynamic so this module (and the pure protocol layer that
+ * depends on it transitively) can be unit-tested without pulling in the Redis
+ * cache stack.
+ */
+export function createTagStorePort(siteId: string): TagStorePort {
+  return {
+    async read(tagId: string): Promise<number | boolean | undefined> {
+      const { tagCache } = await import("../../services/cache/tag-cache.js");
+      const tag = await tagCache.getTagValue(siteId, tagId);
+      if (!tag) return undefined;
+      if (typeof tag.value === "string") {
+        const n = Number(tag.value);
+        return Number.isFinite(n) ? n : undefined;
+      }
+      return tag.value;
+    },
+    async write(tagId: string, value: number | boolean): Promise<void> {
+      const { tagCache } = await import("../../services/cache/tag-cache.js");
+      await tagCache.setTagValue(siteId, {
+        tagId,
+        value,
+        quality: "GOOD",
+        timestamp: new Date(),
+      });
+    },
+  };
+}

--- a/server/services/vendors/modbus-utils.ts
+++ b/server/services/vendors/modbus-utils.ts
@@ -1,34 +1,40 @@
 /**
  * Shared Modbus TCP Utilities
  * Issue #370: Extract duplicated Modbus framing from vendor adapters
+ *
+ * The function-code and exception-code constants now live in the shared,
+ * protocol-agnostic module `@shared/protocols/modbus-constants` so they cannot
+ * drift from the Modbus TCP server's copy (issue #462). They are re-exported
+ * here under their original names — including the legacy "slave" exception
+ * names — so existing vendor-adapter imports keep working unchanged.
  */
 
-/** Standard Modbus function codes */
-export const MODBUS_FC = {
-  READ_COILS: 0x01,
-  READ_DISCRETE_INPUTS: 0x02,
-  READ_HOLDING_REGISTERS: 0x03,
-  READ_INPUT_REGISTERS: 0x04,
-  WRITE_SINGLE_COIL: 0x05,
-  WRITE_SINGLE_REGISTER: 0x06,
-  WRITE_MULTIPLE_COILS: 0x0F,
-  WRITE_MULTIPLE_REGISTERS: 0x10,
-  READ_EXCEPTION_STATUS: 0x07,
-  DIAGNOSTICS: 0x08,
-  READ_DEVICE_IDENTIFICATION: 0x2B,
-} as const;
+import {
+  MODBUS_FUNCTION_CODES,
+  MODBUS_EXCEPTION_CODES,
+} from '@shared/protocols/modbus-constants';
 
-/** Modbus exception codes */
+/**
+ * Standard Modbus function codes.
+ * Re-exported alias of the shared {@link MODBUS_FUNCTION_CODES}.
+ */
+export const MODBUS_FC = MODBUS_FUNCTION_CODES;
+
+/**
+ * Modbus exception codes, using the legacy "slave" naming the vendor adapters
+ * were built against. Values come from the shared {@link MODBUS_EXCEPTION_CODES}
+ * (where 0x04/0x06 use the modern "server" names).
+ */
 export const MODBUS_EXCEPTION = {
-  ILLEGAL_FUNCTION: 0x01,
-  ILLEGAL_DATA_ADDRESS: 0x02,
-  ILLEGAL_DATA_VALUE: 0x03,
-  SLAVE_DEVICE_FAILURE: 0x04,
-  ACKNOWLEDGE: 0x05,
-  SLAVE_DEVICE_BUSY: 0x06,
-  MEMORY_PARITY_ERROR: 0x08,
-  GATEWAY_PATH_UNAVAILABLE: 0x0A,
-  GATEWAY_TARGET_FAILED: 0x0B,
+  ILLEGAL_FUNCTION: MODBUS_EXCEPTION_CODES.ILLEGAL_FUNCTION,
+  ILLEGAL_DATA_ADDRESS: MODBUS_EXCEPTION_CODES.ILLEGAL_DATA_ADDRESS,
+  ILLEGAL_DATA_VALUE: MODBUS_EXCEPTION_CODES.ILLEGAL_DATA_VALUE,
+  SLAVE_DEVICE_FAILURE: MODBUS_EXCEPTION_CODES.SERVER_DEVICE_FAILURE,
+  ACKNOWLEDGE: MODBUS_EXCEPTION_CODES.ACKNOWLEDGE,
+  SLAVE_DEVICE_BUSY: MODBUS_EXCEPTION_CODES.SERVER_DEVICE_BUSY,
+  MEMORY_PARITY_ERROR: MODBUS_EXCEPTION_CODES.MEMORY_PARITY_ERROR,
+  GATEWAY_PATH_UNAVAILABLE: MODBUS_EXCEPTION_CODES.GATEWAY_PATH_UNAVAILABLE,
+  GATEWAY_TARGET_FAILED: MODBUS_EXCEPTION_CODES.GATEWAY_TARGET_FAILED,
 } as const;
 
 let modbusTransactionId = 0;

--- a/shared/protocols/__tests__/modbus-constants.test.ts
+++ b/shared/protocols/__tests__/modbus-constants.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the shared Modbus constants (consolidation of issues #370 + #462).
+ *
+ * Two responsibilities:
+ *   1. Pin the canonical numeric values to the Modbus spec.
+ *   2. Act as a drift guard: assert the vendor-side re-exports (`MODBUS_FC` /
+ *      `MODBUS_EXCEPTION`) and the Modbus-server codec re-exports
+ *      (`FunctionCode` / `ExceptionCode`) all resolve to the same values as the
+ *      shared source of truth. If anyone re-introduces a parallel definition
+ *      with a different value, this fails.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  MODBUS_EXCEPTION_CODES,
+  MODBUS_FUNCTION_CODES,
+} from "../modbus-constants";
+import {
+  MODBUS_EXCEPTION,
+  MODBUS_FC,
+} from "../../../server/services/vendors/modbus-utils";
+import {
+  ExceptionCode,
+  FunctionCode,
+} from "../../../server/protocols/modbus-server/codec";
+
+describe("MODBUS_FUNCTION_CODES (canonical)", () => {
+  it("matches the Modbus spec values", () => {
+    expect(MODBUS_FUNCTION_CODES).toEqual({
+      READ_COILS: 0x01,
+      READ_DISCRETE_INPUTS: 0x02,
+      READ_HOLDING_REGISTERS: 0x03,
+      READ_INPUT_REGISTERS: 0x04,
+      WRITE_SINGLE_COIL: 0x05,
+      WRITE_SINGLE_REGISTER: 0x06,
+      READ_EXCEPTION_STATUS: 0x07,
+      DIAGNOSTICS: 0x08,
+      WRITE_MULTIPLE_COILS: 0x0f,
+      WRITE_MULTIPLE_REGISTERS: 0x10,
+      READ_DEVICE_IDENTIFICATION: 0x2b,
+    });
+  });
+});
+
+describe("MODBUS_EXCEPTION_CODES (canonical)", () => {
+  it("matches the Modbus spec values", () => {
+    expect(MODBUS_EXCEPTION_CODES).toEqual({
+      ILLEGAL_FUNCTION: 0x01,
+      ILLEGAL_DATA_ADDRESS: 0x02,
+      ILLEGAL_DATA_VALUE: 0x03,
+      SERVER_DEVICE_FAILURE: 0x04,
+      ACKNOWLEDGE: 0x05,
+      SERVER_DEVICE_BUSY: 0x06,
+      MEMORY_PARITY_ERROR: 0x08,
+      GATEWAY_PATH_UNAVAILABLE: 0x0a,
+      GATEWAY_TARGET_FAILED: 0x0b,
+    });
+  });
+});
+
+describe("vendor MODBUS_FC re-export stays in sync with the canonical source", () => {
+  it("is an exact alias of MODBUS_FUNCTION_CODES", () => {
+    // Same values, same keys — the vendor side adds nothing of its own here.
+    expect(MODBUS_FC).toEqual(MODBUS_FUNCTION_CODES);
+  });
+});
+
+describe("vendor MODBUS_EXCEPTION re-export stays in sync with the canonical source", () => {
+  it("keeps the legacy slave names but the canonical values", () => {
+    // The two renamed keys map to the modern "server" canonical values...
+    expect(MODBUS_EXCEPTION.SLAVE_DEVICE_FAILURE).toBe(
+      MODBUS_EXCEPTION_CODES.SERVER_DEVICE_FAILURE,
+    );
+    expect(MODBUS_EXCEPTION.SLAVE_DEVICE_BUSY).toBe(
+      MODBUS_EXCEPTION_CODES.SERVER_DEVICE_BUSY,
+    );
+    // ...and every shared (non-renamed) key carries the canonical value.
+    for (const key of [
+      "ILLEGAL_FUNCTION",
+      "ILLEGAL_DATA_ADDRESS",
+      "ILLEGAL_DATA_VALUE",
+      "ACKNOWLEDGE",
+      "MEMORY_PARITY_ERROR",
+      "GATEWAY_PATH_UNAVAILABLE",
+      "GATEWAY_TARGET_FAILED",
+    ] as const) {
+      expect(MODBUS_EXCEPTION[key]).toBe(MODBUS_EXCEPTION_CODES[key]);
+    }
+  });
+});
+
+describe("Modbus-server codec re-export stays in sync with the canonical source", () => {
+  it("FunctionCode is the supported subset of MODBUS_FUNCTION_CODES", () => {
+    for (const [key, value] of Object.entries(FunctionCode)) {
+      expect(value).toBe(
+        MODBUS_FUNCTION_CODES[key as keyof typeof MODBUS_FUNCTION_CODES],
+      );
+      // ...and equal to the vendor-side constant of the same name.
+      expect(value).toBe(MODBUS_FC[key as keyof typeof MODBUS_FC]);
+    }
+  });
+
+  it("ExceptionCode is the subset of MODBUS_EXCEPTION_CODES the server returns", () => {
+    for (const [key, value] of Object.entries(ExceptionCode)) {
+      expect(value).toBe(
+        MODBUS_EXCEPTION_CODES[key as keyof typeof MODBUS_EXCEPTION_CODES],
+      );
+    }
+    // The renamed exception (server vs slave) must agree across both modules.
+    expect(ExceptionCode.SERVER_DEVICE_FAILURE).toBe(
+      MODBUS_EXCEPTION.SLAVE_DEVICE_FAILURE,
+    );
+  });
+});

--- a/shared/protocols/modbus-constants.ts
+++ b/shared/protocols/modbus-constants.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared Modbus protocol constants — the single source of truth for Modbus
+ * function codes and exception codes across 0xSCADA.
+ *
+ * Historically these constants were defined twice:
+ *   - `server/services/vendors/modbus-utils.ts` (`MODBUS_FC`, `MODBUS_EXCEPTION`)
+ *     for the client-side vendor adapters (issue #370).
+ *   - `server/protocols/modbus-server/codec.ts` (`FunctionCode`, `ExceptionCode`)
+ *     for the Modbus TCP server (issue #462).
+ *
+ * Both now re-export from this module so the numeric values can never drift
+ * apart. Those modules keep their original export names (and the legacy
+ * "slave" naming on the vendor side) for backwards compatibility — see the
+ * re-exports there.
+ *
+ * Values follow the "MODBUS Application Protocol Specification V1.1b3".
+ */
+
+/**
+ * Standard (public-function) Modbus function codes.
+ *
+ * The Modbus-server codec supports the first eight; the vendor adapters use the
+ * full set. Vendor-proprietary codes (e.g. Schneider extensions) live with
+ * their adapter, not here.
+ */
+export const MODBUS_FUNCTION_CODES = {
+  READ_COILS: 0x01,
+  READ_DISCRETE_INPUTS: 0x02,
+  READ_HOLDING_REGISTERS: 0x03,
+  READ_INPUT_REGISTERS: 0x04,
+  WRITE_SINGLE_COIL: 0x05,
+  WRITE_SINGLE_REGISTER: 0x06,
+  READ_EXCEPTION_STATUS: 0x07,
+  DIAGNOSTICS: 0x08,
+  WRITE_MULTIPLE_COILS: 0x0f,
+  WRITE_MULTIPLE_REGISTERS: 0x10,
+  READ_DEVICE_IDENTIFICATION: 0x2b,
+} as const;
+
+/** A standard Modbus function code value. */
+export type ModbusFunctionCode =
+  (typeof MODBUS_FUNCTION_CODES)[keyof typeof MODBUS_FUNCTION_CODES];
+
+/**
+ * Modbus exception codes (returned with the function-code high bit set).
+ *
+ * Codes 0x04 and 0x06 are named "server" here per the current spec; the vendor
+ * adapters historically call them "slave" and re-export them under those legacy
+ * names. Both names map to the same numeric values.
+ */
+export const MODBUS_EXCEPTION_CODES = {
+  ILLEGAL_FUNCTION: 0x01,
+  ILLEGAL_DATA_ADDRESS: 0x02,
+  ILLEGAL_DATA_VALUE: 0x03,
+  SERVER_DEVICE_FAILURE: 0x04,
+  ACKNOWLEDGE: 0x05,
+  SERVER_DEVICE_BUSY: 0x06,
+  MEMORY_PARITY_ERROR: 0x08,
+  GATEWAY_PATH_UNAVAILABLE: 0x0a,
+  GATEWAY_TARGET_FAILED: 0x0b,
+} as const;
+
+/** A Modbus exception code value. */
+export type ModbusExceptionCode =
+  (typeof MODBUS_EXCEPTION_CODES)[keyof typeof MODBUS_EXCEPTION_CODES];

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -612,6 +612,37 @@ export const validatorStateWatermarks = pgTable("validator_state_watermarks", {
   nodeKeyIdx: uniqueIndex("idx_validator_state_watermarks_node_key").on(table.nodeId, table.stateKey),
 }));
 
+// ─── Modbus Register Map (Issue #462: Modbus TCP Server Mode) ────────────────
+//
+// Per-site mapping of 0xSCADA tags to Modbus addresses so standard Modbus
+// masters can poll 0xSCADA. One row per (site, area, address). `area` is one of
+// coil | discreteInput | holdingRegister | inputRegister; `dataType` is one of
+// bool | uint16 | int16 | uint32 | int32 | float32 (see
+// server/protocols/modbus-server/register-map.ts for the runtime schema/codec).
+//
+// `writable` defaults to FALSE. Modbus TCP has no authentication, so mapping a
+// tag only ever makes it readable; permitting a master to actuate it is a
+// per-address opt-in that additionally requires the listener to have been
+// started with MODBUS_SERVER_ALLOW_WRITES=true.
+
+export const modbusRegisterMap = pgTable("modbus_register_map", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  siteId: varchar("site_id", { length: 64 }).notNull().references(() => sites.id, { onDelete: "cascade" }),
+  unitId: integer("unit_id").default(1).notNull(),
+  area: varchar("area", { length: 32 }).notNull(),
+  address: integer("address").notNull(),
+  tagId: varchar("tag_id", { length: 255 }).notNull(),
+  dataType: varchar("data_type", { length: 16 }).notNull(),
+  scale: real("scale"),
+  wordOrder: varchar("word_order", { length: 8 }),
+  writable: boolean("writable").default(false).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  siteAreaAddressIdx: uniqueIndex("idx_modbus_register_map_site_area_address").on(table.siteId, table.unitId, table.area, table.address),
+  siteIdIdx: index("idx_modbus_register_map_site_id").on(table.siteId),
+}));
+
 // ─── Schema Exports ──────────────────────────────────────────────────────────
 
 // Insert schemas for validation
@@ -634,6 +665,7 @@ export const insertControllerSchema = createInsertSchema(controllers);
 export const insertValidatorNodeSchema = createInsertSchema(validatorNodes);
 export const insertValidatorPubkeySchema = createInsertSchema(validatorPubkeys);
 export const insertValidatorStateWatermarkSchema = createInsertSchema(validatorStateWatermarks);
+export const insertModbusRegisterMapSchema = createInsertSchema(modbusRegisterMap);
 
 // Type exports
 export type Site = typeof sites.$inferSelect;
@@ -674,3 +706,5 @@ export type ValidatorStateWatermark = typeof validatorStateWatermarks.$inferSele
 export type InsertValidatorNode = typeof validatorNodes.$inferInsert;
 export type InsertValidatorPubkey = typeof validatorPubkeys.$inferInsert;
 export type InsertValidatorStateWatermark = typeof validatorStateWatermarks.$inferInsert;
+export type ModbusRegisterMapRow = typeof modbusRegisterMap.$inferSelect;
+export type InsertModbusRegisterMapRow = typeof modbusRegisterMap.$inferInsert;


### PR DESCRIPTION
> Supersedes the stale draft #523, which was opened against a `main` that has since moved 73 commits and is now conflicting. This branch is built on current `main` and fixes the defect that draft left open.

Closes #462.

## What the review said

> "the Modbus TCP server engine is genuinely correct (MBAP framing, all 8 function codes, exception responses) but it is never wired into the server — a dead library. When enabled per the docs it binds 0.0.0.0 with no auth and its writes mutate live tags. Real core, not a shipped/gated feature."

The codec/handler/framing engine is left alone. This PR fixes how it is exposed.

## The honest part first

**Modbus TCP has no authentication.** No credential, no handshake, no integrity protection on the wire. Any peer that can complete a TCP connection is, protocol-wise, a fully privileged master. Nothing here changes that and nothing here pretends to. What 0xSCADA can do is refuse to be exposed by accident and compensate at the deployment boundary. The code, the docs and `.env.example` all say so in those words.

## Secure defaults

| Control | Default | Opens via |
|---|---|---|
| Listener exists at all | **off** | `MODBUS_SERVER_ENABLED=true` (exactly `"true"`) |
| Bind address | **`127.0.0.1`** | `MODBUS_SERVER_BIND_HOST` |
| Peer allowlist (accept time) | **loopback only** | `MODBUS_SERVER_ALLOWED_PEERS` — *mandatory* once the bind is routable |
| Simultaneous masters | **4** | `MODBUS_SERVER_MAX_CONNECTIONS` |
| Write FCs served | **refused with 0x01** | `MODBUS_SERVER_ALLOW_WRITES=true` |
| A given address writable | **not writable** | `modbus_register_map.writable = true` |

New `peer-filter.ts` (pure, no I/O) parses and matches IPv4, IPv6, and IPv4-mapped IPv6 — the form a dual-stack accept reports for an IPv4 client, so a `10.0.0.0/8` rule cannot be dodged by family confusion. `ModbusTcpServer.admit()` runs the allowlist and the connection cap at accept time, before a `data` listener is attached and before a single protocol byte is read; refusals are counted, logged and the socket destroyed. A `/0` wildcard rule is **rejected**: an allowlist that admits everyone is not an allowlist, least of all for a protocol that cannot authenticate the peers it would admit. A non-loopback bind with no allowlist is likewise rejected, before any socket is created.

## Writes fail closed — twice

1. **Listener level.** FC05/06/15/16 return exception `0x01 Illegal Function` unless writes were separately opted into. Enabling the listener is not enough.
2. **Address level.** Register-map entries carry `writable`, defaulting to **false**. (The rejected slice had `readOnly`, optional and defaulting to *writable* — any mapped tag was actuatable.) Mapping a tag makes it readable; actuation is a per-address opt-in, and a write to a non-writable address is refused with `0x03` even on a write-enabled listener.

Multi-address writes are planned in full and only then committed, so a range containing one non-writable address is rejected outright rather than applied halfway.

## Wiring — it is no longer a dead library

- `config.ts` — Zod-validated deployment config. Invalid values raise `ModbusServerConfigError`; no socket is bound. Blank values in the `.env` template read as unset rather than as failures.
- `register-map-store.ts` — loads the site's map from `modbus_register_map`. Refuses an empty map, an invalid row, a read failure, and the SQLite dev fallback (its Drizzle shim resolves selects to `[]`, which would silently serve an empty map). The table is PostgreSQL-only.
- `startModbusServer()` — called from `server/index.ts` in the `listen` callback next to `startSparkplugBridge()`, matching main's existing gating convention. Returns `null` having done nothing unless enabled. Any failure is logged and leaves the process **with no Modbus listener** — there is no fallback that binds a permissive socket. Enabling writes, and binding non-loopback, each log a `warn` at startup naming exactly what was exposed and how many addresses are writable.

## Transport correctness

The per-connection receive buffer is now snapshot-and-cleared before each drain, with the unconsumed remainder pushed back in front of anything that arrived during it. The earlier form assigned the drain's return value straight back over the buffer, which discarded every byte a **pipelining master** sent while the previous request was still awaiting the data model — the second request was silently swallowed and never answered. That is invisible to a test whose data model resolves in a microtask, so the regression test uses a model with real wall-clock latency, the shape of the live tag store (`await import(...)` + a Redis round-trip).

## Rebase / migration

- `shared/schema.ts` conflict resolved by keeping **both** sides — main's blueprint-persistence tables and this slice's `modbus_register_map`. The diff is purely additive.
- `migrations/meta/_journal.json` rebuilt so main's `0001`, `0002`, `0003_blueprint_persistence`, `0006_blueprint_instance_identity` all survive at their original idx, with `0007_modbus_register_map` appended at idx 4. Journal parses; idx sequence is 0,1,2,3,4. `0007` was a free slot on main.
- Migration column `read_only` renamed to `writable` to match the inverted default. The migration has never been applied on main, so this is a rename, not a data migration.

## Verification

- `npx tsc --noEmit` — exits 0.
- `npx vitest run` — **106 files passed, 2 skipped; 2158 tests passed, 5 skipped.** Baseline on current main was 95 files / 2024 passing with the same 2 files + 5 tests skipped. No regressions; +134 tests.

32 of those are new here, including `bootstrap.test.ts`, which drives `startModbusServer()` over **real TCP sockets**: no-op when disabled, refuses invalid config without binding (proven by re-binding the port afterwards), binds loopback, serves an end-to-end FC03 read, drops a disallowed peer with zero bytes served, enforces the connection cap, answers every write FC with `0x01` while mutating nothing, lands a write on the writable address once opted in, and still refuses the mapped-but-not-writable address with `0x03`.

Every one of those controls was mutation-checked: reverting the loopback default fails 13 tests, disabling the write gate fails 3, disabling the per-address `writable` check and the peer allowlist fails 5, and reverting the buffer fix fails the pipelining test.

## Not run

`__tests__/pymodbus_smoke.py` needs a live server, a PostgreSQL-backed register map, and Python's `pymodbus` — none present in this worktree. It was **not** executed, and its docstring and the docs say so. The request/response path it covers is exercised by the vitest suite, including over real sockets.

## Known limitations

- Modbus TCP Server Mode requires the PostgreSQL backend; it cannot run against the default SQLite dev fallback, and fails closed with a clear error there.
- Per-address write refusal returns `0x03`; some masters would expect `0x02`. The engine's existing mapping was left untouched per the review, and is documented.
- No HTTP surface for editing the register map yet — rows go in via SQL. When that lands it should sit behind `requireControlPlaneAccess`.
- A bad Modbus config is logged and leaves the HTTP server running without a Modbus listener rather than aborting boot, mirroring the existing Sparkplug bridge treatment. Making it fatal is a one-line change if preferred.
---

**Migration numbering — cross-PR coordination.** This branch adds its migration as `0007_*` because that
was the next free slot on `main` (which has `0001`, `0002`, `0003_blueprint_persistence`,
`0006_blueprint_instance_identity`). Two sibling PRs in this batch also add a `0007_*` migration:
`0007_validator_registry` (#454), `0007_blueprint_safe_state_log` (#459) and `0007_modbus_register_map`
(#462). They are independent and each is self-consistent, but whichever merges second and third will need
renumbering plus a `migrations/meta/_journal.json` update. Flagging it here rather than guessing a merge
order.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
