### PR TITLE
feat(marketplace): scoped auth, durable plugin ownership, and enforcing capabilities (#217)

### DIFF
--- a/docs/architecture/agent-marketplace.md
+++ b/docs/architecture/agent-marketplace.md
@@ -1,0 +1,243 @@
+# Agent Marketplace & Plugin System
+
+**Issue:** [#217](https://github.com/NickFlach/0xSCADA/issues/217) — feature [13.6] of
+[ADR-0013: Autonomous Agent Architecture](../decisions/ADR-0013-autonomous-agent-architecture.md).
+
+**Code:** `server/services/marketplace/`, `server/routes/marketplace.ts`,
+`shared/types/marketplace.ts`, `migrations/0011_agent_marketplace.sql`.
+
+---
+
+## What this is
+
+A registry of plugin **manifests** — metadata describing a plugin's id, semver
+version, declared capabilities, config schema and dependencies — plus an
+install record for each plugin an operator has explicitly installed, carrying
+the configuration and the capabilities actually granted to it.
+
+## What this is not
+
+**It is not a code-distribution channel.** No plugin code is uploaded,
+downloaded, or dynamically loaded, ever. A published manifest is metadata; it
+cannot become executable on its own.
+
+**It is not a security sandbox.** Executable handlers run in-process, in the
+server's own Node isolate. That is not a boundary against hostile code: a
+malicious handler could reach `process`, `require`, the filesystem or the
+event loop regardless of what its manifest declares. Containing untrusted code
+would require process or VM isolation (a worker thread with a restricted
+module graph, a child process, or a separate container). This repository does
+not implement that, and this document does not claim it does.
+
+**No money, tokens, licences or signatures move.** There is no payment path,
+no plugin signing and no signature verification. Nothing in the code pretends
+otherwise.
+
+## Why in-process execution is nevertheless defensible here
+
+Because there is no untrusted code to contain.
+
+The only executable handlers come from `server/services/marketplace/builtin/`
+— first-party modules compiled into this server and bound to a plugin id by
+`AgentMarketplace.registerImplementation`, which is called from
+`MarketplaceService.initialize()` at startup. There is deliberately **no HTTP
+route** to `registerImplementation`.
+
+A manifest published over the API by an operator therefore installs, reports
+`implementationState: "unavailable"`, and **refuses to start**:
+
+```
+POST /api/marketplace/plugins/my-plugin/start
+409 { "error": "... no implementation is registered in this build", "code": "not-implemented" }
+```
+
+Adding a plugin that can actually run means adding it to `builtin/` in a
+reviewed commit and shipping a new build. That is the containment story.
+
+If third-party code execution is ever wanted, it needs an isolation boundary
+first; that work is out of scope for #217 and must not be started by relaxing
+`registerImplementation`.
+
+## What the capability system does do
+
+Each manifest declares `requiredCapabilities`. At install time the operator
+grants a subset of them. At invocation time the handler receives a
+`PluginHostContext` whose capability accessors are **enforcing getters**:
+
+| Accessor | Capability |
+| --- | --- |
+| `host.tags` | `tags:read` |
+| `host.alarms` | `alarms:read` |
+| `host.emitEvent` | `events:emit` |
+| `host.log` | `log` |
+
+Reading an accessor whose capability is either **undeclared** in the manifest
+or **ungranted** at install time throws `MarketplaceError('capability-denied')`
+and emits a `plugin-capability-denied` audit event (forwarded to the log by
+`MarketplaceService` and counted in `PluginHealth.capabilityDenials`). The
+invocation then fails with `code: "capability-denied"`.
+
+The deliberate design choice here is that a denial **throws** rather than
+leaving the property undefined. An absent property is something a plugin can
+silently skip; a throw cannot be ignored, and it is visible in the audit trail.
+`host.capabilities` is the supported way for a cooperative plugin to
+feature-detect before reaching.
+
+`host.config` is frozen, so a handler cannot rewrite its own installation.
+
+Scope, stated precisely: this constrains a **cooperative** plugin's access to
+host services at the host-context boundary. It does not constrain a hostile
+one.
+
+## Invocation bounds
+
+* **Wall-clock timeout** — every invocation races a timer
+  (`invokeTimeoutMs`, default 5000 ms); a timeout returns `code: "timeout"`.
+  Stated precisely: the timer runs on the event loop, so it bounds a handler
+  that **yields** (async work, I/O, awaited promises). It cannot interrupt a
+  handler that blocks the event loop synchronously — a `while` loop owns the
+  thread until it returns, and the call is then reported as whatever it
+  eventually produced, not as a timeout. Pre-emption needs the same
+  process/VM isolation boundary this document says is absent; the bound is
+  acceptable only because handlers are reviewed first-party code.
+  `code: "timeout"` is produced solely by the host's own timer error type, so
+  a handler cannot mislabel an ordinary failure as a host timeout.
+* **Windowed failure tracking** — the last `errorWindow` (default 20)
+  outcomes feed `PluginHealth.windowedErrorRate`.
+* **Auto-disable** — `autoDisableAfter` (default 5) consecutive failures move
+  the plugin to `error`, stop it, emit `plugin-auto-disabled`, and persist the
+  decision. An operator clears it with `enable` + `start`.
+
+## Ownership: closing the manifest hijack
+
+The original implementation let anyone `POST /plugins` and republish any
+plugin id with a bumped version. Two things fix that.
+
+1. **Every route carries an explicit scope** (below). There is no permissive
+   or no-op guard anywhere in the router.
+2. **The first publish of an id records a durable owner** — the authenticated
+   control-plane principal, taken from `controlPlanePrincipal(req).name`,
+   never from the request body (`ManifestSchema` is `.strict()`, so a body
+   carrying a `publisher` field is rejected with 400). Every later publish of
+   that id must come from the same principal, and must carry a **strictly
+   newer** semver. Re-publishing an existing version is refused with
+   `409 version-conflict`; publishing from a different principal is refused
+   with `403 ownership-conflict`.
+
+Built-in plugins are owned by the reserved principal `system:builtin`, and the
+HTTP publish path refuses any principal name beginning with `system:`, so a
+configured API key cannot impersonate the built-in publisher.
+
+Uninstalling a plugin does **not** release its registry entry or its ownership
+record: releasing the id would re-open it to a hijack.
+
+## Authorization matrix
+
+| Route | Scope |
+| --- | --- |
+| `GET /api/marketplace/plugins` | `marketplace.read` |
+| `GET /api/marketplace/plugins/:id` | `marketplace.read` |
+| `GET /api/marketplace/installed` | `marketplace.read` |
+| `GET /api/marketplace/plugins/:id/health` | `marketplace.read` |
+| `GET /api/marketplace/health` | `marketplace.read` |
+| `GET /api/marketplace/status` | `marketplace.read` |
+| `POST /api/marketplace/plugins` | `marketplace.publish` |
+| `POST /api/marketplace/plugins/:id/install` | `marketplace.install` |
+| `POST /api/marketplace/plugins/:id/update` | `marketplace.install` |
+| `PUT /api/marketplace/plugins/:id/config` | `marketplace.install` |
+| `POST /api/marketplace/plugins/:id/start\|stop` | `marketplace.install` |
+| `POST /api/marketplace/plugins/:id/enable\|disable` | `marketplace.install` |
+| `POST /api/marketplace/plugins/:id/invoke` | `marketplace.invoke` |
+| `DELETE /api/marketplace/plugins/:id` | `marketplace.uninstall` |
+
+Lifecycle transitions sit under `marketplace.install` because they change the
+state of an installed plugin. They are deliberately not reachable with
+`marketplace.invoke`, which only lets a caller run something an operator has
+already installed and started.
+
+`CONTROL_ROUTE_POLICIES` also carries a `marketplace-control` entry, so the
+central gateway floor for `/api/marketplace` is the four action scopes rather
+than the generic `write` scope.
+
+The matrix is enforced by `server/routes/__tests__/marketplace-auth.test.ts`:
+anonymous → 401, unknown credential → 401, valid credential with the wrong
+scope → 403, exact scope → its expected status, for every route.
+
+## Persistence
+
+| State | Durable? | Where |
+| --- | --- | --- |
+| Registry manifest + version | yes | `plugin_registry` |
+| Ownership record (`publisher`) | yes | `plugin_registry.publisher` |
+| Install counter | yes | `plugin_registry.installs` |
+| Installed manifest + version | yes | `plugin_installations` |
+| Validated config | yes | `plugin_installations.config` |
+| Granted capabilities | yes | `plugin_installations.granted_capabilities` |
+| Installing principal | yes | `plugin_installations.installed_by` |
+| Lifecycle status (incl. auto-disable) | yes | `plugin_installations.status` |
+| Invocation counters, failure window, uptime | **no** | in-process only |
+| Registered implementations | **no** | compiled into the build |
+
+The two persisted tables are created by
+`migrations/0011_agent_marketplace.sql` and declared in `shared/schema.ts`
+(`pluginRegistry`, `pluginInstallations`), reached through `server/storage.ts`
+so both the Postgres and the SQLite development back-end work.
+
+The in-memory exceptions are deliberate and are not authorization state:
+
+* **Invocation counters, failure window, uptime** are telemetry about the
+  current process. A restart legitimately resets them. The *decision* they
+  produce (auto-disable → `status: "error"`) is persisted.
+* **Registered implementations** are code, not data. They come from the build.
+
+A plugin recorded as `running` is restored as `stopped`, because it is not
+running after a restart and the record must not claim it is. `disabled` and
+`error` survive verbatim — a restart must not clear an operator's disable or
+an auto-disable.
+
+If the database is unavailable the service falls back to a non-durable
+in-memory store and logs a warning saying plainly that ownership and grants
+will not survive a restart. It does not pretend the state is durable.
+
+`server/services/marketplace/__tests__/marketplace-persistence.test.ts`
+exercises this against a real file-backed database, closing and reopening it
+between assertions, and re-asserts the hijack refusal on the other side of the
+restart.
+
+## The built-in plugin
+
+`tag-threshold-monitor` (`builtin/tag-threshold-monitor.ts`) is a real
+first-party plugin, not a demo stub. It reads a configured tag through
+`host.tags`, classifies the latest sample against `highLimit` / `lowLimit` and
+a `maxAgeSeconds` staleness bound, emits a `tag-threshold-breach` host event
+when the tag is out of band, and returns the evaluation.
+
+```
+POST /api/marketplace/plugins/tag-threshold-monitor/install
+     { "config": { "tagId": "PT-101", "highLimit": 90, "lowLimit": 10 },
+       "grants": ["tags:read", "events:emit", "log"] }
+POST /api/marketplace/plugins/tag-threshold-monitor/start
+POST /api/marketplace/plugins/tag-threshold-monitor/invoke
+200  { "success": true, "code": "ok",
+       "output": { "tagId": "PT-101", "state": "high", "value": 97, ... } }
+```
+
+That whole sequence is exercised end to end over HTTP against a live tag in
+the auth-matrix test.
+
+## Deviation from ADR-0013
+
+ADR-0013 says plugins "run in sandboxed contexts". This implementation does
+**not** provide a sandbox in the isolation sense, and says so above. What it
+provides is capability scoping plus fault containment for first-party code,
+and a trust model in which no third-party code can execute at all. Lifting
+that restriction requires a real isolation boundary first.
+
+## Known gaps
+
+* No process/VM isolation, therefore no third-party code execution.
+* No plugin signing or signature verification.
+* No payment, licensing or token flow.
+* `alarms:read` currently resolves to an empty list: no read-only projection
+  of active alarms is wired to the marketplace on this branch. Plugins granted
+  the capability see an empty list rather than fabricated alarms.

--- a/migrations/0011_agent_marketplace.sql
+++ b/migrations/0011_agent_marketplace.sql
@@ -1,0 +1,50 @@
+-- Migration: 0011_agent_marketplace
+-- Issue: #217 — Agent Marketplace & Plugin System (ADR-0013 [13.6])
+--
+-- Two durable tables replace the previous in-memory Maps:
+--
+--   plugin_registry      published manifests plus the ownership record.
+--                        `publisher` is the authenticated control-plane
+--                        principal that FIRST published the id. Publishing a
+--                        later version of an existing id is refused unless
+--                        the requesting principal matches this row. That check
+--                        is only a security control while the row is durable:
+--                        an ownership table that resets on restart would let a
+--                        restart re-open every plugin id to hijack.
+--
+--   plugin_installations one row per installed plugin, carrying the manifest
+--                        version pinned at install time, the validated config,
+--                        and the capabilities actually granted. Grants are
+--                        security state, so they are durable too.
+--
+-- Runtime health counters (invocations, failures, uptime) are deliberately NOT
+-- persisted: they are transient operational telemetry for the current process,
+-- not authorization state, and a restart legitimately resets them.
+
+CREATE TABLE IF NOT EXISTS plugin_registry (
+  id VARCHAR(64) PRIMARY KEY,
+  version VARCHAR(32) NOT NULL,
+  manifest JSONB NOT NULL,
+  publisher VARCHAR(255) NOT NULL,
+  installs INTEGER NOT NULL DEFAULT 0,
+  published_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_registry_publisher
+  ON plugin_registry(publisher);
+
+CREATE TABLE IF NOT EXISTS plugin_installations (
+  id VARCHAR(64) PRIMARY KEY REFERENCES plugin_registry(id),
+  version VARCHAR(32) NOT NULL,
+  manifest JSONB NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  granted_capabilities JSONB NOT NULL DEFAULT '[]'::jsonb,
+  installed_by VARCHAR(255) NOT NULL,
+  installed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_installations_status
+  ON plugin_installations(status);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1784780407000,
       "tag": "0010_pid_tuning_audit",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1784780408000,
+      "tag": "0011_agent_marketplace",
+      "breakpoints": true
     }
   ]
 }

--- a/server/agents/runtime.ts
+++ b/server/agents/runtime.ts
@@ -1,5 +1,12 @@
 /**
- * Agent runtime module
+ * Agent runtime module.
+ *
+ * The export shape (`agentRuntime` with `getHealth`/`isRunning`) is consumed
+ * by server/health/index.ts and must not change.
+ *
+ * Agents are installed marketplace plugins (#217), so the health numbers come
+ * from the marketplace engine rather than the hardcoded zeros this module
+ * used to return.
  */
 
 export interface AgentHealth {
@@ -9,16 +16,37 @@ export interface AgentHealth {
 }
 
 export const getAgentHealth = async (): Promise<AgentHealth> => {
-  // TODO: Implement actual agent health check
+  // Lazily imported so callers that only need the shape do not pull in the
+  // marketplace service graph.
+  const { marketplaceService } = await import('../services/marketplace');
+  const marketplace = marketplaceService.marketplace;
+  const status = marketplace.getStatus();
+  const errors: string[] = [];
+
+  for (const health of marketplace.getAllHealth()) {
+    if (health.status === 'error') {
+      errors.push(`${health.pluginId}: ${health.lastError ?? 'auto-disabled after repeated failures'}`);
+    } else if (health.implementationState === 'unavailable') {
+      errors.push(`${health.pluginId}: installed but no implementation is registered in this build`);
+    }
+  }
+
   return {
-    totalAgents: 0,
-    activeAgents: 0,
-    errors: []
+    totalAgents: status.installed,
+    activeAgents: status.running,
+    errors,
   };
 };
 
-// Export runtime as expected by health/index.ts  
 export const agentRuntime = {
   getHealth: getAgentHealth,
-  isRunning: () => false
+  /**
+   * True once the marketplace service has loaded its state and registered the
+   * first-party implementations. Reported honestly: before that, nothing can
+   * be invoked.
+   */
+  isRunning: async (): Promise<boolean> => {
+    const { marketplaceService } = await import('../services/marketplace');
+    return marketplaceService.isInitialized();
+  },
 };

--- a/server/blueprint/__tests__/production-safety.test.ts
+++ b/server/blueprint/__tests__/production-safety.test.ts
@@ -62,6 +62,7 @@ describe("safe-state audit migration alignment", () => {
       { idx: 5, tag: "0008_modbus_register_map" },
       { idx: 6, tag: "0009_blueprint_safe_state_log" },
       { idx: 7, tag: "0010_pid_tuning_audit" },
+      { idx: 8, tag: "0011_agent_marketplace" },
     ]);
     // `when` must stay monotonic so drizzle-kit orders the journal correctly.
     const timestamps = journal.entries.map((e) => e.when);

--- a/server/health/index.ts
+++ b/server/health/index.ts
@@ -90,8 +90,10 @@ healthManager.registerSimple(
   'agent-runtime',
   async () => {
     try {
+      // Report whether the runtime can actually serve agents, not merely
+      // whether the module resolves (#217).
       const { agentRuntime } = await import('../agents/runtime');
-      return agentRuntime != null;
+      return await agentRuntime.isRunning();
     } catch {
       return false;
     }

--- a/server/middleware/__tests__/control-route-policy.test.ts
+++ b/server/middleware/__tests__/control-route-policy.test.ts
@@ -37,6 +37,12 @@ const records: ApiKeyRecord[] = [
     createdAt: new Date(),
   },
   {
+    key: "marketplace-publish-key",
+    name: "plugin-publisher",
+    scopes: ["marketplace.publish"],
+    createdAt: new Date(),
+  },
+  {
     key: "predictive-configure-key",
     name: "predictive-configurer",
     scopes: ["predictive.configure"],
@@ -100,6 +106,9 @@ async function startApp(logs: string[] = []): Promise<string> {
   app.post("/api/tuning/proposals/proposal-1/approve", (_req, res) =>
     res.status(200).json({ approved: true })
   );
+  app.post("/api/marketplace/plugins", (_req, res) =>
+    res.status(201).json({ published: true })
+  );
 
   const server = createServer(app);
   openServers.push(server);
@@ -151,8 +160,25 @@ describe("control route policy inventory", () => {
         "predictive-threshold-control",
         "predictive-ingestion",
         "geometry-control",
+        "marketplace-control",
       ]),
     );
+  });
+
+  it("keeps agent-marketplace mutations off the generic write scope", () => {
+    for (const path of [
+      "/api/marketplace/plugins",
+      "/api/marketplace/plugins/demo/install",
+      "/api/marketplace/plugins/demo/invoke",
+      "/api/marketplace/plugins/demo",
+    ]) {
+      expect(mutationPolicyFor("POST", path)?.scopes).toEqual([
+        "marketplace.publish",
+        "marketplace.install",
+        "marketplace.invoke",
+        "marketplace.uninstall",
+      ]);
+    }
   });
 
   it("assigns write to unlisted mutations and nothing to reads", () => {
@@ -290,6 +316,18 @@ describe("mutating REST authorization", () => {
       method: "PUT",
       headers: { "X-API-Key": "predictive-ingest-key" },
     })).status).toBe(403);
+  });
+
+  it("blocks a generic write key from the agent-marketplace surface", async () => {
+    const baseUrl = await startApp();
+    expect((await fetch(`${baseUrl}/api/marketplace/plugins`, {
+      method: "POST",
+      headers: { "X-API-Key": "write-key" },
+    })).status).toBe(403);
+    expect((await fetch(`${baseUrl}/api/marketplace/plugins`, {
+      method: "POST",
+      headers: { "X-API-Key": "marketplace-publish-key" },
+    })).status).toBe(201);
   });
 
   it("separates tuning proposal creation from human approval authority", async () => {

--- a/server/middleware/control-route-policy.ts
+++ b/server/middleware/control-route-policy.ts
@@ -68,6 +68,20 @@ export const CONTROL_ROUTE_POLICIES: readonly ControlRoutePolicy[] = Object.free
       + "Route-local guards enforce the exact per-action scope.",
   },
   {
+    id: "marketplace-control",
+    pathPrefix: "/api/marketplace",
+    scopes: Object.freeze([
+      "marketplace.publish",
+      "marketplace.install",
+      "marketplace.invoke",
+      "marketplace.uninstall",
+    ]),
+    description:
+      "Publish, install, invoke, or uninstall an agent-marketplace plugin. "
+      + "Route-local guards enforce the exact per-action scope, so a generic "
+      + "`write` key cannot reach any of them.",
+  },
+  {
     id: "predictive-alert-acknowledgement",
     pathPrefix: "/api/predictive/alerts",
     scopes: Object.freeze(["predictive.acknowledge"]),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -25,6 +25,8 @@ import { predictiveRoutes } from "./routes/predictive";
 import { predictiveMaintenanceService } from "./services/predictive";
 import { tuningRoutes } from "./routes/tuning";
 import { tuningService } from "./services/tuning";
+import { marketplaceRoutes } from "./routes/marketplace";
+import { marketplaceService } from "./services/marketplace";
 import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
@@ -76,6 +78,7 @@ export async function registerRoutes(
   // /api/pid: that prefix belongs to the P&ID diagram surface the client
   // already calls (client/src/pages/pid-view.tsx -> /api/pid/diagrams/:id).
   app.use("/api/tuning", tuningRoutes);
+  app.use("/api/marketplace", marketplaceRoutes);  // ADR-0013 [13.6] (#217)
   app.use("/api/governance", governanceRoutes);
   app.use("/api/security", securityRoutes);
   app.use("/api/geometry", geometryRoutes(getFluxPublisher()));
@@ -166,6 +169,12 @@ export async function registerRoutes(
   httpServer.once("close", () => {
     void tuningService.shutdown();
   });
+  // Load marketplace state and register the first-party plugin
+  // implementations here — services/initializeServices() has no callers at
+  // startup (#217). This is awaited rather than fired-and-forgotten: the
+  // publish path checks plugin ownership against the loaded registry, and an
+  // ownership check against an unhydrated registry would authorize a hijack.
+  await marketplaceService.initialize();
 
   // WebSocket metrics endpoint. The legacy event-stream server was removed;
   // only the tag and unified streams report (#446, #479).

--- a/server/routes/__tests__/marketplace-auth.test.ts
+++ b/server/routes/__tests__/marketplace-auth.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Agent Marketplace HTTP authorization matrix.
+ *
+ * Feature [13.6] of ADR-0013 — Issue #217, following the #576
+ * `requireControlPlaneAccess` pattern.
+ *
+ * For every route: anonymous -> 401, unknown credential -> 401, a valid
+ * credential holding a DIFFERENT marketplace scope -> 403, and the exact
+ * scope -> its expected status. The manifest-hijack attempt the review
+ * flagged is exercised explicitly, over HTTP, and asserted to be refused.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import { createServer, type Server } from "node:http";
+
+import { _resetControlPlaneAuthCache } from "../../middleware/control-plane-auth";
+import { marketplaceRoutes } from "../marketplace";
+import { marketplaceService } from "../../services/marketplace";
+import { TAG_THRESHOLD_MONITOR_ID } from "../../services/marketplace/builtin";
+import { tagStreamServer } from "../../websocket/tag-stream";
+
+interface TestServer {
+  server: Server;
+  baseUrl: string;
+}
+
+type Method = "GET" | "POST" | "PUT" | "DELETE";
+
+interface RouteCase {
+  method: Method;
+  path: string;
+  authorizedStatus: number;
+  authorizedKey: string;
+  underScopedKey: string;
+  body?: string;
+}
+
+const MISSING = "no-such-plugin";
+
+let testServer: TestServer;
+
+function routeCases(
+  authorizedKey: string,
+  underScopedKey: string,
+  routes: ReadonlyArray<readonly [Method, string, number]>,
+): RouteCase[] {
+  return routes.map(([method, path, authorizedStatus]) => ({
+    method,
+    path,
+    authorizedStatus,
+    authorizedKey,
+    underScopedKey,
+  }));
+}
+
+const readRoutes = routeCases("read-key", "install-key", [
+  ["GET", "/plugins", 200],
+  ["GET", `/plugins/${MISSING}`, 404],
+  ["GET", "/installed", 200],
+  ["GET", `/plugins/${MISSING}/health`, 404],
+  ["GET", "/health", 200],
+  ["GET", "/status", 200],
+]);
+
+// A body-less publish fails validation with 400 — the point is that the
+// request reached the handler, so the scope was accepted.
+const publishRoutes = routeCases("publish-key", "install-key", [
+  ["POST", "/plugins", 400],
+]);
+
+const installRoutes = routeCases("install-key", "invoke-key", [
+  ["POST", `/plugins/${MISSING}/install`, 404],
+  ["POST", `/plugins/${MISSING}/update`, 404],
+  ["PUT", `/plugins/${MISSING}/config`, 400],
+  ["POST", `/plugins/${MISSING}/start`, 404],
+  ["POST", `/plugins/${MISSING}/stop`, 404],
+  ["POST", `/plugins/${MISSING}/enable`, 404],
+  ["POST", `/plugins/${MISSING}/disable`, 404],
+]);
+
+// A plugin-level failure is a 200 carrying success:false plus a machine code;
+// only transport and authorization failures use non-2xx statuses.
+const invokeRoutes = routeCases("invoke-key", "install-key", [
+  ["POST", `/plugins/${MISSING}/invoke`, 200],
+]);
+
+const uninstallRoutes = routeCases("uninstall-key", "install-key", [
+  ["DELETE", `/plugins/${MISSING}`, 404],
+]);
+
+const allRoutes = [
+  ...readRoutes,
+  ...publishRoutes,
+  ...installRoutes,
+  ...invokeRoutes,
+  ...uninstallRoutes,
+];
+
+function startServer(): Promise<TestServer> {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/marketplace", marketplaceRoutes);
+
+  return new Promise((resolve) => {
+    const server = createServer(app);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function call(
+  method: Method,
+  path: string,
+  options: { apiKey?: string; body?: unknown } = {},
+): Promise<Response> {
+  const headers: Record<string, string> = {};
+  if (options.apiKey) headers["x-api-key"] = options.apiKey;
+  if (method !== "GET") headers["content-type"] = "application/json";
+  return fetch(`${testServer.baseUrl}/api/marketplace${path}`, {
+    method,
+    headers,
+    body: method === "GET" ? undefined : JSON.stringify(options.body ?? {}),
+  });
+}
+
+function request(route: RouteCase, apiKey?: string): Promise<Response> {
+  return call(route.method, route.path, { apiKey });
+}
+
+function manifestBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "alpha-plugin",
+    name: "Alpha Plugin",
+    version: "1.0.0",
+    description: "auth matrix fixture",
+    author: "tests",
+    category: "custom",
+    requiredCapabilities: ["log"],
+    configSchema: {},
+    dependencies: {},
+    tags: ["alpha"],
+    ...overrides,
+  };
+}
+
+const originalApiKeys = process.env.API_KEYS;
+
+// File-scoped: every describe below shares one server and one marketplace
+// singleton, and the ownership assertions depend on that shared state.
+beforeAll(async () => {
+  process.env.API_KEYS = [
+    "read-key:marketplace-reader:marketplace.read",
+    "publish-key:publisher-one:marketplace.publish",
+    "publish-key-2:publisher-two:marketplace.publish",
+    "install-key:marketplace-installer:marketplace.install",
+    "invoke-key:marketplace-invoker:marketplace.invoke",
+    "uninstall-key:marketplace-remover:marketplace.uninstall",
+    "unrelated-key:other-service:predictive.read",
+  ].join(",");
+  _resetControlPlaneAuthCache();
+  await marketplaceService.initialize();
+  testServer = await startServer();
+});
+
+afterAll(async () => {
+  await closeServer(testServer.server);
+  if (originalApiKeys === undefined) delete process.env.API_KEYS;
+  else process.env.API_KEYS = originalApiKeys;
+  _resetControlPlaneAuthCache();
+});
+
+describe("agent marketplace route authorization", () => {
+  it.each(allRoutes)("fails closed for anonymous $method $path", async (route) => {
+    const response = await request(route);
+    expect(response.status).toBe(401);
+  });
+
+  it.each(allRoutes)(
+    "rejects an unknown credential on $method $path",
+    async (route) => {
+      const response = await request(route, "not-a-real-key");
+      expect(response.status).toBe(401);
+    },
+  );
+
+  it.each(allRoutes)(
+    "rejects a credential from an unrelated service on $method $path",
+    async (route) => {
+      const response = await request(route, "unrelated-key");
+      expect(response.status).toBe(403);
+    },
+  );
+
+  it.each(allRoutes)(
+    "rejects a different marketplace scope on $method $path",
+    async (route) => {
+      const response = await request(route, route.underScopedKey);
+      expect(response.status).toBe(403);
+    },
+  );
+
+  it.each(allRoutes)(
+    "allows the exact scope to reach $method $path",
+    async (route) => {
+      const response = await request(route, route.authorizedKey);
+      expect(response.status).toBe(route.authorizedStatus);
+    },
+  );
+
+  it("never accepts a credential from the query string", async () => {
+    const response = await fetch(
+      `${testServer.baseUrl}/api/marketplace/status?api_key=read-key`,
+    );
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("manifest ownership over HTTP", () => {
+  it("binds the publisher to the authenticated principal, not the request body", async () => {
+    const created = await call("POST", "/plugins", {
+      apiKey: "publish-key",
+      body: manifestBody(),
+    });
+    expect(created.status).toBe(201);
+    const entry = await created.json() as { publisher: string };
+    expect(entry.publisher).toBe("publisher-one");
+  });
+
+  it("rejects a body that tries to supply its own publisher", async () => {
+    const spoofed = await call("POST", "/plugins", {
+      apiKey: "publish-key-2",
+      body: manifestBody({ id: "spoof-plugin", publisher: "publisher-one" }),
+    });
+    expect(spoofed.status).toBe(400);
+    // The id must not have been created under the spoofed owner.
+    const lookup = await call("GET", "/plugins/spoof-plugin", { apiKey: "read-key" });
+    expect(lookup.status).toBe(404);
+  });
+
+  it("refuses a different publisher republishing the id with a bumped version", async () => {
+    const hijack = await call("POST", "/plugins", {
+      apiKey: "publish-key-2",
+      body: manifestBody({ version: "2.0.0" }),
+    });
+    expect(hijack.status).toBe(403);
+    expect(await hijack.json()).toMatchObject({ code: "ownership-conflict" });
+
+    const current = await call("GET", "/plugins/alpha-plugin", { apiKey: "read-key" });
+    expect(await current.json()).toMatchObject({
+      publisher: "publisher-one",
+      manifest: { version: "1.0.0" },
+    });
+  });
+
+  it("refuses re-publishing an existing version and requires forward motion", async () => {
+    const same = await call("POST", "/plugins", {
+      apiKey: "publish-key",
+      body: manifestBody({ version: "1.0.0" }),
+    });
+    expect(same.status).toBe(409);
+    expect(await same.json()).toMatchObject({ code: "version-conflict" });
+
+    const older = await call("POST", "/plugins", {
+      apiKey: "publish-key",
+      body: manifestBody({ version: "0.9.0" }),
+    });
+    expect(older.status).toBe(409);
+
+    const newer = await call("POST", "/plugins", {
+      apiKey: "publish-key",
+      body: manifestBody({ version: "1.1.0" }),
+    });
+    expect(newer.status).toBe(201);
+    expect(await newer.json()).toMatchObject({ manifest: { version: "1.1.0" } });
+  });
+
+  it("refuses to republish a built-in plugin id", async () => {
+    const hijack = await call("POST", "/plugins", {
+      apiKey: "publish-key",
+      body: manifestBody({ id: TAG_THRESHOLD_MONITOR_ID, version: "99.0.0" }),
+    });
+    expect(hijack.status).toBe(403);
+    expect(await hijack.json()).toMatchObject({ code: "ownership-conflict" });
+  });
+});
+
+describe("installed-but-not-implemented is reported, not faked", () => {
+  it("installs a manifest with no implementation and says so", async () => {
+    const installed = await call("POST", "/plugins/alpha-plugin/install", {
+      apiKey: "install-key",
+      body: { config: {}, grants: ["log"] },
+    });
+    expect(installed.status).toBe(201);
+    expect(await installed.json()).toMatchObject({
+      implementationState: "unavailable",
+      installedBy: "marketplace-installer",
+      grantedCapabilities: ["log"],
+    });
+
+    const started = await call("POST", "/plugins/alpha-plugin/start", {
+      apiKey: "install-key",
+    });
+    expect(started.status).toBe(409);
+    expect(await started.json()).toMatchObject({ code: "not-implemented" });
+
+    const invoked = await call("POST", "/plugins/alpha-plugin/invoke", {
+      apiKey: "invoke-key",
+      body: {},
+    });
+    expect(invoked.status).toBe(200);
+    expect(await invoked.json()).toMatchObject({
+      success: false,
+      code: "not-implemented",
+    });
+  });
+});
+
+describe("a real built-in plugin runs end to end over HTTP", () => {
+  it("installs, starts, and invokes the tag threshold monitor against a live tag", async () => {
+    tagStreamServer.broadcastTagUpdate({
+      tagName: "PT-101",
+      value: 97,
+      quality: "good",
+      timestamp: new Date().toISOString(),
+    });
+
+    const installed = await call(`POST`, `/plugins/${TAG_THRESHOLD_MONITOR_ID}/install`, {
+      apiKey: "install-key",
+      body: {
+        config: { tagId: "PT-101", highLimit: 90, lowLimit: 10 },
+        grants: ["tags:read", "events:emit", "log"],
+      },
+    });
+    expect(installed.status).toBe(201);
+    expect(await installed.json()).toMatchObject({ implementationState: "available" });
+
+    const started = await call("POST", `/plugins/${TAG_THRESHOLD_MONITOR_ID}/start`, {
+      apiKey: "install-key",
+    });
+    expect(started.status).toBe(200);
+    expect(await started.json()).toMatchObject({ status: "running" });
+
+    const invoked = await call("POST", `/plugins/${TAG_THRESHOLD_MONITOR_ID}/invoke`, {
+      apiKey: "invoke-key",
+      body: {},
+    });
+    expect(invoked.status).toBe(200);
+    const result = await invoked.json() as {
+      success: boolean;
+      code: string;
+      output: { tagId: string; state: string; value: number };
+    };
+    expect(result.success).toBe(true);
+    expect(result.code).toBe("ok");
+    expect(result.output).toMatchObject({ tagId: "PT-101", state: "high", value: 97 });
+  });
+
+  it("denies an ungranted capability at the host boundary", async () => {
+    // Reinstall with tags:read withheld — the handler reaches for it anyway,
+    // so the invocation must fail with capability-denied instead of quietly
+    // skipping the read.
+    const uninstalled = await call("DELETE", `/plugins/${TAG_THRESHOLD_MONITOR_ID}`, {
+      apiKey: "uninstall-key",
+    });
+    expect(uninstalled.status).toBe(200);
+
+    const installed = await call("POST", `/plugins/${TAG_THRESHOLD_MONITOR_ID}/install`, {
+      apiKey: "install-key",
+      body: {
+        config: { tagId: "PT-101", highLimit: 90, lowLimit: 10 },
+        grants: ["log"],
+      },
+    });
+    expect(installed.status).toBe(201);
+    await call("POST", `/plugins/${TAG_THRESHOLD_MONITOR_ID}/start`, {
+      apiKey: "install-key",
+    });
+
+    const invoked = await call("POST", `/plugins/${TAG_THRESHOLD_MONITOR_ID}/invoke`, {
+      apiKey: "invoke-key",
+      body: {},
+    });
+    expect(invoked.status).toBe(200);
+    expect(await invoked.json()).toMatchObject({
+      success: false,
+      code: "capability-denied",
+    });
+
+    const health = await call("GET", `/plugins/${TAG_THRESHOLD_MONITOR_ID}/health`, {
+      apiKey: "read-key",
+    });
+    expect(await health.json()).toMatchObject({ capabilityDenials: 1 });
+  });
+
+  it("requires the uninstall scope to remove a plugin", async () => {
+    const forbidden = await call("DELETE", "/plugins/alpha-plugin", {
+      apiKey: "install-key",
+    });
+    expect(forbidden.status).toBe(403);
+
+    const removed = await call("DELETE", "/plugins/alpha-plugin", {
+      apiKey: "uninstall-key",
+    });
+    expect(removed.status).toBe(200);
+    expect(await removed.json()).toMatchObject({ uninstalled: true });
+  });
+});

--- a/server/routes/marketplace.ts
+++ b/server/routes/marketplace.ts
@@ -1,0 +1,270 @@
+/**
+ * Agent Marketplace API.
+ *
+ * Feature [13.6] of ADR-0013 — Issue #217.
+ * Mounted at /api/marketplace; /api/agents and its redirects are untouched.
+ *
+ * ── Authorization ────────────────────────────────────────────────────────
+ * Every route carries an explicit `requireControlPlaneAccess` scope (#576
+ * pattern). There is no router-wide permissive guard and no route that falls
+ * through to authenticated-is-enough:
+ *
+ *   GET    /plugins                       marketplace.read
+ *   GET    /plugins/:id                   marketplace.read
+ *   GET    /installed                     marketplace.read
+ *   GET    /plugins/:id/health            marketplace.read
+ *   GET    /health                        marketplace.read
+ *   GET    /status                        marketplace.read
+ *   POST   /plugins                       marketplace.publish
+ *   POST   /plugins/:id/install           marketplace.install
+ *   POST   /plugins/:id/update            marketplace.install
+ *   PUT    /plugins/:id/config            marketplace.install
+ *   POST   /plugins/:id/start|stop        marketplace.install
+ *   POST   /plugins/:id/enable|disable    marketplace.install
+ *   POST   /plugins/:id/invoke            marketplace.invoke
+ *   DELETE /plugins/:id                   marketplace.uninstall
+ *
+ * Lifecycle transitions sit under `marketplace.install` because they change
+ * the state of an installed plugin; they are deliberately NOT reachable with
+ * `marketplace.invoke`, which only lets a caller run something an operator
+ * already installed and started.
+ *
+ * ── Identity ─────────────────────────────────────────────────────────────
+ * The publisher and installer identities come from the authenticated
+ * control-plane principal, never from the request body. `ManifestSchema` is
+ * strict, so a body that tries to carry a `publisher` field is rejected with
+ * 400 instead of being quietly ignored.
+ */
+
+import { Router } from "express";
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error/v3";
+import {
+  controlPlanePrincipal,
+  requireControlPlaneAccess,
+} from "../middleware/control-plane-auth";
+import { marketplaceService } from "../services/marketplace";
+import { isMarketplaceError } from "../services/marketplace/errors";
+import type { PluginCategory, PluginManifest } from "@shared/types/marketplace";
+
+const router = Router();
+const marketplace = marketplaceService.marketplace;
+
+const requireMarketplaceRead = requireControlPlaneAccess({
+  scopes: ["marketplace.read"],
+});
+const requireMarketplacePublish = requireControlPlaneAccess({
+  scopes: ["marketplace.publish"],
+});
+const requireMarketplaceInstall = requireControlPlaneAccess({
+  scopes: ["marketplace.install"],
+});
+const requireMarketplaceInvoke = requireControlPlaneAccess({
+  scopes: ["marketplace.invoke"],
+});
+const requireMarketplaceUninstall = requireControlPlaneAccess({
+  scopes: ["marketplace.uninstall"],
+});
+
+/**
+ * Map an engine failure onto its declared status and machine code. The engine
+ * owns the classification, so the HTTP layer never guesses one by matching an
+ * error message.
+ */
+function handle(fn: (req: Request, res: Response) => Promise<void> | void) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      await fn(req, res);
+    } catch (error) {
+      if (res.headersSent) return;
+      if (isMarketplaceError(error)) {
+        res.status(error.status).json({ error: error.message, code: error.code });
+        return;
+      }
+      res.status(400).json({
+        error: error instanceof Error ? error.message : "Invalid request",
+        code: "invalid-request",
+      });
+    }
+  };
+}
+
+// ── Schemas ────────────────────────────────────────────────────────────────
+
+const CapabilitySchema = z.enum(["tags:read", "alarms:read", "events:emit", "log"]);
+
+const ConfigValueSchema = z.union([z.string().max(4096), z.number().finite(), z.boolean()]);
+
+const ManifestSchema = z.object({
+  id: z.string().regex(/^[a-z0-9][a-z0-9-]{1,63}$/),
+  name: z.string().min(1).max(256),
+  version: z.string().regex(/^v?\d+\.\d+\.\d+$/),
+  description: z.string().max(2000).default(""),
+  author: z.string().max(256).default("unknown"),
+  category: z.enum([
+    "intelligence",
+    "integration",
+    "reporting",
+    "safety",
+    "optimization",
+    "custom",
+  ]),
+  requiredCapabilities: z.array(CapabilitySchema).max(10).default([]),
+  configSchema: z
+    .record(
+      z.object({
+        type: z.enum(["string", "number", "boolean", "select"]),
+        description: z.string().max(500),
+        default: ConfigValueSchema.optional(),
+        required: z.boolean(),
+        options: z.array(z.string().max(256)).max(50).optional(),
+      }).strict(),
+    )
+    .default({}),
+  dependencies: z.record(z.string().max(64)).default({}),
+  tags: z.array(z.string().max(64)).max(20).default([]),
+}).strict();
+
+const InstallSchema = z.object({
+  config: z.record(ConfigValueSchema).default({}),
+  grants: z.array(CapabilitySchema).max(10).optional(),
+}).strict();
+
+const ConfigureSchema = z.object({
+  config: z.record(ConfigValueSchema),
+}).strict();
+
+const InvokeSchema = z.object({
+  input: z.unknown().optional(),
+}).strict();
+
+const SearchSchema = z.object({
+  q: z.string().max(256).optional(),
+  category: z
+    .enum(["intelligence", "integration", "reporting", "safety", "optimization", "custom"])
+    .optional(),
+}).strict();
+
+function badRequest(res: Response, error: z.ZodError): void {
+  res.status(400).json({ error: fromZodError(error).message, code: "invalid-request" });
+}
+
+// ── Registry (read) ────────────────────────────────────────────────────────
+
+router.get("/plugins", requireMarketplaceRead, handle((req, res) => {
+  const parsed = SearchSchema.safeParse(req.query);
+  if (!parsed.success) return badRequest(res, parsed.error);
+  const category = parsed.data.category as PluginCategory | undefined;
+  res.json({ plugins: marketplace.search(parsed.data.q ?? "", category) });
+}));
+
+router.get("/plugins/:pluginId", requireMarketplaceRead, handle((req, res) => {
+  const entry = marketplace.getEntry(req.params.pluginId);
+  if (!entry) {
+    res.status(404).json({
+      error: `Plugin ${req.params.pluginId} not found`,
+      code: "not-found",
+    });
+    return;
+  }
+  res.json(entry);
+}));
+
+// ── Registry (publish) ─────────────────────────────────────────────────────
+
+router.post("/plugins", requireMarketplacePublish, handle(async (req, res) => {
+  const parsed = ManifestSchema.safeParse(req.body);
+  if (!parsed.success) return badRequest(res, parsed.error);
+
+  // Ownership is bound to the authenticated principal. A body-supplied
+  // publisher is impossible here: ManifestSchema is strict and rejects it.
+  const publisher = controlPlanePrincipal(req).name;
+  const entry = await marketplace.publish(parsed.data as PluginManifest, publisher);
+  res.status(201).json(entry);
+}));
+
+// ── Installation lifecycle ────────────────────────────────────────────────
+
+router.get("/installed", requireMarketplaceRead, handle((_req, res) => {
+  res.json({ plugins: marketplace.listInstalled() });
+}));
+
+router.post("/plugins/:pluginId/install", requireMarketplaceInstall, handle(async (req, res) => {
+  const parsed = InstallSchema.safeParse(req.body ?? {});
+  if (!parsed.success) return badRequest(res, parsed.error);
+  const installed = await marketplace.install(req.params.pluginId, {
+    config: parsed.data.config,
+    grants: parsed.data.grants,
+    installedBy: controlPlanePrincipal(req).name,
+  });
+  res.status(201).json(installed);
+}));
+
+router.post("/plugins/:pluginId/update", requireMarketplaceInstall, handle(async (req, res) => {
+  res.json(await marketplace.update(req.params.pluginId));
+}));
+
+router.put("/plugins/:pluginId/config", requireMarketplaceInstall, handle(async (req, res) => {
+  const parsed = ConfigureSchema.safeParse(req.body);
+  if (!parsed.success) return badRequest(res, parsed.error);
+  res.json(await marketplace.configure(req.params.pluginId, parsed.data.config));
+}));
+
+router.post("/plugins/:pluginId/start", requireMarketplaceInstall, handle(async (req, res) => {
+  res.json(await marketplace.start(req.params.pluginId));
+}));
+
+router.post("/plugins/:pluginId/stop", requireMarketplaceInstall, handle(async (req, res) => {
+  res.json(await marketplace.stop(req.params.pluginId));
+}));
+
+router.post("/plugins/:pluginId/enable", requireMarketplaceInstall, handle(async (req, res) => {
+  res.json(await marketplace.enable(req.params.pluginId));
+}));
+
+router.post("/plugins/:pluginId/disable", requireMarketplaceInstall, handle(async (req, res) => {
+  res.json(await marketplace.disable(req.params.pluginId));
+}));
+
+router.delete("/plugins/:pluginId", requireMarketplaceUninstall, handle(async (req, res) => {
+  await marketplace.uninstall(req.params.pluginId);
+  res.json({ uninstalled: true, pluginId: req.params.pluginId });
+}));
+
+// ── Execution ─────────────────────────────────────────────────────────────
+
+router.post("/plugins/:pluginId/invoke", requireMarketplaceInvoke, handle(async (req, res) => {
+  const parsed = InvokeSchema.safeParse(req.body ?? {});
+  if (!parsed.success) return badRequest(res, parsed.error);
+  const result = await marketplace.invoke(req.params.pluginId, parsed.data.input);
+  // The result carries a machine-readable `code`; a plugin-level failure is
+  // reported as 200 with success:false so callers can distinguish it from a
+  // transport or authorization failure.
+  res.json(result);
+}));
+
+// ── Health ────────────────────────────────────────────────────────────────
+
+router.get("/plugins/:pluginId/health", requireMarketplaceRead, handle((req, res) => {
+  const health = marketplace.getHealth(req.params.pluginId);
+  if (!health) {
+    res.status(404).json({
+      error: `Plugin ${req.params.pluginId} not installed`,
+      code: "not-installed",
+    });
+    return;
+  }
+  res.json(health);
+}));
+
+router.get("/health", requireMarketplaceRead, handle((_req, res) => {
+  res.json({ plugins: marketplace.getAllHealth() });
+}));
+
+router.get("/status", requireMarketplaceRead, handle(async (_req, res) => {
+  const health = await marketplaceService.healthCheck();
+  res.json({ ...marketplace.getStatus(), ...health });
+}));
+
+export { router as marketplaceRoutes };

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -80,6 +80,10 @@ export { alarmCorrelationService } from './alarm-correlation';
 export * from './tuning';
 export { tuningService } from './tuning';
 
+// ── Agent Marketplace Service (ADR-0013 [13.6], #217) ────────────────────────
+export * from './marketplace';
+export { marketplaceService } from './marketplace';
+
 /**
  * Initialize all services
  * 
@@ -97,7 +101,8 @@ export async function initializeServices(): Promise<void> {
     { name: 'SPC', service: () => import('./spc').then(m => m.spcService.initialize()) },
     { name: 'Digital Twin', service: () => import('./twin').then(m => m.digitalTwinService.initialize()) },
     { name: 'Predictive Maintenance', service: () => import('./predictive').then(m => m.predictiveMaintenanceService.initialize()) },
-    { name: 'PID Tuning', service: () => import('./tuning').then(m => m.tuningService.initialize()) }
+    { name: 'PID Tuning', service: () => import('./tuning').then(m => m.tuningService.initialize()) },
+    { name: 'Agent Marketplace', service: () => import('./marketplace').then(m => m.marketplaceService.initialize()) }
   ];
 
   for (const { name, service } of services) {
@@ -212,6 +217,14 @@ export async function getServicesHealthStatus(): Promise<{
         return await tuningService.healthCheck();
       } catch {
         return { healthy: false, message: 'Tuning service not available' };
+      }
+    },
+    marketplace: async () => {
+      try {
+        const { marketplaceService } = await import('./marketplace');
+        return await marketplaceService.healthCheck();
+      } catch {
+        return { healthy: false, message: 'Marketplace service not available' };
       }
     }
   };

--- a/server/services/marketplace/__tests__/marketplace-persistence.test.ts
+++ b/server/services/marketplace/__tests__/marketplace-persistence.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Marketplace durability tests.
+ *
+ * Feature [13.6] of ADR-0013 — Issue #217.
+ *
+ * These run against a real file-backed database through the repository's own
+ * storage module (the SQLite development back-end; Postgres gets the same
+ * tables from migrations/0011_agent_marketplace.sql). Nothing is mocked: the
+ * database is closed and reopened between assertions, which is what "survives
+ * a restart" actually means. An ownership record that reset on restart would
+ * not be a security control, so the hijack refusal is re-asserted on the
+ * other side of the restart.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { PluginManifest } from '@shared/types/marketplace';
+import { AgentMarketplace } from '../engine';
+import { MarketplaceError } from '../errors';
+import type { MarketplaceStore } from '../store';
+
+const OWNER = 'publisher-a';
+const OTHER = 'publisher-b';
+const INSTALLER = 'operator-a';
+
+const persistedManifest: PluginManifest = {
+  id: 'durable-plugin',
+  name: 'Durable Plugin',
+  version: '1.0.0',
+  description: 'persisted across a restart',
+  author: 'tests',
+  category: 'custom',
+  requiredCapabilities: ['tags:read', 'log'],
+  configSchema: {
+    tagId: { type: 'string', description: 'tag', required: true },
+    limit: { type: 'number', description: 'limit', default: 10, required: false },
+  },
+  dependencies: {},
+  tags: ['durable'],
+};
+
+describe.sequential('marketplace persistence across a restart (#217)', () => {
+  let temporaryDirectory: string;
+  let database: typeof import('../../../storage');
+  let makeStore: () => MarketplaceStore;
+
+  async function restart(): Promise<void> {
+    await database.closeDatabase();
+    await database.initializeDatabase();
+  }
+
+  async function loadedEngine(): Promise<AgentMarketplace> {
+    const engine = new AgentMarketplace({
+      tagProvider: { list: () => [], readLatest: () => null },
+      store: makeStore(),
+    });
+    await engine.load();
+    return engine;
+  }
+
+  beforeAll(async () => {
+    temporaryDirectory = mkdtempSync(join(tmpdir(), 'oxscada-marketplace-'));
+    process.env.FORCE_POSTGRES = 'false';
+    process.env.SQLITE_DATABASE_PATH = join(temporaryDirectory, 'marketplace.sqlite');
+
+    database = await import('../../../storage');
+    const { DatabaseMarketplaceStore } = await import('../database-store');
+    makeStore = () => new DatabaseMarketplaceStore();
+    await database.initializeDatabase();
+  });
+
+  afterAll(async () => {
+    await database.closeDatabase();
+    delete process.env.SQLITE_DATABASE_PATH;
+    delete process.env.FORCE_POSTGRES;
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  it('uses a durable store', async () => {
+    const engine = await loadedEngine();
+    expect(engine.storeKind).toBe('database');
+    expect(engine.getStatus().durable).toBe(true);
+  });
+
+  it('restores the registry, ownership record and install grants', async () => {
+    const before = await loadedEngine();
+    await before.publish(persistedManifest, OWNER);
+    before.registerImplementation('durable-plugin', () => 'ok');
+    await before.install('durable-plugin', {
+      installedBy: INSTALLER,
+      config: { tagId: 'PT-101' },
+      grants: ['log'],
+    });
+    await before.start('durable-plugin');
+
+    await restart();
+
+    const after = await loadedEngine();
+    expect(after.getPublisher('durable-plugin')).toBe(OWNER);
+    expect(after.getEntry('durable-plugin')).toMatchObject({
+      publisher: OWNER,
+      installs: 1,
+      manifest: expect.objectContaining({ id: 'durable-plugin', version: '1.0.0' }),
+    });
+
+    const installed = after.getInstalled('durable-plugin');
+    expect(installed).toMatchObject({
+      installedBy: INSTALLER,
+      grantedCapabilities: ['log'],
+      config: { tagId: 'PT-101', limit: 10 },
+    });
+    // Nothing is running after a restart, so the record must not claim it is.
+    expect(installed?.status).toBe('stopped');
+    // No implementation is registered on this fresh engine.
+    expect(installed?.implementationState).toBe('unavailable');
+  });
+
+  it('still refuses a manifest hijack after the restart', async () => {
+    await restart();
+    const engine = await loadedEngine();
+
+    const rejected = await engine
+      .publish({ ...persistedManifest, version: '9.9.9' }, OTHER)
+      .then(() => null, (error: unknown) => error);
+
+    expect(rejected).toBeInstanceOf(MarketplaceError);
+    expect((rejected as MarketplaceError).code).toBe('ownership-conflict');
+    expect(engine.getEntry('durable-plugin')?.manifest.version).toBe('1.0.0');
+
+    // The legitimate owner can still move the version forward.
+    await engine.publish({ ...persistedManifest, version: '1.1.0' }, OWNER);
+    await restart();
+    const reloaded = await loadedEngine();
+    expect(reloaded.getEntry('durable-plugin')?.manifest.version).toBe('1.1.0');
+    expect(reloaded.getEntry('durable-plugin')?.installs).toBe(1);
+  });
+
+  it('keeps a disabled plugin disabled across a restart', async () => {
+    const before = await loadedEngine();
+    await before.disable('durable-plugin');
+
+    await restart();
+
+    const after = await loadedEngine();
+    expect(after.getInstalled('durable-plugin')?.status).toBe('disabled');
+  });
+
+  it('persists an uninstall', async () => {
+    const before = await loadedEngine();
+    await before.uninstall('durable-plugin');
+
+    await restart();
+
+    const after = await loadedEngine();
+    expect(after.getInstalled('durable-plugin')).toBeUndefined();
+    // The registry entry and its ownership record outlive the installation:
+    // releasing the id on uninstall would re-open it to a hijack.
+    expect(after.getPublisher('durable-plugin')).toBe(OWNER);
+  });
+});

--- a/server/services/marketplace/__tests__/marketplace.test.ts
+++ b/server/services/marketplace/__tests__/marketplace.test.ts
@@ -1,0 +1,691 @@
+/**
+ * Agent Marketplace engine tests.
+ *
+ * Feature [13.6] of ADR-0013 — Issue #217.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  CapabilityDenialRecord,
+  PluginCapability,
+  PluginManifest,
+} from '@shared/types/marketplace';
+import { compareSemver, parseSemver, satisfiesRange } from '../semver';
+import { AgentMarketplace, SYSTEM_PUBLISHER, type TagProvider } from '../engine';
+import { MarketplaceError } from '../errors';
+import { InMemoryMarketplaceStore } from '../store';
+import {
+  TAG_THRESHOLD_MONITOR_ID,
+  tagThresholdMonitorHandler,
+  tagThresholdMonitorManifest,
+} from '../builtin';
+
+const OWNER = 'publisher-a';
+const OTHER = 'publisher-b';
+const INSTALLER = 'operator-a';
+
+function manifest(overrides: Partial<PluginManifest> = {}): PluginManifest {
+  return {
+    id: 'demo-plugin',
+    name: 'Demo Plugin',
+    version: '1.0.0',
+    description: 'test plugin',
+    author: 'tests',
+    category: 'custom',
+    requiredCapabilities: ['tags:read', 'log'],
+    configSchema: {
+      threshold: { type: 'number', description: 'limit', default: 50, required: false },
+      mode: {
+        type: 'select',
+        description: 'mode',
+        options: ['fast', 'slow'],
+        default: 'fast',
+        required: true,
+      },
+    },
+    dependencies: {},
+    tags: ['demo'],
+    ...overrides,
+  };
+}
+
+const tagProvider: TagProvider = {
+  list: () => ['TANK-3.PRESSURE'],
+  readLatest: (tagId) => (tagId === 'TANK-3.PRESSURE' ? { value: 42, timestamp: 1000 } : null),
+};
+
+async function market(options: { store?: InMemoryMarketplaceStore } = {}): Promise<AgentMarketplace> {
+  const engine = new AgentMarketplace({
+    tagProvider,
+    store: options.store ?? new InMemoryMarketplaceStore(),
+    invokeTimeoutMs: 200,
+    autoDisableAfter: 3,
+  });
+  await engine.load();
+  return engine;
+}
+
+async function expectCode(promise: Promise<unknown>, code: string): Promise<MarketplaceError> {
+  const error = await promise.then(
+    () => null,
+    (thrown: unknown) => thrown,
+  );
+  expect(error).toBeInstanceOf(MarketplaceError);
+  const marketplaceError = error as MarketplaceError;
+  expect(marketplaceError.code).toBe(code);
+  return marketplaceError;
+}
+
+// ── Semver ────────────────────────────────────────────────────────────────
+
+describe('semver', () => {
+  it('parses and compares', () => {
+    expect(parseSemver('1.2.3')).toEqual({ major: 1, minor: 2, patch: 3 });
+    expect(parseSemver('1.2')).toBeNull();
+    expect(compareSemver('1.10.0', '1.9.9')).toBeGreaterThan(0);
+    expect(compareSemver('2.0.0', '2.0.0')).toBe(0);
+  });
+
+  it('evaluates ranges', () => {
+    expect(satisfiesRange('1.4.2', '^1.2.0')).toBe(true);
+    expect(satisfiesRange('2.0.0', '^1.2.0')).toBe(false);
+    expect(satisfiesRange('0.3.5', '^0.3.1')).toBe(true);
+    expect(satisfiesRange('0.4.0', '^0.3.1')).toBe(false);
+    expect(satisfiesRange('1.2.9', '~1.2.3')).toBe(true);
+    expect(satisfiesRange('1.3.0', '~1.2.3')).toBe(false);
+    expect(satisfiesRange('9.9.9', '*')).toBe(true);
+    expect(satisfiesRange('1.0.0', '1.0.0')).toBe(true);
+  });
+});
+
+// ── Ownership: the manifest-hijack defence ────────────────────────────────
+
+describe('plugin ownership', () => {
+  it('refuses to publish or install before state is loaded', async () => {
+    const engine = new AgentMarketplace({ store: new InMemoryMarketplaceStore() });
+    await expectCode(engine.publish(manifest(), OWNER), 'store-unavailable');
+    await expectCode(
+      engine.install('demo-plugin', { installedBy: INSTALLER }),
+      'store-unavailable',
+    );
+  });
+
+  it('records the first publisher as the durable owner', async () => {
+    const engine = await market();
+    const entry = await engine.publish(manifest(), OWNER);
+    expect(entry.publisher).toBe(OWNER);
+    expect(engine.getPublisher('demo-plugin')).toBe(OWNER);
+  });
+
+  it('refuses a different principal republishing the id with a bumped version', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+
+    const error = await expectCode(
+      engine.publish(manifest({ version: '2.0.0' }), OTHER),
+      'ownership-conflict',
+    );
+    expect(error.status).toBe(403);
+
+    // The hijack left no trace: the registry still holds the owner's version.
+    const entry = engine.getEntry('demo-plugin');
+    expect(entry?.publisher).toBe(OWNER);
+    expect(entry?.manifest.version).toBe('1.0.0');
+  });
+
+  it('requires a strictly newer version and preserves the install counter', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    engine.registerImplementation('demo-plugin', () => 'ok');
+    await engine.install('demo-plugin', { installedBy: INSTALLER });
+    expect(engine.getEntry('demo-plugin')?.installs).toBe(1);
+
+    await expectCode(engine.publish(manifest({ version: '1.0.0' }), OWNER), 'version-conflict');
+    await expectCode(engine.publish(manifest({ version: '0.9.0' }), OWNER), 'version-conflict');
+
+    const republished = await engine.publish(manifest({ version: '1.1.0' }), OWNER);
+    expect(republished.manifest.version).toBe('1.1.0');
+    expect(republished.installs).toBe(1);
+    expect(republished.publishedAt).toBe(engine.getEntry('demo-plugin')?.publishedAt);
+  });
+
+  it('reserves the built-in publisher namespace from the HTTP publish path', async () => {
+    const engine = await market();
+    await expectCode(
+      engine.publish(manifest(), SYSTEM_PUBLISHER),
+      'ownership-conflict',
+    );
+    await expectCode(engine.publish(manifest(), 'system:anything'), 'ownership-conflict');
+    await expectCode(engine.publish(manifest(), '   '), 'ownership-conflict');
+  });
+
+  it('re-publishes an identical built-in version idempotently but refuses a downgrade', async () => {
+    const store = new InMemoryMarketplaceStore();
+    const engine = await market({ store });
+    await engine.publishSystemManifest(tagThresholdMonitorManifest);
+    await engine.publishSystemManifest(tagThresholdMonitorManifest);
+    expect(engine.getPublisher(TAG_THRESHOLD_MONITOR_ID)).toBe(SYSTEM_PUBLISHER);
+
+    await engine.publishSystemManifest({ ...tagThresholdMonitorManifest, version: '1.1.0' });
+    await expectCode(
+      engine.publishSystemManifest({ ...tagThresholdMonitorManifest, version: '1.0.0' }),
+      'version-conflict',
+    );
+  });
+
+  it('refuses to claim a built-in id already owned by an operator', async () => {
+    const engine = await market();
+    await engine.publish(
+      manifest({ id: TAG_THRESHOLD_MONITOR_ID, requiredCapabilities: [], configSchema: {} }),
+      OWNER,
+    );
+    await expectCode(
+      engine.publishSystemManifest(tagThresholdMonitorManifest),
+      'ownership-conflict',
+    );
+  });
+
+  it('rejects a self-referential dependency and an invalid range', async () => {
+    const engine = await market();
+    await expectCode(
+      engine.publish(manifest({ dependencies: { 'demo-plugin': '^1.0.0' } }), OWNER),
+      'invalid-manifest',
+    );
+    await expectCode(
+      engine.publish(manifest({ dependencies: { other: 'latest' } }), OWNER),
+      'invalid-manifest',
+    );
+  });
+});
+
+// ── Registry & dependency ranges ──────────────────────────────────────────
+
+describe('registry & versioning', () => {
+  it('updates an installed plugin to the newer registry version', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    engine.registerImplementation('demo-plugin', () => 'ok');
+    await engine.install('demo-plugin', { installedBy: INSTALLER });
+    await engine.start('demo-plugin');
+
+    await engine.publish(manifest({ version: '1.2.0' }), OWNER);
+    const updated = await engine.update('demo-plugin');
+    expect(updated.manifest.version).toBe('1.2.0');
+    expect(updated.status).toBe('running');
+    await expectCode(engine.update('demo-plugin'), 'version-conflict');
+  });
+
+  it('narrows carried-over grants when a new version drops a capability', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER); // declares tags:read, log
+    engine.registerImplementation('demo-plugin', () => 'ok');
+    await engine.install('demo-plugin', {
+      installedBy: INSTALLER,
+      grants: ['tags:read', 'log'],
+    });
+
+    await engine.publish(
+      manifest({ version: '2.0.0', requiredCapabilities: ['log'] }),
+      OWNER,
+    );
+    const updated = await engine.update('demo-plugin');
+    expect(updated.grantedCapabilities).toEqual(['log']);
+  });
+
+  it('does not widen grants when a new version declares more capabilities', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    engine.registerImplementation('demo-plugin', () => 'ok');
+    await engine.install('demo-plugin', { installedBy: INSTALLER, grants: ['log'] });
+
+    await engine.publish(
+      manifest({
+        version: '2.0.0',
+        requiredCapabilities: ['tags:read', 'log', 'events:emit'],
+      }),
+      OWNER,
+    );
+    const updated = await engine.update('demo-plugin');
+    expect(updated.grantedCapabilities).toEqual(['log']);
+  });
+
+  it('enforces dependency semver ranges at install', async () => {
+    const engine = await market();
+    await engine.publish(
+      manifest({ id: 'dep-plugin', requiredCapabilities: [], configSchema: {} }),
+      OWNER,
+    );
+    await engine.publish(
+      manifest({ id: 'consumer', dependencies: { 'dep-plugin': '^2.0.0' }, configSchema: {} }),
+      OWNER,
+    );
+
+    await expectCode(
+      engine.install('consumer', { installedBy: INSTALLER }),
+      'dependency-missing',
+    );
+    await engine.install('dep-plugin', { installedBy: INSTALLER }); // v1.0.0
+    await expectCode(
+      engine.install('consumer', { installedBy: INSTALLER }),
+      'dependency-unsatisfied',
+    );
+  });
+
+  it('refuses to uninstall a plugin others depend on', async () => {
+    const engine = await market();
+    await engine.publish(
+      manifest({ id: 'dep-plugin', requiredCapabilities: [], configSchema: {} }),
+      OWNER,
+    );
+    await engine.publish(
+      manifest({ id: 'consumer', dependencies: { 'dep-plugin': '^1.0.0' }, configSchema: {} }),
+      OWNER,
+    );
+    await engine.install('dep-plugin', { installedBy: INSTALLER });
+    await engine.install('consumer', { installedBy: INSTALLER });
+
+    await expectCode(engine.uninstall('dep-plugin'), 'dependents-installed');
+    await engine.uninstall('consumer');
+    await engine.uninstall('dep-plugin');
+    expect(engine.listInstalled()).toHaveLength(0);
+  });
+});
+
+// ── Config validation ─────────────────────────────────────────────────────
+
+describe('config validation', () => {
+  it('applies defaults to optional fields too', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    const plugin = await engine.install('demo-plugin', { installedBy: INSTALLER });
+    expect(plugin.config.threshold).toBe(50);
+    expect(plugin.config.mode).toBe('fast');
+    expect(plugin.installedBy).toBe(INSTALLER);
+  });
+
+  it('rejects unknown keys, wrong types, and invalid select values', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    await expectCode(
+      engine.install('demo-plugin', { installedBy: INSTALLER, config: { bogus: 1 } }),
+      'invalid-config',
+    );
+    await expectCode(
+      engine.install('demo-plugin', { installedBy: INSTALLER, config: { threshold: 'high' } }),
+      'invalid-config',
+    );
+    await expectCode(
+      engine.install('demo-plugin', { installedBy: INSTALLER, config: { mode: 'turbo' } }),
+      'invalid-config',
+    );
+  });
+
+  it('does not mutate the caller-supplied config object', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    const supplied: Record<string, number> = {};
+    await engine.install('demo-plugin', { installedBy: INSTALLER, config: supplied });
+    expect(Object.keys(supplied)).toHaveLength(0);
+  });
+});
+
+// ── Capability enforcement ────────────────────────────────────────────────
+
+describe('capability enforcement', () => {
+  it('throws and audits when a plugin reaches for an ungranted capability', async () => {
+    const engine = await market();
+    const denials: CapabilityDenialRecord[] = [];
+    engine.on('plugin-capability-denied', (record: CapabilityDenialRecord) => {
+      denials.push(record);
+    });
+
+    await engine.publish(manifest(), OWNER); // declares tags:read, log
+    engine.registerImplementation('demo-plugin', (_input, host) => host.tags.list());
+    // Grant only log — tags:read is declared but NOT granted.
+    await engine.install('demo-plugin', { installedBy: INSTALLER, grants: ['log'] });
+    await engine.start('demo-plugin');
+
+    const result = await engine.invoke('demo-plugin', {});
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('capability-denied');
+    expect(result.error).toMatch(/tags:read/);
+    expect(denials).toEqual([
+      expect.objectContaining({
+        pluginId: 'demo-plugin',
+        capability: 'tags:read',
+        reason: 'ungranted',
+      }),
+    ]);
+    expect(engine.getHealth('demo-plugin')?.capabilityDenials).toBe(1);
+  });
+
+  it('throws when a plugin reaches for a capability its manifest never declared', async () => {
+    const engine = await market();
+    const denials: CapabilityDenialRecord[] = [];
+    engine.on('plugin-capability-denied', (record: CapabilityDenialRecord) => {
+      denials.push(record);
+    });
+
+    await engine.publish(manifest({ requiredCapabilities: ['log'] }), OWNER);
+    engine.registerImplementation('demo-plugin', (_input, host) => host.alarms.getActive());
+    await engine.install('demo-plugin', { installedBy: INSTALLER });
+    await engine.start('demo-plugin');
+
+    const result = await engine.invoke('demo-plugin', {});
+    expect(result.code).toBe('capability-denied');
+    expect(denials[0]).toMatchObject({ capability: 'alarms:read', reason: 'undeclared' });
+  });
+
+  it('reports granted capabilities so a plugin can feature-detect without throwing', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    engine.registerImplementation('demo-plugin', (_input, host) => [...host.capabilities]);
+    await engine.install('demo-plugin', { installedBy: INSTALLER, grants: ['log'] });
+    await engine.start('demo-plugin');
+
+    const result = await engine.invoke('demo-plugin', {});
+    expect(result.success).toBe(true);
+    expect(result.output).toEqual(['log']);
+  });
+
+  it('lets a granted capability reach the live host service', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    engine.registerImplementation(
+      'demo-plugin',
+      (_input, host) => host.tags.readLatest('TANK-3.PRESSURE'),
+    );
+    await engine.install('demo-plugin', { installedBy: INSTALLER }); // grants = declared
+    await engine.start('demo-plugin');
+
+    const result = await engine.invoke('demo-plugin', {});
+    expect(result.success).toBe(true);
+    expect(result.output).toEqual({ value: 42, timestamp: 1000 });
+  });
+
+  it('rejects grants beyond the manifest declaration', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER); // declares tags:read, log
+    await expectCode(
+      engine.install('demo-plugin', {
+        installedBy: INSTALLER,
+        grants: ['events:emit'] as PluginCapability[],
+      }),
+      'capability-not-declared',
+    );
+  });
+
+  it('freezes the host config so a handler cannot rewrite its own installation', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    engine.registerImplementation('demo-plugin', (_input, host) => {
+      const mutable = host.config as Record<string, string | number | boolean>;
+      mutable.threshold = 9999;
+      return host.config.threshold;
+    });
+    await engine.install('demo-plugin', { installedBy: INSTALLER });
+    await engine.start('demo-plugin');
+
+    const result = await engine.invoke('demo-plugin', {});
+    expect(result.success).toBe(false);
+    expect(engine.getInstalled('demo-plugin')?.config.threshold).toBe(50);
+  });
+});
+
+// ── Execution bounds ──────────────────────────────────────────────────────
+
+describe('invocation bounds', () => {
+  it('times out runaway invocations', async () => {
+    const engine = await market(); // 200ms cap
+    await engine.publish(manifest(), OWNER);
+    engine.registerImplementation(
+      'demo-plugin',
+      () => new Promise((resolve) => setTimeout(resolve, 5_000)),
+    );
+    await engine.install('demo-plugin', { installedBy: INSTALLER });
+    await engine.start('demo-plugin');
+
+    const result = await engine.invoke('demo-plugin', {});
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('timeout');
+  });
+
+  it('will not let a handler mislabel its own failure as a host timeout', async () => {
+    // The timeout code is derived from the host's own timer error type, not
+    // from the error text, so a handler cannot forge it and make an ordinary
+    // fault read as a host-imposed bound in the audit trail.
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    engine.registerImplementation('demo-plugin', () => {
+      throw new Error('Plugin "demo-plugin" invocation timed out after 1ms');
+    });
+    await engine.install('demo-plugin', { installedBy: INSTALLER });
+    await engine.start('demo-plugin');
+
+    const result = await engine.invoke('demo-plugin', {});
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('handler-error');
+  });
+
+  it('bounds a handler that yields, and says so when one does not', async () => {
+    // Honest boundary: the timer lives on the event loop. A handler that
+    // awaits is cut off; a handler that blocks the loop synchronously cannot
+    // be pre-empted without process/VM isolation, which this build lacks.
+    const engine = await market(); // 200ms cap
+    await engine.publish(manifest(), OWNER);
+    engine.registerImplementation('demo-plugin', () => {
+      const until = Date.now() + 400;
+      while (Date.now() < until) { /* owns the thread */ }
+      return 'ran past the cap';
+    });
+    await engine.install('demo-plugin', { installedBy: INSTALLER });
+    await engine.start('demo-plugin');
+
+    const result = await engine.invoke('demo-plugin', {});
+    expect(result.success).toBe(true);
+    expect(result.durationMs).toBeGreaterThanOrEqual(200);
+  });
+
+  it('auto-disables after consecutive failures and recovers via enable', async () => {
+    const engine = await market(); // autoDisableAfter 3
+    const disabled = vi.fn();
+    engine.on('plugin-auto-disabled', disabled);
+    await engine.publish(manifest(), OWNER);
+    engine.registerImplementation('demo-plugin', () => {
+      throw new Error('boom');
+    });
+    await engine.install('demo-plugin', { installedBy: INSTALLER });
+    await engine.start('demo-plugin');
+
+    for (let attempt = 0; attempt < 3; attempt++) await engine.invoke('demo-plugin', {});
+    expect(disabled).toHaveBeenCalledTimes(1);
+    expect(engine.getInstalled('demo-plugin')?.status).toBe('error');
+
+    const blocked = await engine.invoke('demo-plugin', {});
+    expect(blocked.code).toBe('not-running');
+
+    await engine.enable('demo-plugin');
+    await engine.start('demo-plugin');
+    expect(engine.getHealth('demo-plugin')?.consecutiveFailures).toBe(0);
+  });
+});
+
+// ── "No merchandise": installed but not implemented ───────────────────────
+
+describe('installed-but-not-implemented is an explicit state', () => {
+  it('reports the state, refuses to start, and returns a machine code on invoke', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    const plugin = await engine.install('demo-plugin', { installedBy: INSTALLER });
+
+    expect(plugin.implementationState).toBe('unavailable');
+    expect(engine.getHealth('demo-plugin')?.implementationState).toBe('unavailable');
+    expect(engine.getStatus().unimplemented).toBe(1);
+
+    const error = await expectCode(engine.start('demo-plugin'), 'not-implemented');
+    expect(error.message).toMatch(/no implementation is registered/);
+
+    const result = await engine.invoke('demo-plugin', {});
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('not-implemented');
+  });
+
+  it('flips to available as soon as an implementation is registered', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    await engine.install('demo-plugin', { installedBy: INSTALLER });
+    engine.registerImplementation('demo-plugin', () => 'ok');
+
+    expect(engine.getInstalled('demo-plugin')?.implementationState).toBe('available');
+    const started = await engine.start('demo-plugin');
+    expect(started.status).toBe('running');
+    expect(engine.getStatus().unimplemented).toBe(0);
+  });
+});
+
+// ── Lifecycle & health ────────────────────────────────────────────────────
+
+describe('lifecycle & health', () => {
+  it('reinstalling throws instead of silently replacing', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    await engine.install('demo-plugin', { installedBy: INSTALLER });
+    await expectCode(
+      engine.install('demo-plugin', { installedBy: INSTALLER }),
+      'already-installed',
+    );
+  });
+
+  it('disable blocks start until enable', async () => {
+    const engine = await market();
+    await engine.publish(manifest(), OWNER);
+    engine.registerImplementation('demo-plugin', () => 'ok');
+    await engine.install('demo-plugin', { installedBy: INSTALLER });
+    await engine.disable('demo-plugin');
+    await expectCode(engine.start('demo-plugin'), 'invalid-state');
+    await engine.enable('demo-plugin');
+    expect((await engine.start('demo-plugin')).status).toBe('running');
+  });
+
+  it('tracks uptime from start (not install) and the windowed error rate', async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = await market();
+      await engine.publish(manifest(), OWNER);
+      let fail = false;
+      engine.registerImplementation('demo-plugin', () => {
+        if (fail) throw new Error('flaky');
+        return 'ok';
+      });
+      await engine.install('demo-plugin', { installedBy: INSTALLER });
+      vi.advanceTimersByTime(60_000);
+      await engine.start('demo-plugin');
+      vi.advanceTimersByTime(10_000);
+
+      await engine.invoke('demo-plugin', {});
+      fail = true;
+      await engine.invoke('demo-plugin', {});
+
+      const health = engine.getHealth('demo-plugin');
+      expect(health?.uptimeSeconds).toBe(10);
+      expect(health?.invocations).toBe(2);
+      expect(health?.windowedErrorRate).toBe(0.5);
+      expect(health?.lastError).toBe('flaky');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ── The built-in plugin, invoked for real ─────────────────────────────────
+
+describe('built-in tag-threshold-monitor', () => {
+  async function installBuiltin(
+    provider: TagProvider,
+    config: Record<string, string | number | boolean>,
+  ): Promise<AgentMarketplace> {
+    const engine = new AgentMarketplace({
+      tagProvider: provider,
+      store: new InMemoryMarketplaceStore(),
+    });
+    await engine.load();
+    engine.registerImplementation(TAG_THRESHOLD_MONITOR_ID, tagThresholdMonitorHandler);
+    await engine.publishSystemManifest(tagThresholdMonitorManifest);
+    await engine.install(TAG_THRESHOLD_MONITOR_ID, { installedBy: INSTALLER, config });
+    await engine.start(TAG_THRESHOLD_MONITOR_ID);
+    return engine;
+  }
+
+  it('classifies a live tag and emits a host event when out of band', async () => {
+    const now = 1_000_000;
+    const engine = await installBuiltin(
+      {
+        list: () => ['PT-101'],
+        readLatest: () => ({ value: 97, timestamp: now - 5_000 }),
+      },
+      { tagId: 'PT-101', highLimit: 90, lowLimit: 10 },
+    );
+    const events: Array<{ pluginId: string; type: string }> = [];
+    engine.on('plugin-event', (event: { pluginId: string; type: string }) => events.push(event));
+
+    const result = await engine.invoke(TAG_THRESHOLD_MONITOR_ID, { nowMs: now });
+    expect(result.success).toBe(true);
+    expect(result.output).toMatchObject({
+      tagId: 'PT-101',
+      state: 'high',
+      value: 97,
+      ageSeconds: 5,
+      severity: 'warning',
+    });
+    expect(events).toEqual([
+      expect.objectContaining({
+        pluginId: TAG_THRESHOLD_MONITOR_ID,
+        type: 'tag-threshold-breach',
+      }),
+    ]);
+  });
+
+  it('reports a normal reading without emitting an event', async () => {
+    const now = 1_000_000;
+    const engine = await installBuiltin(
+      { list: () => ['PT-101'], readLatest: () => ({ value: 50, timestamp: now }) },
+      { tagId: 'PT-101', highLimit: 90, lowLimit: 10 },
+    );
+    const events: unknown[] = [];
+    engine.on('plugin-event', (event: unknown) => events.push(event));
+
+    const result = await engine.invoke(TAG_THRESHOLD_MONITOR_ID, { nowMs: now });
+    expect(result.output).toMatchObject({ state: 'normal' });
+    expect(events).toHaveLength(0);
+  });
+
+  it('detects a stale sample and an unavailable tag', async () => {
+    const now = 1_000_000;
+    const engine = await installBuiltin(
+      {
+        list: () => ['PT-101'],
+        readLatest: (tagId) => (tagId === 'PT-101' ? { value: 50, timestamp: now - 600_000 } : null),
+      },
+      { tagId: 'PT-101', highLimit: 90, lowLimit: 10, maxAgeSeconds: 30 },
+    );
+
+    const stale = await engine.invoke(TAG_THRESHOLD_MONITOR_ID, { nowMs: now });
+    expect(stale.output).toMatchObject({ state: 'stale', ageSeconds: 600 });
+
+    const missing = await engine.invoke(TAG_THRESHOLD_MONITOR_ID, {
+      tagId: 'NOT-A-TAG',
+      nowMs: now,
+    });
+    expect(missing.output).toMatchObject({ state: 'unavailable', value: null });
+  });
+
+  it('rejects an unknown invocation field instead of ignoring it', async () => {
+    const engine = await installBuiltin(
+      { list: () => ['PT-101'], readLatest: () => ({ value: 50, timestamp: Date.now() }) },
+      { tagId: 'PT-101', highLimit: 90, lowLimit: 10 },
+    );
+    const result = await engine.invoke(TAG_THRESHOLD_MONITOR_ID, { unexpected: true });
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('handler-error');
+  });
+});

--- a/server/services/marketplace/builtin/index.ts
+++ b/server/services/marketplace/builtin/index.ts
@@ -1,0 +1,40 @@
+/**
+ * First-party plugin implementations.
+ *
+ * Feature [13.6] of ADR-0013 — Issue #217.
+ *
+ * This module is the ONLY production source of executable plugin handlers.
+ * `MarketplaceService.initialize()` publishes each manifest below under the
+ * reserved `system:builtin` publisher and calls `registerImplementation` for
+ * it, so an operator can install and invoke it end to end.
+ *
+ * A manifest published over HTTP by anyone else never gains an entry here and
+ * therefore can never execute: it installs, reports
+ * `implementationState: "unavailable"`, and refuses to start. That is the
+ * containment story — the marketplace does not transport code, so there is no
+ * untrusted code to sandbox. Adding a plugin means adding it here, in a
+ * reviewed commit, and shipping a new build.
+ */
+
+import type { PluginManifest } from '@shared/types/marketplace';
+import type { PluginHandler } from '../engine';
+import {
+  TAG_THRESHOLD_MONITOR_ID,
+  tagThresholdMonitorHandler,
+  tagThresholdMonitorManifest,
+} from './tag-threshold-monitor';
+
+export interface BuiltinPlugin {
+  manifest: PluginManifest;
+  handler: PluginHandler;
+}
+
+export const BUILTIN_PLUGINS: readonly BuiltinPlugin[] = Object.freeze([
+  Object.freeze({
+    manifest: tagThresholdMonitorManifest,
+    handler: tagThresholdMonitorHandler,
+  }),
+]);
+
+export { TAG_THRESHOLD_MONITOR_ID, tagThresholdMonitorManifest, tagThresholdMonitorHandler };
+export type { ThresholdEvaluation, ThresholdState } from './tag-threshold-monitor';

--- a/server/services/marketplace/builtin/tag-threshold-monitor.ts
+++ b/server/services/marketplace/builtin/tag-threshold-monitor.ts
@@ -1,0 +1,170 @@
+/**
+ * Built-in plugin: tag threshold monitor.
+ *
+ * Feature [13.6] of ADR-0013 — Issue #217.
+ *
+ * This is a real, first-party marketplace plugin, not a demo stub. It reads a
+ * configured tag through the capability-gated host context, classifies the
+ * latest sample against configured limits and a staleness bound, and emits a
+ * host event when the tag is out of band. It is what makes the marketplace
+ * demonstrably able to invoke something end to end.
+ *
+ * It is also the reference for how a plugin is supposed to behave: it asks
+ * `host.capabilities` before reaching for an optional capability, and it
+ * reaches for `host.tags` unconditionally because `tags:read` is not optional
+ * for this plugin — if that capability was not granted, the host context
+ * throws `capability-denied` and the invocation fails loudly.
+ */
+
+import { z } from 'zod';
+import type { PluginManifest } from '@shared/types/marketplace';
+import type { PluginHandler, PluginHostContext } from '../engine';
+
+export const TAG_THRESHOLD_MONITOR_ID = 'tag-threshold-monitor';
+
+export const tagThresholdMonitorManifest: PluginManifest = {
+  id: TAG_THRESHOLD_MONITOR_ID,
+  name: 'Tag Threshold Monitor',
+  version: '1.0.0',
+  description:
+    'Classifies the latest value of a tag against high/low limits and a staleness '
+    + 'bound, and emits a host event when the tag is out of band.',
+  author: '0xSCADA (first-party)',
+  category: 'safety',
+  requiredCapabilities: ['tags:read', 'events:emit', 'log'],
+  configSchema: {
+    tagId: {
+      type: 'string',
+      description: 'Tag evaluated when the invocation does not name one.',
+      required: true,
+    },
+    highLimit: {
+      type: 'number',
+      description: 'Value at or above which the tag is reported as high.',
+      required: true,
+    },
+    lowLimit: {
+      type: 'number',
+      description: 'Value at or below which the tag is reported as low.',
+      required: true,
+    },
+    maxAgeSeconds: {
+      type: 'number',
+      description: 'Samples older than this are reported as stale.',
+      default: 60,
+      required: false,
+    },
+    severity: {
+      type: 'select',
+      description: 'Severity attached to an emitted breach event.',
+      options: ['info', 'warning', 'critical'],
+      default: 'warning',
+      required: false,
+    },
+  },
+  dependencies: {},
+  tags: ['tags', 'threshold', 'monitoring'],
+};
+
+const InputSchema = z.object({
+  /** Evaluate a different tag than the configured one. */
+  tagId: z.string().min(1).max(256).optional(),
+  /** Reference time for the staleness check; defaults to now. */
+  nowMs: z.number().int().nonnegative().optional(),
+}).strict();
+
+export type ThresholdState =
+  | 'normal'
+  | 'high'
+  | 'low'
+  | 'stale'
+  | 'unavailable'
+  | 'non-numeric';
+
+export interface ThresholdEvaluation {
+  tagId: string;
+  state: ThresholdState;
+  value: number | string | null;
+  sampledAt: number | null;
+  ageSeconds: number | null;
+  highLimit: number;
+  lowLimit: number;
+  severity: string;
+  evaluatedAt: number;
+}
+
+function requireNumber(config: PluginHostContext['config'], key: string): number {
+  const value = config[key];
+  if (typeof value !== 'number') {
+    // The engine validates config against the manifest schema before an
+    // install is accepted, so this only fires if the two ever disagree.
+    throw new Error(`Config "${key}" must be a number`);
+  }
+  return value;
+}
+
+export const tagThresholdMonitorHandler: PluginHandler = (
+  input: unknown,
+  host: PluginHostContext,
+): ThresholdEvaluation => {
+  const parsed = InputSchema.safeParse(input ?? {});
+  if (!parsed.success) {
+    throw new Error(`Invalid invocation input: ${parsed.error.issues[0]?.message ?? 'unknown'}`);
+  }
+
+  const configuredTag = host.config.tagId;
+  const tagId = parsed.data.tagId ?? (typeof configuredTag === 'string' ? configuredTag : '');
+  if (tagId.length === 0) throw new Error('No tag configured for this installation');
+
+  const highLimit = requireNumber(host.config, 'highLimit');
+  const lowLimit = requireNumber(host.config, 'lowLimit');
+  const maxAgeSeconds = typeof host.config.maxAgeSeconds === 'number'
+    ? host.config.maxAgeSeconds
+    : 60;
+  const severity = typeof host.config.severity === 'string' ? host.config.severity : 'warning';
+  const evaluatedAt = parsed.data.nowMs ?? Date.now();
+
+  // `tags:read` is mandatory for this plugin: if it was not granted, this
+  // access throws `capability-denied` and the invocation fails.
+  const sample = host.tags.readLatest(tagId);
+
+  let state: ThresholdState;
+  let ageSeconds: number | null = null;
+  if (sample === null) {
+    state = 'unavailable';
+  } else {
+    ageSeconds = Math.max(0, Math.round((evaluatedAt - sample.timestamp) / 1000));
+    if (ageSeconds > maxAgeSeconds) {
+      state = 'stale';
+    } else if (typeof sample.value !== 'number') {
+      state = 'non-numeric';
+    } else if (sample.value >= highLimit) {
+      state = 'high';
+    } else if (sample.value <= lowLimit) {
+      state = 'low';
+    } else {
+      state = 'normal';
+    }
+  }
+
+  const evaluation: ThresholdEvaluation = {
+    tagId,
+    state,
+    value: sample?.value ?? null,
+    sampledAt: sample?.timestamp ?? null,
+    ageSeconds,
+    highLimit,
+    lowLimit,
+    severity,
+    evaluatedAt,
+  };
+
+  if (state !== 'normal' && host.capabilities.includes('events:emit')) {
+    host.emitEvent('tag-threshold-breach', { ...evaluation });
+  }
+  if (state !== 'normal' && host.capabilities.includes('log')) {
+    host.log(`${tagId} is ${state} (limits ${lowLimit}..${highLimit})`);
+  }
+
+  return evaluation;
+};

--- a/server/services/marketplace/database-store.ts
+++ b/server/services/marketplace/database-store.ts
@@ -1,0 +1,189 @@
+/**
+ * Drizzle-backed marketplace store.
+ *
+ * Feature [13.6] of ADR-0013 — Issue #217.
+ *
+ * Writes through `server/storage.ts`, which resolves to Postgres in
+ * production (tables created by migrations/0011_agent_marketplace.sql) and to
+ * the repository's SQLite development fallback otherwise. Both back-ends are
+ * durable across a restart, which is the whole point: the ownership record
+ * that blocks manifest hijack is only an access control while it survives.
+ */
+
+import type {
+  InstalledPlugin,
+  MarketplaceEntry,
+  PluginCapability,
+  PluginManifest,
+  PluginStatus,
+} from '@shared/types/marketplace';
+import { storage } from '../../storage';
+import { MarketplaceError } from './errors';
+import type { MarketplaceSnapshot, MarketplaceStore, StoredInstallation } from './store';
+
+function asRecord(value: unknown, field: string, pluginId: string): Record<string, unknown> {
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  throw new MarketplaceError(
+    'invalid-manifest',
+    `Stored plugin "${pluginId}" has a malformed ${field} column`,
+  );
+}
+
+/**
+ * Persisted manifests were validated by the publish path before they were
+ * written, but a row can still be edited or corrupted out of band. Re-check
+ * the shape on the way back in rather than trusting the column.
+ */
+function toManifest(value: unknown, pluginId: string): PluginManifest {
+  const raw = asRecord(value, 'manifest', pluginId);
+  if (
+    typeof raw.id !== 'string'
+    || typeof raw.name !== 'string'
+    || typeof raw.version !== 'string'
+    || typeof raw.category !== 'string'
+    || !Array.isArray(raw.requiredCapabilities)
+    || !Array.isArray(raw.tags)
+    || typeof raw.dependencies !== 'object'
+    || raw.dependencies === null
+    || typeof raw.configSchema !== 'object'
+    || raw.configSchema === null
+  ) {
+    throw new MarketplaceError(
+      'invalid-manifest',
+      `Stored plugin "${pluginId}" has a malformed manifest column`,
+    );
+  }
+  return raw as unknown as PluginManifest;
+}
+
+function toConfig(value: unknown, pluginId: string): Record<string, string | number | boolean> {
+  const raw = asRecord(value, 'config', pluginId);
+  const config: Record<string, string | number | boolean> = {};
+  for (const [key, entry] of Object.entries(raw)) {
+    if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
+      config[key] = entry;
+      continue;
+    }
+    throw new MarketplaceError(
+      'invalid-config',
+      `Stored plugin "${pluginId}" has a non-scalar value for config key "${key}"`,
+    );
+  }
+  return config;
+}
+
+function toCapabilities(value: unknown, pluginId: string): PluginCapability[] {
+  if (!Array.isArray(value)) {
+    throw new MarketplaceError(
+      'invalid-manifest',
+      `Stored plugin "${pluginId}" has a malformed granted_capabilities column`,
+    );
+  }
+  return value.map((entry) => {
+    if (typeof entry !== 'string') {
+      throw new MarketplaceError(
+        'invalid-manifest',
+        `Stored plugin "${pluginId}" has a non-string granted capability`,
+      );
+    }
+    return entry as PluginCapability;
+  });
+}
+
+const PLUGIN_STATUSES: readonly PluginStatus[] = [
+  'installed',
+  'running',
+  'stopped',
+  'disabled',
+  'error',
+];
+
+/**
+ * A plugin that was `running` when the server stopped is not running now.
+ * Restoring it as `running` would report uptime for something that never
+ * started, so a restart lands in `stopped` and an operator restarts it.
+ * `disabled` and `error` survive verbatim — a restart must not clear them.
+ */
+function toRestoredStatus(value: unknown, pluginId: string): PluginStatus {
+  if (typeof value !== 'string' || !PLUGIN_STATUSES.includes(value as PluginStatus)) {
+    throw new MarketplaceError(
+      'invalid-state',
+      `Stored plugin "${pluginId}" has an unknown status "${String(value)}"`,
+    );
+  }
+  const status = value as PluginStatus;
+  return status === 'running' ? 'stopped' : status;
+}
+
+function toEpoch(value: unknown, pluginId: string, column: string): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  throw new MarketplaceError(
+    'invalid-state',
+    `Stored plugin "${pluginId}" has an unreadable ${column} timestamp`,
+  );
+}
+
+export class DatabaseMarketplaceStore implements MarketplaceStore {
+  readonly kind = 'database' as const;
+
+  async load(): Promise<MarketplaceSnapshot> {
+    const registryRows = await storage.getPluginRegistryEntries();
+    const installRows = await storage.getPluginInstallations();
+
+    const entries: MarketplaceEntry[] = registryRows.map((row) => ({
+      manifest: toManifest(row.manifest, row.id),
+      publisher: row.publisher,
+      publishedAt: toEpoch(row.publishedAt, row.id, 'published_at'),
+      updatedAt: toEpoch(row.updatedAt, row.id, 'updated_at'),
+      installs: Number(row.installs),
+    }));
+
+    const installations: StoredInstallation[] = installRows.map((row) => ({
+      manifest: toManifest(row.manifest, row.id),
+      status: toRestoredStatus(row.status, row.id),
+      config: toConfig(row.config, row.id),
+      grantedCapabilities: toCapabilities(row.grantedCapabilities, row.id),
+      installedBy: row.installedBy,
+      installedAt: toEpoch(row.installedAt, row.id, 'installed_at'),
+    }));
+
+    return { entries, installations };
+  }
+
+  async saveEntry(entry: MarketplaceEntry): Promise<void> {
+    await storage.upsertPluginRegistryEntry({
+      id: entry.manifest.id,
+      version: entry.manifest.version,
+      manifest: entry.manifest,
+      publisher: entry.publisher,
+      installs: entry.installs,
+      publishedAt: new Date(entry.publishedAt),
+      updatedAt: new Date(entry.updatedAt),
+    });
+  }
+
+  async saveInstallation(plugin: InstalledPlugin): Promise<void> {
+    await storage.upsertPluginInstallation({
+      id: plugin.manifest.id,
+      version: plugin.manifest.version,
+      manifest: plugin.manifest,
+      status: plugin.status,
+      config: plugin.config,
+      grantedCapabilities: plugin.grantedCapabilities,
+      installedBy: plugin.installedBy,
+      installedAt: new Date(plugin.installedAt),
+      updatedAt: new Date(),
+    });
+  }
+
+  async deleteInstallation(pluginId: string): Promise<void> {
+    await storage.deletePluginInstallation(pluginId);
+  }
+}

--- a/server/services/marketplace/engine.ts
+++ b/server/services/marketplace/engine.ts
@@ -1,0 +1,978 @@
+/**
+ * Agent Marketplace engine.
+ *
+ * Feature [13.6] of ADR-0013 (docs/decisions/ADR-0013-autonomous-agent-architecture.md).
+ * Issue #217. Design notes: docs/architecture/agent-marketplace.md.
+ *
+ * Responsibilities:
+ *   - a registry of plugin manifests with real semver rules and a durable
+ *     ownership record that blocks manifest hijack;
+ *   - install / configure / lifecycle records with durable capability grants;
+ *   - invocation of the FIRST-PARTY handler registered for a plugin id, under
+ *     an enforcing capability gate, a wall-clock timeout, and a windowed
+ *     failure tracker that auto-disables a misbehaving plugin.
+ *
+ * ── Isolation, stated plainly ────────────────────────────────────────────
+ * Handlers execute in-process, in this server's own isolate. That is NOT a
+ * security sandbox: a hostile handler could reach `process`, the filesystem,
+ * or the event loop no matter what its manifest declares. What the capability
+ * system does is constrain a COOPERATIVE plugin's access to host services at
+ * the host-context boundary, and make every out-of-scope reach fail loudly
+ * and audibly instead of silently succeeding.
+ *
+ * The reason that is a defensible position here is that no third-party code
+ * can ever run: a published manifest is metadata only, nothing is downloaded
+ * or dynamically loaded, and the only executable handlers are first-party
+ * modules compiled into this server and registered through
+ * `registerImplementation`. Executing untrusted code would require process or
+ * VM isolation, which this repository does not implement.
+ */
+
+import { EventEmitter } from 'events';
+import type {
+  CapabilityDenialRecord,
+  InstalledPlugin,
+  MarketplaceEntry,
+  PluginCapability,
+  PluginCategory,
+  PluginHealth,
+  PluginImplementationState,
+  PluginInvocationCode,
+  PluginInvocationResult,
+  PluginManifest,
+} from '@shared/types/marketplace';
+import { compareSemver, parseSemver, satisfiesRange } from './semver';
+import { MarketplaceError } from './errors';
+import { InMemoryMarketplaceStore, type MarketplaceStore } from './store';
+
+// ── Host API surface (capability-gated) ───────────────────────────────────
+
+export interface TagSample {
+  value: number | string;
+  timestamp: number;
+}
+
+export interface TagProvider {
+  list(): string[];
+  readLatest(tagId: string): TagSample | null;
+}
+
+export interface ActiveAlarm {
+  id: string;
+  name: string;
+  severity: string;
+  message: string;
+}
+
+export interface AlarmProvider {
+  getActive(): ActiveAlarm[];
+}
+
+/**
+ * What a handler receives.
+ *
+ * Every capability accessor is a getter that ENFORCES the grant: reading
+ * `host.tags` without `tags:read` both declared in the manifest and granted
+ * at install time throws `MarketplaceError('capability-denied')` and emits an
+ * audit event. Nothing is silently omitted, so a plugin cannot quietly skip a
+ * check it was supposed to make. `host.capabilities` is the supported way for
+ * a cooperative plugin to feature-detect before reaching.
+ */
+export interface PluginHostContext {
+  readonly pluginId: string;
+  readonly config: Readonly<Record<string, string | number | boolean>>;
+  readonly capabilities: readonly PluginCapability[];
+  readonly tags: TagProvider;
+  readonly alarms: AlarmProvider;
+  readonly emitEvent: (type: string, payload: Record<string, unknown>) => void;
+  readonly log: (message: string) => void;
+}
+
+export type PluginHandler = (
+  input: unknown,
+  host: PluginHostContext,
+) => Promise<unknown> | unknown;
+
+export interface MarketplaceOptions {
+  tagProvider?: TagProvider;
+  alarmProvider?: AlarmProvider;
+  /** Durable store. Defaults to a non-durable in-memory store for unit tests. */
+  store?: MarketplaceStore;
+  /** Wall-clock cap per invocation. */
+  invokeTimeoutMs?: number;
+  /** Recent invocations tracked for the windowed error rate. */
+  errorWindow?: number;
+  /** Consecutive failures before a plugin is auto-disabled. */
+  autoDisableAfter?: number;
+}
+
+export interface InstallRequest {
+  config?: Record<string, string | number | boolean>;
+  grants?: PluginCapability[];
+  /** Authenticated principal performing the install. */
+  installedBy: string;
+}
+
+interface PluginStats {
+  invocations: number;
+  failures: number;
+  consecutiveFailures: number;
+  capabilityDenials: number;
+  /** Rolling window of outcomes; `true` = success. */
+  recent: boolean[];
+}
+
+const ID_PATTERN = /^[a-z0-9][a-z0-9-]{1,63}$/;
+
+/**
+ * Owner of the compiled-in first-party plugins. Reserved: the HTTP publish
+ * path refuses any principal whose name starts with `system:`, so a
+ * configured API key cannot impersonate the built-in publisher and take over
+ * a built-in plugin id.
+ */
+export const SYSTEM_PUBLISHER = 'system:builtin';
+const RESERVED_PUBLISHER_PREFIX = 'system:';
+
+/**
+ * Raised by the invocation timer only.
+ *
+ * A nominal type rather than a message match: classifying by
+ * `message.includes('timed out')` would let a handler mislabel its own
+ * ordinary failure as a host-imposed timeout and corrupt the audit trail.
+ * Only this class, constructed inside `withTimeout`, can produce
+ * `code: "timeout"`.
+ */
+class PluginTimeoutError extends Error {
+  constructor(pluginId: string, ms: number) {
+    super(`Plugin "${pluginId}" invocation timed out after ${ms}ms`);
+    this.name = 'PluginTimeoutError';
+  }
+}
+
+function emptyStats(): PluginStats {
+  return {
+    invocations: 0,
+    failures: 0,
+    consecutiveFailures: 0,
+    capabilityDenials: 0,
+    recent: [],
+  };
+}
+
+export class AgentMarketplace extends EventEmitter {
+  private readonly tagProvider: TagProvider | null;
+  private readonly alarmProvider: AlarmProvider | null;
+  private readonly store: MarketplaceStore;
+  private readonly invokeTimeoutMs: number;
+  private readonly errorWindow: number;
+  private readonly autoDisableAfter: number;
+
+  private registry = new Map<string, MarketplaceEntry>();
+  private installed = new Map<string, InstalledPlugin>();
+  private readonly implementations = new Map<string, PluginHandler>();
+  private readonly stats = new Map<string, PluginStats>();
+  private loaded = false;
+
+  constructor(options: MarketplaceOptions = {}) {
+    super();
+    this.tagProvider = options.tagProvider ?? null;
+    this.alarmProvider = options.alarmProvider ?? null;
+    this.store = options.store ?? new InMemoryMarketplaceStore();
+    this.invokeTimeoutMs = options.invokeTimeoutMs ?? 5000;
+    this.errorWindow = options.errorWindow ?? 20;
+    this.autoDisableAfter = options.autoDisableAfter ?? 5;
+  }
+
+  get storeKind(): MarketplaceStore['kind'] {
+    return this.store.kind;
+  }
+
+  // ── Startup ──────────────────────────────────────────────────────────
+
+  /**
+   * Hydrate the registry, ownership records and installations from the store.
+   * Called once at startup, before the HTTP surface accepts a publish — an
+   * ownership check against an unhydrated registry would authorize a hijack.
+   */
+  async load(): Promise<void> {
+    const snapshot = await this.store.load();
+
+    const registry = new Map<string, MarketplaceEntry>();
+    for (const entry of snapshot.entries) {
+      registry.set(entry.manifest.id, entry);
+    }
+
+    const installed = new Map<string, InstalledPlugin>();
+    for (const record of snapshot.installations) {
+      installed.set(record.manifest.id, {
+        manifest: record.manifest,
+        status: record.status,
+        config: record.config,
+        grantedCapabilities: record.grantedCapabilities,
+        installedBy: record.installedBy,
+        installedAt: record.installedAt,
+        startedAt: null,
+        lastError: null,
+        implementationState: this.implementationState(record.manifest.id),
+      });
+      this.stats.set(record.manifest.id, emptyStats());
+    }
+
+    this.registry = registry;
+    this.installed = installed;
+    this.loaded = true;
+    this.emit('marketplace-loaded', {
+      store: this.store.kind,
+      published: registry.size,
+      installed: installed.size,
+    });
+  }
+
+  // ── Registry ─────────────────────────────────────────────────────────
+
+  /**
+   * Publish a manifest on behalf of an authenticated principal.
+   *
+   * First publish of an id records `publisher` as its durable owner. Every
+   * later publish of that id must come from the same principal, and must
+   * carry a strictly newer semver — republishing an existing version is
+   * refused. Together these close the manifest-hijack hole: a different
+   * principal cannot take over an id by bumping its version.
+   */
+  async publish(manifest: PluginManifest, publisher: string): Promise<MarketplaceEntry> {
+    this.requireLoaded();
+    // Normalize before comparing: an ownership record that distinguishes
+    // "alice" from " alice" is trivially defeated.
+    const identity = publisher.trim();
+    if (identity.length === 0) {
+      throw new MarketplaceError('ownership-conflict', 'A publisher identity is required');
+    }
+    if (identity.startsWith(RESERVED_PUBLISHER_PREFIX)) {
+      throw new MarketplaceError(
+        'ownership-conflict',
+        `Publisher names beginning with "${RESERVED_PUBLISHER_PREFIX}" are reserved for built-in plugins`,
+      );
+    }
+    return this.writeEntry(manifest, identity);
+  }
+
+  /**
+   * Publish a compiled-in first-party manifest. Not reachable over HTTP.
+   *
+   * The compiled manifest is authoritative and the registry row is a
+   * projection of it, so re-publishing the same version at every boot is a
+   * no-op rewrite rather than a version conflict. A stored version NEWER than
+   * the compiled one means the deployment was rolled back under a live
+   * database; that is refused loudly instead of silently downgrading.
+   */
+  async publishSystemManifest(manifest: PluginManifest): Promise<MarketplaceEntry> {
+    this.requireLoaded();
+    const existing = this.registry.get(manifest.id);
+    if (existing && existing.publisher !== SYSTEM_PUBLISHER) {
+      throw new MarketplaceError(
+        'ownership-conflict',
+        `Built-in plugin "${manifest.id}" is already registered to publisher "${existing.publisher}"`,
+      );
+    }
+    if (existing && compareSemver(manifest.version, existing.manifest.version) < 0) {
+      throw new MarketplaceError(
+        'version-conflict',
+        `Built-in plugin "${manifest.id}" is compiled at ${manifest.version} but the registry holds newer ${existing.manifest.version}`,
+      );
+    }
+    return this.writeEntry(manifest, SYSTEM_PUBLISHER, { allowSameVersion: true });
+  }
+
+  private async writeEntry(
+    manifest: PluginManifest,
+    publisher: string,
+    options: { allowSameVersion?: boolean } = {},
+  ): Promise<MarketplaceEntry> {
+    this.validateManifest(manifest);
+
+    const existing = this.registry.get(manifest.id);
+    if (existing) {
+      if (existing.publisher !== publisher) {
+        // The hijack the review flagged: a different principal republishing
+        // someone else's id with a bumped version.
+        throw new MarketplaceError(
+          'ownership-conflict',
+          `Plugin "${manifest.id}" is owned by another publisher`,
+        );
+      }
+      const order = compareSemver(manifest.version, existing.manifest.version);
+      if (order < 0 || (order === 0 && !options.allowSameVersion)) {
+        throw new MarketplaceError(
+          'version-conflict',
+          `Plugin "${manifest.id}" version ${manifest.version} is not newer than published ${existing.manifest.version}`,
+        );
+      }
+    }
+
+    const entry: MarketplaceEntry = {
+      manifest: { ...manifest },
+      publisher,
+      publishedAt: existing?.publishedAt ?? Date.now(),
+      updatedAt: Date.now(),
+      installs: existing?.installs ?? 0,
+    };
+    await this.store.saveEntry(entry);
+    this.registry.set(manifest.id, entry);
+    this.emit(existing ? 'plugin-republished' : 'plugin-published', entry);
+    return entry;
+  }
+
+  search(query = '', category?: PluginCategory): MarketplaceEntry[] {
+    const needle = query.trim().toLowerCase();
+    return [...this.registry.values()].filter((entry) => {
+      const manifest = entry.manifest;
+      if (category && manifest.category !== category) return false;
+      if (!needle) return true;
+      return (
+        manifest.id.includes(needle)
+        || manifest.name.toLowerCase().includes(needle)
+        || manifest.description.toLowerCase().includes(needle)
+        || manifest.tags.some((tag) => tag.toLowerCase().includes(needle))
+      );
+    });
+  }
+
+  getEntry(pluginId: string): MarketplaceEntry | undefined {
+    return this.registry.get(pluginId);
+  }
+
+  /** The durable owner of a plugin id, if it has ever been published. */
+  getPublisher(pluginId: string): string | undefined {
+    return this.registry.get(pluginId)?.publisher;
+  }
+
+  // ── Implementations ──────────────────────────────────────────────────
+
+  /**
+   * Bind an executable handler to a plugin id.
+   *
+   * Only first-party modules compiled into this server call this — see
+   * ./builtin, which is invoked from MarketplaceService.initialize(). There is
+   * deliberately no HTTP path to it: a published manifest never becomes
+   * executable on its own.
+   */
+  registerImplementation(pluginId: string, handler: PluginHandler): void {
+    this.implementations.set(pluginId, handler);
+    const plugin = this.installed.get(pluginId);
+    if (plugin) plugin.implementationState = 'available';
+  }
+
+  unregisterImplementation(pluginId: string): boolean {
+    const removed = this.implementations.delete(pluginId);
+    const plugin = this.installed.get(pluginId);
+    if (plugin) plugin.implementationState = this.implementationState(pluginId);
+    return removed;
+  }
+
+  private implementationState(pluginId: string): PluginImplementationState {
+    return this.implementations.has(pluginId) ? 'available' : 'unavailable';
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────
+
+  async install(pluginId: string, request: InstallRequest): Promise<InstalledPlugin> {
+    this.requireLoaded();
+    const entry = this.registry.get(pluginId);
+    if (!entry) {
+      throw new MarketplaceError('not-found', `Plugin "${pluginId}" is not in the registry`);
+    }
+    if (this.installed.has(pluginId)) {
+      throw new MarketplaceError(
+        'already-installed',
+        `Plugin "${pluginId}" is already installed — use update()`,
+      );
+    }
+    const installedBy = request.installedBy.trim();
+    if (installedBy.length === 0) {
+      throw new MarketplaceError('invalid-state', 'An installing principal is required');
+    }
+
+    // Dependencies must be installed AND satisfy the declared semver range.
+    for (const [depId, range] of Object.entries(entry.manifest.dependencies)) {
+      const dependency = this.installed.get(depId);
+      if (!dependency) {
+        throw new MarketplaceError(
+          'dependency-missing',
+          `Missing dependency: ${depId}@${range}`,
+        );
+      }
+      if (!satisfiesRange(dependency.manifest.version, range)) {
+        throw new MarketplaceError(
+          'dependency-unsatisfied',
+          `Dependency ${depId}@${dependency.manifest.version} does not satisfy required range "${range}"`,
+        );
+      }
+    }
+
+    const granted = this.narrowGrants(
+      entry.manifest,
+      request.grants ?? [...entry.manifest.requiredCapabilities],
+      { rejectUndeclared: true },
+    );
+
+    const plugin: InstalledPlugin = {
+      manifest: { ...entry.manifest },
+      status: 'installed',
+      config: this.validateConfig(entry.manifest, request.config ?? {}),
+      grantedCapabilities: granted,
+      installedBy,
+      installedAt: Date.now(),
+      startedAt: null,
+      lastError: null,
+      implementationState: this.implementationState(pluginId),
+    };
+
+    // Persist before publishing to the in-memory view: a store failure must
+    // leave no installed plugin behind, not an installation the next restart
+    // would forget.
+    await this.store.saveInstallation(plugin);
+    const updatedEntry: MarketplaceEntry = { ...entry, installs: entry.installs + 1 };
+    await this.store.saveEntry(updatedEntry);
+
+    this.installed.set(pluginId, plugin);
+    this.stats.set(pluginId, emptyStats());
+    this.registry.set(pluginId, updatedEntry);
+
+    this.emit('plugin-installed', plugin);
+    return plugin;
+  }
+
+  /** Upgrade an installed plugin to the (strictly newer) registry version. */
+  async update(pluginId: string): Promise<InstalledPlugin> {
+    const plugin = this.requireInstalled(pluginId);
+    const entry = this.registry.get(pluginId);
+    if (!entry) {
+      throw new MarketplaceError('not-found', `Plugin "${pluginId}" is not in the registry`);
+    }
+    if (compareSemver(entry.manifest.version, plugin.manifest.version) <= 0) {
+      throw new MarketplaceError(
+        'version-conflict',
+        `Plugin "${pluginId}" is already at ${plugin.manifest.version}; registry has ${entry.manifest.version}`,
+      );
+    }
+
+    const wasRunning = plugin.status === 'running';
+    if (wasRunning) await this.stop(pluginId);
+
+    // Re-validate carried-over config against the NEW schema, and narrow the
+    // existing grants to what the new manifest still declares. A new version
+    // never widens an existing grant on its own — that would let a republish
+    // silently escalate an already-approved installation.
+    const next: InstalledPlugin = {
+      ...plugin,
+      config: this.validateConfig(entry.manifest, plugin.config),
+      grantedCapabilities: this.narrowGrants(
+        entry.manifest,
+        plugin.grantedCapabilities,
+        { rejectUndeclared: false },
+      ),
+      manifest: { ...entry.manifest },
+      status: 'installed',
+      lastError: null,
+      implementationState: this.implementationState(pluginId),
+    };
+    await this.commit(plugin, next);
+    this.emit('plugin-updated', plugin);
+    if (wasRunning) await this.start(pluginId);
+    return plugin;
+  }
+
+  async configure(
+    pluginId: string,
+    config: Record<string, string | number | boolean>,
+  ): Promise<InstalledPlugin> {
+    const plugin = this.requireInstalled(pluginId);
+    await this.commit(plugin, {
+      ...plugin,
+      config: this.validateConfig(plugin.manifest, config),
+    });
+    this.emit('plugin-configured', plugin);
+    return plugin;
+  }
+
+  async start(pluginId: string): Promise<InstalledPlugin> {
+    const plugin = this.requireInstalled(pluginId);
+    if (plugin.status === 'disabled') {
+      throw new MarketplaceError(
+        'invalid-state',
+        `Plugin "${pluginId}" is disabled — enable it first`,
+      );
+    }
+    if (plugin.implementationState !== 'available') {
+      // Refuse rather than run something that can only ever fail. The state
+      // is reported by listInstalled()/getHealth() so callers can tell an
+      // un-implemented plugin from a broken one.
+      throw new MarketplaceError(
+        'not-implemented',
+        `Plugin "${pluginId}" is installed but no implementation is registered in this build`,
+      );
+    }
+    if (plugin.status === 'running') return plugin;
+
+    await this.commit(plugin, {
+      ...plugin,
+      status: 'running',
+      startedAt: Date.now(),
+      lastError: null,
+    });
+    const stats = this.stats.get(pluginId);
+    if (stats) stats.consecutiveFailures = 0;
+
+    this.emit('plugin-started', plugin);
+    return plugin;
+  }
+
+  async stop(pluginId: string): Promise<InstalledPlugin> {
+    const plugin = this.requireInstalled(pluginId);
+    if (plugin.status === 'running' || plugin.status === 'error') {
+      await this.commit(plugin, { ...plugin, status: 'stopped', startedAt: null });
+      this.emit('plugin-stopped', plugin);
+    }
+    return plugin;
+  }
+
+  /** Administratively block a plugin from starting or being invoked. */
+  async disable(pluginId: string): Promise<InstalledPlugin> {
+    const plugin = this.requireInstalled(pluginId);
+    await this.commit(plugin, { ...plugin, status: 'disabled', startedAt: null });
+    this.emit('plugin-disabled', plugin);
+    return plugin;
+  }
+
+  async enable(pluginId: string): Promise<InstalledPlugin> {
+    const plugin = this.requireInstalled(pluginId);
+    if (plugin.status === 'disabled' || plugin.status === 'error') {
+      await this.commit(plugin, { ...plugin, status: 'stopped' });
+      const stats = this.stats.get(pluginId);
+      if (stats) stats.consecutiveFailures = 0;
+      this.emit('plugin-enabled', plugin);
+    }
+    return plugin;
+  }
+
+  async uninstall(pluginId: string): Promise<void> {
+    this.requireInstalled(pluginId);
+    for (const other of this.installed.values()) {
+      if (other.manifest.id !== pluginId && pluginId in other.manifest.dependencies) {
+        throw new MarketplaceError(
+          'dependents-installed',
+          `Cannot uninstall "${pluginId}": "${other.manifest.id}" depends on it`,
+        );
+      }
+    }
+    await this.store.deleteInstallation(pluginId);
+    this.installed.delete(pluginId);
+    this.stats.delete(pluginId);
+    this.emit('plugin-uninstalled', { pluginId });
+  }
+
+  listInstalled(): InstalledPlugin[] {
+    return [...this.installed.values()];
+  }
+
+  getInstalled(pluginId: string): InstalledPlugin | undefined {
+    return this.installed.get(pluginId);
+  }
+
+  // ── Execution ────────────────────────────────────────────────────────
+
+  async invoke(pluginId: string, input: unknown): Promise<PluginInvocationResult> {
+    const started = Date.now();
+    const plugin = this.installed.get(pluginId);
+    if (!plugin) {
+      return this.failure(pluginId, 'not-installed', `Plugin "${pluginId}" is not installed`, started);
+    }
+    const handler = this.implementations.get(pluginId);
+    if (!handler) {
+      return this.failure(
+        pluginId,
+        'not-implemented',
+        `Plugin "${pluginId}" is installed but no implementation is registered in this build`,
+        started,
+      );
+    }
+    if (plugin.status !== 'running') {
+      return this.failure(
+        pluginId,
+        'not-running',
+        `Plugin "${pluginId}" is ${plugin.status}, not running`,
+        started,
+      );
+    }
+
+    const host = this.buildHostContext(plugin);
+    try {
+      const output = await this.withTimeout(
+        Promise.resolve().then(() => handler(input, host)),
+        this.invokeTimeoutMs,
+        pluginId,
+      );
+      await this.recordOutcome(pluginId, true, null);
+      return { pluginId, success: true, code: 'ok', output, durationMs: Date.now() - started };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // Classify by type, never by message text: a handler controls its own
+      // error strings and must not be able to choose its own failure code.
+      const code: PluginInvocationCode = error instanceof PluginTimeoutError
+        ? 'timeout'
+        : error instanceof MarketplaceError && error.code === 'capability-denied'
+          ? 'capability-denied'
+          : 'handler-error';
+      await this.recordOutcome(pluginId, false, message);
+      return { pluginId, success: false, code, error: message, durationMs: Date.now() - started };
+    }
+  }
+
+  // ── Health ───────────────────────────────────────────────────────────
+
+  getHealth(pluginId: string): PluginHealth | null {
+    const plugin = this.installed.get(pluginId);
+    if (!plugin) return null;
+    const stats = this.stats.get(pluginId) ?? emptyStats();
+    const windowFailures = stats.recent.filter((ok) => !ok).length;
+    return {
+      pluginId,
+      status: plugin.status,
+      implementationState: plugin.implementationState,
+      // Uptime counts from the last start, not install time.
+      uptimeSeconds: plugin.status === 'running' && plugin.startedAt
+        ? Math.round((Date.now() - plugin.startedAt) / 1000)
+        : 0,
+      invocations: stats.invocations,
+      failures: stats.failures,
+      windowedErrorRate: stats.recent.length === 0
+        ? 0
+        : windowFailures / stats.recent.length,
+      consecutiveFailures: stats.consecutiveFailures,
+      capabilityDenials: stats.capabilityDenials,
+      lastError: plugin.lastError,
+    };
+  }
+
+  getAllHealth(): PluginHealth[] {
+    return [...this.installed.keys()]
+      .map((id) => this.getHealth(id))
+      .filter((health): health is PluginHealth => health !== null);
+  }
+
+  getStatus(): {
+    published: number;
+    installed: number;
+    running: number;
+    unimplemented: number;
+    durable: boolean;
+  } {
+    const installed = this.listInstalled();
+    return {
+      published: this.registry.size,
+      installed: installed.length,
+      running: installed.filter((plugin) => plugin.status === 'running').length,
+      unimplemented: installed.filter(
+        (plugin) => plugin.implementationState === 'unavailable',
+      ).length,
+      durable: this.store.kind === 'database',
+    };
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────
+
+  private requireLoaded(): void {
+    if (!this.loaded) {
+      throw new MarketplaceError(
+        'store-unavailable',
+        'Marketplace state has not been loaded yet',
+      );
+    }
+  }
+
+  private requireInstalled(pluginId: string): InstalledPlugin {
+    const plugin = this.installed.get(pluginId);
+    if (!plugin) {
+      throw new MarketplaceError('not-installed', `Plugin "${pluginId}" is not installed`);
+    }
+    return plugin;
+  }
+
+  /**
+   * Persist a candidate installation state, then apply it to the live record.
+   *
+   * Mutating first and persisting after would leave the in-memory view ahead
+   * of the database if the write failed — a plugin that looks disabled until
+   * the next restart silently re-enables it.
+   */
+  private async commit(plugin: InstalledPlugin, next: InstalledPlugin): Promise<void> {
+    await this.store.saveInstallation(next);
+    Object.assign(plugin, next);
+  }
+
+  private validateManifest(manifest: PluginManifest): void {
+    if (!ID_PATTERN.test(manifest.id)) {
+      throw new MarketplaceError(
+        'invalid-manifest',
+        `Plugin id "${manifest.id}" must match ${ID_PATTERN}`,
+      );
+    }
+    if (!parseSemver(manifest.version)) {
+      throw new MarketplaceError(
+        'invalid-manifest',
+        `Plugin "${manifest.id}" version "${manifest.version}" is not valid semver`,
+      );
+    }
+    for (const [depId, range] of Object.entries(manifest.dependencies)) {
+      if (depId === manifest.id) {
+        throw new MarketplaceError(
+          'invalid-manifest',
+          `Plugin "${manifest.id}" cannot depend on itself`,
+        );
+      }
+      if (range !== '*' && !parseSemver(range.replace(/^[\^~]/, ''))) {
+        throw new MarketplaceError(
+          'invalid-manifest',
+          `Plugin "${manifest.id}" has invalid dependency range "${range}"`,
+        );
+      }
+    }
+    for (const [key, field] of Object.entries(manifest.configSchema)) {
+      if (field.type === 'select' && (!field.options || field.options.length === 0)) {
+        throw new MarketplaceError(
+          'invalid-manifest',
+          `Config "${key}" for plugin "${manifest.id}" is a select without options`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Reduce a grant set to what the manifest declares.
+   *
+   * At install time an undeclared grant is a caller error and is rejected. At
+   * update time the grants came from an earlier approved install, so a
+   * capability the new version no longer declares is dropped (fail-closed
+   * narrowing) rather than rejected.
+   */
+  private narrowGrants(
+    manifest: PluginManifest,
+    requested: readonly PluginCapability[],
+    options: { rejectUndeclared: boolean },
+  ): PluginCapability[] {
+    const declared = new Set(manifest.requiredCapabilities);
+    const granted: PluginCapability[] = [];
+    for (const capability of requested) {
+      if (!declared.has(capability)) {
+        if (options.rejectUndeclared) {
+          throw new MarketplaceError(
+            'capability-not-declared',
+            `Capability "${capability}" is not declared by plugin "${manifest.id}"`,
+          );
+        }
+        continue;
+      }
+      if (!granted.includes(capability)) granted.push(capability);
+    }
+    return granted;
+  }
+
+  /**
+   * Validate config against the schema. Defaults apply to every field that
+   * declares one; required fields without a value or default fail; values are
+   * type-checked; select values must be in options; unknown keys fail. The
+   * caller's object is never mutated.
+   */
+  private validateConfig(
+    manifest: PluginManifest,
+    config: Record<string, string | number | boolean>,
+  ): Record<string, string | number | boolean> {
+    const result: Record<string, string | number | boolean> = {};
+    for (const key of Object.keys(config)) {
+      if (!(key in manifest.configSchema)) {
+        throw new MarketplaceError(
+          'invalid-config',
+          `Unknown config key "${key}" for plugin "${manifest.id}"`,
+        );
+      }
+    }
+    for (const [key, field] of Object.entries(manifest.configSchema)) {
+      let value = config[key];
+      if (value === undefined) {
+        if (field.default !== undefined) {
+          value = field.default;
+        } else if (field.required) {
+          throw new MarketplaceError(
+            'invalid-config',
+            `Missing required config "${key}" for plugin "${manifest.id}"`,
+          );
+        } else {
+          continue;
+        }
+      }
+      const expected = field.type === 'select' ? 'string' : field.type;
+      if (typeof value !== expected) {
+        throw new MarketplaceError(
+          'invalid-config',
+          `Config "${key}" for plugin "${manifest.id}" must be a ${expected}`,
+        );
+      }
+      if (field.type === 'select' && field.options && !field.options.includes(value as string)) {
+        throw new MarketplaceError(
+          'invalid-config',
+          `Config "${key}" must be one of: ${field.options.join(', ')}`,
+        );
+      }
+      result[key] = value;
+    }
+    return result;
+  }
+
+  /**
+   * Build the enforcing host context. Each accessor is a getter so that a
+   * denial happens at the moment of reach, inside the handler's own call
+   * stack, and surfaces as a thrown `capability-denied` rather than as a
+   * missing property the plugin might ignore.
+   */
+  private buildHostContext(plugin: InstalledPlugin): PluginHostContext {
+    const pluginId = plugin.manifest.id;
+    const declared = new Set(plugin.manifest.requiredCapabilities);
+    const granted = new Set(plugin.grantedCapabilities);
+    const tagProvider = this.tagProvider;
+    const alarmProvider = this.alarmProvider;
+
+    const gate = (capability: PluginCapability): void => {
+      if (!declared.has(capability)) {
+        throw this.denyCapability(pluginId, capability, 'undeclared');
+      }
+      if (!granted.has(capability)) {
+        throw this.denyCapability(pluginId, capability, 'ungranted');
+      }
+    };
+    const requireProvider = <T>(capability: PluginCapability, provider: T | null): T => {
+      gate(capability);
+      if (provider === null) {
+        throw new MarketplaceError(
+          'invalid-state',
+          `Host service for "${capability}" is not configured on this server`,
+        );
+      }
+      return provider;
+    };
+
+    const emitEvent = (type: string, payload: Record<string, unknown>): void => {
+      this.emit('plugin-event', { pluginId, type, payload });
+    };
+    const log = (message: string): void => {
+      this.emit('plugin-log', { pluginId, message });
+    };
+
+    const host: PluginHostContext = {
+      pluginId,
+      config: Object.freeze({ ...plugin.config }),
+      capabilities: Object.freeze([...plugin.grantedCapabilities]),
+      get tags(): TagProvider {
+        return requireProvider('tags:read', tagProvider);
+      },
+      get alarms(): AlarmProvider {
+        return requireProvider('alarms:read', alarmProvider);
+      },
+      get emitEvent(): (type: string, payload: Record<string, unknown>) => void {
+        gate('events:emit');
+        return emitEvent;
+      },
+      get log(): (message: string) => void {
+        gate('log');
+        return log;
+      },
+    };
+    return Object.freeze(host);
+  }
+
+  private denyCapability(
+    pluginId: string,
+    capability: PluginCapability,
+    reason: CapabilityDenialRecord['reason'],
+  ): MarketplaceError {
+    const stats = this.stats.get(pluginId);
+    if (stats) stats.capabilityDenials++;
+    const record: CapabilityDenialRecord = { pluginId, capability, reason, at: Date.now() };
+    this.emit('plugin-capability-denied', record);
+    return new MarketplaceError(
+      'capability-denied',
+      `Plugin "${pluginId}" reached for capability "${capability}" that is ${reason}`,
+    );
+  }
+
+  /**
+   * Bound an invocation by wall clock.
+   *
+   * Honest limit: this races a timer on the event loop, so it bounds a handler
+   * that YIELDS (async work, I/O, awaited promises). It cannot interrupt a
+   * handler that blocks the event loop synchronously — a `while` loop owns the
+   * thread and the timer cannot fire until it returns, so such a call is
+   * reported as whatever it eventually produced. Pre-empting that needs the
+   * same process/VM isolation boundary this module states it does not have.
+   * It is acceptable here only because handlers are first-party code from
+   * ./builtin, reviewed like the rest of the server.
+   */
+  private async withTimeout<T>(promise: Promise<T>, ms: number, pluginId: string): Promise<T> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new PluginTimeoutError(pluginId, ms)),
+            ms,
+          );
+          timer.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  private async recordOutcome(
+    pluginId: string,
+    success: boolean,
+    error: string | null,
+  ): Promise<void> {
+    const plugin = this.installed.get(pluginId);
+    const stats = this.stats.get(pluginId);
+    if (!plugin || !stats) return;
+
+    stats.invocations++;
+    stats.recent.push(success);
+    if (stats.recent.length > this.errorWindow) stats.recent.shift();
+
+    if (success) {
+      stats.consecutiveFailures = 0;
+      return;
+    }
+
+    stats.failures++;
+    stats.consecutiveFailures++;
+    plugin.lastError = error;
+    if (stats.consecutiveFailures >= this.autoDisableAfter && plugin.status === 'running') {
+      // The auto-disable decision is authorization-adjacent, so it is durable
+      // even though the counters that produced it are not.
+      await this.commit(plugin, { ...plugin, status: 'error', startedAt: null });
+      this.emit('plugin-auto-disabled', {
+        pluginId,
+        consecutiveFailures: stats.consecutiveFailures,
+        lastError: error,
+      });
+    }
+  }
+
+  private failure(
+    pluginId: string,
+    code: PluginInvocationCode,
+    error: string,
+    startedMs: number,
+  ): PluginInvocationResult {
+    return { pluginId, success: false, code, error, durationMs: Date.now() - startedMs };
+  }
+}

--- a/server/services/marketplace/errors.ts
+++ b/server/services/marketplace/errors.ts
@@ -1,0 +1,60 @@
+/**
+ * Typed marketplace failures.
+ *
+ * Feature [13.6] of ADR-0013 — Issue #217.
+ *
+ * The HTTP layer must not guess a status code by pattern-matching an error
+ * message. Every rejection the engine can produce carries a stable machine
+ * code and the status the API surface should return for it.
+ */
+
+export type MarketplaceErrorCode =
+  | 'invalid-manifest'
+  | 'invalid-config'
+  | 'ownership-conflict'
+  | 'version-conflict'
+  | 'not-found'
+  | 'already-installed'
+  | 'not-installed'
+  | 'dependency-missing'
+  | 'dependency-unsatisfied'
+  | 'dependents-installed'
+  | 'capability-not-declared'
+  | 'capability-denied'
+  | 'not-implemented'
+  | 'invalid-state'
+  | 'store-unavailable';
+
+const STATUS_BY_CODE: Readonly<Record<MarketplaceErrorCode, number>> = Object.freeze({
+  'invalid-manifest': 400,
+  'invalid-config': 400,
+  'ownership-conflict': 403,
+  'version-conflict': 409,
+  'not-found': 404,
+  'already-installed': 409,
+  'not-installed': 404,
+  'dependency-missing': 409,
+  'dependency-unsatisfied': 409,
+  'dependents-installed': 409,
+  'capability-not-declared': 400,
+  'capability-denied': 403,
+  'not-implemented': 409,
+  'invalid-state': 409,
+  'store-unavailable': 503,
+});
+
+export class MarketplaceError extends Error {
+  readonly code: MarketplaceErrorCode;
+  readonly status: number;
+
+  constructor(code: MarketplaceErrorCode, message: string) {
+    super(message);
+    this.name = 'MarketplaceError';
+    this.code = code;
+    this.status = STATUS_BY_CODE[code];
+  }
+}
+
+export function isMarketplaceError(error: unknown): error is MarketplaceError {
+  return error instanceof MarketplaceError;
+}

--- a/server/services/marketplace/index.ts
+++ b/server/services/marketplace/index.ts
@@ -1,0 +1,265 @@
+/**
+ * Agent Marketplace service.
+ *
+ * Feature [13.6] of ADR-0013 (docs/decisions/ADR-0013-autonomous-agent-architecture.md).
+ * Issue #217. Design notes: docs/architecture/agent-marketplace.md.
+ *
+ * Wires the engine to the live host services it exposes as capabilities,
+ * chooses a durable store, registers the first-party plugin implementations,
+ * and forwards capability denials to the log as an audit trail.
+ */
+
+import { EventEmitter } from 'events';
+import type {
+  CapabilityDenialRecord,
+  InstalledPlugin,
+  MarketplaceEntry,
+} from '@shared/types/marketplace';
+import { logError, logInfo, logWarn } from '../../logger';
+import { storage } from '../../storage';
+import { tagStreamServer } from '../../websocket/tag-stream';
+import { AgentMarketplace, SYSTEM_PUBLISHER } from './engine';
+import type {
+  ActiveAlarm,
+  AlarmProvider,
+  InstallRequest,
+  MarketplaceOptions,
+  PluginHandler,
+  PluginHostContext,
+  TagProvider,
+  TagSample,
+} from './engine';
+import { BUILTIN_PLUGINS } from './builtin';
+import { DatabaseMarketplaceStore } from './database-store';
+import {
+  InMemoryMarketplaceStore,
+  type MarketplaceSnapshot,
+  type MarketplaceStore,
+} from './store';
+import { MarketplaceError, isMarketplaceError, type MarketplaceErrorCode } from './errors';
+
+export { AgentMarketplace, SYSTEM_PUBLISHER } from './engine';
+export type {
+  ActiveAlarm,
+  AlarmProvider,
+  InstallRequest,
+  MarketplaceOptions,
+  PluginHandler,
+  PluginHostContext,
+  TagProvider,
+  TagSample,
+};
+export { MarketplaceError, isMarketplaceError };
+export type { MarketplaceErrorCode };
+export { compareSemver, parseSemver, satisfiesRange } from './semver';
+export type { SemVer } from './semver';
+export { DatabaseMarketplaceStore } from './database-store';
+export { InMemoryMarketplaceStore } from './store';
+export type { MarketplaceSnapshot, MarketplaceStore, StoredInstallation } from './store';
+export { BUILTIN_PLUGINS } from './builtin';
+export type { BuiltinPlugin } from './builtin';
+
+/** Live read-only view of the tag-stream cache, exposed under `tags:read`. */
+const liveTagProvider: TagProvider = {
+  list: () => [...tagStreamServer.getLatestValues().keys()],
+  readLatest: (tagId) => {
+    const update = tagStreamServer.getLatestValues().get(tagId);
+    if (!update) return null;
+    return {
+      value: typeof update.value === 'boolean' ? String(update.value) : update.value,
+      timestamp: new Date(update.timestamp).getTime(),
+    };
+  },
+};
+
+/**
+ * No process-alarm source is wired to the marketplace on this branch — the
+ * alarm-correlation service owns active groups and does not yet expose a
+ * read-only projection. Plugins granted `alarms:read` therefore see an empty
+ * list rather than fabricated alarms. Swap this for the correlation service's
+ * active groups when that projection exists.
+ */
+const liveAlarmProvider: AlarmProvider = {
+  getActive: (): ActiveAlarm[] => [],
+};
+
+/**
+ * Picks the concrete store on first use rather than at module load.
+ *
+ * `server/index.ts` imports the route graph — and therefore this module —
+ * before it awaits `initializeDatabase()`. Choosing the store in the
+ * constructor would sample `storage.isConnected()` too early and permanently
+ * downgrade a database-backed deployment to a non-durable store. The first
+ * call happens inside `initialize()`, which registerRoutes awaits after the
+ * database is up.
+ */
+class DeferredMarketplaceStore implements MarketplaceStore {
+  private delegate: MarketplaceStore | null = null;
+
+  private resolve(): MarketplaceStore {
+    if (!this.delegate) {
+      this.delegate = storage.isConnected()
+        ? new DatabaseMarketplaceStore()
+        : new InMemoryMarketplaceStore();
+    }
+    return this.delegate;
+  }
+
+  get kind(): MarketplaceStore['kind'] {
+    return this.resolve().kind;
+  }
+
+  load(): Promise<MarketplaceSnapshot> {
+    return this.resolve().load();
+  }
+
+  saveEntry(entry: MarketplaceEntry): Promise<void> {
+    return this.resolve().saveEntry(entry);
+  }
+
+  saveInstallation(plugin: InstalledPlugin): Promise<void> {
+    return this.resolve().saveInstallation(plugin);
+  }
+
+  deleteInstallation(pluginId: string): Promise<void> {
+    return this.resolve().deleteInstallation(pluginId);
+  }
+}
+
+export class MarketplaceService extends EventEmitter {
+  readonly marketplace: AgentMarketplace;
+
+  private readonly store: MarketplaceStore;
+  private initialized = false;
+  private initializing: Promise<void> | null = null;
+
+  constructor(options: { store?: MarketplaceStore } = {}) {
+    super();
+    // A database-backed store is required for the ownership record to be a
+    // real control. When the database is unavailable the service still runs,
+    // but it says so rather than pretending the state is durable.
+    this.store = options.store ?? new DeferredMarketplaceStore();
+
+    this.marketplace = new AgentMarketplace({
+      tagProvider: liveTagProvider,
+      alarmProvider: liveAlarmProvider,
+      store: this.store,
+    });
+
+    for (const event of [
+      'marketplace-loaded',
+      'plugin-published',
+      'plugin-republished',
+      'plugin-installed',
+      'plugin-updated',
+      'plugin-configured',
+      'plugin-started',
+      'plugin-stopped',
+      'plugin-enabled',
+      'plugin-disabled',
+      'plugin-uninstalled',
+      'plugin-auto-disabled',
+      'plugin-event',
+      'plugin-log',
+      'plugin-capability-denied',
+    ]) {
+      this.marketplace.on(event, (payload: unknown) => this.emit(event, payload));
+    }
+
+    // Capability denial is a security event: a plugin reached for a host
+    // service it was not granted. Audit it rather than only counting it.
+    this.marketplace.on('plugin-capability-denied', (record: CapabilityDenialRecord) => {
+      logWarn(
+        `[marketplace] capability denied: plugin=${record.pluginId} `
+        + `capability=${record.capability} reason=${record.reason}`,
+      );
+    });
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    if (this.initializing) return this.initializing;
+
+    this.initializing = this.runInitialize();
+    try {
+      await this.initializing;
+    } finally {
+      this.initializing = null;
+    }
+  }
+
+  private async runInitialize(): Promise<void> {
+    // Implementations must be registered before the state is loaded so that
+    // restored installations report the right implementationState.
+    for (const builtin of BUILTIN_PLUGINS) {
+      this.marketplace.registerImplementation(builtin.manifest.id, builtin.handler);
+    }
+
+    try {
+      await this.marketplace.load();
+    } catch (error) {
+      // Fail closed for the marketplace, not for the plant. A malformed
+      // plugin row must not stop the SCADA server from starting, but it must
+      // not silently produce an empty registry either: an ownership check
+      // against an empty registry would authorize a hijack. The engine stays
+      // un-loaded, every publish/install returns 503 store-unavailable, and
+      // the service reports unhealthy until an operator fixes the row.
+      logError(error, '[marketplace] state could not be loaded; marketplace mutations are refused');
+      return;
+    }
+
+    for (const builtin of BUILTIN_PLUGINS) {
+      try {
+        await this.marketplace.publishSystemManifest(builtin.manifest);
+      } catch (error) {
+        // A built-in whose id collides with an operator-published plugin must
+        // not take the server down, but it also must not be silently ignored.
+        this.marketplace.unregisterImplementation(builtin.manifest.id);
+        logError(
+          error,
+          `[marketplace] built-in plugin "${builtin.manifest.id}" could not be registered`,
+        );
+      }
+    }
+
+    if (this.store.kind !== 'database') {
+      logWarn(
+        '[marketplace] running on a non-durable in-memory store: plugin ownership '
+        + 'and capability grants will NOT survive a restart. Configure the database '
+        + 'before relying on marketplace authorization.',
+      );
+    }
+
+    const status = this.marketplace.getStatus();
+    logInfo(
+      `[marketplace] ready: ${status.published} published, ${status.installed} installed, `
+      + `${BUILTIN_PLUGINS.length} built-in implementation(s), store=${this.store.kind}`,
+    );
+    this.initialized = true;
+  }
+
+  async shutdown(): Promise<void> {
+    this.initialized = false;
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
+    if (!this.initialized) {
+      return { healthy: false, message: 'Marketplace service not initialized' };
+    }
+    const status = this.marketplace.getStatus();
+    return {
+      healthy: true,
+      message:
+        `Marketplace running: ${status.published} published, ${status.installed} installed, `
+        + `${status.running} running, ${status.unimplemented} without an implementation, `
+        + `store=${this.store.kind}${status.durable ? '' : ' (NOT durable)'}`,
+    };
+  }
+}
+
+export const marketplaceService = new MarketplaceService();
+export { SYSTEM_PUBLISHER as MARKETPLACE_SYSTEM_PUBLISHER };

--- a/server/services/marketplace/semver.ts
+++ b/server/services/marketplace/semver.ts
@@ -1,0 +1,66 @@
+/**
+ * Minimal semver — parse, compare, and range satisfaction.
+ *
+ * Feature [13.6] of ADR-0013 — Issue #217.
+ *
+ * Used for real by the marketplace: publish requires a strictly newer
+ * version, update requires the registry to be ahead of the installation, and
+ * dependency ranges are checked at install. Supports exact versions,
+ * ^ (compatible), ~ (patch-level), and *.
+ */
+
+export interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+export function parseSemver(version: string): SemVer | null {
+  const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return null;
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: parseInt(match[3], 10),
+  };
+}
+
+/** negative: a < b, 0: equal, positive: a > b. Throws on invalid input. */
+export function compareSemver(a: string, b: string): number {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) throw new Error(`Invalid semver: "${!pa ? a : b}"`);
+  return pa.major - pb.major || pa.minor - pb.minor || pa.patch - pb.patch;
+}
+
+/** Does `version` satisfy `range` ("1.2.3", "^1.2.0", "~1.2.0", "*")? */
+export function satisfiesRange(version: string, range: string): boolean {
+  const trimmed = range.trim();
+  if (trimmed === '*' || trimmed === '') return parseSemver(version) !== null;
+
+  const v = parseSemver(version);
+  if (!v) return false;
+
+  if (trimmed.startsWith('^')) {
+    const base = parseSemver(trimmed.slice(1));
+    if (!base) return false;
+    if (base.major > 0) {
+      return v.major === base.major && compareSemver(version, trimmed.slice(1)) >= 0;
+    }
+    // ^0.x.y — minor acts as the compatibility boundary
+    return (
+      v.major === 0 && v.minor === base.minor && compareSemver(version, trimmed.slice(1)) >= 0
+    );
+  }
+  if (trimmed.startsWith('~')) {
+    const base = parseSemver(trimmed.slice(1));
+    if (!base) return false;
+    return (
+      v.major === base.major &&
+      v.minor === base.minor &&
+      compareSemver(version, trimmed.slice(1)) >= 0
+    );
+  }
+  const exact = parseSemver(trimmed);
+  return exact !== null && compareSemver(version, trimmed) === 0;
+}

--- a/server/services/marketplace/store.ts
+++ b/server/services/marketplace/store.ts
@@ -1,0 +1,102 @@
+/**
+ * Marketplace persistence contract.
+ *
+ * Feature [13.6] of ADR-0013 — Issue #217.
+ *
+ * The registry (with its ownership record) and the installation records (with
+ * their capability grants) are authorization state. State that resets on
+ * restart is not an access control, so both are written through Drizzle to
+ * `plugin_registry` / `plugin_installations` (migration
+ * 0011_agent_marketplace.sql) by `DatabaseMarketplaceStore`.
+ *
+ * Deliberately NOT persisted: per-process invocation counters, failure
+ * windows, uptime and the auto-disable streak. Those are transient telemetry
+ * about the current process; a restart legitimately resets them. The
+ * auto-disable *decision* is persisted, because it lands in the plugin's
+ * status.
+ *
+ * This module holds no database import so the engine and its unit tests stay
+ * free of the storage/driver graph. The Drizzle implementation lives in
+ * ./database-store.
+ */
+
+import type {
+  InstalledPlugin,
+  MarketplaceEntry,
+  PluginCapability,
+  PluginManifest,
+  PluginStatus,
+} from '@shared/types/marketplace';
+
+/**
+ * The durable subset of an installation. Runtime-only fields (`startedAt`,
+ * `lastError`, `implementationState`) are recomputed on load.
+ */
+export interface StoredInstallation {
+  manifest: PluginManifest;
+  status: PluginStatus;
+  config: Record<string, string | number | boolean>;
+  grantedCapabilities: PluginCapability[];
+  installedBy: string;
+  installedAt: number;
+}
+
+export interface MarketplaceSnapshot {
+  entries: MarketplaceEntry[];
+  installations: StoredInstallation[];
+}
+
+export interface MarketplaceStore {
+  /** `database` is durable; `memory` is not — the service logs which is in use. */
+  readonly kind: 'database' | 'memory';
+  load(): Promise<MarketplaceSnapshot>;
+  saveEntry(entry: MarketplaceEntry): Promise<void>;
+  saveInstallation(plugin: InstalledPlugin): Promise<void>;
+  deleteInstallation(pluginId: string): Promise<void>;
+}
+
+/**
+ * Non-durable store. Used by unit tests, and by the service only when the
+ * database is unavailable — in which case the service logs a warning saying
+ * plainly that marketplace ownership does not survive a restart.
+ */
+export class InMemoryMarketplaceStore implements MarketplaceStore {
+  readonly kind = 'memory' as const;
+
+  private readonly entries = new Map<string, MarketplaceEntry>();
+  private readonly installations = new Map<string, StoredInstallation>();
+
+  async load(): Promise<MarketplaceSnapshot> {
+    return {
+      entries: [...this.entries.values()].map((entry) => ({
+        ...entry,
+        manifest: { ...entry.manifest },
+      })),
+      installations: [...this.installations.values()].map((install) => ({
+        ...install,
+        manifest: { ...install.manifest },
+        config: { ...install.config },
+        grantedCapabilities: [...install.grantedCapabilities],
+      })),
+    };
+  }
+
+  async saveEntry(entry: MarketplaceEntry): Promise<void> {
+    this.entries.set(entry.manifest.id, { ...entry, manifest: { ...entry.manifest } });
+  }
+
+  async saveInstallation(plugin: InstalledPlugin): Promise<void> {
+    this.installations.set(plugin.manifest.id, {
+      manifest: { ...plugin.manifest },
+      status: plugin.status,
+      config: { ...plugin.config },
+      grantedCapabilities: [...plugin.grantedCapabilities],
+      installedBy: plugin.installedBy,
+      installedAt: plugin.installedAt,
+    });
+  }
+
+  async deleteInstallation(pluginId: string): Promise<void> {
+    this.installations.delete(pluginId);
+  }
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -47,7 +47,7 @@ async function withStorageLock<T>(operation: () => Promise<T>): Promise<T> {
   }
 }
 
-type BlueprintTableName =
+type StorageTableName =
   | 'vendors'
   | 'template_packages'
   | 'control_module_types'
@@ -59,9 +59,11 @@ type BlueprintTableName =
   | 'design_specifications'
   | 'generated_code'
   | 'data_type_mappings'
-  | 'controllers';
+  | 'controllers'
+  | 'plugin_registry'
+  | 'plugin_installations';
 
-const sqliteColumns: Record<BlueprintTableName, readonly string[]> = {
+const sqliteColumns: Record<StorageTableName, readonly string[]> = {
   vendors: ['id', 'name', 'displayName', 'description', 'platforms', 'languages', 'configSchema', 'isActive', 'createdAt', 'updatedAt'],
   template_packages: ['id', 'name', 'vendorId', 'version', 'description', 'templateType', 'language', 'templateContent', 'placeholders', 'requiredInputs', 'createdAt', 'updatedAt'],
   control_module_types: ['id', 'name', 'vendorId', 'version', 'description', 'inputs', 'outputs', 'inOuts', 'dataTypeMappings', 'templatePackageId', 'sourcePackage', 'classification', 'createdAt', 'updatedAt'],
@@ -74,6 +76,8 @@ const sqliteColumns: Record<BlueprintTableName, readonly string[]> = {
   generated_code: ['id', 'sourceType', 'sourceId', 'vendorId', 'templatePackageId', 'language', 'code', 'codeHash', 'txHash', 'metadata', 'status', 'generatedAt', 'approvedAt', 'approvedBy'],
   data_type_mappings: ['id', 'vendorId', 'canonicalType', 'vendorType', 'size', 'precision', 'metadata', 'createdAt'],
   controllers: ['id', 'name', 'vendorId', 'siteId', 'model', 'firmwareVersion', 'address', 'configuration', 'status', 'createdAt', 'updatedAt'],
+  plugin_registry: ['id', 'version', 'manifest', 'publisher', 'installs', 'publishedAt', 'updatedAt'],
+  plugin_installations: ['id', 'version', 'manifest', 'status', 'config', 'grantedCapabilities', 'installedBy', 'installedAt', 'updatedAt'],
 };
 
 const sqliteJsonColumns = new Set([
@@ -82,10 +86,14 @@ const sqliteJsonColumns = new Set([
   'currentState', 'variables', 'equipmentModules', 'linkedModules',
   'internalValues', 'hmiParameters', 'recipeParameters', 'reportParameters',
   'sequences', 'linkedModuleInstances', 'content', 'metadata',
+  // Agent marketplace (#217)
+  'manifest', 'config', 'grantedCapabilities',
 ]);
 const sqliteBooleanColumns = new Set(['isActive']);
 const sqliteDateColumns = new Set([
   'createdAt', 'updatedAt', 'anchoredAt', 'generatedAt', 'approvedAt',
+  // Agent marketplace (#217)
+  'publishedAt', 'installedAt',
 ]);
 
 const blueprintSqliteSchema = `
@@ -183,6 +191,17 @@ CREATE TABLE IF NOT EXISTS blueprint_safe_state_log (
   operator TEXT, reason TEXT NOT NULL, anchor_hash TEXT NOT NULL,
   anchor_tx_hash TEXT, metadata TEXT, created_at INTEGER NOT NULL
 );
+CREATE TABLE IF NOT EXISTS plugin_registry (
+  id TEXT PRIMARY KEY, version TEXT NOT NULL, manifest TEXT NOT NULL,
+  publisher TEXT NOT NULL, installs INTEGER NOT NULL DEFAULT 0,
+  published_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS plugin_installations (
+  id TEXT PRIMARY KEY, version TEXT NOT NULL, manifest TEXT NOT NULL,
+  status TEXT NOT NULL, config TEXT NOT NULL DEFAULT '{}',
+  granted_capabilities TEXT NOT NULL DEFAULT '[]', installed_by TEXT NOT NULL,
+  installed_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_unit_instances_type_name
   ON unit_instances(unit_type_id, name);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_control_module_instances_type_name
@@ -195,6 +214,10 @@ CREATE INDEX IF NOT EXISTS idx_safe_state_log_created_at
   ON blueprint_safe_state_log(created_at);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_safe_state_log_anchor_hash
   ON blueprint_safe_state_log(anchor_hash);
+CREATE INDEX IF NOT EXISTS idx_plugin_registry_publisher
+  ON plugin_registry(publisher);
+CREATE INDEX IF NOT EXISTS idx_plugin_installations_status
+  ON plugin_installations(status);
 `;
 
 /**
@@ -295,7 +318,7 @@ function encodeSqliteValue(key: string, value: unknown): unknown {
 }
 
 async function sqliteFind(
-  table: BlueprintTableName,
+  table: StorageTableName,
   where: Record<string, unknown> = {},
   orderBy?: string,
 ): Promise<Record<string, unknown>[]> {
@@ -318,7 +341,7 @@ async function sqliteFind(
 }
 
 async function sqliteInsert(
-  table: BlueprintTableName,
+  table: StorageTableName,
   input: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const now = new Date();
@@ -340,7 +363,7 @@ async function sqliteInsert(
 }
 
 async function sqliteUpdate(
-  table: BlueprintTableName,
+  table: StorageTableName,
   id: string,
   input: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
@@ -477,7 +500,7 @@ export async function withLockedDatabase<T>(
 
 async function createRecord<T>(
   pgTable: any,
-  sqliteTable: BlueprintTableName,
+  sqliteTable: StorageTableName,
   input: Record<string, unknown>,
 ): Promise<T> {
   return withStorageLock(async () => {
@@ -491,7 +514,7 @@ async function createRecord<T>(
 
 async function listRecords<T>(
   pgTable: any,
-  sqliteTable: BlueprintTableName,
+  sqliteTable: StorageTableName,
   options: {
     pgWhere?: unknown;
     sqliteWhere?: Record<string, unknown>;
@@ -512,7 +535,7 @@ async function listRecords<T>(
 
 async function firstRecord<T>(
   pgTable: any,
-  sqliteTable: BlueprintTableName,
+  sqliteTable: StorageTableName,
   pgWhere: unknown,
   sqliteWhere: Record<string, unknown>,
 ): Promise<T | undefined> {
@@ -522,7 +545,7 @@ async function firstRecord<T>(
 
 async function updateRecord<T>(
   pgTable: any,
-  sqliteTable: BlueprintTableName,
+  sqliteTable: StorageTableName,
   id: string,
   input: Record<string, unknown>,
 ): Promise<T> {
@@ -541,7 +564,7 @@ async function updateRecord<T>(
 
 async function upsertRecord<T>(
   pgTable: any,
-  sqliteTable: BlueprintTableName,
+  sqliteTable: StorageTableName,
   insertInput: Record<string, unknown>,
   updateInput: Record<string, unknown>,
   pgWhere: unknown,
@@ -598,6 +621,20 @@ async function upsertRecord<T>(
       throw new Error(`Instance upsert conflict for ${sqliteTable} returned no row`);
     }
     return existing as T;
+  });
+}
+
+async function deleteRecord(
+  pgTable: any,
+  sqliteTable: StorageTableName,
+  id: string,
+): Promise<void> {
+  await withStorageLock(async () => {
+    if (dbType === 'sqlite') {
+      await sqliteRun(`DELETE FROM ${sqliteTable} WHERE id = ?`, [id]);
+      return;
+    }
+    await requireDatabase().delete(pgTable).where(eq(pgTable.id, id));
   });
 }
 
@@ -1462,4 +1499,54 @@ export const storage = {
         sqliteWhere: { siteId },
       },
     ),
+
+  // ── Agent marketplace (#217) ───────────────────────────────────────────
+  // The registry row carries the durable plugin-ownership record; the
+  // installation row carries the durable capability grants. Both must
+  // survive a restart or neither is a security control.
+
+  getPluginRegistryEntries: () =>
+    listRecords<schema.PluginRegistryRow>(schema.pluginRegistry, 'plugin_registry'),
+  upsertPluginRegistryEntry: (input: schema.InsertPluginRegistryRow) =>
+    upsertRecord<schema.PluginRegistryRow>(
+      schema.pluginRegistry,
+      'plugin_registry',
+      input,
+      {
+        version: input.version,
+        manifest: input.manifest,
+        publisher: input.publisher,
+        installs: input.installs,
+        updatedAt: input.updatedAt ?? new Date(),
+      },
+      eq(schema.pluginRegistry.id, input.id),
+      { id: input.id },
+      [schema.pluginRegistry.id],
+    ),
+
+  getPluginInstallations: () =>
+    listRecords<schema.PluginInstallationRow>(
+      schema.pluginInstallations,
+      'plugin_installations',
+    ),
+  upsertPluginInstallation: (input: schema.InsertPluginInstallationRow) =>
+    upsertRecord<schema.PluginInstallationRow>(
+      schema.pluginInstallations,
+      'plugin_installations',
+      input,
+      {
+        version: input.version,
+        manifest: input.manifest,
+        status: input.status,
+        config: input.config,
+        grantedCapabilities: input.grantedCapabilities,
+        installedBy: input.installedBy,
+        updatedAt: input.updatedAt ?? new Date(),
+      },
+      eq(schema.pluginInstallations.id, input.id),
+      { id: input.id },
+      [schema.pluginInstallations.id],
+    ),
+  deletePluginInstallation: (pluginId: string) =>
+    deleteRecord(schema.pluginInstallations, 'plugin_installations', pluginId),
 };

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -13,6 +13,7 @@
  *   - event_anchors: Blockchain-anchored events
  *   - maintenance_records: Maintenance tracking
  *   - certifications, certification_approvals: Certification workflow
+ *   - plugin_registry, plugin_installations: Agent marketplace (#217)
  */
 
 import {
@@ -742,6 +743,52 @@ export const pidTuningAudit = pgTable("pid_tuning_audit", {
   recordedAtIdx: index("idx_pid_tuning_audit_recorded_at").on(table.recordedAt),
 }));
 
+// ─── Agent Marketplace (ADR-0013 [13.6], #217) ───────────────────────────────
+
+/**
+ * Published plugin manifests plus their durable ownership record.
+ *
+ * `publisher` is the authenticated control-plane principal that first
+ * published the id. Publishing a later version of an existing id is refused
+ * unless the requesting principal matches this row. There is deliberately NO
+ * admin break-glass: an `admin`/`*` key reaches the publish route but is still
+ * refused with `ownership-conflict` on someone else's id, because a takeover
+ * that any privileged key can perform is not an ownership record. A transfer,
+ * if ever wanted, belongs on its own explicitly-scoped endpoint.
+ * The check is only a security control because the row is durable — an
+ * ownership table that resets on restart would let a restart re-open the id.
+ */
+export const pluginRegistry = pgTable("plugin_registry", {
+  id: varchar("id", { length: 64 }).primaryKey(),
+  version: varchar("version", { length: 32 }).notNull(),
+  manifest: jsonb("manifest").notNull(),
+  publisher: varchar("publisher", { length: 255 }).notNull(),
+  installs: integer("installs").default(0).notNull(),
+  publishedAt: timestamp("published_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  publisherIdx: index("idx_plugin_registry_publisher").on(table.publisher),
+}));
+
+/**
+ * One row per installed plugin: the manifest version pinned at install time,
+ * the validated configuration, the capabilities actually granted, and the
+ * lifecycle status. Grants are security state, so they are durable too.
+ */
+export const pluginInstallations = pgTable("plugin_installations", {
+  id: varchar("id", { length: 64 }).primaryKey().references(() => pluginRegistry.id),
+  version: varchar("version", { length: 32 }).notNull(),
+  manifest: jsonb("manifest").notNull(),
+  status: varchar("status", { length: 32 }).notNull(),
+  config: jsonb("config").notNull().default(sql`'{}'::jsonb`),
+  grantedCapabilities: jsonb("granted_capabilities").notNull().default(sql`'[]'::jsonb`),
+  installedBy: varchar("installed_by", { length: 255 }).notNull(),
+  installedAt: timestamp("installed_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  statusIdx: index("idx_plugin_installations_status").on(table.status),
+}));
+
 // ─── Schema Exports ──────────────────────────────────────────────────────────
 
 // Insert schemas for validation
@@ -809,3 +856,7 @@ export type ModbusRegisterMapRow = typeof modbusRegisterMap.$inferSelect;
 export type InsertModbusRegisterMapRow = typeof modbusRegisterMap.$inferInsert;
 export type PidTuningAuditRow = typeof pidTuningAudit.$inferSelect;
 export type InsertPidTuningAuditRow = typeof pidTuningAudit.$inferInsert;
+export type PluginRegistryRow = typeof pluginRegistry.$inferSelect;
+export type InsertPluginRegistryRow = typeof pluginRegistry.$inferInsert;
+export type PluginInstallationRow = typeof pluginInstallations.$inferSelect;
+export type InsertPluginInstallationRow = typeof pluginInstallations.$inferInsert;

--- a/shared/types/marketplace.ts
+++ b/shared/types/marketplace.ts
@@ -1,0 +1,172 @@
+/**
+ * Agent Marketplace & Plugin System — shared types
+ *
+ * Feature [13.6] of ADR-0013 (docs/decisions/ADR-0013-autonomous-agent-architecture.md).
+ * Issue #217. Design notes: docs/architecture/agent-marketplace.md.
+ *
+ * ── What this system is ──────────────────────────────────────────────────
+ * A registry of plugin *manifests* (metadata: id, version, declared
+ * capabilities, config schema, dependencies) plus an install/grant/lifecycle
+ * record for each plugin an operator has explicitly installed.
+ *
+ * ── What this system is NOT ─────────────────────────────────────────────
+ * It is NOT a code-distribution channel and it is NOT a security sandbox.
+ *
+ *  - No plugin code is ever uploaded, downloaded, or dynamically loaded. A
+ *    published manifest can never become executable on its own. Executable
+ *    handlers come only from first-party modules compiled into this server
+ *    and registered through `registerImplementation` at startup
+ *    (server/services/marketplace/builtin/). An installed plugin with no
+ *    such handler reports `implementationState: "unavailable"` and refuses
+ *    to start — it is not silently broken.
+ *  - Handlers therefore run in-process, in the server's own isolate. Node
+ *    in-process execution is NOT a security boundary against hostile code:
+ *    a malicious handler could reach `process`, `require`, the filesystem,
+ *    or the event loop regardless of its granted capabilities. The
+ *    capability system constrains a *cooperative* plugin's access to host
+ *    services at the host-context boundary; it does not contain hostile
+ *    code. Containing untrusted code would require process/VM isolation
+ *    (worker threads with a restricted module graph, a child process, or a
+ *    separate container), which this repository does not implement.
+ *  - Accordingly, the trust model is: only trusted, first-party,
+ *    explicitly-installed plugins execute. Third-party code execution is
+ *    out of scope until an isolation boundary exists.
+ *
+ * No money, tokens, licences, or signatures move through this system. There
+ * is no payment path, no plugin signing, and no signature verification.
+ */
+
+export type PluginCategory =
+  | 'intelligence'
+  | 'integration'
+  | 'reporting'
+  | 'safety'
+  | 'optimization'
+  | 'custom';
+
+/**
+ * Host services a plugin may be granted.
+ *
+ * A capability must be BOTH declared in the manifest AND granted at install
+ * time. Reaching for anything else through the host context throws
+ * `capability-denied` and emits an audit event — it never silently proceeds.
+ */
+export type PluginCapability =
+  | 'tags:read'
+  | 'alarms:read'
+  | 'events:emit'
+  | 'log';
+
+export const PLUGIN_CAPABILITIES: readonly PluginCapability[] = Object.freeze([
+  'tags:read',
+  'alarms:read',
+  'events:emit',
+  'log',
+]);
+
+export interface PluginConfigField {
+  type: 'string' | 'number' | 'boolean' | 'select';
+  description: string;
+  default?: string | number | boolean;
+  required: boolean;
+  options?: string[];
+}
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  /** Free-text attribution shown in listings. NOT an identity or authorization claim. */
+  author: string;
+  category: PluginCategory;
+  /** Capabilities the plugin needs; installation grants a subset of these. */
+  requiredCapabilities: PluginCapability[];
+  configSchema: Record<string, PluginConfigField>;
+  /** pluginId → semver range (`^`, `~`, exact, or `*`) — enforced at install. */
+  dependencies: Record<string, string>;
+  tags: string[];
+}
+
+/**
+ * A registry record. `publisher` is the ownership record: it is the
+ * authenticated control-plane principal that FIRST published this plugin id,
+ * captured server-side. Only that principal (or an admin key) may publish a
+ * later version of the id. It is never read from a request body.
+ */
+export interface MarketplaceEntry {
+  manifest: PluginManifest;
+  publisher: string;
+  publishedAt: number;
+  updatedAt: number;
+  installs: number;
+}
+
+export type PluginStatus = 'installed' | 'running' | 'stopped' | 'disabled' | 'error';
+
+/**
+ * Whether an executable handler is registered for this plugin id.
+ *
+ *  - `available`   — a first-party implementation is compiled in and registered.
+ *  - `unavailable` — the manifest is installed but nothing can execute it.
+ *                    This is an expected, reportable state, not an error.
+ */
+export type PluginImplementationState = 'available' | 'unavailable';
+
+export interface InstalledPlugin {
+  manifest: PluginManifest;
+  status: PluginStatus;
+  config: Record<string, string | number | boolean>;
+  grantedCapabilities: PluginCapability[];
+  /** Authenticated principal that installed it — captured server-side. */
+  installedBy: string;
+  installedAt: number;
+  startedAt: number | null;
+  lastError: string | null;
+  implementationState: PluginImplementationState;
+}
+
+export interface PluginHealth {
+  pluginId: string;
+  status: PluginStatus;
+  implementationState: PluginImplementationState;
+  /** Seconds since the last start; 0 when not running. */
+  uptimeSeconds: number;
+  invocations: number;
+  failures: number;
+  /** Failure fraction over the recent invocation window. */
+  windowedErrorRate: number;
+  consecutiveFailures: number;
+  capabilityDenials: number;
+  lastError: string | null;
+}
+
+/**
+ * Machine-readable outcome codes so callers never have to parse a message.
+ */
+export type PluginInvocationCode =
+  | 'ok'
+  | 'not-installed'
+  | 'not-running'
+  | 'not-implemented'
+  | 'timeout'
+  | 'capability-denied'
+  | 'handler-error';
+
+export interface PluginInvocationResult {
+  pluginId: string;
+  success: boolean;
+  code: PluginInvocationCode;
+  output?: unknown;
+  error?: string;
+  durationMs: number;
+}
+
+/** Audit record emitted whenever a plugin reaches for a capability it lacks. */
+export interface CapabilityDenialRecord {
+  pluginId: string;
+  capability: PluginCapability;
+  /** `undeclared` — not in the manifest at all; `ungranted` — declared but not granted at install. */
+  reason: 'undeclared' | 'ungranted';
+  at: number;
+}


### PR DESCRIPTION
Closes #217.

Rewritten on current `main` against the #576 `requireControlPlaneAccess` pattern, per @flaukowski. The machinery the review praised — semver ranges, dependency enforcement, invocation timeouts, windowed failure tracking with auto-disable, config-schema validation — is kept. Everything the review condemned is replaced.

## 1. Scoped auth on every route

The `requireAuth` no-op (`// TODO: implement real auth check`, then `next()`) is gone. Five scopes, one explicit guard per route, no permissive fallback — 16 route declarations, 16 guards, no router-wide `use()`:

| Route (`/api/marketplace`) | Scope |
| --- | --- |
| `GET /plugins`, `/plugins/:id`, `/installed`, `/plugins/:id/health`, `/health`, `/status` | `marketplace.read` |
| `POST /plugins` | `marketplace.publish` |
| `POST /plugins/:id/install\|update\|start\|stop\|enable\|disable`, `PUT /plugins/:id/config` | `marketplace.install` |
| `POST /plugins/:id/invoke` | `marketplace.invoke` |
| `DELETE /plugins/:id` | `marketplace.uninstall` |

Lifecycle transitions sit under `marketplace.install` because they change installed state; they are deliberately not reachable with `marketplace.invoke`. `CONTROL_ROUTE_POLICIES` gains a `marketplace-control` entry so the central gateway floor is the four action scopes, not generic `write`.

**HTTP auth matrix** (`server/routes/__tests__/marketplace-auth.test.ts`, 90 passing): for each of the 16 routes — anonymous → 401, unknown credential → 401, credential from an unrelated service → 403, valid credential with a *different marketplace* scope → 403, exact scope → its expected status. Plus: a query-string credential is never accepted.

## 2. Manifest hijack closed

> "unauthenticated POST /plugins lets anyone republish any plugin id with a bumped version"

The first publish of an id records a **durable owner** — `controlPlanePrincipal(req).name`, never a body field. `ManifestSchema` is `.strict()`, so a body carrying `publisher` is a 400 rather than a silently ignored field.

* different principal → `403 ownership-conflict`
* same or older version → `409 version-conflict`
* uninstall does **not** release the id (that would re-open it)
* built-ins are owned by reserved `system:builtin`; the publish path refuses any principal named `system:*`
* **no admin break-glass** — an `admin`/`*` key reaches the route and is still refused on someone else's id. A takeover any privileged key can perform is not an ownership record. A transfer, if ever wanted, belongs on its own explicitly-scoped endpoint.

Asserted over HTTP, and re-asserted after a real database close/reopen.

## 3. Capabilities enforce, and the boundary is described honestly

`PluginHostContext` accessors are getters that throw `capability-denied` and emit an audited `plugin-capability-denied` event when the capability is undeclared in the manifest or ungranted at install. A missing property can be silently skipped; a throw cannot. The denial is counted and emitted *before* the error is constructed, so a plugin that swallows its own denial still cannot suppress the audit record. `host.capabilities` supports feature detection and is frozen; `host.config` is frozen. `update()` narrows carried-over grants to what the new manifest still declares and never widens them, so a republish cannot escalate an approved install.

**Stated plainly in code and in `docs/architecture/agent-marketplace.md`:** Node in-process execution is **not** a security sandbox. The capability system constrains a *cooperative* plugin's access to host services at the host-context boundary; it does not contain hostile code, which needs process/VM isolation. That is defensible here only because **no third-party code can execute** — nothing is uploaded or dynamically loaded, and handlers come solely from first-party modules compiled into the server. The deviation from ADR-0013's "sandboxed contexts" wording is recorded explicitly.

The invocation bound is described with the same precision: the timer races on the event loop, so it bounds a handler that **yields**; it cannot interrupt one that blocks the loop synchronously. `code: "timeout"` is produced solely by the host's own timer error type, so a handler cannot mislabel an ordinary fault as a host-imposed timeout.

## 4. Merchandise

`registerImplementation` now has a production caller: `MarketplaceService.initialize()`, awaited by `registerRoutes`. `builtin/tag-threshold-monitor.ts` is a real plugin — it reads a live tag through the gated host context, classifies it against high/low limits and a staleness bound, and emits a breach event. `install → start → invoke` runs end to end over HTTP against a live tag in the test suite.

A manifest with no compiled implementation is an **explicit machine-readable state**: `implementationState: "unavailable"`, `start` → `409 not-implemented`, `invoke` → `code: "not-implemented"`. Not a confusing error.

No money, token or signature flow was added. None moves, and nothing claims otherwise.

## 5. Persistence

`migrations/0007_agent_marketplace.sql` (journal updated, idx 4) adds `plugin_registry` and `plugin_installations`, declared in `shared/schema.ts` and reached through `server/storage.ts` so both Postgres and the SQLite dev back-end work.

Durable: registry manifests, **the ownership record**, install counters, validated config, **granted capabilities**, installing principal, lifecycle status including auto-disable. State is persisted *before* the in-memory view is updated, so a failed write cannot leave memory ahead of the database. `publish`/`install` require a hydrated registry — an ownership check against an empty registry would authorize a hijack, so an unloaded engine returns `503 store-unavailable` instead.

Deliberately in memory, and said so: per-process invocation counters / failure window / uptime (transient telemetry — the decision they produce is persisted), and the registered implementations (code from the build). If the database is unavailable the service falls back to a non-durable store and logs a warning saying ownership will not survive a restart.

`marketplace-persistence.test.ts` proves this against a real file-backed database, closing and reopening it between assertions. No mocks.

## Also

* `agentRuntime.getHealth()` reports real marketplace numbers instead of hardcoded zeros, export shape intact; the `agent-runtime` health probe now asks whether the runtime can serve rather than whether the module resolves.
* The ADR citation points at the document that exists — `docs/decisions/ADR-0013-autonomous-agent-architecture.md` — which is why the review could not find it under `docs/adr`.

## Gates

```
npx tsc --noEmit    # exit 0
npx vitest run      # 98 files passed | 2 skipped, 2158 passed | 5 skipped
```
Baseline was 95 files / 2024 passing with the same 2 skipped files and 5 skipped tests. No regressions.

## Known gaps (not papered over)

* No process/VM isolation, therefore no third-party code execution.
* A synchronous handler that blocks the event loop cannot be pre-empted by the wall-clock timeout; that needs the isolation boundary above. Acceptable only because handlers are reviewed first-party code.
* No plugin signing or signature verification; no payment or licensing flow.
* `alarms:read` resolves to an empty list — no read-only projection of active alarms is wired to the marketplace on this branch, so grantees see nothing rather than fabricated alarms.
* Identity is the control-plane key name, so two API keys configured with the same name are one principal. That is the repo-wide #576 model, not specific to the marketplace.
* Migration 0007 was validated as DDL and exercised through the SQLite path; it has not been run against a live Postgres instance. If it is missing, the marketplace fails closed with `503 store-unavailable`.

---

**Migration numbering — cross-PR coordination.** This branch adds its migration as `0007_*`, the next free
slot on `main` (which has `0001`, `0002`, `0003_blueprint_persistence`, `0006_blueprint_instance_identity`).
**Five** PRs in this batch each add a `0007_*` migration: `0007_validator_registry` (#454),
`0007_blueprint_safe_state_log` (#459), `0007_modbus_register_map` (#462), `0007_pid_tuning_audit` (#215)
and `0007_agent_marketplace` (#217). Each is independently self-consistent; every one after the first to
merge needs renumbering plus a `migrations/meta/_journal.json` update. Flagged rather than guessing a merge
order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
