### PR TITLE
feat(iec61850-goose): live EtherType 0x88B8 capture on a configurable interface (#465)

### DIFF
--- a/docs/protocols/iec61850-goose.md
+++ b/docs/protocols/iec61850-goose.md
@@ -2,10 +2,15 @@
 
 > Status: **subscriber-only** (the GOOSE *publisher* is a later wave).
 >
-> **Live Layer-2 capture is NOT provided by this repository.** GOOSE rides
-> directly on Ethernet and Node has no way to receive those frames without a
-> native addon; none is shipped. What *is* provided and fully works is offline
-> **pcap replay**, plus an injection point for a live backend you supply.
+> **Live Layer-2 capture is provided**, opt-in via `GOOSE_CAPTURE=live`, by
+> spawning a libpcap capture tool (`dumpcap`/`tcpdump`) that streams pcap on
+> stdout. No native addon and no new npm dependency. It requires a
+> Linux/BSD/macOS host, that tool installed, and `CAP_NET_RAW`.
+> **It has not been run against a real IED or a real substation bus here** —
+> see [What is *not* verified](#what-is-not-verified).
+>
+> Offline **pcap replay** is also provided and fully works, and any other frame
+> source can be injected as a backend.
 >
 > Issue: [#465](https://github.com/NickFlach/0xSCADA/issues/465) — *Build IEC
 > 61850 GOOSE Subscriber*.
@@ -28,22 +33,24 @@ surfaces decoded dataset values as tag updates with `origin = "goose"`.
 The subscriber does **not** own capture. It consumes frames from an injected
 `GooseCaptureBackend`, which is the only environment-dependent part:
 
-| Backend | Ships here? | Delivers frames? |
-|---------|-------------|------------------|
-| `NullGooseCaptureBackend` (**default**) | yes | **no** — reports why, in `start()` and in a log line |
-| `GoosePcapReplayBackend` | yes | **yes** — replays a captured `.pcap` offline |
-| live AF_PACKET / native addon | **no** | you implement and inject it |
+| Backend | `GOOSE_CAPTURE` | Delivers frames? |
+|---------|-----------------|------------------|
+| `NullGooseCaptureBackend` (**default**) | `none` | **no** — reports why, in `start()` and in a log line |
+| `GoosePcapReplayBackend` | `pcap` | **yes** — replays a captured `.pcap` offline |
+| `GooseLiveCaptureBackend` | `live` | **yes** — real frames off a real interface, via `dumpcap`/`tcpdump` |
+| your own implementation | — | inject it as `options.backend` |
 
 Consequences you should plan around:
 
-- With the default backend, `start()` resolves to **`"unavailable"`**. It does
-  not throw, and it never claims to be running. The decode/validation core is
-  still fully usable via `handleFrame()`.
-- A raw Layer-2 capture socket (`AF_PACKET` / `SOCK_RAW`) requires **all** of:
-  Linux (AF_PACKET is Linux-only), `CAP_NET_RAW` (root, or
-  `setcap cap_net_raw+ep $(command -v node)`), **and** a native L2 capture
-  binding. `detectRawSocketCapability()` reports which of these your host is
-  missing so the log line is host-specific rather than a generic "disabled".
+- **Capture is opt-in.** With none of the `GOOSE_*` capture variables set, the
+  service constructs the null backend, `start()` resolves to **`"unavailable"`**
+  and it says why. It does not throw, it never claims to be running, and it
+  never starts a capture process. The decode/validation core is still fully
+  usable via `handleFrame()`.
+- Live capture has hard host requirements — a supported OS, a capture tool, and
+  `CAP_NET_RAW`; see [Live capture](#live-capture-goose_capturelive).
+  `availability()` names what your host is missing before anything is spawned,
+  and `open()` reports what only the kernel can tell you.
 - No native capture dependency is added to `package.json`, and nothing in this
   module pretends one exists.
 
@@ -72,11 +79,13 @@ The `IECGoosePdu` (IEC 61850-8-1 Annex A) carries: `gocbRef`,
 | `subscription.ts` | Per-subscription config (Zod) + validation state machine |
 | `capture-backend.ts` | The `GooseCaptureBackend` seam, EtherType filter, null backend, raw-socket capability probe |
 | `pcap.ts` | Classic libpcap reader/writer (both byte orders, µs and ns magics) |
+| `pcap-stream.ts` | `PcapStreamDecoder` — incremental pcap decode for a live byte stream |
 | `pcap-backend.ts` | `GoosePcapReplayBackend` — replays a capture with recorded timing |
+| `live-backend.ts` | `GooseLiveCaptureBackend` — live capture via a spawned libpcap tool |
 | `config.ts` | `GOOSE_*` environment configuration (Zod-validated) |
 | `metrics.ts` | Prometheus metrics on the shared registry |
 | `index.ts` | `GooseSubscriber` service + `startGooseSubscriber()` startup wiring |
-| `__tests__/` | Frame/PDU, subscription, pcap codec, end-to-end replay and config tests |
+| `__tests__/` | Frame/PDU, subscription, pcap codec, pcap stream, live capture, end-to-end replay and config tests |
 
 ## Validation performed
 
@@ -109,11 +118,145 @@ tag stream.
 
 Validation always uses the receive timestamp the backend supplies with the
 frame, and the TTL watchdog uses `backend.clockNowMs?.()` when the backend
-provides it. A live backend supplies wall-clock times. **The pcap backend
-supplies the capture's own recorded timestamps**, so TTL countdown and
-round-trip latency are evaluated in the trace's time base — replaying a
-two-year-old capture reports the latencies that existed when it was recorded,
-not the age of the file.
+provides it.
+
+- **The pcap backend supplies the capture's own recorded timestamps**, so TTL
+  countdown and round-trip latency are evaluated in the trace's time base —
+  replaying a two-year-old capture reports the latencies that existed when it
+  was recorded, not the age of the file.
+- **The live backend supplies the kernel's capture timestamp** for each frame,
+  taken from the pcap record, and `Date.now()` for `clockNowMs()`. Both come
+  from the same host clock. The kernel timestamp is used rather than "when Node
+  got round to it" because the capture tool's buffering, the pipe and Node's
+  event loop are all comparable to the sub-4 ms budget `goose_round_trip_us`
+  measures; using `Date.now()` at the point of decode would fold our own
+  latency into the metric. So on the live backend **`goose_round_trip_us` is
+  publisher `t` → kernel capture time**, and does not include the time to get
+  the frame into Node. If the recorded timestamps disagree with the local clock
+  by more than five minutes they are discarded in favour of the wall clock
+  (otherwise every subscription would look permanently TTL-expired); that is
+  counted and logged once.
+
+## Live capture (`GOOSE_CAPTURE=live`)
+
+`GooseLiveCaptureBackend` captures real EtherType 0x88B8 frames off a real
+interface. It does so by spawning a libpcap capture tool that writes a classic
+pcap stream to stdout, and decoding that stream incrementally:
+
+```
+dumpcap -i eth0 -P -q -s 65535 -w - -f 'ether proto 0x88b8 or (vlan and ether proto 0x88b8)'
+tcpdump -i eth0 -U -n -s 65535 -w - 'ether proto 0x88b8 or (vlan and ether proto 0x88b8)'
+```
+
+Be precise about where the raw socket lives: **libpcap opens it inside the
+capture tool** (`AF_PACKET`/`SOCK_RAW` on Linux, BPF devices on the BSDs), binds
+it to the configured interface, and attaches the EtherType filter as a kernel
+BPF program. Node never holds the socket; it reads the resulting pcap stream
+over a pipe. That is why there is no native addon, no `node-gyp` and no new npm
+dependency — and why the privilege requirement lands on the tool rather than on
+the Node process. The pcap decoding on this side is the same code the offline
+replay backend uses.
+
+The tool is spawned with an **argv array and no shell**, so an interface name or
+filter containing shell metacharacters is one opaque argument.
+
+`-P` (dumpcap) is mandatory — modern dumpcap defaults to pcapNG, which this
+decoder does not read. `-U` (tcpdump) is mandatory — without packet-buffered
+output tcpdump holds frames in a 4 KiB stdio buffer.
+
+### Requirements
+
+All of these must hold, or capture will not start:
+
+1. **A Linux/BSD/macOS host.** Windows is reported as unavailable: capture there
+   goes through Npcap with a different privilege model and different packaging,
+   and none of it is implemented or tested here.
+2. **`dumpcap` or `tcpdump` installed** and on `PATH` (or pointed at by
+   `GOOSE_CAPTURE_TOOL_PATH`). `dumpcap` is preferred: it is the small,
+   privilege-separated capture binary Wireshark ships for exactly this purpose.
+3. **`CAP_NET_RAW`.** Opening a capture handle is privileged. Grant it once to
+   the capture tool rather than running the whole Node process as root:
+
+   ```bash
+   # Debian/Ubuntu: the packaged way — puts dumpcap in the `wireshark` group
+   sudo dpkg-reconfigure wireshark-common     # answer "yes"
+   sudo usermod -aG wireshark "$SERVICE_USER" # then re-login the service
+
+   # or grant the capability directly
+   sudo setcap cap_net_raw,cap_net_admin+eip "$(command -v dumpcap)"
+   getcap "$(command -v dumpcap)"             # verify
+   ```
+
+   Under systemd, `AmbientCapabilities=CAP_NET_RAW` on the unit works too.
+4. **The NIC must actually see the GOOSE traffic.** GOOSE is Layer-2 multicast:
+   it is not routed and does not cross a VLAN boundary. The interface must be on
+   the station/process bus, in the GOOSE VLAN (or on a mirror/SPAN port carrying
+   it), and must not be a `-i any` pseudo-interface — that yields
+   `LINKTYPE_LINUX_SLL`, which has no Ethernet header, and the backend refuses
+   it explicitly.
+
+### VLAN tagging — why the filter is what it is
+
+`ether proto 0x88b8` on its own is **wrong** for a substation bus. It compiles
+to a comparison at Ethernet offset 12, and on an 802.1Q-tagged frame offset 12
+holds the tag's TPID (0x8100) — the real EtherType has moved to offset 16. Since
+GOOSE is normally published on a dedicated priority-tagged VLAN, that filter
+silently drops exactly the traffic you subscribed to.
+
+libpcap's `vlan` keyword fixes it, with one sharp edge: it is not an ordinary
+predicate. Per `pcap-filter(7)`, the first `vlan` in an expression re-bases every
+offset *after* it by 4 bytes. So the terms are not interchangeable:
+
+```
+ether proto 0x88b8                 → offset 12 → untagged GOOSE
+or (vlan and ether proto 0x88b8)   → `vlan` matches the tag and shifts the base,
+                                     so this test reads offset 16 → tagged GOOSE
+```
+
+Putting the VLAN term first would leave the untagged test reading a shifted
+offset. Exactly **one** tag is unwrapped, matching what `readFrameEtherType()`
+and the frame parser decode; a QinQ (0x88A8/0x9100) outer tag is not handled by
+either, so the filter does not pretend to.
+
+Whatever the filter does, every delivered frame is re-checked with the same
+`isGooseFrame()` helper the offline backend uses, so a mis-set
+`GOOSE_CAPTURE_FILTER` cannot feed non-GOOSE traffic into the BER decoder.
+
+### Startup, failure and shutdown
+
+- `availability()` never throws and never guesses. It reports the unsupported
+  platform, or that no capture tool is installed, or the exact command it would
+  run. It explicitly does **not** claim your process holds `CAP_NET_RAW` — only
+  the kernel can answer that, and it does so when the tool starts.
+- `open()` resolves only once the pcap **global header** has been decoded.
+  libpcap emits it when the capture handle is open, so `start()` reporting
+  `"running"` means capture genuinely started rather than "we launched
+  something". If the tool exits first, the rejection carries its exit status and
+  its stderr; a permission failure is recognised and answered with the `setcap`
+  remedy above, and a bad interface name is called out as such. A tool that
+  emits nothing at all is abandoned after `startupTimeoutMs` (default 5 s).
+- Nothing is ever fabricated. If capture cannot start there are no frames, no
+  synthetic values, and the subscriber reports `"error"` or `"unavailable"`.
+- `close()` kills the child (SIGTERM, then SIGKILL after a grace period), waits
+  for it to be reaped, and is safe to call twice or when `open()` was never
+  called. A `process.on("exit")` hook covers a shutdown that forgets to call it.
+  Neither can survive a `SIGKILL` of the server, so run under a supervisor that
+  kills the whole control group (systemd's default `KillMode=control-group`) if
+  an orphaned `dumpcap` would be a problem for you.
+- Frames snapped by the snapshot length (`incl_len < orig_len`) are **dropped**
+  and counted, not decoded — a cut-off APDU would otherwise yield a partial
+  dataset.
+- The stream decoder is bounded: an over-large record header is rejected before
+  its body is buffered, and the undecodable residue between chunks is capped.
+  A framing error stops the capture rather than being silently ignored, because
+  pcap has no resynchronisation marker.
+
+```bash
+GOOSE_SUBSCRIPTIONS_FILE=/etc/0xscada/goose-subscriptions.json \
+GOOSE_CAPTURE=live \
+GOOSE_IFACE=eth0 \
+npm run start
+```
 
 ## pcap replay (fully supported)
 
@@ -164,11 +307,12 @@ degradation to `invalid`, a stale frame re-injected on the bus (stNum
 regression), the simulation bit, an 802.1Q-tagged frame and a foreign control
 block.
 
-## Injecting a live capture backend
+## Injecting your own capture backend
 
-Implement `GooseCaptureBackend` against whatever binding you are willing to
-deploy (`cap`, `pcap`, a custom AF_PACKET addon, a userspace DPDK shim…) and
-pass it to the subscriber. Nothing else changes.
+If the spawned-tool approach does not suit your deployment, implement
+`GooseCaptureBackend` against whatever binding you are willing to deploy (`cap`,
+`pcap`, a custom AF_PACKET addon, a userspace DPDK shim…) and pass it to the
+subscriber. Nothing else changes.
 
 ```ts
 import type {
@@ -222,21 +366,32 @@ Contract for a backend:
 ## Configuration
 
 The subscriber is **off** unless subscriptions are configured — a substation's
-control-block map cannot be guessed.
+control-block map cannot be guessed — and capture is **off** unless a source is
+selected. With none of these variables set, the service behaves exactly as it
+did before live capture existed.
 
 | Variable | Meaning |
 |----------|---------|
 | `GOOSE_SUBSCRIPTIONS_FILE` | Path to a JSON array of subscription configs. **Required to enable the service.** |
-| `GOOSE_PCAP_FILE` | Path to a classic `.pcap` to replay. When set, the pcap backend is used. |
+| `GOOSE_CAPTURE` | `none` \| `pcap` \| `live`. Defaults to `pcap` when `GOOSE_PCAP_FILE` is set, else `none`. `live` is never chosen implicitly. |
+| `GOOSE_PCAP_FILE` | Path to a classic `.pcap` to replay. |
 | `GOOSE_PCAP_REALTIME` | `false`/`0` to drain the capture with no delay. Default honours recorded timing. |
-| `GOOSE_IFACE` | Interface a live backend *would* bind. Used only in the "capture unavailable" explanation. |
+| `GOOSE_IFACE` | Interface to capture on. Default `eth0`. Used by the live backend; named in the "capture unavailable" explanation otherwise. |
+| `GOOSE_CAPTURE_TOOL` | `auto` (default) \| `dumpcap` \| `tcpdump`. |
+| `GOOSE_CAPTURE_TOOL_PATH` | Absolute path to that tool, bypassing the `PATH` search. Requires an explicit `GOOSE_CAPTURE_TOOL`, because the two tools take different arguments. |
+| `GOOSE_CAPTURE_SNAPLEN` | Snapshot length, 68–262144. Default 65535. |
+| `GOOSE_CAPTURE_FILTER` | BPF filter override (advanced). The EtherType 0x88B8 check is applied to every delivered frame regardless. |
 
 `server/index.ts` calls `startGooseSubscriber()` at boot. Startup outcomes:
 
 - no `GOOSE_SUBSCRIPTIONS_FILE` → one info line, service stays off;
 - subscriptions but no capture source → `"unavailable"` plus a warning naming
   exactly what is missing;
-- subscriptions + `GOOSE_PCAP_FILE` → `"running"`, frames replayed.
+- subscriptions + `GOOSE_PCAP_FILE` → `"running"`, frames replayed;
+- subscriptions + `GOOSE_CAPTURE=live` → `"running"` once the capture tool has
+  opened its handle; `"unavailable"` if the host cannot capture at all (wrong
+  platform, no tool installed); `"error"`, with the tool's stderr and a remedy,
+  if it could have but did not (no `CAP_NET_RAW`, no such interface).
 
 Example `goose-subscriptions.json`:
 
@@ -294,13 +449,51 @@ Run `npx vitest run server/protocols/iec61850-goose`.
 - `pcap.test.ts` — global-header parse against a hand-assembled little-endian
   capture, the full byte-order × timestamp-resolution matrix, truncation and
   pcapng errors, and the EtherType filter.
+- `pcap-stream.test.ts` — the incremental decoder, checked against `parsePcap()`
+  for **every** single split point of a multi-packet capture, every pair of
+  split points of a small one, and a byte-at-a-time feed; plus the byte-order ×
+  resolution matrix, snaplen truncation flagging, both bounds, and failing
+  closed after a framing error.
+- `live-backend.test.ts` — the live path, driven by a fake capture command
+  (`process.execPath -e …`) that emits a known pcap byte stream on stdout. This
+  exercises the real spawn → stdout stream → incremental decode → EtherType
+  filter → frame handler → subscriber path, including pathological chunk sizes,
+  genuinely separate pipe chunks, both byte orders and the ns magic, truncated-
+  frame rejection, non-GOOSE filtering, the record bound, spawn `ENOENT`,
+  non-zero exit with the tool's stderr surfaced, the permission-denied remedy,
+  the startup timeout, `close()` reaping the child, double-close, reopen, and an
+  end-to-end run producing tag updates and moving the Prometheus counters.
 - `pcap-replay.test.ts` — the issue's Verification section, executable: replay
   the committed capture, assert the expected dataset decodes, that the
   quality-bit change surfaces as a tag update, that mean round-trip stays inside
   the 4 ms budget, that the stale re-injected frame is rejected, and that the
   received/rejected counters and round-trip histogram move by exactly the
   expected amounts.
-- `config.test.ts` — environment parsing and the three startup outcomes.
+- `config.test.ts` — environment parsing, backend selection, and the startup
+  outcomes. Includes the guarantee that an unconfigured environment selects no
+  capture at all.
 
-Not verified here, because it cannot be: live multicast capture. There is no
-test, and no code, that receives a frame from a real substation bus.
+### What is *not* verified
+
+Everything below is written from the tools' and the standard's documented
+behaviour. None of it has been observed here, and nothing in this repository
+claims otherwise:
+
+- **No frame has ever been captured from a real IED or a real substation bus.**
+  No such hardware is available to this repository. The end-to-end live tests
+  use a fake capture command emitting a known pcap stream; the code on this side
+  of the pipe is real, the bus is not.
+- The `dumpcap`/`tcpdump` argument vectors and the BPF filter have not been run
+  against a real libpcap in CI — CI has no capture privileges and no GOOSE
+  traffic. If a tool rejects the filter or an argument, it exits and its stderr
+  is surfaced verbatim; that path *is* tested.
+- Timing under real load — GOOSE retransmission storms, a saturated process bus,
+  the latency the pipe adds under pressure — is unmeasured. The sub-4 ms figure
+  the histogram reports is publisher `t` → kernel capture time, which excludes
+  the pipe.
+- The committed replay capture is **synthetic**: hand-encoded by the test
+  fixtures, not sniffed from a relay.
+
+Before trusting this on a live bus, capture a trace with Wireshark first, replay
+it through `GOOSE_PCAP_FILE`, and confirm the decode and the subscription map
+against the IED's SCL.

--- a/server/index.ts
+++ b/server/index.ts
@@ -194,9 +194,10 @@ registerSwaggerRoutes(app, gatewayConfig);
       }
 
       // Start the IEC 61850 GOOSE subscriber (Issue #465) — no-op unless
-      // GOOSE_SUBSCRIPTIONS_FILE is configured. Live Layer-2 capture is NOT
-      // provided (it needs a native addon); with GOOSE_PCAP_FILE set it
-      // replays a capture, otherwise it starts "unavailable" and logs why.
+      // GOOSE_SUBSCRIPTIONS_FILE is configured. Capture is opt-in: with
+      // GOOSE_PCAP_FILE it replays a capture, with GOOSE_CAPTURE=live it
+      // captures EtherType 0x88B8 off GOOSE_IFACE through a libpcap tool
+      // (needs CAP_NET_RAW), otherwise it starts "unavailable" and logs why.
       try {
         const { startGooseSubscriber } = await import("./protocols/iec61850-goose");
         await startGooseSubscriber();

--- a/server/protocols/iec61850-goose/__tests__/config.test.ts
+++ b/server/protocols/iec61850-goose/__tests__/config.test.ts
@@ -6,7 +6,13 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { loadGooseServiceConfig, loadGooseSubscriptionsFile } from "../config.js";
-import { startGooseSubscriber, stopGooseSubscriber, getGooseSubscriber } from "../index.js";
+import {
+  createGooseCaptureBackend,
+  startGooseSubscriber,
+  stopGooseSubscriber,
+  getGooseSubscriber,
+} from "../index.js";
+import { GooseLiveCaptureBackend, GOOSE_BPF_FILTER } from "../live-backend.js";
 import { REPLAY_APP_ID, REPLAY_GOCB_REF } from "./fixtures.js";
 import { REPLAY_PCAP_PATH } from "./generate-replay-pcap.js";
 
@@ -29,12 +35,18 @@ afterEach(async () => {
 });
 
 describe("loadGooseServiceConfig", () => {
-  it("defaults to no subscriptions, no capture file and eth0", () => {
+  it("defaults to no subscriptions, no capture at all and eth0", () => {
     const config = loadGooseServiceConfig({});
     expect(config.subscriptions).toEqual([]);
     expect(config.pcapPath).toBeUndefined();
     expect(config.iface).toBe("eth0");
     expect(config.pcapRealtime).toBe(true);
+    // Capture is opt-in: an unconfigured environment must never start one.
+    expect(config.capture).toBe("none");
+    expect(config.captureTool).toBe("auto");
+    expect(config.captureToolPath).toBeUndefined();
+    expect(config.captureSnapLen).toBe(65535);
+    expect(config.captureFilter).toBeUndefined();
   });
 
   it("reads subscriptions from GOOSE_SUBSCRIPTIONS_FILE", () => {
@@ -60,6 +72,64 @@ describe("loadGooseServiceConfig", () => {
     );
     expect(config.pcapPath).toBe("trace.pcap");
     expect(config.pcapRealtime).toBe(false);
+    // GOOSE_PCAP_FILE alone still selects replay — unchanged behaviour.
+    expect(config.capture).toBe("pcap");
+  });
+
+  it("only selects live capture when it is asked for explicitly", () => {
+    expect(loadGooseServiceConfig({ GOOSE_IFACE: "eth4" }).capture).toBe("none");
+    expect(loadGooseServiceConfig({ GOOSE_CAPTURE_TOOL: "tcpdump" }).capture).toBe("none");
+    expect(loadGooseServiceConfig({ GOOSE_CAPTURE_SNAPLEN: "1500" }).capture).toBe("none");
+    expect(loadGooseServiceConfig({ GOOSE_CAPTURE: "live" }).capture).toBe("live");
+  });
+
+  it("lets GOOSE_CAPTURE=none override a configured capture file", () => {
+    const config = loadGooseServiceConfig({
+      GOOSE_CAPTURE: "none",
+      GOOSE_PCAP_FILE: "trace.pcap",
+    });
+    expect(config.capture).toBe("none");
+  });
+
+  it("reads the live-capture settings", () => {
+    const config = loadGooseServiceConfig({
+      GOOSE_CAPTURE: "live",
+      GOOSE_IFACE: "ens1f0",
+      GOOSE_CAPTURE_TOOL: "tcpdump",
+      GOOSE_CAPTURE_TOOL_PATH: "/usr/sbin/tcpdump",
+      GOOSE_CAPTURE_SNAPLEN: "1500",
+      GOOSE_CAPTURE_FILTER: "ether proto 0x88b8",
+    });
+    expect(config.capture).toBe("live");
+    expect(config.iface).toBe("ens1f0");
+    expect(config.captureTool).toBe("tcpdump");
+    expect(config.captureToolPath).toBe("/usr/sbin/tcpdump");
+    expect(config.captureSnapLen).toBe(1500);
+    expect(config.captureFilter).toBe("ether proto 0x88b8");
+  });
+
+  it("rejects an unknown capture mode", () => {
+    expect(() => loadGooseServiceConfig({ GOOSE_CAPTURE: "sniff" })).toThrow();
+  });
+
+  it("rejects GOOSE_CAPTURE=pcap without a capture file", () => {
+    expect(() => loadGooseServiceConfig({ GOOSE_CAPTURE: "pcap" })).toThrow(/GOOSE_PCAP_FILE/);
+  });
+
+  it("rejects a tool path without an explicit tool, because argv differs per tool", () => {
+    expect(() =>
+      loadGooseServiceConfig({
+        GOOSE_CAPTURE: "live",
+        GOOSE_CAPTURE_TOOL_PATH: "/usr/sbin/tcpdump",
+      }),
+    ).toThrow(/GOOSE_CAPTURE_TOOL/);
+  });
+
+  it("rejects a non-integer or out-of-range snapshot length", () => {
+    expect(() => loadGooseServiceConfig({ GOOSE_CAPTURE_SNAPLEN: "big" })).toThrow(
+      /GOOSE_CAPTURE_SNAPLEN must be an integer/,
+    );
+    expect(() => loadGooseServiceConfig({ GOOSE_CAPTURE_SNAPLEN: "4" })).toThrow();
   });
 
   it("rejects a subscription list that fails schema validation", () => {
@@ -87,6 +157,49 @@ describe("loadGooseServiceConfig", () => {
         throw new Error("ENOENT");
       }),
     ).toThrow(/missing\.json/);
+  });
+});
+
+describe("createGooseCaptureBackend", () => {
+  it("builds the null backend when no capture is configured", () => {
+    const backend = createGooseCaptureBackend(loadGooseServiceConfig({}));
+    expect(backend.name).toBe("null");
+    expect(backend.availability().available).toBe(false);
+  });
+
+  it("builds the replay backend for a configured capture file", () => {
+    const backend = createGooseCaptureBackend(
+      loadGooseServiceConfig({ GOOSE_PCAP_FILE: REPLAY_PCAP_PATH }),
+    );
+    expect(backend.name).toBe("pcap-replay");
+  });
+
+  it("builds the live backend on the configured interface and filter", () => {
+    const backend = createGooseCaptureBackend(
+      loadGooseServiceConfig({ GOOSE_CAPTURE: "live", GOOSE_IFACE: "ens1f0" }),
+    );
+    expect(backend.name).toBe("live-pcap");
+    expect(backend).toBeInstanceOf(GooseLiveCaptureBackend);
+    const live = backend as GooseLiveCaptureBackend;
+    expect(live.getInterface()).toBe("ens1f0");
+    expect(live.getFilter()).toBe(GOOSE_BPF_FILTER);
+  });
+
+  it("defaults the live backend to eth0, per the acceptance criterion", () => {
+    const backend = createGooseCaptureBackend(loadGooseServiceConfig({ GOOSE_CAPTURE: "live" }));
+    expect((backend as GooseLiveCaptureBackend).getInterface()).toBe("eth0");
+  });
+
+  it("passes a filter override through to the live backend", () => {
+    const backend = createGooseCaptureBackend(
+      loadGooseServiceConfig({
+        GOOSE_CAPTURE: "live",
+        GOOSE_CAPTURE_FILTER: "ether proto 0x88b8 and vlan 100",
+      }),
+    );
+    expect((backend as GooseLiveCaptureBackend).getFilter()).toBe(
+      "ether proto 0x88b8 and vlan 100",
+    );
   });
 });
 

--- a/server/protocols/iec61850-goose/__tests__/live-backend.test.ts
+++ b/server/protocols/iec61850-goose/__tests__/live-backend.test.ts
@@ -1,0 +1,949 @@
+/**
+ * Tests for the LIVE GOOSE capture backend.
+ *
+ * A real substation bus is not available here, and no test in this repository
+ * captures from one. What these tests do prove is the whole real code path
+ * around the capture tool: the backend spawns a child process with an argv
+ * array, reads classic pcap off its stdout in whatever chunks the pipe hands
+ * over, decodes it incrementally, applies the EtherType 0x88B8 filter, and
+ * feeds the subscriber — which decodes, validates, emits tag updates and moves
+ * the Prometheus counters.
+ *
+ * The child is a fake: `process.execPath -e <script>` replaying a known pcap
+ * byte stream (and, in the failure tests, exiting with a real capture tool's
+ * stderr). Everything on this side of the pipe is production code, including
+ * the parts that are hardest to get right — chunk boundaries, process
+ * lifecycle, and the failure diagnostics.
+ *
+ * Issue: #465
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  GooseLiveCaptureBackend,
+  GOOSE_BPF_FILTER,
+  DEFAULT_GOOSE_IFACE,
+  DEFAULT_GOOSE_SNAPLEN,
+  buildDumpcapArgs,
+  buildTcpdumpArgs,
+  buildCaptureCommand,
+  resolveExecutable,
+  type GooseCaptureCommand,
+} from "../live-backend.js";
+import { GooseSubscriber } from "../index.js";
+import { encodePcap } from "../pcap.js";
+import { GOOSE_ETHERTYPE, VLAN_TPID } from "../types.js";
+import type { GooseTagUpdate } from "../types.js";
+import type { GooseSubscriptionConfig } from "../subscription.js";
+import {
+  gooseFramesReceivedTotal,
+  gooseFramesRejectedTotal,
+  gooseRoundTripUs,
+  type GooseRejectReason,
+} from "../metrics.js";
+import {
+  buildArpRequestFrame,
+  buildFrame,
+  buildPdu,
+  canonicalFrame,
+  data,
+  REPLAY_APP_ID,
+  REPLAY_CONF_REV,
+  REPLAY_DAT_SET,
+  REPLAY_DEST_MAC,
+  REPLAY_GOCB_REF,
+  REPLAY_PUBLISH_LATENCY_MS,
+  REPLAY_SRC_MAC,
+} from "./fixtures.js";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fake capture tool: emits a pcap byte stream on stdout, exactly as
+// `dumpcap -w -` / `tcpdump -w -` do.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * argv (after the script): pcapFile, chunkBytes, delayMs, exitCode, stderrText,
+ * mode. `mode === "hang"` keeps the process alive after the stream, which is
+ * how a real capture tool behaves — it never finishes on its own.
+ */
+const FAKE_CAPTURE_SCRIPT = `
+const fs = require("node:fs");
+const [file, chunkArg, delayArg, codeArg, stderrText, mode] = process.argv.slice(1);
+if (stderrText) process.stderr.write(stderrText);
+const exitCode = Number(codeArg) || 0;
+const buf = file ? fs.readFileSync(file) : Buffer.alloc(0);
+const size = Number(chunkArg) > 0 ? Number(chunkArg) : (buf.length || 1);
+const wait = Number(delayArg) || 0;
+let i = 0;
+function done() {
+  if (mode === "hang") { setInterval(function () {}, 1000); return; }
+  if (exitCode) process.exitCode = exitCode;
+}
+function step() {
+  if (wait > 0) {
+    if (i >= buf.length) { done(); return; }
+    process.stdout.write(buf.subarray(i, i + size));
+    i += size;
+    setTimeout(step, wait);
+    return;
+  }
+  while (i < buf.length) { process.stdout.write(buf.subarray(i, i + size)); i += size; }
+  done();
+}
+step();
+`;
+
+interface FakeCaptureOptions {
+  /** Path of the pcap file to stream. Omit to emit nothing on stdout. */
+  pcapPath?: string;
+  /** Bytes per stdout write. Omit to write the whole file in one go. */
+  chunkBytes?: number;
+  /** Delay between writes, forcing genuinely separate chunks on the pipe. */
+  delayMs?: number;
+  /** Exit code once the stream is done. */
+  exitCode?: number;
+  /** Text written to stderr before anything else. */
+  stderr?: string;
+  /** Stay alive after streaming, like a real capture tool. */
+  hang?: boolean;
+}
+
+function fakeCapture(options: FakeCaptureOptions = {}): GooseCaptureCommand {
+  return {
+    file: process.execPath,
+    args: [
+      "-e",
+      FAKE_CAPTURE_SCRIPT,
+      options.pcapPath ?? "",
+      String(options.chunkBytes ?? 0),
+      String(options.delayMs ?? 0),
+      String(options.exitCode ?? 0),
+      options.stderr ?? "",
+      options.hang ? "hang" : "exit",
+    ],
+    label: "fake-capture",
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixtures on disk
+// ───────────────────────────────────────────────────────────────────────────
+
+let workDir: string;
+
+/** Write a pcap into the temp dir and return its path. */
+function writeCapture(name: string, bytes: Buffer): string {
+  const path = join(workDir, name);
+  writeFileSync(path, bytes);
+  return path;
+}
+
+beforeAll(() => {
+  workDir = mkdtempSync(join(tmpdir(), "goose-live-"));
+});
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+/** Collect the frames a backend delivers over one open/close cycle. */
+async function captureFrames(
+  backend: GooseLiveCaptureBackend,
+): Promise<Array<{ frame: Buffer; receivedAtMs: number }>> {
+  const frames: Array<{ frame: Buffer; receivedAtMs: number }> = [];
+  await backend.open((frame, receivedAtMs) => frames.push({ frame, receivedAtMs }));
+  await backend.completion();
+  await backend.close();
+  return frames;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("GOOSE BPF filter", () => {
+  it("matches GOOSE both untagged and behind one 802.1Q tag", () => {
+    expect(GOOSE_BPF_FILTER).toBe("ether proto 0x88b8 or (vlan and ether proto 0x88b8)");
+    expect(GOOSE_ETHERTYPE).toBe(0x88b8);
+  });
+
+  it("puts the untagged term before `vlan`, which shifts later offsets by 4", () => {
+    // pcap-filter(7): the first `vlan` in an expression re-bases every offset
+    // after it. `ether proto 0x88b8` before it therefore reads offset 12
+    // (untagged) and the one after it reads offset 16 (tagged). Reversing the
+    // two terms would leave the untagged test looking at the wrong offset.
+    const vlanIndex = GOOSE_BPF_FILTER.indexOf("vlan");
+    const firstProtoIndex = GOOSE_BPF_FILTER.indexOf("ether proto");
+    expect(firstProtoIndex).toBeGreaterThanOrEqual(0);
+    expect(vlanIndex).toBeGreaterThan(firstProtoIndex);
+    // Exactly one tag is unwrapped — matching what the frame parser can decode.
+    expect(GOOSE_BPF_FILTER.match(/vlan/g)).toHaveLength(1);
+  });
+});
+
+describe("capture tool argv", () => {
+  it("builds dumpcap argv that forces classic pcap on stdout", () => {
+    const args = buildDumpcapArgs("eth0", 65535, GOOSE_BPF_FILTER);
+    expect(args).toEqual([
+      "-i", "eth0",
+      "-P", // pcap, not pcapng — the decoder reads classic pcap only
+      "-q",
+      "-s", "65535",
+      "-w", "-",
+      "-f", GOOSE_BPF_FILTER,
+    ]);
+  });
+
+  it("builds tcpdump argv with packet-buffered output", () => {
+    const args = buildTcpdumpArgs("eth1", 1500, GOOSE_BPF_FILTER);
+    expect(args).toEqual([
+      "-i", "eth1",
+      "-U", // flush per packet; without it frames sit in a 4 KiB stdio buffer
+      "-n",
+      "-s", "1500",
+      "-w", "-",
+      GOOSE_BPF_FILTER,
+    ]);
+  });
+
+  it("keeps the filter as a single argv element, so no shell can see it", () => {
+    const hostile = "ether proto 0x88b8; rm -rf /";
+    const command = buildCaptureCommand("tcpdump", "/usr/bin/tcpdump", "eth0", 65535, hostile);
+    expect(command.args.filter((a) => a === hostile)).toHaveLength(1);
+    expect(command.args.some((a) => a.includes(" ") && a !== hostile)).toBe(false);
+  });
+
+  it("passes an interface name through verbatim rather than interpolating it", () => {
+    const command = buildCaptureCommand("dumpcap", "dumpcap", "eth0 && reboot", 65535, "x");
+    expect(command.args).toContain("eth0 && reboot");
+  });
+});
+
+describe("resolveExecutable", () => {
+  /** A POSIX filesystem with exactly one capture tool installed. */
+  const posixFs = (present: string) => (path: string) => path === present;
+
+  it("searches a colon-separated PATH in order", () => {
+    expect(
+      resolveExecutable(
+        "tcpdump",
+        { PATH: "/sbin:/usr/sbin:/usr/bin" },
+        "linux",
+        posixFs("/usr/bin/tcpdump"),
+      ),
+    ).toBe("/usr/bin/tcpdump");
+  });
+
+  it("returns null when nothing on PATH matches", () => {
+    expect(resolveExecutable("dumpcap", { PATH: "/sbin:/usr/bin" }, "linux", () => false)).toBeNull();
+    expect(resolveExecutable("", {}, "linux", () => true)).toBeNull();
+    expect(resolveExecutable("dumpcap", {}, "linux", () => true)).toBeNull();
+  });
+
+  it("checks a path-qualified name directly instead of searching PATH", () => {
+    expect(
+      resolveExecutable(
+        "/opt/wireshark/dumpcap",
+        { PATH: "/usr/bin" },
+        "linux",
+        posixFs("/opt/wireshark/dumpcap"),
+      ),
+    ).toBe("/opt/wireshark/dumpcap");
+    expect(
+      resolveExecutable("/definitely/not/here/dumpcap", {}, "linux", () => false),
+    ).toBeNull();
+  });
+
+  it("finds a real file on this host's own filesystem", () => {
+    const binDir = join(workDir, "bin-real");
+    mkdirSync(binDir, { recursive: true });
+    const toolPath = join(binDir, process.platform === "win32" ? "tcpdump.exe" : "tcpdump");
+    writeFileSync(toolPath, "");
+    const found = resolveExecutable("tcpdump", { PATH: binDir }, process.platform);
+    // Windows resolves through PATHEXT, whose case is the environment's, not
+    // the file's — the path is the same file either way.
+    expect(found?.toLowerCase()).toBe(toolPath.toLowerCase());
+    expect(resolveExecutable(process.execPath, {}, process.platform)).toBe(process.execPath);
+  });
+});
+
+describe("availability()", () => {
+  it("reports the platform truthfully on this host, and never throws", () => {
+    const backend = new GooseLiveCaptureBackend({ iface: "eth0" });
+    const availability = backend.availability();
+
+    if (process.platform === "win32") {
+      // Windows capture is Npcap-based and is not implemented here.
+      expect(availability.available).toBe(false);
+      expect(availability.reason).toMatch(/win32/);
+      expect(availability.reason).toMatch(/not supported/i);
+    } else if (availability.available) {
+      // A capture tool really is installed on this host.
+      expect(availability.reason).toMatch(/dumpcap|tcpdump/);
+      expect(availability.reason).toContain("eth0");
+    } else {
+      expect(availability.reason).toMatch(/no GOOSE capture tool found on PATH/i);
+    }
+  });
+
+  it("names the unsupported platform rather than claiming a generic failure", () => {
+    const backend = new GooseLiveCaptureBackend({ platform: "win32", iface: "eth0" });
+    expect(backend.availability()).toEqual({
+      available: false,
+      reason: expect.stringContaining("platform=win32"),
+    });
+    expect(backend.availability().reason).toMatch(/Npcap/);
+  });
+
+  it("reports a missing capture tool with the names it looked for", () => {
+    const backend = new GooseLiveCaptureBackend({
+      platform: "linux",
+      env: { PATH: "/usr/bin" },
+      exists: () => false,
+    });
+    const availability = backend.availability();
+    expect(availability.available).toBe(false);
+    expect(availability.reason).toMatch(/dumpcap, tcpdump/);
+    expect(availability.reason).toMatch(/GOOSE_CAPTURE_TOOL_PATH/);
+  });
+
+  it("reports available, naming the tool, when one is on PATH", () => {
+    const backend = new GooseLiveCaptureBackend({
+      platform: "linux",
+      env: { PATH: "/usr/bin" },
+      exists: (path) => path === "/usr/bin/dumpcap",
+      iface: "eth9",
+    });
+    const availability = backend.availability();
+    expect(availability.available).toBe(true);
+    expect(availability.reason).toMatch(/dumpcap/);
+    expect(availability.reason).toContain("eth9");
+    // Honest about what it has NOT proven.
+    expect(availability.reason).toMatch(/permission is only proven/i);
+  });
+
+  it("does not claim availability for a configured command that does not exist", () => {
+    const backend = new GooseLiveCaptureBackend({
+      command: { file: join(workDir, "no-such-tool"), args: [], label: "missing" },
+    });
+    expect(backend.availability().available).toBe(false);
+    expect(backend.availability().reason).toMatch(/not found/i);
+  });
+
+  it("prefers dumpcap over tcpdump when both are installed", () => {
+    const both = (path: string): boolean =>
+      path === "/usr/bin/dumpcap" || path === "/usr/bin/tcpdump";
+    const backend = new GooseLiveCaptureBackend({
+      platform: "linux",
+      env: { PATH: "/usr/bin" },
+      exists: both,
+    });
+    expect(backend.getCommand()?.label).toBe("dumpcap (/usr/bin/dumpcap)");
+
+    const forced = new GooseLiveCaptureBackend({
+      platform: "linux",
+      env: { PATH: "/usr/bin" },
+      exists: both,
+      tool: "tcpdump",
+    });
+    expect(forced.getCommand()?.label).toBe("tcpdump (/usr/bin/tcpdump)");
+    expect(forced.getCommand()?.args).toEqual(
+      buildTcpdumpArgs("eth0", DEFAULT_GOOSE_SNAPLEN, GOOSE_BPF_FILTER),
+    );
+  });
+
+  it("reports a configured tool path that does not exist", () => {
+    const backend = new GooseLiveCaptureBackend({
+      platform: "linux",
+      tool: "dumpcap",
+      toolPath: "/opt/wireshark/dumpcap",
+      exists: () => false,
+    });
+    expect(backend.availability()).toEqual({
+      available: false,
+      reason: "configured GOOSE capture tool not found: /opt/wireshark/dumpcap",
+    });
+  });
+
+  it("defaults to eth0 and a 65535-byte snapshot length", () => {
+    const backend = new GooseLiveCaptureBackend();
+    expect(backend.getInterface()).toBe(DEFAULT_GOOSE_IFACE);
+    expect(DEFAULT_GOOSE_IFACE).toBe("eth0");
+    expect(backend.getFilter()).toBe(GOOSE_BPF_FILTER);
+    expect(DEFAULT_GOOSE_SNAPLEN).toBe(65535);
+  });
+
+  it("rejects a nonsensical interface or snapshot length at construction", () => {
+    expect(() => new GooseLiveCaptureBackend({ iface: "  " })).toThrow(/interface name/i);
+    expect(() => new GooseLiveCaptureBackend({ snapLen: 0 })).toThrow(/snapLen/);
+  });
+});
+
+describe("live capture — streaming a pcap off a child process", () => {
+  it("delivers every GOOSE frame from a capture streamed in one write", async () => {
+    const path = writeCapture(
+      "single-write.pcap",
+      encodePcap([
+        { timestampMs: Date.now(), data: canonicalFrame({ stNum: 1 }) },
+        { timestampMs: Date.now(), data: canonicalFrame({ stNum: 2 }) },
+      ]),
+    );
+    const backend = new GooseLiveCaptureBackend({ command: fakeCapture({ pcapPath: path }) });
+    const frames = await captureFrames(backend);
+
+    expect(frames).toHaveLength(2);
+    expect(backend.getStats().gooseFrames).toBe(2);
+    expect(backend.getStats().recordsDecoded).toBe(2);
+    expect(backend.getLastError()).toBeNull();
+  });
+
+  it("reassembles frames across pathological chunk boundaries", async () => {
+    // 7 bytes per write splits inside the global header, inside record headers
+    // and inside frame bodies — the boundaries a pipe really produces.
+    const frames = [
+      canonicalFrame({ stNum: 1 }),
+      canonicalFrame({ stNum: 2 }),
+      canonicalFrame({ stNum: 3 }),
+    ];
+    const path = writeCapture(
+      "chunked.pcap",
+      encodePcap(frames.map((data, i) => ({ timestampMs: Date.now() + i, data }))),
+    );
+
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path, chunkBytes: 7 }),
+    });
+    const captured = await captureFrames(backend);
+
+    expect(captured).toHaveLength(3);
+    captured.forEach((entry, i) => {
+      expect(entry.frame.equals(frames[i])).toBe(true);
+    });
+  });
+
+  it("reassembles frames when the writes really are separate pipe chunks", async () => {
+    const frames = [canonicalFrame({ stNum: 1 }), canonicalFrame({ stNum: 2 })];
+    const path = writeCapture(
+      "delayed.pcap",
+      encodePcap(frames.map((data, i) => ({ timestampMs: Date.now() + i, data }))),
+    );
+
+    // 13-byte writes 1 ms apart: the reader observes many small, genuinely
+    // distinct chunks rather than one coalesced buffer.
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path, chunkBytes: 13, delayMs: 1 }),
+    });
+    const captured = await captureFrames(backend);
+
+    expect(captured).toHaveLength(2);
+    expect(captured[0].frame.equals(frames[0])).toBe(true);
+    expect(captured[1].frame.equals(frames[1])).toBe(true);
+  });
+
+  for (const options of [
+    { byteOrder: "big" as const, nanosecondPrecision: false, name: "big-endian µs" },
+    { byteOrder: "little" as const, nanosecondPrecision: true, name: "little-endian ns" },
+    { byteOrder: "big" as const, nanosecondPrecision: true, name: "big-endian ns" },
+  ]) {
+    it(`decodes a ${options.name} capture stream`, async () => {
+      const frame = canonicalFrame({ stNum: 4 });
+      const path = writeCapture(
+        `byteorder-${options.byteOrder}-${options.nanosecondPrecision}.pcap`,
+        encodePcap([{ timestampMs: Date.now(), data: frame }], {
+          byteOrder: options.byteOrder,
+          nanosecondPrecision: options.nanosecondPrecision,
+        }),
+      );
+      const backend = new GooseLiveCaptureBackend({
+        command: fakeCapture({ pcapPath: path, chunkBytes: 5 }),
+      });
+      const captured = await captureFrames(backend);
+      expect(captured).toHaveLength(1);
+      expect(captured[0].frame.equals(frame)).toBe(true);
+    });
+  }
+
+  it("filters out non-GOOSE frames even if they reach stdout", async () => {
+    const goose = canonicalFrame();
+    const path = writeCapture(
+      "mixed.pcap",
+      encodePcap([
+        { timestampMs: Date.now(), data: buildArpRequestFrame() },
+        { timestampMs: Date.now(), data: goose },
+      ]),
+    );
+    const backend = new GooseLiveCaptureBackend({ command: fakeCapture({ pcapPath: path }) });
+    const captured = await captureFrames(backend);
+
+    // The BPF filter would normally drop the ARP frame in the kernel; the
+    // backend re-checks the EtherType so a mis-set GOOSE_CAPTURE_FILTER cannot
+    // feed non-GOOSE traffic to the BER decoder.
+    expect(captured).toHaveLength(1);
+    expect(captured[0].frame.equals(goose)).toBe(true);
+    expect(backend.getStats().nonGooseFrames).toBe(1);
+    expect(backend.getStats().gooseFrames).toBe(1);
+  });
+
+  it("delivers a VLAN-tagged GOOSE frame, and only unwraps one tag", async () => {
+    // GOOSE is normally published on a dedicated priority-tagged VLAN — that is
+    // the entire reason GOOSE_BPF_FILTER carries the `vlan` term. Assert the
+    // tagged case as an actual FRAME through the whole path, not just as a
+    // string in the filter, and assert the QinQ boundary the filter stops at.
+    const tagged = canonicalFrame({ stNum: 6 }, { vlan: { id: 100, priority: 4 } });
+    expect(tagged.readUInt16BE(12)).toBe(VLAN_TPID);
+    expect(tagged.readUInt16BE(16)).toBe(GOOSE_ETHERTYPE);
+
+    // The same frame behind an additional 0x88a8 outer tag.
+    const qinq = Buffer.concat([
+      tagged.subarray(0, 12),
+      Buffer.from([0x88, 0xa8, 0x00, 0x64]),
+      tagged.subarray(12),
+    ]);
+
+    const path = writeCapture(
+      "vlan-tagged.pcap",
+      encodePcap([
+        { timestampMs: Date.now(), data: qinq },
+        { timestampMs: Date.now(), data: tagged },
+      ]),
+    );
+    // 9-byte writes, so the tag itself lands across a chunk boundary.
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path, chunkBytes: 9 }),
+    });
+    const captured = await captureFrames(backend);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].frame.equals(tagged)).toBe(true);
+    // Exactly one tag is unwrapped: the QinQ frame is filtered out rather than
+    // half-decoded, matching what readFrameEtherType()/the frame parser handle.
+    expect(backend.getStats().gooseFrames).toBe(1);
+    expect(backend.getStats().nonGooseFrames).toBe(1);
+  });
+
+  it("rejects a snapped frame instead of decoding a partial APDU", async () => {
+    const frame = canonicalFrame();
+    const path = writeCapture(
+      "snapped.pcap",
+      encodePcap([
+        { timestampMs: Date.now(), data: frame.subarray(0, 30), originalLength: frame.length },
+        { timestampMs: Date.now(), data: frame },
+      ]),
+    );
+    const backend = new GooseLiveCaptureBackend({ command: fakeCapture({ pcapPath: path }) });
+    const captured = await captureFrames(backend);
+
+    expect(backend.getStats().truncatedFrames).toBe(1);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].frame.equals(frame)).toBe(true);
+  });
+
+  it("uses the kernel capture timestamp when it agrees with the local clock", async () => {
+    const capturedAt = Date.now() - 25;
+    const path = writeCapture(
+      "timestamps.pcap",
+      encodePcap([{ timestampMs: capturedAt, data: canonicalFrame() }]),
+    );
+    const backend = new GooseLiveCaptureBackend({ command: fakeCapture({ pcapPath: path }) });
+    const frames = await captureFrames(backend);
+
+    expect(frames[0].receivedAtMs).toBe(capturedAt);
+    expect(backend.getStats().clockFallbacks).toBe(0);
+    expect(backend.clockNowMs()).toBeGreaterThanOrEqual(capturedAt);
+  });
+
+  it("falls back to the wall clock when capture timestamps are implausible", async () => {
+    // A 2023 timestamp on a capture claiming to be live: using it would make
+    // every subscription instantly TTL-expired.
+    const path = writeCapture(
+      "skewed.pcap",
+      encodePcap([{ timestampMs: 1_700_000_000_000, data: canonicalFrame() }]),
+    );
+    const now = 1_800_000_000_000;
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path }),
+      now: () => now,
+    });
+    const frames = await captureFrames(backend);
+
+    expect(frames[0].receivedAtMs).toBe(now);
+    expect(backend.getStats().clockFallbacks).toBe(1);
+  });
+
+  it("kills the capture tool when the stream exceeds the record bound", async () => {
+    const path = writeCapture(
+      "oversized.pcap",
+      encodePcap([{ timestampMs: Date.now(), data: canonicalFrame() }]),
+    );
+    // 24-byte writes: the first is exactly the global header, so the capture is
+    // already "started" when the oversized record header arrives.
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path, chunkBytes: 24, delayMs: 5, hang: true }),
+      maxRecordBytes: 32,
+    });
+    const frames: Buffer[] = [];
+    await backend.open((frame) => frames.push(frame));
+    await backend.completion();
+
+    expect(frames).toHaveLength(0);
+    expect(backend.getLastError()?.message).toMatch(/exceeds the 32-byte record limit/i);
+    expect(backend.isRunning()).toBe(false);
+    await backend.close();
+  });
+
+  it("refuses to start when the very first record is over the bound", async () => {
+    const path = writeCapture(
+      "oversized-at-start.pcap",
+      encodePcap([{ timestampMs: Date.now(), data: canonicalFrame() }]),
+    );
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path, hang: true }),
+      maxRecordBytes: 32,
+    });
+    await expect(backend.open(() => {})).rejects.toThrow(/exceeds the 32-byte record limit/i);
+    await backend.close();
+  });
+
+  it("refuses a capture whose link type is not Ethernet", async () => {
+    const path = writeCapture(
+      "sll.pcap",
+      encodePcap([{ timestampMs: Date.now(), data: Buffer.alloc(32) }], { linkType: 113 }),
+    );
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path, hang: true }),
+      iface: "any",
+    });
+    await expect(backend.open(() => {})).rejects.toThrow(/link type 113, not Ethernet/i);
+    await backend.close();
+  });
+
+  it("refuses to be opened twice concurrently", async () => {
+    const path = writeCapture(
+      "concurrent.pcap",
+      encodePcap([{ timestampMs: Date.now(), data: canonicalFrame() }]),
+    );
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path, hang: true }),
+    });
+    await backend.open(() => {});
+    await expect(backend.open(() => {})).rejects.toThrow(/already capturing/i);
+    await backend.close();
+  });
+});
+
+describe("live capture — failure modes", () => {
+  it("reports a missing capture tool clearly on spawn ENOENT", async () => {
+    const backend = new GooseLiveCaptureBackend({
+      command: {
+        file: join(workDir, "0xscada-no-such-capture-tool"),
+        args: [],
+        label: "missing-tool",
+      },
+    });
+    await expect(backend.open(() => {})).rejects.toThrow(/capture tool not found/i);
+    await backend.close();
+  });
+
+  it("surfaces the tool's stderr when it exits before capturing", async () => {
+    const backend = new GooseLiveCaptureBackend({
+      iface: "eth7",
+      command: fakeCapture({
+        exitCode: 1,
+        stderr: "tcpdump: eth7: No such device exists (SIOCGIFHWADDR: No such device)",
+      }),
+    });
+    await expect(backend.open(() => {})).rejects.toThrow(/No such device exists/);
+    expect(backend.getLastError()?.message).toMatch(/could not open interface 'eth7'/i);
+    expect(backend.getLastError()?.message).toMatch(/GOOSE_IFACE/);
+    await backend.close();
+  });
+
+  it("turns a permission failure into an actionable CAP_NET_RAW message", async () => {
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({
+        exitCode: 2,
+        stderr:
+          "dumpcap: You don't have permission to capture on that device " +
+          "(socket: Operation not permitted).",
+      }),
+    });
+    await expect(backend.open(() => {})).rejects.toThrow(/CAP_NET_RAW/);
+    const message = backend.getLastError()?.message ?? "";
+    expect(message).toMatch(/denied permission/i);
+    expect(message).toMatch(/setcap cap_net_raw/);
+    // The tool's own words are kept, not paraphrased away.
+    expect(message).toMatch(/Operation not permitted/);
+    await backend.close();
+  });
+
+  it("reports an exit with no stderr rather than an empty message", async () => {
+    const backend = new GooseLiveCaptureBackend({ command: fakeCapture({ exitCode: 3 }) });
+    await expect(backend.open(() => {})).rejects.toThrow(/exit code 3.*no stderr output/is);
+    await backend.close();
+  });
+
+  it("gives up when the tool never emits a pcap header", async () => {
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ hang: true }),
+      startupTimeoutMs: 200,
+    });
+    await expect(backend.open(() => {})).rejects.toThrow(/no pcap header within 200ms/i);
+    // The hung tool must have been killed, not left running.
+    await backend.completion();
+    await backend.close();
+    expect(backend.isRunning()).toBe(false);
+  });
+
+  it("never fabricates a frame when capture cannot start", async () => {
+    const frames: Buffer[] = [];
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ exitCode: 1, stderr: "dumpcap: permission denied" }),
+    });
+    await expect(backend.open((frame) => frames.push(frame))).rejects.toThrow();
+    expect(frames).toHaveLength(0);
+    expect(backend.getStats().gooseFrames).toBe(0);
+    await backend.close();
+  });
+});
+
+describe("live capture — lifecycle", () => {
+  it("close() kills a capture tool that would otherwise run forever", async () => {
+    const path = writeCapture(
+      "hang.pcap",
+      encodePcap([{ timestampMs: Date.now(), data: canonicalFrame() }]),
+    );
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path, hang: true }),
+    });
+
+    const frames: Buffer[] = [];
+    await backend.open((frame) => frames.push(frame));
+    expect(frames).toHaveLength(1);
+    expect(backend.isRunning()).toBe(true);
+
+    // close() only returns once the child is reaped, so this test hanging would
+    // itself be the failure signal for a leaked process.
+    await backend.close();
+    expect(backend.isRunning()).toBe(false);
+    const stats = backend.getStats();
+    expect(stats.exitCode !== null || stats.exitSignal !== null).toBe(true);
+  });
+
+  it("close() is safe twice and when the backend was never opened", async () => {
+    const fresh = new GooseLiveCaptureBackend();
+    await expect(fresh.close()).resolves.toBeUndefined();
+    await expect(fresh.close()).resolves.toBeUndefined();
+
+    const path = writeCapture(
+      "double-close.pcap",
+      encodePcap([{ timestampMs: Date.now(), data: canonicalFrame() }]),
+    );
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path, hang: true }),
+    });
+    await backend.open(() => {});
+    await backend.close();
+    await expect(backend.close()).resolves.toBeUndefined();
+  });
+
+  it("does not accumulate process exit listeners across captures", async () => {
+    const path = writeCapture(
+      "listeners.pcap",
+      encodePcap([{ timestampMs: Date.now(), data: canonicalFrame() }]),
+    );
+    const before = process.listenerCount("exit");
+    for (let i = 0; i < 5; i++) {
+      const backend = new GooseLiveCaptureBackend({
+        command: fakeCapture({ pcapPath: path, hang: true }),
+      });
+      await backend.open(() => {});
+      // The hook that kills an orphaned capture tool is installed while running.
+      expect(process.listenerCount("exit")).toBe(before + 1);
+      await backend.close();
+    }
+    expect(process.listenerCount("exit")).toBe(before);
+  });
+
+  it("can be reopened after a clean close", async () => {
+    const path = writeCapture(
+      "reopen.pcap",
+      encodePcap([{ timestampMs: Date.now(), data: canonicalFrame() }]),
+    );
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path, hang: true }),
+    });
+    const first: Buffer[] = [];
+    await backend.open((frame) => first.push(frame));
+    await backend.close();
+
+    const second: Buffer[] = [];
+    await backend.open((frame) => second.push(frame));
+    await backend.close();
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// End to end: live backend → subscriber → tag updates + metrics
+// ───────────────────────────────────────────────────────────────────────────
+
+const TAG_POSITION = "IED1/XCBR1.Pos.stVal";
+const TAG_QUALITY = "IED1/XCBR1.Pos.q";
+const TAG_CURRENT = "IED1/MMXU1.A.phsA.cVal.mag.f";
+
+const liveSubscription: GooseSubscriptionConfig = {
+  gocbRef: REPLAY_GOCB_REF,
+  appId: REPLAY_APP_ID,
+  expectedDestMac: REPLAY_DEST_MAC,
+  expectedSrcMac: REPLAY_SRC_MAC,
+  expectedConfRev: REPLAY_CONF_REV,
+  dataset: [
+    { tagName: TAG_POSITION, type: "boolean" },
+    { tagName: TAG_QUALITY, type: "quality", isQuality: true },
+    { tagName: TAG_CURRENT, type: "float" },
+  ],
+};
+
+function rejected(reason: GooseRejectReason): number {
+  return gooseFramesRejectedTotal.get({ reason });
+}
+
+function received(appId: number): number {
+  return gooseFramesReceivedTotal.get({ app_id: `0x${appId.toString(16)}` });
+}
+
+function roundTrip(gocbRef: string): { sum: number; count: number } {
+  const entry = gooseRoundTripUs.collect().find((e) => e.labels.gocb_ref === gocbRef);
+  return entry ? { sum: entry.sum, count: entry.count } : { sum: 0, count: 0 };
+}
+
+/**
+ * A short bus trace timed against the current wall clock, so the timestamps a
+ * live capture would carry are realistic: each PDU is published 2 ms before the
+ * frame is captured.
+ */
+function buildLiveTrace(startMs: number): Buffer {
+  const frame = (offsetMs: number, stNum: number, position: boolean, amps: number): Buffer => {
+    const timestampMs = startMs + offsetMs;
+    return buildFrame(
+      buildPdu({
+        gocbRef: REPLAY_GOCB_REF,
+        timeAllowedToLive: 2000,
+        datSet: REPLAY_DAT_SET,
+        goID: "gcb01",
+        confRev: REPLAY_CONF_REV,
+        t: timestampMs - REPLAY_PUBLISH_LATENCY_MS,
+        stNum,
+        sqNum: 0,
+        allData: [data.boolean(position), data.quality({ validity: "good" }), data.float32(amps)],
+      }),
+      { destMac: REPLAY_DEST_MAC, srcMac: REPLAY_SRC_MAC, appId: REPLAY_APP_ID },
+    );
+  };
+
+  return encodePcap([
+    { timestampMs: startMs, data: frame(0, 1, false, 41) },
+    { timestampMs: startMs + 20, data: buildArpRequestFrame() },
+    { timestampMs: startMs + 40, data: frame(40, 2, true, 42.5) },
+    { timestampMs: startMs + 60, data: frame(60, 3, true, 43.25) },
+  ]);
+}
+
+describe("live capture → GooseSubscriber (end to end)", () => {
+  it("produces tag updates and moves the Prometheus counters", async () => {
+    const startMs = Date.now() - 100;
+    const path = writeCapture("e2e.pcap", buildLiveTrace(startMs));
+
+    const beforeReceived = received(REPLAY_APP_ID);
+    const beforeNoSubscription = rejected("no_subscription");
+    const beforeParseError = rejected("parse_error");
+    const beforeRoundTrip = roundTrip(REPLAY_GOCB_REF);
+
+    const updates: GooseTagUpdate[] = [];
+    // 11-byte writes: the subscriber is fed from a stream that is fragmented
+    // through every part of the pcap framing.
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ pcapPath: path, chunkBytes: 11, hang: true }),
+    });
+    const subscriber = new GooseSubscriber({
+      backend,
+      subscriptions: [liveSubscription],
+      onTagUpdate: (update) => updates.push(update),
+    });
+
+    const state = await subscriber.start();
+    expect(state).toBe("running");
+
+    // Wait for the whole trace to arrive, then shut the capture down.
+    await waitFor(() => updates.length >= 9);
+    await subscriber.stop();
+    expect(subscriber.getState()).toBe("stopped");
+
+    // 3 accepted GOOSE frames x 3 dataset members.
+    expect(updates).toHaveLength(9);
+    expect(updates.every((u) => u.origin === "goose")).toBe(true);
+    expect(updates.every((u) => u.gocbRef === REPLAY_GOCB_REF)).toBe(true);
+    expect(updates.filter((u) => u.tagName === TAG_POSITION).map((u) => u.value)).toEqual([
+      false,
+      true,
+      true,
+    ]);
+    expect(updates.filter((u) => u.tagName === TAG_CURRENT).map((u) => u.value)).toEqual([
+      41, 42.5, 43.25,
+    ]);
+    expect(updates.filter((u) => u.tagName === TAG_QUALITY).every((u) => u.quality === "good")).toBe(
+      true,
+    );
+
+    expect(received(REPLAY_APP_ID) - beforeReceived).toBe(3);
+    expect(rejected("no_subscription") - beforeNoSubscription).toBe(0);
+    // The ARP frame was dropped by the EtherType filter, so it was never parsed.
+    expect(rejected("parse_error") - beforeParseError).toBe(0);
+
+    const after = roundTrip(REPLAY_GOCB_REF);
+    const count = after.count - beforeRoundTrip.count;
+    const sum = after.sum - beforeRoundTrip.sum;
+    expect(count).toBe(3);
+    // Round trip is publisher `t` → kernel capture time, so it reflects the
+    // trace's own 2 ms publish latency and not this test's scheduling.
+    expect(sum / count).toBeCloseTo(REPLAY_PUBLISH_LATENCY_MS * 1000, 0);
+    expect(sum / count).toBeLessThan(4000);
+
+    const stats = backend.getStats();
+    expect(stats.gooseFrames).toBe(3);
+    expect(stats.nonGooseFrames).toBe(1);
+    expect(stats.clockFallbacks).toBe(0);
+    expect(backend.getBufferedBytes()).toBe(0);
+  });
+
+  it("reports 'unavailable' instead of running when the tool is missing", async () => {
+    const backend = new GooseLiveCaptureBackend({
+      platform: "linux",
+      env: { PATH: "/nonexistent" },
+    });
+    const subscriber = new GooseSubscriber({ backend, subscriptions: [liveSubscription] });
+    await expect(subscriber.start()).resolves.toBe("unavailable");
+    await subscriber.stop();
+  });
+
+  it("reports 'error' when the capture tool fails to start", async () => {
+    const backend = new GooseLiveCaptureBackend({
+      command: fakeCapture({ exitCode: 1, stderr: "dumpcap: Operation not permitted" }),
+    });
+    const subscriber = new GooseSubscriber({ backend, subscriptions: [liveSubscription] });
+    await expect(subscriber.start()).resolves.toBe("error");
+    await subscriber.stop();
+  });
+});
+
+/** Poll until `predicate` holds, or fail the test by timing out. */
+async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error("timed out waiting for capture output");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/server/protocols/iec61850-goose/__tests__/pcap-stream.test.ts
+++ b/server/protocols/iec61850-goose/__tests__/pcap-stream.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Unit tests for the incremental pcap decoder.
+ *
+ * The point of this decoder is that a live capture arrives in arbitrary chunks,
+ * so the tests are deliberately exhaustive about chunk boundaries: every
+ * possible one-cut and two-cut split of a multi-packet capture, plus a
+ * byte-at-a-time feed, must all decode to exactly what `parsePcap()` produces
+ * from the same bytes. Boundaries inside the global header, inside a record
+ * header and inside packet data are therefore all covered by construction.
+ *
+ * Issue: #465
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  PcapStreamDecoder,
+  PcapStreamOverflowError,
+  DEFAULT_MAX_RECORD_BYTES,
+  DEFAULT_MAX_BUFFERED_BYTES,
+  type StreamedPcapPacket,
+} from "../pcap-stream.js";
+import {
+  encodePcap,
+  parsePcap,
+  PcapParseError,
+  PCAP_GLOBAL_HEADER_LENGTH,
+  PCAP_RECORD_HEADER_LENGTH,
+  LINKTYPE_ETHERNET,
+  type PcapByteOrder,
+} from "../pcap.js";
+import { canonicalFrame, buildArpRequestFrame } from "./fixtures.js";
+
+const START_MS = 1_700_000_000_000;
+
+/** A three-packet Ethernet capture: two GOOSE frames around one ARP frame. */
+function threePacketCapture(
+  options: { byteOrder?: PcapByteOrder; nanosecondPrecision?: boolean } = {},
+): Buffer {
+  return encodePcap(
+    [
+      { timestampMs: START_MS, data: canonicalFrame({ stNum: 1, sqNum: 0 }) },
+      { timestampMs: START_MS + 40, data: buildArpRequestFrame() },
+      { timestampMs: START_MS + 80.5, data: canonicalFrame({ stNum: 2, sqNum: 0 }) },
+    ],
+    options,
+  );
+}
+
+/** A deliberately tiny capture, so an O(n²) split sweep stays fast. */
+function tinyCapture(): Buffer {
+  return encodePcap([
+    { timestampMs: START_MS, data: Buffer.from("aabbcc", "hex") },
+    { timestampMs: START_MS + 1, data: Buffer.from("dd", "hex") },
+  ]);
+}
+
+function splitAt(buf: Buffer, ...cuts: number[]): Buffer[] {
+  const bounds = [0, ...cuts, buf.length];
+  const chunks: Buffer[] = [];
+  for (let i = 0; i < bounds.length - 1; i++) {
+    const chunk = buf.subarray(bounds[i], bounds[i + 1]);
+    if (chunk.length > 0) chunks.push(chunk);
+  }
+  return chunks;
+}
+
+function feed(chunks: Buffer[], decoder = new PcapStreamDecoder()): StreamedPcapPacket[] {
+  const packets: StreamedPcapPacket[] = [];
+  for (const chunk of chunks) packets.push(...decoder.push(chunk));
+  decoder.end();
+  return packets;
+}
+
+function summarise(packets: readonly StreamedPcapPacket[]): string {
+  return packets.map((p) => `${p.index}:${p.timestampMs}:${p.data.toString("hex")}`).join("|");
+}
+
+describe("PcapStreamDecoder — whole-stream equivalence", () => {
+  it("decodes a capture pushed as one chunk exactly like parsePcap", () => {
+    const capture = threePacketCapture();
+    const packets = feed([capture]);
+    const reference = parsePcap(capture);
+
+    expect(packets).toHaveLength(reference.packets.length);
+    packets.forEach((packet, i) => {
+      expect(packet.timestampMs).toBe(reference.packets[i].timestampMs);
+      expect(packet.seconds).toBe(reference.packets[i].seconds);
+      expect(packet.subSeconds).toBe(reference.packets[i].subSeconds);
+      expect(packet.capturedLength).toBe(reference.packets[i].capturedLength);
+      expect(packet.originalLength).toBe(reference.packets[i].originalLength);
+      expect(packet.data.equals(reference.packets[i].data)).toBe(true);
+      expect(packet.index).toBe(i);
+      expect(packet.truncated).toBe(false);
+    });
+  });
+
+  it("exposes the decoded global header", () => {
+    const decoder = new PcapStreamDecoder();
+    expect(decoder.getHeader()).toBeNull();
+    decoder.push(threePacketCapture());
+    expect(decoder.getHeader()).toMatchObject({
+      byteOrder: "little",
+      nanosecondPrecision: false,
+      linkType: LINKTYPE_ETHERNET,
+    });
+    expect(decoder.getPacketCount()).toBe(3);
+    expect(decoder.getBufferedBytes()).toBe(0);
+    expect(decoder.getTotalBytes()).toBe(threePacketCapture().length);
+  });
+});
+
+describe("PcapStreamDecoder — chunk boundaries", () => {
+  const capture = threePacketCapture();
+  const expected = summarise(feed([capture]));
+
+  it("decodes identically for every single split point in the stream", () => {
+    for (let cut = 0; cut <= capture.length; cut++) {
+      expect(summarise(feed(splitAt(capture, cut)))).toBe(expected);
+    }
+  });
+
+  it("decodes identically one byte at a time", () => {
+    const chunks: Buffer[] = [];
+    for (let i = 0; i < capture.length; i++) chunks.push(capture.subarray(i, i + 1));
+    expect(summarise(feed(chunks))).toBe(expected);
+  });
+
+  it("survives a split inside the global header at every offset", () => {
+    for (let cut = 1; cut < PCAP_GLOBAL_HEADER_LENGTH; cut++) {
+      const decoder = new PcapStreamDecoder();
+      expect(decoder.push(capture.subarray(0, cut))).toHaveLength(0);
+      expect(decoder.getHeader()).toBeNull();
+      const rest = decoder.push(capture.subarray(cut));
+      decoder.end();
+      expect(decoder.getHeader()).not.toBeNull();
+      expect(summarise(rest)).toBe(expected);
+    }
+  });
+
+  it("survives a split inside the first record header at every offset", () => {
+    for (let inner = 1; inner < PCAP_RECORD_HEADER_LENGTH; inner++) {
+      const cut = PCAP_GLOBAL_HEADER_LENGTH + inner;
+      const decoder = new PcapStreamDecoder();
+      expect(decoder.push(capture.subarray(0, cut))).toHaveLength(0);
+      expect(decoder.getBufferedBytes()).toBe(inner);
+      const rest = decoder.push(capture.subarray(cut));
+      decoder.end();
+      expect(summarise(rest)).toBe(expected);
+    }
+  });
+
+  it("decodes identically for every pair of split points", () => {
+    const tiny = tinyCapture();
+    const reference = summarise(feed([tiny]));
+    for (let first = 0; first <= tiny.length; first++) {
+      for (let second = first; second <= tiny.length; second++) {
+        expect(summarise(feed(splitAt(tiny, first, second)))).toBe(reference);
+      }
+    }
+  });
+
+  it("emits each packet on the push that completes it, not before", () => {
+    const decoder = new PcapStreamDecoder();
+    const firstRecordEnd =
+      PCAP_GLOBAL_HEADER_LENGTH + PCAP_RECORD_HEADER_LENGTH + parsePcap(capture).packets[0].data.length;
+
+    expect(decoder.push(capture.subarray(0, firstRecordEnd - 1))).toHaveLength(0);
+    expect(decoder.push(capture.subarray(firstRecordEnd - 1, firstRecordEnd))).toHaveLength(1);
+    expect(decoder.push(capture.subarray(firstRecordEnd))).toHaveLength(2);
+    decoder.end();
+  });
+});
+
+describe("PcapStreamDecoder — byte order and timestamp resolution", () => {
+  const cases: Array<{ byteOrder: PcapByteOrder; nanosecondPrecision: boolean }> = [
+    { byteOrder: "little", nanosecondPrecision: false },
+    { byteOrder: "big", nanosecondPrecision: false },
+    { byteOrder: "little", nanosecondPrecision: true },
+    { byteOrder: "big", nanosecondPrecision: true },
+  ];
+
+  for (const options of cases) {
+    it(`decodes a ${options.byteOrder}-endian ${
+      options.nanosecondPrecision ? "ns" : "µs"
+    } stream fed one byte at a time`, () => {
+      const capture = threePacketCapture(options);
+      const chunks: Buffer[] = [];
+      for (let i = 0; i < capture.length; i++) chunks.push(capture.subarray(i, i + 1));
+
+      const decoder = new PcapStreamDecoder();
+      const packets = feed(chunks, decoder);
+      expect(decoder.getHeader()).toMatchObject(options);
+      expect(packets.map((p) => p.timestampMs)).toEqual([START_MS, START_MS + 40, START_MS + 80.5]);
+    });
+  }
+
+  it("rejects a sub-second field impossible for the declared resolution", () => {
+    const capture = threePacketCapture();
+    // Corrupt the first record's ts_usec to more than one second of microseconds.
+    capture.writeUInt32LE(2_000_000, PCAP_GLOBAL_HEADER_LENGTH + 4);
+    const decoder = new PcapStreamDecoder();
+    expect(() => decoder.push(capture)).toThrow(/packet 0: sub-second field/i);
+  });
+});
+
+describe("PcapStreamDecoder — snaplen truncation", () => {
+  it("flags a record whose captured length is short of the wire length", () => {
+    const frame = canonicalFrame();
+    const capture = encodePcap([
+      { timestampMs: START_MS, data: frame.subarray(0, 40), originalLength: frame.length },
+      { timestampMs: START_MS + 10, data: frame },
+    ]);
+
+    const packets = feed([capture]);
+    expect(packets[0].truncated).toBe(true);
+    expect(packets[0].capturedLength).toBe(40);
+    expect(packets[0].originalLength).toBe(frame.length);
+    expect(packets[0].data).toHaveLength(40);
+    // A snapped record must not stall or corrupt the records after it.
+    expect(packets[1].truncated).toBe(false);
+    expect(packets[1].data.equals(frame)).toBe(true);
+  });
+});
+
+describe("PcapStreamDecoder — bounds", () => {
+  it("has bounds enabled by default", () => {
+    expect(DEFAULT_MAX_RECORD_BYTES).toBe(262_144);
+    expect(DEFAULT_MAX_BUFFERED_BYTES).toBe(8 * 1024 * 1024);
+  });
+
+  it("rejects an oversized incl_len before buffering the body", () => {
+    const capture = threePacketCapture();
+    capture.writeUInt32LE(50_000_000, PCAP_GLOBAL_HEADER_LENGTH + 8); // incl_len
+    const decoder = new PcapStreamDecoder();
+    expect(() => decoder.push(capture)).toThrow(PcapStreamOverflowError);
+    expect(decoder.getBufferedBytes()).toBe(0);
+  });
+
+  it("honours a caller-supplied record bound", () => {
+    const decoder = new PcapStreamDecoder({ maxRecordBytes: 32 });
+    expect(() => decoder.push(threePacketCapture())).toThrow(/exceeds the 32-byte record limit/i);
+  });
+
+  it("rejects an undecodable residue larger than the buffered bound", () => {
+    // A record that promises 500 bytes but only 30 arrive: under the record
+    // bound, over the buffered bound.
+    const capture = encodePcap([{ timestampMs: START_MS, data: Buffer.alloc(500) }]);
+    const decoder = new PcapStreamDecoder({ maxRecordBytes: 1000, maxBufferedBytes: 40 });
+    expect(() =>
+      decoder.push(capture.subarray(0, PCAP_GLOBAL_HEADER_LENGTH + PCAP_RECORD_HEADER_LENGTH + 30)),
+    ).toThrow(/undecodable bytes, over the 40-byte limit/i);
+  });
+
+  it("rejects nonsensical bounds at construction", () => {
+    expect(() => new PcapStreamDecoder({ maxRecordBytes: 0 })).toThrow(PcapParseError);
+    expect(() => new PcapStreamDecoder({ maxBufferedBytes: -1 })).toThrow(PcapParseError);
+  });
+});
+
+describe("PcapStreamDecoder — failing closed", () => {
+  it("rethrows the original failure on every later push", () => {
+    const junk = Buffer.alloc(PCAP_GLOBAL_HEADER_LENGTH);
+    junk.writeUInt32BE(0x12345678, 0);
+    const decoder = new PcapStreamDecoder();
+
+    expect(() => decoder.push(junk)).toThrow(/unknown magic/i);
+    // pcap has no resynchronisation marker: everything after a framing error is
+    // noise, so the decoder must not pretend to recover.
+    expect(() => decoder.push(threePacketCapture())).toThrow(/unknown magic/i);
+    expect(() => decoder.end()).toThrow(/unknown magic/i);
+    expect(decoder.getFailure()).toBeInstanceOf(PcapParseError);
+  });
+
+  it("rejects a pcapng stream with an actionable message", () => {
+    const pcapng = Buffer.alloc(PCAP_GLOBAL_HEADER_LENGTH);
+    pcapng.writeUInt32BE(0x0a0d0d0a, 0);
+    expect(() => new PcapStreamDecoder().push(pcapng)).toThrow(/pcapng/i);
+  });
+
+  it("propagates and latches an onHeader rejection", () => {
+    const decoder = new PcapStreamDecoder({
+      onHeader: (header) => {
+        if (header.linkType === LINKTYPE_ETHERNET) throw new Error("link type refused by consumer");
+      },
+    });
+    expect(() => decoder.push(threePacketCapture())).toThrow(/refused by consumer/);
+    expect(() => decoder.push(Buffer.alloc(4))).toThrow(/refused by consumer/);
+  });
+
+  it("does not deliver packets from the chunk that failed", () => {
+    const capture = threePacketCapture();
+    capture.writeUInt32LE(50_000_000, PCAP_GLOBAL_HEADER_LENGTH + 8);
+    const decoder = new PcapStreamDecoder();
+    let delivered: StreamedPcapPacket[] = [];
+    try {
+      delivered = decoder.push(capture);
+    } catch {
+      // expected
+    }
+    expect(delivered).toHaveLength(0);
+  });
+});
+
+describe("PcapStreamDecoder — end of stream", () => {
+  it("accepts a stream that ends on a record boundary", () => {
+    const decoder = new PcapStreamDecoder();
+    decoder.push(threePacketCapture());
+    expect(() => decoder.end()).not.toThrow();
+  });
+
+  it("reports a stream that ends mid-record", () => {
+    const capture = threePacketCapture();
+    const decoder = new PcapStreamDecoder();
+    decoder.push(capture.subarray(0, capture.length - 5));
+    expect(() => decoder.end()).toThrow(
+      /ended mid-record: \d+ trailing bytes after 2 complete packet\(s\)/i,
+    );
+  });
+
+  it("reports a stream that ends before the global header", () => {
+    const decoder = new PcapStreamDecoder();
+    decoder.push(threePacketCapture().subarray(0, 10));
+    expect(() => decoder.end()).toThrow(/before the 24-byte global header/i);
+  });
+
+  it("reports a stream that produced no output at all", () => {
+    expect(() => new PcapStreamDecoder().end()).toThrow(/without producing any output/i);
+  });
+});

--- a/server/protocols/iec61850-goose/capture-backend.ts
+++ b/server/protocols/iec61850-goose/capture-backend.ts
@@ -13,13 +13,16 @@
  *
  *   - {@link NullGooseCaptureBackend} — the default. Delivers nothing and says
  *     so. It never throws at import and never reports itself as running.
- *   - `GoosePcapReplayBackend` (pcap-backend.ts) — fully working: replays a
- *     captured `.pcap` offline, honouring recorded inter-frame timing.
+ *   - `GoosePcapReplayBackend` (pcap-backend.ts) — replays a captured `.pcap`
+ *     offline, honouring recorded inter-frame timing.
+ *   - `GooseLiveCaptureBackend` (live-backend.ts) — live capture, by spawning a
+ *     libpcap tool (`dumpcap`/`tcpdump`) that streams pcap on stdout. Opt-in
+ *     via `GOOSE_CAPTURE=live`; needs a Linux/BSD/macOS host and CAP_NET_RAW.
  *
- * NOT shipped: a live AF_PACKET / native-addon backend. See
- * {@link detectRawSocketCapability} and docs/protocols/iec61850-goose.md for
- * what such a backend must do; implement this interface and pass it to
- * `new GooseSubscriber({ backend })`.
+ * NOT shipped: an in-process AF_PACKET binding. Node has none and this
+ * repository adds no native addon — see {@link detectRawSocketCapability}. Any
+ * other frame source can be added by implementing this interface and passing it
+ * to `new GooseSubscriber({ backend })`.
  *
  * Issue: #465
  */
@@ -108,13 +111,15 @@ export function isGooseFrame(frame: Buffer): boolean {
 }
 
 /**
- * Determine whether a raw AF_PACKET capture socket could be opened in this
- * environment. Pure / side-effect-free so it can be unit tested.
+ * Determine whether an IN-PROCESS raw AF_PACKET capture socket could be opened
+ * here. Pure / side-effect-free so it can be unit tested.
  *
  * This never returns `available: true`: even on Linux as root, Node has no
  * AF_PACKET binding, and this repository intentionally ships no native capture
- * addon. The function exists to produce an accurate, host-specific explanation
- * of what is missing rather than a generic "disabled".
+ * addon. Live capture is instead done out-of-process by
+ * `GooseLiveCaptureBackend`. The function exists to produce an accurate,
+ * host-specific explanation of what the DEFAULT backend is missing rather than
+ * a generic "disabled".
  */
 export function detectRawSocketCapability(
   platform: NodeJS.Platform = process.platform,
@@ -139,7 +144,8 @@ export function detectRawSocketCapability(
     available: false,
     reason:
       "no native L2 capture binding is present — Node cannot open AF_PACKET; " +
-      "inject a backend implementing GooseCaptureBackend to enable live capture",
+      "set GOOSE_CAPTURE=live to capture through a libpcap tool instead, or " +
+      "inject a backend implementing GooseCaptureBackend",
   };
 }
 

--- a/server/protocols/iec61850-goose/config.ts
+++ b/server/protocols/iec61850-goose/config.ts
@@ -3,19 +3,34 @@
  *
  * The subscriber is OFF unless subscriptions are configured — a substation
  * control block map cannot be guessed, so there is deliberately no default.
+ * Capture is OFF unless a source is selected: with none of these variables set
+ * the service behaves exactly as it did before live capture existed.
  *
  *   GOOSE_SUBSCRIPTIONS_FILE  path to a JSON array of subscription configs
  *                             (the shape validated by
  *                             `gooseSubscriptionConfigSchema`). Required to
  *                             enable the service.
+ *   GOOSE_CAPTURE             none | pcap | live. Selects the capture backend.
+ *                             Defaults to "pcap" when GOOSE_PCAP_FILE is set
+ *                             (the pre-existing behaviour) and "none"
+ *                             otherwise. "live" opts in to real Layer-2
+ *                             capture and is never chosen implicitly.
  *   GOOSE_PCAP_FILE           path to a classic `.pcap` capture to replay.
- *                             When set, the pcap replay backend is used and
- *                             the subscriber genuinely receives frames.
  *   GOOSE_PCAP_REALTIME       "false"/"0" to drain the capture with no delay
  *                             instead of honouring recorded timing.
- *   GOOSE_IFACE               interface a live backend would bind. Used only in
- *                             the "capture unavailable" explanation, because no
- *                             live backend ships with this repository.
+ *   GOOSE_IFACE               interface to capture on. Default "eth0". Used by
+ *                             the live backend, and named in the "capture
+ *                             unavailable" explanation otherwise.
+ *   GOOSE_CAPTURE_TOOL        auto | dumpcap | tcpdump. Which libpcap CLI tool
+ *                             the live backend spawns. Default "auto"
+ *                             (dumpcap, then tcpdump).
+ *   GOOSE_CAPTURE_TOOL_PATH   absolute path to that tool, bypassing the PATH
+ *                             search. Requires an explicit GOOSE_CAPTURE_TOOL
+ *                             because the argument style differs per tool.
+ *   GOOSE_CAPTURE_SNAPLEN     capture snapshot length in bytes. Default 65535.
+ *   GOOSE_CAPTURE_FILTER      override the BPF filter (advanced). The
+ *                             EtherType 0x88B8 check is still applied to every
+ *                             delivered frame regardless of this value.
  *
  * Issue: #465
  */
@@ -24,16 +39,57 @@ import { readFileSync } from "node:fs";
 import { z } from "zod";
 import { gooseSubscriptionConfigSchema } from "./subscription.js";
 
-export const gooseServiceConfigSchema = z.object({
-  /** Interface name reported by the null backend. */
-  iface: z.string().min(1).default("eth0"),
-  /** Capture file to replay, when the pcap backend should be used. */
-  pcapPath: z.string().min(1).optional(),
-  /** Honour recorded inter-frame timing during replay. */
-  pcapRealtime: z.boolean().default(true),
-  /** Control blocks to subscribe to. Empty means the service stays off. */
-  subscriptions: z.array(gooseSubscriptionConfigSchema).default([]),
-});
+/** Which capture backend the service should construct. */
+export const gooseCaptureModeSchema = z.enum(["none", "pcap", "live"]);
+export type GooseCaptureMode = z.infer<typeof gooseCaptureModeSchema>;
+
+/** Which libpcap CLI tool the live backend should drive. */
+export const gooseCaptureToolSchema = z.enum(["auto", "dumpcap", "tcpdump"]);
+export type GooseCaptureToolConfig = z.infer<typeof gooseCaptureToolSchema>;
+
+export const gooseServiceConfigSchema = z
+  .object({
+    /** Capture backend selection. "none" delivers no frames (the default). */
+    capture: gooseCaptureModeSchema.default("none"),
+    /** Interface the live backend binds, and the one the null backend names. */
+    iface: z.string().min(1).default("eth0"),
+    /** Capture file to replay, when the pcap backend should be used. */
+    pcapPath: z.string().min(1).optional(),
+    /** Honour recorded inter-frame timing during replay. */
+    pcapRealtime: z.boolean().default(true),
+    /** Capture tool selection for the live backend. */
+    captureTool: gooseCaptureToolSchema.default("auto"),
+    /** Explicit capture-tool path, bypassing the PATH search. */
+    captureToolPath: z.string().min(1).optional(),
+    /**
+     * Snapshot length. The floor of 68 is libpcap's own minimum useful snaplen;
+     * the ceiling is dumpcap's maximum. A GOOSE frame fits in ~1500 bytes, so
+     * the default of 65535 never truncates one.
+     */
+    captureSnapLen: z.number().int().min(68).max(262_144).default(65535),
+    /** BPF filter override for the live backend. */
+    captureFilter: z.string().min(1).optional(),
+    /** Control blocks to subscribe to. Empty means the service stays off. */
+    subscriptions: z.array(gooseSubscriptionConfigSchema).default([]),
+  })
+  .superRefine((config, ctx) => {
+    if (config.capture === "pcap" && !config.pcapPath) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["pcapPath"],
+        message: "GOOSE_CAPTURE=pcap requires GOOSE_PCAP_FILE to point at a capture file",
+      });
+    }
+    if (config.captureToolPath && config.captureTool === "auto") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["captureTool"],
+        message:
+          "GOOSE_CAPTURE_TOOL_PATH requires GOOSE_CAPTURE_TOOL=dumpcap or tcpdump — " +
+          "the two tools take different arguments, so the path alone is ambiguous",
+      });
+    }
+  });
 
 export type GooseServiceConfig = z.output<typeof gooseServiceConfigSchema>;
 
@@ -41,6 +97,20 @@ export type GooseServiceConfig = z.output<typeof gooseServiceConfigSchema>;
 function envFlag(raw: string | undefined, fallback: boolean): boolean {
   if (raw === undefined || raw === "") return fallback;
   return !["0", "false", "no", "off"].includes(raw.trim().toLowerCase());
+}
+
+/**
+ * Parse an integer env var. Rejected here rather than in Zod so the error names
+ * the variable and the offending text instead of reporting "expected number,
+ * received nan".
+ */
+function envInt(name: string, raw: string | undefined): number | undefined {
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const value = Number(raw.trim());
+  if (!Number.isInteger(value)) {
+    throw new Error(`${name} must be an integer, got "${raw}"`);
+  }
+  return value;
 }
 
 /**
@@ -89,10 +159,21 @@ export function loadGooseServiceConfig(
     ? loadGooseSubscriptionsFile(subscriptionsFile, read)
     : [];
 
+  const pcapPath = env.GOOSE_PCAP_FILE?.trim() || undefined;
+  // Back-compatible default: GOOSE_PCAP_FILE alone still selects replay, and an
+  // environment with none of these variables still selects no capture at all.
+  // Live capture is only ever reached by asking for it explicitly.
+  const capture = env.GOOSE_CAPTURE?.trim().toLowerCase() || (pcapPath ? "pcap" : "none");
+
   return gooseServiceConfigSchema.parse({
+    capture,
     iface: env.GOOSE_IFACE?.trim() || undefined,
-    pcapPath: env.GOOSE_PCAP_FILE?.trim() || undefined,
+    pcapPath,
     pcapRealtime: envFlag(env.GOOSE_PCAP_REALTIME, true),
+    captureTool: env.GOOSE_CAPTURE_TOOL?.trim().toLowerCase() || undefined,
+    captureToolPath: env.GOOSE_CAPTURE_TOOL_PATH?.trim() || undefined,
+    captureSnapLen: envInt("GOOSE_CAPTURE_SNAPLEN", env.GOOSE_CAPTURE_SNAPLEN),
+    captureFilter: env.GOOSE_CAPTURE_FILTER?.trim() || undefined,
     subscriptions,
   });
 }

--- a/server/protocols/iec61850-goose/index.ts
+++ b/server/protocols/iec61850-goose/index.ts
@@ -8,18 +8,23 @@
  *
  * WHAT THIS CAN AND CANNOT DO
  * ---------------------------
- * GOOSE is Layer-2 multicast. Node cannot receive those frames without a
- * native addon, and this repository ships none. Therefore:
+ * GOOSE is Layer-2 multicast; Node cannot receive those frames from a socket,
+ * and this repository ships no native addon. Three backends exist:
  *
- *   - LIVE capture is NOT provided. The default {@link NullGooseCaptureBackend}
- *     delivers nothing, `start()` resolves to "unavailable", and it says why in
- *     a log line. It does not throw and it never reports itself as running.
- *   - OFFLINE replay IS provided and fully works: point
- *     {@link GoosePcapReplayBackend} at a captured `.pcap` and the decoder,
- *     validator, tag-update emission and metrics all run on real frames.
- *   - A live backend is an injection point: implement
- *     {@link GooseCaptureBackend} against a native binding and pass it as
- *     `options.backend`. Nothing else in this module needs to change.
+ *   - {@link NullGooseCaptureBackend} — the default. Delivers nothing,
+ *     `start()` resolves to "unavailable", and it says why in a log line. It
+ *     does not throw and it never reports itself as running.
+ *   - {@link GoosePcapReplayBackend} — offline replay of a captured `.pcap`.
+ *     The decoder, validator, tag-update emission and metrics all run on real
+ *     frames, in the capture's own time base.
+ *   - {@link GooseLiveCaptureBackend} — LIVE capture, opt-in via
+ *     `GOOSE_CAPTURE=live`. It spawns a libpcap CLI tool (`dumpcap`/`tcpdump`)
+ *     that streams pcap on stdout, so frames come off the wire through libpcap
+ *     with no native addon. It needs a Linux/BSD/macOS host, the tool
+ *     installed, and CAP_NET_RAW. It has NOT been run against a real substation
+ *     bus in this repository — see live-backend.ts.
+ *
+ * Any other frame source can be injected as `options.backend`.
  *
  * Issue: #465
  */
@@ -35,6 +40,7 @@ import {
   type GooseCaptureBackend,
 } from "./capture-backend.js";
 import { GoosePcapReplayBackend } from "./pcap-backend.js";
+import { GooseLiveCaptureBackend } from "./live-backend.js";
 import { loadGooseServiceConfig, type GooseServiceConfig } from "./config.js";
 import {
   gooseFramesReceivedTotal,
@@ -139,7 +145,8 @@ export class GooseSubscriber {
       logWarn(
         `[goose] capture backend "${this.backend.name}" cannot receive frames: ` +
           `${availability.reason}. Decode/validation stay available via handleFrame(); ` +
-          "replay a capture with GOOSE_PCAP_FILE or inject a live GooseCaptureBackend.",
+          "capture live with GOOSE_CAPTURE=live, replay a capture with GOOSE_PCAP_FILE, " +
+          "or inject your own GooseCaptureBackend.",
       );
       return this.state;
     }
@@ -282,6 +289,35 @@ export class GooseSubscriber {
 let _subscriber: GooseSubscriber | null = null;
 
 /**
+ * Construct the capture backend the configuration selects.
+ *
+ * The selection is explicit (`GOOSE_CAPTURE`), and "none" — no capture at all —
+ * is the default, so no configuration change can start a capture process by
+ * accident.
+ */
+export function createGooseCaptureBackend(config: GooseServiceConfig): GooseCaptureBackend {
+  switch (config.capture) {
+    case "pcap":
+      // The schema guarantees pcapPath is set when capture === "pcap".
+      return new GoosePcapReplayBackend({
+        path: config.pcapPath as string,
+        realtime: config.pcapRealtime,
+      });
+    case "live":
+      return new GooseLiveCaptureBackend({
+        iface: config.iface,
+        tool: config.captureTool,
+        toolPath: config.captureToolPath,
+        snapLen: config.captureSnapLen,
+        filter: config.captureFilter,
+      });
+    case "none":
+    default:
+      return new NullGooseCaptureBackend({ iface: config.iface });
+  }
+}
+
+/**
  * Build a subscriber from the environment and start it.
  *
  * Returns null when no subscriptions are configured — the service stays off
@@ -305,9 +341,7 @@ export async function startGooseSubscriber(
     return null;
   }
 
-  const backend: GooseCaptureBackend = config.pcapPath
-    ? new GoosePcapReplayBackend({ path: config.pcapPath, realtime: config.pcapRealtime })
-    : new NullGooseCaptureBackend({ iface: config.iface });
+  const backend = createGooseCaptureBackend(config);
 
   const subscriber = new GooseSubscriber({
     backend,
@@ -359,19 +393,51 @@ export type {
 export { GoosePcapReplayBackend } from "./pcap-backend.js";
 export type { GoosePcapReplayOptions, GoosePcapReplayStats } from "./pcap-backend.js";
 export {
+  GooseLiveCaptureBackend,
+  buildCaptureCommand,
+  buildDumpcapArgs,
+  buildTcpdumpArgs,
+  resolveExecutable,
+  DEFAULT_GOOSE_IFACE,
+  DEFAULT_GOOSE_SNAPLEN,
+  GOOSE_BPF_FILTER,
+} from "./live-backend.js";
+export type {
+  GooseCaptureCommand,
+  GooseCaptureToolName,
+  GooseCaptureToolSelection,
+  GooseLiveCaptureOptions,
+  GooseLiveCaptureStats,
+} from "./live-backend.js";
+export {
   parsePcap,
   encodePcap,
   readPcapGlobalHeader,
+  decodePcapRecordHeader,
+  subSecondsPerSecond,
   PcapParseError,
   LINKTYPE_ETHERNET,
   PCAP_MAGIC_MICROSECONDS,
   PCAP_MAGIC_NANOSECONDS,
 } from "./pcap.js";
-export type { PcapFile, PcapPacket, PcapGlobalHeader } from "./pcap.js";
+export type { PcapFile, PcapPacket, PcapGlobalHeader, PcapRecordHeader } from "./pcap.js";
+export {
+  PcapStreamDecoder,
+  PcapStreamOverflowError,
+  DEFAULT_MAX_RECORD_BYTES,
+  DEFAULT_MAX_BUFFERED_BYTES,
+} from "./pcap-stream.js";
+export type { StreamedPcapPacket, PcapStreamDecoderOptions } from "./pcap-stream.js";
 export {
   loadGooseServiceConfig,
   gooseServiceConfigSchema,
+  gooseCaptureModeSchema,
+  gooseCaptureToolSchema,
   loadGooseSubscriptionsFile,
 } from "./config.js";
-export type { GooseServiceConfig } from "./config.js";
+export type {
+  GooseServiceConfig,
+  GooseCaptureMode,
+  GooseCaptureToolConfig,
+} from "./config.js";
 export * from "./types.js";

--- a/server/protocols/iec61850-goose/live-backend.ts
+++ b/server/protocols/iec61850-goose/live-backend.ts
@@ -1,0 +1,959 @@
+/**
+ * LIVE GOOSE capture backend — real Layer-2 frames off a real interface.
+ *
+ * GOOSE is EtherType 0x88B8 riding directly on Ethernet: no IP, no UDP, so no
+ * Node socket can receive it. The usual answer is a native libpcap addon, which
+ * this repository deliberately does not take on (node-gyp in CI). The answer
+ * here is the other half of the same libpcap: a capture TOOL that streams
+ * classic pcap on stdout, spawned as a child process.
+ *
+ *   dumpcap -i eth0 -P -q -s 65535 -w - -f '<bpf>'     (preferred)
+ *   tcpdump -i eth0 -U -n -s 65535 -w - '<bpf>'        (fallback)
+ *
+ * The frames are genuinely captured — libpcap opens the capture handle, the
+ * kernel copies the frames, the BPF filter runs in the kernel — and the pipe
+ * carries them into {@link PcapStreamDecoder}, the same pcap machinery the
+ * offline replay backend uses. What this module owns is the process lifecycle,
+ * the filter, and the honesty of {@link GooseLiveCaptureBackend.availability}.
+ *
+ * WHAT IS AND IS NOT VERIFIED
+ * ---------------------------
+ * The whole path — spawn → stdout → incremental pcap decode → EtherType filter
+ * → frame handler → subscriber → tag updates + metrics — is covered by tests
+ * that point the backend at a fake capture command emitting a known pcap byte
+ * stream. What is NOT verified anywhere in this repository is capture from a
+ * real substation bus or a real IED: no such hardware is available here. The
+ * argv, the BPF filter and the privilege requirements are written from the
+ * tools' documented behaviour, not from an observed live capture.
+ *
+ * PRIVILEGE. Opening a capture handle needs CAP_NET_RAW (or root). This backend
+ * never tries to acquire it; it detects the failure and reports it with the
+ * command needed to fix it. See docs/protocols/iec61850-goose.md.
+ *
+ * Issue: #465
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { logError, logInfo, logWarn } from "../../logger.js";
+import { GooseCaptureUnavailableError, isGooseFrame } from "./capture-backend.js";
+import type {
+  GooseCaptureAvailability,
+  GooseCaptureBackend,
+  GooseFrameHandler,
+} from "./capture-backend.js";
+import { LINKTYPE_ETHERNET, type PcapGlobalHeader } from "./pcap.js";
+import { PcapStreamDecoder, type StreamedPcapPacket } from "./pcap-stream.js";
+import { GOOSE_ETHERTYPE } from "./types.js";
+
+/** Interface bound when none is configured — the acceptance criterion's default. */
+export const DEFAULT_GOOSE_IFACE = "eth0";
+
+/** Default snapshot length. A GOOSE frame never approaches this. */
+export const DEFAULT_GOOSE_SNAPLEN = 65535;
+
+/**
+ * BPF filter matching GOOSE both untagged and behind one 802.1Q tag.
+ *
+ * `ether proto 0x88b8` alone is WRONG for a substation bus. It compiles to a
+ * comparison at Ethernet offset 12, and on a VLAN-tagged frame offset 12 holds
+ * the 802.1Q TPID (0x8100) — the real EtherType has been pushed out to offset
+ * 16. Since GOOSE is normally published on a dedicated priority-tagged VLAN,
+ * that filter would silently drop exactly the traffic being subscribed to.
+ *
+ * libpcap's `vlan` keyword is the fix, with one sharp edge: it is not a plain
+ * predicate. The first `vlan` in an expression shifts the decoding offsets of
+ * everything AFTER it by 4 bytes (pcap-filter(7)). So the two terms are not
+ * interchangeable and the order matters:
+ *
+ *   ether proto 0x88b8            → offset 12, matches untagged GOOSE
+ *   or (vlan and ether proto 0x88b8) → `vlan` matches the TPID and shifts the
+ *                                       base, so this `ether proto` reads
+ *                                       offset 16 and matches tagged GOOSE
+ *
+ * Writing the VLAN term first would leave the offsets shifted for the untagged
+ * term and match nothing sane.
+ *
+ * Only ONE tag is unwrapped. That is deliberate: it matches
+ * `readFrameEtherType()` and the frame parser, neither of which decodes a QinQ
+ * (0x88A8/0x9100) outer tag. Widening the filter to `vlan and vlan` would
+ * deliver frames the decoder would then reject.
+ */
+export const GOOSE_BPF_FILTER = `ether proto 0x${GOOSE_ETHERTYPE.toString(16)} or (vlan and ether proto 0x${GOOSE_ETHERTYPE.toString(16)})`;
+
+/**
+ * Platforms where the `<tool> -w -` capture path is used. Windows is excluded
+ * on purpose: capture there goes through Npcap with a different privilege model
+ * and different tool packaging, and nothing in this repository has been written
+ * or tested against it — so it reports unavailable rather than guessing.
+ */
+const SUPPORTED_PLATFORMS: ReadonlySet<NodeJS.Platform> = new Set<NodeJS.Platform>([
+  "linux",
+  "darwin",
+  "freebsd",
+  "openbsd",
+  "netbsd",
+  "sunos",
+  "aix",
+]);
+
+/** Capture tools this backend knows how to drive. */
+export type GooseCaptureToolName = "dumpcap" | "tcpdump";
+
+/** Tool selection: `auto` prefers dumpcap, then tcpdump. */
+export type GooseCaptureToolSelection = GooseCaptureToolName | "auto";
+
+/**
+ * A resolved capture command. `args` is an ARGUMENT VECTOR, never a shell
+ * string: the child is spawned without a shell, so an interface name or filter
+ * containing shell metacharacters is passed through as one opaque argument and
+ * cannot be interpreted as a command.
+ */
+export interface GooseCaptureCommand {
+  /** Executable path or bare name. */
+  file: string;
+  /** Argument vector, one element per argument. */
+  args: readonly string[];
+  /** Human-readable description used in logs and availability reasons. */
+  label: string;
+}
+
+/** Counters describing what the live capture has actually seen. */
+export interface GooseLiveCaptureStats {
+  /** Bytes read from the capture tool's stdout. */
+  bytesRead: number;
+  /** pcap records decoded from the stream. */
+  recordsDecoded: number;
+  /** Records whose EtherType is 0x88B8 and were handed to the subscriber. */
+  gooseFrames: number;
+  /** Records dropped because they are not GOOSE (belt-and-braces behind the BPF). */
+  nonGooseFrames: number;
+  /** Records dropped because the snapshot length cut the frame short. */
+  truncatedFrames: number;
+  /** Frames whose recorded capture timestamp was unusable, so wall clock was used. */
+  clockFallbacks: number;
+  /** Capture tool exit code, once it has exited. */
+  exitCode: number | null;
+  /** Signal that killed the capture tool, if any. */
+  exitSignal: NodeJS.Signals | null;
+}
+
+export interface GooseLiveCaptureOptions {
+  /** Interface to capture on. Default {@link DEFAULT_GOOSE_IFACE} ("eth0"). */
+  iface?: string;
+  /** Which capture tool to use. Default "auto" (dumpcap, then tcpdump). */
+  tool?: GooseCaptureToolSelection;
+  /** Explicit path to the capture tool, bypassing the PATH search. */
+  toolPath?: string;
+  /** Snapshot length passed to the tool. Default {@link DEFAULT_GOOSE_SNAPLEN}. */
+  snapLen?: number;
+  /** Override the BPF filter. Default {@link GOOSE_BPF_FILTER}. */
+  filter?: string;
+  /**
+   * Fully-specified command, bypassing tool resolution entirely. The operator
+   * takes responsibility for it emitting classic pcap on stdout. Tests use this
+   * to drive the real spawn/stream/decode path from a known byte stream.
+   */
+  command?: GooseCaptureCommand;
+  /**
+   * How long to wait for the tool to emit the pcap global header before giving
+   * up. This is the readiness signal: libpcap writes it once the capture handle
+   * is open, so `open()` resolving means capture really started. Default 5000.
+   */
+  startupTimeoutMs?: number;
+  /** Grace period between SIGTERM and SIGKILL on close. Default 2000. */
+  killGraceMs?: number;
+  /** Upper bound on how long `close()` waits for the child to exit. Default 5000. */
+  closeTimeoutMs?: number;
+  /** Largest accepted pcap record. Defaults to the snapshot length. */
+  maxRecordBytes?: number;
+  /** Largest undecodable residue held between chunks. */
+  maxBufferedBytes?: number;
+  /** Override the detected platform (testing). */
+  platform?: NodeJS.Platform;
+  /** Environment used for the PATH search (testing). */
+  env?: NodeJS.ProcessEnv;
+  /** Executable-existence probe (testing). */
+  exists?: (path: string) => boolean;
+  /** Clock, ms since epoch. Default `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * Largest disagreement tolerated between a frame's recorded capture timestamp
+ * and the local wall clock before the recorded value is discarded. libpcap
+ * timestamps come from the same host clock as `Date.now()`, so a gap this large
+ * means the timestamps are not usable (a mis-synced NIC hardware clock, or a
+ * stream that is not really live) — and using them would make every
+ * subscription instantly TTL-expired.
+ */
+const MAX_CAPTURE_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+/** Stderr kept for diagnostics; the tail is what carries the error. */
+const MAX_STDERR_CHARS = 8192;
+
+/** Patterns that identify the "libpcap could not get CAP_NET_RAW" family. */
+const PERMISSION_PATTERNS: readonly RegExp[] = [
+  /permission denied/i,
+  /operation not permitted/i,
+  /you don'?t have permission/i,
+  /are you root/i,
+  /must be root/i,
+  /root privileges/i,
+  /\beperm\b/i,
+  /\beacces\b/i,
+  /cap_net_raw/i,
+];
+
+/** Patterns that identify a bad interface name. */
+const NO_SUCH_DEVICE_PATTERNS: readonly RegExp[] = [
+  /no such device/i,
+  /doesn'?t exist/i,
+  /does not exist/i,
+  /no such capture device/i,
+  /that device does not exist/i,
+];
+
+const PERMISSION_REMEDY =
+  "libpcap needs CAP_NET_RAW to open a capture handle. Either grant it to the " +
+  "capture tool (`sudo setcap cap_net_raw,cap_net_admin+eip $(command -v dumpcap)`), " +
+  "add the service account to the group that owns dumpcap (Debian/Ubuntu: " +
+  "`sudo dpkg-reconfigure wireshark-common` then `sudo usermod -aG wireshark <user>`), " +
+  "or run the capture tool as root.";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Executable resolution (platform-injectable so it is unit-testable anywhere)
+// ───────────────────────────────────────────────────────────────────────────
+
+function pathDelimiter(platform: NodeJS.Platform): string {
+  return platform === "win32" ? ";" : ":";
+}
+
+function hasPathSeparator(file: string, platform: NodeJS.Platform): boolean {
+  return platform === "win32" ? /[\\/]/.test(file) : file.includes("/");
+}
+
+function joinPath(dir: string, file: string, platform: NodeJS.Platform): string {
+  const sep = platform === "win32" ? "\\" : "/";
+  return /[\\/]$/.test(dir) ? `${dir}${file}` : `${dir}${sep}${file}`;
+}
+
+/**
+ * Resolve `file` to an existing executable, searching PATH when it is a bare
+ * name. Returns null when nothing matches — this is what makes
+ * {@link GooseLiveCaptureBackend.availability} able to say "no capture tool is
+ * installed" without spawning anything.
+ */
+export function resolveExecutable(
+  file: string,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+  exists: (path: string) => boolean = existsSync,
+): string | null {
+  if (file === "") return null;
+  const extensions =
+    platform === "win32"
+      ? [
+          "",
+          ...(env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+            .split(";")
+            .map((e) => e.trim())
+            .filter((e) => e.length > 0),
+        ]
+      : [""];
+
+  const probe = (candidate: string): string | null => {
+    for (const ext of extensions) {
+      const full = `${candidate}${ext}`;
+      if (exists(full)) return full;
+    }
+    return null;
+  };
+
+  if (hasPathSeparator(file, platform)) return probe(file);
+
+  const search = (env.PATH ?? env.Path ?? "").split(pathDelimiter(platform));
+  for (const rawDir of search) {
+    const dir = rawDir.trim().replace(/^"|"$/g, "");
+    if (dir === "") continue;
+    const hit = probe(joinPath(dir, file, platform));
+    if (hit) return hit;
+  }
+  return null;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Command construction
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * argv for `dumpcap`.
+ *
+ * `-P` is not optional: dumpcap defaults to pcapNG, which this decoder does not
+ * read. `-q` suppresses the running packet-count display on stderr so stderr
+ * stays useful for errors. `-w -` streams the capture file to stdout.
+ */
+export function buildDumpcapArgs(iface: string, snapLen: number, filter: string): string[] {
+  return ["-i", iface, "-P", "-q", "-s", String(snapLen), "-w", "-", "-f", filter];
+}
+
+/**
+ * argv for `tcpdump`.
+ *
+ * `-U` is not optional: without packet-buffered output tcpdump holds frames in
+ * a 4 KiB stdio buffer, which would add unbounded latency to a protocol with a
+ * sub-4 ms budget. `-n` avoids name lookups. tcpdump writes classic pcap.
+ */
+export function buildTcpdumpArgs(iface: string, snapLen: number, filter: string): string[] {
+  return ["-i", iface, "-U", "-n", "-s", String(snapLen), "-w", "-", filter];
+}
+
+/** Build the argv for a known tool. */
+export function buildCaptureCommand(
+  tool: GooseCaptureToolName,
+  file: string,
+  iface: string,
+  snapLen: number,
+  filter: string,
+): GooseCaptureCommand {
+  const args =
+    tool === "dumpcap"
+      ? buildDumpcapArgs(iface, snapLen, filter)
+      : buildTcpdumpArgs(iface, snapLen, filter);
+  return { file, args, label: `${tool} (${file})` };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Backend
+// ───────────────────────────────────────────────────────────────────────────
+
+function emptyStats(): GooseLiveCaptureStats {
+  return {
+    bytesRead: 0,
+    recordsDecoded: 0,
+    gooseFrames: 0,
+    nonGooseFrames: 0,
+    truncatedFrames: 0,
+    clockFallbacks: 0,
+    exitCode: null,
+    exitSignal: null,
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}
+
+function matchesAny(text: string, patterns: readonly RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+/**
+ * Live GOOSE capture via a libpcap CLI tool.
+ *
+ * ```ts
+ * const backend = new GooseLiveCaptureBackend({ iface: "eth0" });
+ * if (!backend.availability().available) { ... }
+ * const subscriber = new GooseSubscriber({ backend, subscriptions });
+ * await subscriber.start();  // "running" only once frames can actually flow
+ * ```
+ */
+export class GooseLiveCaptureBackend implements GooseCaptureBackend {
+  readonly name = "live-pcap";
+
+  private readonly iface: string;
+  private readonly tool: GooseCaptureToolSelection;
+  private readonly toolPath?: string;
+  private readonly snapLen: number;
+  private readonly filter: string;
+  private readonly commandOverride?: GooseCaptureCommand;
+  private readonly startupTimeoutMs: number;
+  private readonly killGraceMs: number;
+  private readonly closeTimeoutMs: number;
+  private readonly maxRecordBytes: number;
+  private readonly maxBufferedBytes?: number;
+  private readonly platform: NodeJS.Platform;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly exists: (path: string) => boolean;
+  private readonly now: () => number;
+
+  private child: ChildProcess | null = null;
+  private command: GooseCaptureCommand | null = null;
+  private decoder: PcapStreamDecoder | null = null;
+  private stderrTail = "";
+  private stats: GooseLiveCaptureStats = emptyStats();
+  private lastError: Error | null = null;
+  private closing = false;
+  private warnedTruncation = false;
+  private warnedClockSkew = false;
+  private startupTimer: ReturnType<typeof setTimeout> | null = null;
+  private killTimer: ReturnType<typeof setTimeout> | null = null;
+  private exitPromise: Promise<void> = Promise.resolve();
+  private resolveExit: (() => void) | null = null;
+  /** Registered on `process.exit` while a capture runs; see {@link installExitHook}. */
+  private exitHook: (() => void) | null = null;
+
+  constructor(options: GooseLiveCaptureOptions = {}) {
+    this.iface = options.iface ?? DEFAULT_GOOSE_IFACE;
+    this.tool = options.tool ?? "auto";
+    this.toolPath = options.toolPath;
+    this.snapLen = options.snapLen ?? DEFAULT_GOOSE_SNAPLEN;
+    this.filter = options.filter ?? GOOSE_BPF_FILTER;
+    this.commandOverride = options.command;
+    this.startupTimeoutMs = options.startupTimeoutMs ?? 5000;
+    this.killGraceMs = options.killGraceMs ?? 2000;
+    this.closeTimeoutMs = options.closeTimeoutMs ?? 5000;
+    this.maxRecordBytes = options.maxRecordBytes ?? this.snapLen;
+    this.maxBufferedBytes = options.maxBufferedBytes;
+    this.platform = options.platform ?? process.platform;
+    this.env = options.env ?? process.env;
+    this.exists = options.exists ?? existsSync;
+    this.now = options.now ?? (() => Date.now());
+
+    if (this.iface.trim() === "") {
+      throw new Error("GooseLiveCaptureBackend requires a non-empty interface name");
+    }
+    if (!Number.isInteger(this.snapLen) || this.snapLen <= 0) {
+      throw new Error(
+        `GooseLiveCaptureBackend: snapLen must be a positive integer, got ${this.snapLen}`,
+      );
+    }
+  }
+
+  /** The interface this backend captures on. */
+  getInterface(): string {
+    return this.iface;
+  }
+
+  /** The BPF filter handed to the capture tool. */
+  getFilter(): string {
+    return this.filter;
+  }
+
+  /** The command in use (after open) or the one that would be used. */
+  getCommand(): GooseCaptureCommand | null {
+    if (this.command) return this.command;
+    try {
+      return this.resolveCommand();
+    } catch {
+      return null;
+    }
+  }
+
+  /** Snapshot of the capture counters. */
+  getStats(): GooseLiveCaptureStats {
+    return { ...this.stats };
+  }
+
+  /** The most recent capture failure, if any. */
+  getLastError(): Error | null {
+    return this.lastError;
+  }
+
+  /** Bytes the pcap decoder is holding while it waits for the rest of a record. */
+  getBufferedBytes(): number {
+    return this.decoder?.getBufferedBytes() ?? 0;
+  }
+
+  /** True while a capture process is running and has not been asked to stop. */
+  isRunning(): boolean {
+    return this.child !== null && !this.closing;
+  }
+
+  /** Resolves when the capture process has exited (immediately if never started). */
+  completion(): Promise<void> {
+    return this.exitPromise;
+  }
+
+  /**
+   * Whether a capture could be started here. Truthful and non-throwing: it
+   * reports the unsupported platform, or that no capture tool is installed, or
+   * the command that would be run.
+   *
+   * It does NOT prove the capture will succeed — only the kernel can say
+   * whether this process holds CAP_NET_RAW and whether the interface exists.
+   * Those failures surface from {@link open}, with the remedy in the message.
+   */
+  availability(): GooseCaptureAvailability {
+    try {
+      const command = this.resolveCommand();
+      if (this.commandOverride) {
+        const resolved = resolveExecutable(command.file, this.env, this.platform, this.exists);
+        if (!resolved) {
+          return {
+            available: false,
+            reason: `configured GOOSE capture command not found: ${command.file}`,
+          };
+        }
+      }
+      return {
+        available: true,
+        reason:
+          `${command.label} on iface=${this.iface}, filter='${this.filter}' ` +
+          "(capture permission is only proven when the tool starts)",
+      };
+    } catch (err) {
+      return { available: false, reason: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Spawn the capture tool and stream frames to `onFrame`.
+   *
+   * Resolves only once the pcap global header has been decoded — libpcap emits
+   * it when the capture handle is open, so a resolved promise means frames can
+   * actually arrive. Rejects (with the tool's stderr, and a remedy for the
+   * permission case) if the tool cannot start.
+   */
+  open(onFrame: GooseFrameHandler): Promise<void> {
+    if (this.child) {
+      return Promise.reject(
+        new Error(`GooseLiveCaptureBackend is already capturing on ${this.iface}`),
+      );
+    }
+
+    let command: GooseCaptureCommand;
+    try {
+      command = this.resolveCommand();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
+    this.closing = false;
+    this.stderrTail = "";
+    this.stats = emptyStats();
+    this.lastError = null;
+    this.warnedTruncation = false;
+    this.warnedClockSkew = false;
+    this.command = command;
+
+    const decoder = new PcapStreamDecoder({
+      maxRecordBytes: this.maxRecordBytes,
+      maxBufferedBytes: this.maxBufferedBytes,
+      onHeader: (header) => this.checkCaptureHeader(header),
+    });
+    this.decoder = decoder;
+
+    this.exitPromise = new Promise<void>((resolveExit) => {
+      this.resolveExit = resolveExit;
+    });
+
+    // No shell: `command.args` is an argv array, so an interface name or filter
+    // containing shell metacharacters is one opaque argument, never a command.
+    const child = spawn(command.file, [...command.args], {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    this.child = child;
+    this.installExitHook(child);
+
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      const settleOk = (): void => {
+        if (settled) return;
+        settled = true;
+        this.clearStartupTimer();
+        logInfo(
+          `[goose] live capture started: ${command.label} on ${this.iface} ` +
+            `(snaplen=${this.snapLen}, filter='${this.filter}')`,
+        );
+        resolve();
+      };
+
+      const settleErr = (err: Error): void => {
+        if (settled) {
+          this.lastError = err;
+          return;
+        }
+        settled = true;
+        this.clearStartupTimer();
+        this.abort(err);
+        reject(err);
+      };
+
+      this.startupTimer = setTimeout(() => {
+        this.startupTimer = null;
+        settleErr(
+          new Error(
+            `${command.label} produced no pcap header within ${this.startupTimeoutMs}ms on ` +
+              `${this.iface}; the capture never started${this.stderrSuffix()}`,
+          ),
+        );
+      }, this.startupTimeoutMs);
+      // The capture tool's own handle keeps the loop alive while it runs; this
+      // watchdog must not extend the process lifetime on its own.
+      this.startupTimer.unref?.();
+
+      child.once("error", (err: NodeJS.ErrnoException) => {
+        settleErr(this.spawnError(err, command));
+        // A spawn failure leaves no process to reap; release the handle so the
+        // backend can be opened again without a phantom "already capturing".
+        this.child = null;
+        this.clearExitHook();
+        this.settleExit();
+      });
+
+      child.stderr?.setEncoding("utf8");
+      child.stderr?.on("data", (text: string) => {
+        this.stderrTail = (this.stderrTail + text).slice(-MAX_STDERR_CHARS);
+      });
+
+      child.stdout?.on("data", (chunk: Buffer) => {
+        this.stats.bytesRead += chunk.length;
+        let packets: StreamedPcapPacket[];
+        try {
+          packets = decoder.push(chunk);
+        } catch (err) {
+          const failure =
+            err instanceof Error ? err : new Error(`pcap stream decode failed: ${String(err)}`);
+          if (!settled) {
+            settleErr(failure);
+          } else {
+            // Framing is lost and pcap has no resync marker: stop the tool
+            // rather than feed the decoder garbage for the rest of the run.
+            logError(
+              failure,
+              `[goose] live capture on ${this.iface} lost pcap framing; stopping the capture tool`,
+            );
+            this.abort(failure);
+          }
+          return;
+        }
+
+        if (!settled && decoder.getHeader() !== null) settleOk();
+        for (const packet of packets) this.deliver(packet, onFrame);
+      });
+
+      child.once("close", (code: number | null, signal: NodeJS.Signals | null) => {
+        this.stats.exitCode = code;
+        this.stats.exitSignal = signal;
+        this.child = null;
+        this.clearKillTimer();
+        this.clearExitHook();
+        this.settleExit();
+
+        if (!settled) {
+          settleErr(this.startupExitError(code, signal, command));
+          return;
+        }
+        if (this.closing) return; // we asked it to stop
+
+        if (signal === null && code === 0) {
+          // A clean exit is the end of the capture, not a failure (a tool run
+          // with `-a duration:N` or `-c N` ends this way). Frames have stopped
+          // arriving either way, so it is still worth a line.
+          logWarn(
+            `[goose] ${command.label} exited normally; live GOOSE capture on ` +
+              `${this.iface} has stopped after ${this.stats.gooseFrames} frame(s)`,
+          );
+          try {
+            decoder.end();
+          } catch (endErr) {
+            logWarn(`[goose] live capture stream ended mid-record: ${(endErr as Error).message}`);
+          }
+          return;
+        }
+
+        const err = new Error(
+          `${command.label} stopped capturing on ${this.iface} ` +
+            `(${describeExit(code, signal)})${this.stderrSuffix()}`,
+        );
+        this.lastError = err;
+        logError(err, "[goose] live GOOSE capture ended unexpectedly");
+      });
+    });
+  }
+
+  /**
+   * Stop the capture. Kills the child (SIGTERM, then SIGKILL after the grace
+   * period), waits for it to exit, and is safe to call twice or when open() was
+   * never called.
+   */
+  async close(): Promise<void> {
+    this.closing = true;
+    this.clearStartupTimer();
+    if (!this.child) {
+      this.clearKillTimer();
+      this.clearExitHook();
+      return;
+    }
+    this.terminate();
+    // Bounded: stop() must never hang the server on a wedged capture tool.
+    await Promise.race([this.exitPromise, delay(this.closeTimeoutMs)]);
+    this.clearKillTimer();
+    this.clearExitHook();
+  }
+
+  /**
+   * Wall clock, matching the epoch of the capture timestamps delivered with
+   * each frame (libpcap timestamps come from this same host clock).
+   */
+  clockNowMs(): number {
+    return this.now();
+  }
+
+  // ── internals ────────────────────────────────────────────────────────────
+
+  /**
+   * Reject a capture whose link layer is not Ethernet. `-i any` on Linux yields
+   * LINKTYPE_LINUX_SLL, whose frames have no Ethernet header at all, so every
+   * "GOOSE frame" decoded from it would be misaligned nonsense.
+   */
+  private checkCaptureHeader(header: PcapGlobalHeader): void {
+    if (header.linkType !== LINKTYPE_ETHERNET) {
+      throw new Error(
+        `capture on ${this.iface} has link type ${header.linkType}, not Ethernet ` +
+          `(${LINKTYPE_ETHERNET}); GOOSE frames only exist on a real Ethernet interface ` +
+          "(a Linux `any` capture yields LINKTYPE_LINUX_SLL and cannot be used)",
+      );
+    }
+  }
+
+  /** Apply the EtherType filter and hand the frame on. */
+  private deliver(packet: StreamedPcapPacket, onFrame: GooseFrameHandler): void {
+    this.stats.recordsDecoded += 1;
+
+    if (packet.truncated) {
+      // The snapshot length cut the frame short: the BER APDU is incomplete, so
+      // decoding it would either throw or yield a partial dataset. Neither is
+      // acceptable for a protection-grade signal — drop it and say so.
+      this.stats.truncatedFrames += 1;
+      if (!this.warnedTruncation) {
+        this.warnedTruncation = true;
+        logWarn(
+          `[goose] dropping snapped frame on ${this.iface}: captured ` +
+            `${packet.capturedLength} of ${packet.originalLength} bytes — raise the ` +
+            `snapshot length (currently ${this.snapLen})`,
+        );
+      }
+      return;
+    }
+
+    // Belt and braces behind the kernel BPF filter: the same test the offline
+    // backend applies, so a mis-set GOOSE_CAPTURE_FILTER cannot feed non-GOOSE
+    // traffic into the BER decoder.
+    if (!isGooseFrame(packet.data)) {
+      this.stats.nonGooseFrames += 1;
+      return;
+    }
+
+    this.stats.gooseFrames += 1;
+    try {
+      onFrame(packet.data, this.receiveTimestamp(packet));
+    } catch (err) {
+      logError(err, "[goose] live capture frame handler threw");
+    }
+  }
+
+  /**
+   * Receive time for a captured frame.
+   *
+   * Prefers the pcap record's timestamp, which libpcap takes from the kernel at
+   * the moment the frame was copied off the NIC. That excludes the capture
+   * tool's buffering, the pipe and Node's scheduling — all of which are
+   * comparable to the sub-4 ms budget `goose_round_trip_us` is measuring, so
+   * using `Date.now()` here would inflate the metric with our own latency.
+   *
+   * Falls back to the wall clock when the recorded timestamp cannot be
+   * reconciled with it (see {@link MAX_CAPTURE_CLOCK_SKEW_MS}), because TTL
+   * expiry is judged against `clockNowMs()` and a skewed timestamp would make
+   * every subscription look permanently stale.
+   */
+  private receiveTimestamp(packet: StreamedPcapPacket): number {
+    const wall = this.now();
+    const captured = packet.timestampMs;
+    if (Number.isFinite(captured) && Math.abs(wall - captured) <= MAX_CAPTURE_CLOCK_SKEW_MS) {
+      return captured;
+    }
+    this.stats.clockFallbacks += 1;
+    if (!this.warnedClockSkew) {
+      this.warnedClockSkew = true;
+      logWarn(
+        `[goose] capture timestamps on ${this.iface} disagree with the local clock by ` +
+          `more than ${MAX_CAPTURE_CLOCK_SKEW_MS}ms (recorded ${captured}, local ${wall}); ` +
+          "using the local clock for TTL and round-trip latency",
+      );
+    }
+    return wall;
+  }
+
+  /** Decide which command to run. Throws when nothing can be run here. */
+  private resolveCommand(): GooseCaptureCommand {
+    if (this.commandOverride) return this.commandOverride;
+
+    if (!SUPPORTED_PLATFORMS.has(this.platform)) {
+      throw new GooseCaptureUnavailableError(
+        `live GOOSE capture is not supported on platform=${this.platform}: it spawns a ` +
+          "libpcap tool (dumpcap/tcpdump) that streams pcap on stdout, which is a " +
+          "Linux/BSD/macOS path. Windows capture goes through Npcap and is not " +
+          "implemented here — use GOOSE_CAPTURE=pcap to replay a capture instead",
+      );
+    }
+
+    const names: GooseCaptureToolName[] =
+      this.tool === "auto" ? ["dumpcap", "tcpdump"] : [this.tool];
+    for (const name of names) {
+      const candidate = this.toolPath ?? name;
+      const resolved = resolveExecutable(candidate, this.env, this.platform, this.exists);
+      if (resolved) return buildCaptureCommand(name, resolved, this.iface, this.snapLen, this.filter);
+    }
+
+    throw new GooseCaptureUnavailableError(
+      this.toolPath
+        ? `configured GOOSE capture tool not found: ${this.toolPath}`
+        : `no GOOSE capture tool found on PATH (looked for ${names.join(", ")}); ` +
+          "install wireshark's dumpcap or tcpdump, or set GOOSE_CAPTURE_TOOL_PATH",
+    );
+  }
+
+  /** Map a spawn failure onto an actionable message. */
+  private spawnError(err: NodeJS.ErrnoException, command: GooseCaptureCommand): Error {
+    if (err.code === "ENOENT") {
+      return new Error(
+        `GOOSE capture tool not found: ${command.file} (install wireshark's dumpcap or ` +
+          "tcpdump, or set GOOSE_CAPTURE_TOOL_PATH to its absolute path)",
+      );
+    }
+    if (err.code === "EACCES") {
+      return new Error(
+        `GOOSE capture tool ${command.file} is not executable by this process (EACCES). ` +
+          PERMISSION_REMEDY,
+      );
+    }
+    return new Error(`failed to start ${command.label}: ${err.message}`);
+  }
+
+  /** Diagnose an exit that happened before the capture ever started. */
+  private startupExitError(
+    code: number | null,
+    signal: NodeJS.Signals | null,
+    command: GooseCaptureCommand,
+  ): Error {
+    const stderr = this.stderrTail.trim();
+    if (matchesAny(stderr, PERMISSION_PATTERNS)) {
+      return new Error(
+        `${command.label} was denied permission to capture on ${this.iface} ` +
+          `(${describeExit(code, signal)}). ${PERMISSION_REMEDY}${this.stderrSuffix()}`,
+      );
+    }
+    if (matchesAny(stderr, NO_SUCH_DEVICE_PATTERNS)) {
+      return new Error(
+        `${command.label} could not open interface '${this.iface}' ` +
+          `(${describeExit(code, signal)}) — check the interface name and that it is up ` +
+          `(set GOOSE_IFACE)${this.stderrSuffix()}`,
+      );
+    }
+    return new Error(
+      `${command.label} exited before capturing on ${this.iface} ` +
+        `(${describeExit(code, signal)})${this.stderrSuffix()}`,
+    );
+  }
+
+  private stderrSuffix(): string {
+    const stderr = this.stderrTail.trim();
+    return stderr === "" ? " (no stderr output)" : `: ${stderr}`;
+  }
+
+  /**
+   * Record a fatal capture failure and stop the tool. Marks the backend as no
+   * longer running so the `close` handler does not report the shutdown we
+   * ourselves initiated as a second, unexplained failure.
+   */
+  private abort(err: Error): void {
+    this.lastError = err;
+    this.closing = true;
+    this.terminate();
+  }
+
+  /** Stop reading and kill the capture tool. Idempotent. */
+  private terminate(): void {
+    const child = this.child;
+    if (!child) return;
+    child.stdout?.removeAllListeners("data");
+    if (child.exitCode === null && child.signalCode === null) {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // Already reaped between the check and the signal — nothing to do.
+      }
+      if (!this.killTimer) {
+        const timer = setTimeout(() => {
+          this.killTimer = null;
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // Already gone.
+          }
+        }, this.killGraceMs);
+        timer.unref?.();
+        this.killTimer = timer;
+      }
+    }
+  }
+
+  /**
+   * Kill the capture tool if this process exits without closing the backend.
+   *
+   * A child spawned by Node is NOT killed when its parent exits, so a server
+   * that shuts down without calling `stop()` would leave `dumpcap` capturing
+   * forever. This closes the common case (normal exit, `process.exit()`).
+   *
+   * It cannot close every case: a `SIGKILL`, or an unhandled `SIGTERM`/`SIGINT`
+   * with no listener, terminates the process without running `exit` handlers.
+   * Under a process supervisor that kills the whole control group (systemd's
+   * default `KillMode`) or from a terminal — where the signal reaches the whole
+   * foreground process group — the child dies with the parent anyway.
+   *
+   * The listener is removed as soon as the child is reaped, so a long-lived
+   * process that opens and closes captures does not accumulate listeners.
+   */
+  private installExitHook(child: ChildProcess): void {
+    this.clearExitHook();
+    const hook = (): void => {
+      // Must be synchronous: `exit` handlers cannot await anything.
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    };
+    this.exitHook = hook;
+    process.once("exit", hook);
+  }
+
+  private clearExitHook(): void {
+    if (this.exitHook) {
+      process.removeListener("exit", this.exitHook);
+      this.exitHook = null;
+    }
+  }
+
+  private settleExit(): void {
+    const resolveExit = this.resolveExit;
+    this.resolveExit = null;
+    resolveExit?.();
+  }
+
+  private clearStartupTimer(): void {
+    if (this.startupTimer) {
+      clearTimeout(this.startupTimer);
+      this.startupTimer = null;
+    }
+  }
+
+  private clearKillTimer(): void {
+    if (this.killTimer) {
+      clearTimeout(this.killTimer);
+      this.killTimer = null;
+    }
+  }
+}
+
+function describeExit(code: number | null, signal: NodeJS.Signals | null): string {
+  if (signal) return `killed by ${signal}`;
+  return `exit code ${code ?? "unknown"}`;
+}

--- a/server/protocols/iec61850-goose/pcap-stream.ts
+++ b/server/protocols/iec61850-goose/pcap-stream.ts
@@ -1,0 +1,281 @@
+/**
+ * Incremental (streaming) classic-libpcap decoder.
+ *
+ * {@link ./pcap.js#parsePcap} needs the whole capture in one Buffer, which is
+ * fine for a file but useless for a live capture: `dumpcap -w -` / `tcpdump -w -`
+ * write pcap to a pipe, and a pipe hands Node arbitrary chunk boundaries. A
+ * chunk can end in the middle of the 24-byte global header, in the middle of a
+ * 16-byte record header, or in the middle of packet data — at ANY byte offset.
+ *
+ * This decoder keeps the undecodable residue and resumes from it, so the byte
+ * stream is decoded identically no matter how it is sliced. The record layout
+ * and byte-order handling are NOT duplicated here: both come from
+ * {@link decodePcapRecordHeader} / {@link readPcapGlobalHeader} in pcap.ts, so a
+ * whole-buffer parse and a streaming parse cannot drift apart.
+ *
+ * BOUNDED BY CONSTRUCTION. A capture tool that is faster than the consumer, a
+ * corrupted stream, or a hostile process on the other end of the pipe must not
+ * be able to grow the internal buffer without limit:
+ *
+ *   - `maxRecordBytes` rejects a record header whose `incl_len` is larger than
+ *     any frame the capture could legitimately contain. It is checked the
+ *     instant the record header is readable, i.e. BEFORE the body is buffered.
+ *   - `maxBufferedBytes` bounds the residue that survives a decode pass.
+ *
+ * Either bound trips {@link PcapStreamOverflowError} and puts the decoder into a
+ * permanent failed state: a pcap stream has no resynchronisation marker, so
+ * once the framing is lost, every subsequent byte is meaningless. Failing
+ * closed is the only honest option.
+ *
+ * SNAPLEN TRUNCATION. When the capture was snapped (`incl_len < orig_len`) the
+ * stored bytes are a prefix of the real frame. The record still decodes — it is
+ * a valid pcap record — but it is flagged {@link StreamedPcapPacket.truncated}
+ * so the consumer can reject it instead of handing a cut-off GOOSE APDU to a
+ * BER decoder that would either throw or, worse, decode a partial dataset.
+ *
+ * Issue: #465
+ */
+
+import {
+  PCAP_GLOBAL_HEADER_LENGTH,
+  PCAP_RECORD_HEADER_LENGTH,
+  PcapParseError,
+  decodePcapRecordHeader,
+  readPcapGlobalHeader,
+  type PcapGlobalHeader,
+  type PcapPacket,
+} from "./pcap.js";
+
+/**
+ * Largest single record accepted by default: 262 144 bytes, which is dumpcap's
+ * own default snapshot length. Anything larger is a corrupt or hostile
+ * `incl_len`, not a captured frame.
+ */
+export const DEFAULT_MAX_RECORD_BYTES = 262_144;
+
+/**
+ * Largest undecodable residue kept between chunks by default. Reached only if a
+ * record header promises a large body that never fully arrives; the record
+ * bound normally trips first.
+ */
+export const DEFAULT_MAX_BUFFERED_BYTES = 8 * 1024 * 1024;
+
+/** Thrown when a stream exceeds one of the decoder's hard bounds. */
+export class PcapStreamOverflowError extends PcapParseError {
+  constructor(message: string) {
+    super(message);
+    this.name = "PcapStreamOverflowError";
+  }
+}
+
+/** A packet decoded from a stream, with its stream position and snap state. */
+export interface StreamedPcapPacket extends PcapPacket {
+  /** 0-based index of this record within the stream. */
+  index: number;
+  /**
+   * True when the capture stored fewer bytes than the frame had on the wire
+   * (`incl_len < orig_len`), i.e. the snapshot length cut the frame short.
+   * `data` then holds only the first {@link PcapPacket.capturedLength} bytes.
+   */
+  truncated: boolean;
+}
+
+export interface PcapStreamDecoderOptions {
+  /** Reject any record whose `incl_len` exceeds this. Default {@link DEFAULT_MAX_RECORD_BYTES}. */
+  maxRecordBytes?: number;
+  /** Reject when the undecodable residue exceeds this. Default {@link DEFAULT_MAX_BUFFERED_BYTES}. */
+  maxBufferedBytes?: number;
+  /**
+   * Called once, during the {@link PcapStreamDecoder.push} that completes the
+   * global header. Throwing from it aborts that push and fails the decoder —
+   * which is how a consumer rejects an unusable link type before any packet is
+   * delivered.
+   */
+  onHeader?: (header: PcapGlobalHeader) => void;
+}
+
+const EMPTY = Buffer.alloc(0);
+
+/**
+ * Feed bytes in with {@link push}; get complete packets back out.
+ *
+ * ```ts
+ * const decoder = new PcapStreamDecoder({ maxRecordBytes: 65535 });
+ * child.stdout.on("data", (chunk: Buffer) => {
+ *   for (const packet of decoder.push(chunk)) { ... }
+ * });
+ * ```
+ */
+export class PcapStreamDecoder {
+  private readonly maxRecordBytes: number;
+  private readonly maxBufferedBytes: number;
+  private readonly onHeader?: (header: PcapGlobalHeader) => void;
+
+  /** Bytes received but not yet decoded into a packet. */
+  private pending: Buffer = EMPTY;
+  private header: PcapGlobalHeader | null = null;
+  private packetIndex = 0;
+  private totalBytes = 0;
+  /** Set once the stream is unusable; every later call rethrows it. */
+  private failure: Error | null = null;
+
+  constructor(options: PcapStreamDecoderOptions = {}) {
+    this.maxRecordBytes = options.maxRecordBytes ?? DEFAULT_MAX_RECORD_BYTES;
+    this.maxBufferedBytes = options.maxBufferedBytes ?? DEFAULT_MAX_BUFFERED_BYTES;
+    this.onHeader = options.onHeader;
+    if (!(this.maxRecordBytes > 0)) {
+      throw new PcapParseError(`maxRecordBytes must be > 0, got ${this.maxRecordBytes}`);
+    }
+    if (!(this.maxBufferedBytes > 0)) {
+      throw new PcapParseError(`maxBufferedBytes must be > 0, got ${this.maxBufferedBytes}`);
+    }
+  }
+
+  /** The global header, once enough bytes have arrived to decode it. */
+  getHeader(): PcapGlobalHeader | null {
+    return this.header;
+  }
+
+  /** Bytes currently held back waiting for the rest of their record. */
+  getBufferedBytes(): number {
+    return this.pending.length;
+  }
+
+  /** Total bytes handed to {@link push}. */
+  getTotalBytes(): number {
+    return this.totalBytes;
+  }
+
+  /** Number of complete records emitted so far. */
+  getPacketCount(): number {
+    return this.packetIndex;
+  }
+
+  /** The error that put the decoder into its permanent failed state, if any. */
+  getFailure(): Error | null {
+    return this.failure;
+  }
+
+  /**
+   * Absorb a chunk and return every record that became complete because of it.
+   *
+   * A chunk that fails yields nothing at all, including any records that
+   * decoded before the failure: the stream is finished either way, and the
+   * consumer's next action is to stop the producer, not to process a partial
+   * batch from a stream it has just declared corrupt.
+   *
+   * @throws {PcapParseError} on malformed input, {@link PcapStreamOverflowError}
+   *   when a bound is exceeded. Both are permanent — the decoder cannot
+   *   resynchronise and rethrows on every subsequent call.
+   */
+  push(chunk: Buffer): StreamedPcapPacket[] {
+    if (this.failure) throw this.failure;
+    this.totalBytes += chunk.length;
+    this.pending = this.pending.length === 0 ? chunk : Buffer.concat([this.pending, chunk]);
+
+    try {
+      const packets = this.drain();
+      if (this.pending.length > this.maxBufferedBytes) {
+        throw new PcapStreamOverflowError(
+          `pcap stream buffered ${this.pending.length} undecodable bytes, ` +
+            `over the ${this.maxBufferedBytes}-byte limit`,
+        );
+      }
+      return packets;
+    } catch (err) {
+      this.fail(err);
+      throw err;
+    }
+  }
+
+  /**
+   * Declare the stream finished. Throws when the stream stopped part-way
+   * through a record or before the global header — a caller that deliberately
+   * killed the producer (e.g. `close()`) should skip this or ignore the throw.
+   */
+  end(): void {
+    if (this.failure) throw this.failure;
+    if (this.header === null) {
+      const err = new PcapParseError(
+        this.totalBytes === 0
+          ? "pcap stream ended without producing any output"
+          : `pcap stream ended after ${this.totalBytes} bytes, before the ` +
+            `${PCAP_GLOBAL_HEADER_LENGTH}-byte global header was complete`,
+      );
+      this.fail(err);
+      throw err;
+    }
+    if (this.pending.length > 0) {
+      const err = new PcapParseError(
+        `pcap stream ended mid-record: ${this.pending.length} trailing bytes after ` +
+          `${this.packetIndex} complete packet(s)`,
+      );
+      this.fail(err);
+      throw err;
+    }
+  }
+
+  /** Decode as much of `pending` as is complete. */
+  private drain(): StreamedPcapPacket[] {
+    const packets: StreamedPcapPacket[] = [];
+
+    for (;;) {
+      if (this.header === null) {
+        if (this.pending.length < PCAP_GLOBAL_HEADER_LENGTH) break;
+        // readPcapGlobalHeader detects byte order + timestamp resolution from the
+        // magic and rejects pcapng/unknown magics with an actionable message.
+        this.header = readPcapGlobalHeader(this.pending.subarray(0, PCAP_GLOBAL_HEADER_LENGTH));
+        this.consume(PCAP_GLOBAL_HEADER_LENGTH);
+        this.onHeader?.(this.header);
+        continue;
+      }
+
+      if (this.pending.length < PCAP_RECORD_HEADER_LENGTH) break;
+      const record = decodePcapRecordHeader(this.pending, 0, this.header, this.packetIndex);
+
+      // Bound BEFORE buffering the body: a corrupt or hostile incl_len must not
+      // be able to reserve memory just by being announced.
+      if (record.capturedLength > this.maxRecordBytes) {
+        throw new PcapStreamOverflowError(
+          `packet ${this.packetIndex}: incl_len ${record.capturedLength} exceeds the ` +
+            `${this.maxRecordBytes}-byte record limit — the stream is corrupt or the ` +
+            "capture tool ignored the configured snapshot length",
+        );
+      }
+
+      const total = PCAP_RECORD_HEADER_LENGTH + record.capturedLength;
+      if (this.pending.length < total) break; // body still in flight
+
+      packets.push({
+        timestampMs: record.timestampMs,
+        seconds: record.seconds,
+        subSeconds: record.subSeconds,
+        capturedLength: record.capturedLength,
+        originalLength: record.originalLength,
+        // Copy: `pending` is sliced and reassigned, and the caller keeps the frame.
+        data: Buffer.from(this.pending.subarray(PCAP_RECORD_HEADER_LENGTH, total)),
+        index: this.packetIndex,
+        truncated: record.capturedLength < record.originalLength,
+      });
+      this.packetIndex += 1;
+      this.consume(total);
+    }
+
+    return packets;
+  }
+
+  private consume(bytes: number): void {
+    // subarray is a view, so consuming never copies the remainder.
+    this.pending = bytes >= this.pending.length ? EMPTY : this.pending.subarray(bytes);
+  }
+
+  /**
+   * Enter the permanent failed state. A pcap stream carries no framing marker
+   * to resynchronise on, so anything after a framing error is noise.
+   */
+  private fail(err: unknown): void {
+    if (this.failure) return;
+    this.failure = err instanceof Error ? err : new PcapParseError(String(err));
+    this.pending = EMPTY;
+  }
+}

--- a/server/protocols/iec61850-goose/pcap.ts
+++ b/server/protocols/iec61850-goose/pcap.ts
@@ -104,6 +104,20 @@ export interface PcapFile {
   packets: PcapPacket[];
 }
 
+/** The four fixed-width fields of a per-packet record header. */
+export interface PcapRecordHeader {
+  /** Absolute capture time in ms since the Unix epoch, fractional. */
+  timestampMs: number;
+  /** Exact `ts_sec` field. */
+  seconds: number;
+  /** Exact `ts_subsec` field (µs or ns per the global header's magic). */
+  subSeconds: number;
+  /** `incl_len` — bytes of packet data stored after this header. */
+  capturedLength: number;
+  /** `orig_len` — length of the packet on the wire. */
+  originalLength: number;
+}
+
 function readU32(buf: Buffer, offset: number, order: PcapByteOrder): number {
   return order === "big" ? buf.readUInt32BE(offset) : buf.readUInt32LE(offset);
 }
@@ -168,6 +182,48 @@ export function readPcapGlobalHeader(buf: Buffer): PcapGlobalHeader {
   };
 }
 
+/** Sub-second units per second implied by the global header's magic number. */
+export function subSecondsPerSecond(header: PcapGlobalHeader): number {
+  return header.nanosecondPrecision ? 1_000_000_000 : 1_000_000;
+}
+
+/**
+ * Decode one 16-byte packet record header at `offset`.
+ *
+ * Shared by {@link parsePcap} and the incremental {@link
+ * ./pcap-stream.js#PcapStreamDecoder}, so a whole-buffer parse and a streaming
+ * parse can never disagree about the record layout or the byte order handling.
+ * The caller is responsible for having {@link PCAP_RECORD_HEADER_LENGTH} bytes
+ * available; `packetIndex` only appears in error messages.
+ */
+export function decodePcapRecordHeader(
+  buf: Buffer,
+  offset: number,
+  header: PcapGlobalHeader,
+  packetIndex: number,
+): PcapRecordHeader {
+  const perSecond = subSecondsPerSecond(header);
+  const seconds = readU32(buf, offset, header.byteOrder);
+  const subSeconds = readU32(buf, offset + 4, header.byteOrder);
+  const capturedLength = readU32(buf, offset + 8, header.byteOrder);
+  const originalLength = readU32(buf, offset + 12, header.byteOrder);
+
+  if (subSeconds >= perSecond) {
+    throw new PcapParseError(
+      `packet ${packetIndex}: sub-second field ${subSeconds} exceeds ` +
+        `${perSecond} — byte order or magic is wrong`,
+    );
+  }
+
+  return {
+    timestampMs: seconds * 1000 + (subSeconds / perSecond) * 1000,
+    seconds,
+    subSeconds,
+    capturedLength,
+    originalLength,
+  };
+}
+
 /**
  * Parse a complete classic-pcap buffer into its header and packet records.
  *
@@ -178,7 +234,6 @@ export function readPcapGlobalHeader(buf: Buffer): PcapGlobalHeader {
 export function parsePcap(buf: Buffer): PcapFile {
   const header = readPcapGlobalHeader(buf);
   const packets: PcapPacket[] = [];
-  const subSecondsPerSecond = header.nanosecondPrecision ? 1_000_000_000 : 1_000_000;
 
   let offset = PCAP_GLOBAL_HEADER_LENGTH;
   while (offset < buf.length) {
@@ -188,34 +243,25 @@ export function parsePcap(buf: Buffer): PcapFile {
           `(${buf.length - offset} of ${PCAP_RECORD_HEADER_LENGTH} bytes)`,
       );
     }
-    const seconds = readU32(buf, offset, header.byteOrder);
-    const subSeconds = readU32(buf, offset + 4, header.byteOrder);
-    const capturedLength = readU32(buf, offset + 8, header.byteOrder);
-    const originalLength = readU32(buf, offset + 12, header.byteOrder);
+    const record = decodePcapRecordHeader(buf, offset, header, packets.length);
     offset += PCAP_RECORD_HEADER_LENGTH;
 
-    if (subSeconds >= subSecondsPerSecond) {
+    if (offset + record.capturedLength > buf.length) {
       throw new PcapParseError(
-        `packet ${packets.length}: sub-second field ${subSeconds} exceeds ` +
-          `${subSecondsPerSecond} — byte order or magic is wrong`,
-      );
-    }
-    if (offset + capturedLength > buf.length) {
-      throw new PcapParseError(
-        `truncated packet ${packets.length}: incl_len ${capturedLength} at offset ` +
+        `truncated packet ${packets.length}: incl_len ${record.capturedLength} at offset ` +
           `${offset} exceeds the ${buf.length}-byte file`,
       );
     }
 
     packets.push({
-      timestampMs: seconds * 1000 + (subSeconds / subSecondsPerSecond) * 1000,
-      seconds,
-      subSeconds,
-      capturedLength,
-      originalLength,
-      data: Buffer.from(buf.subarray(offset, offset + capturedLength)),
+      timestampMs: record.timestampMs,
+      seconds: record.seconds,
+      subSeconds: record.subSeconds,
+      capturedLength: record.capturedLength,
+      originalLength: record.originalLength,
+      data: Buffer.from(buf.subarray(offset, offset + record.capturedLength)),
     });
-    offset += capturedLength;
+    offset += record.capturedLength;
   }
 
   return { header, packets };
@@ -257,7 +303,7 @@ export function encodePcap(
   const nanosecondPrecision = options.nanosecondPrecision ?? false;
   const snapLen = options.snapLen ?? 65535;
   const linkType = options.linkType ?? LINKTYPE_ETHERNET;
-  const subSecondsPerSecond = nanosecondPrecision ? 1_000_000_000 : 1_000_000;
+  const perSecond = nanosecondPrecision ? 1_000_000_000 : 1_000_000;
 
   const writeU32 = (target: Buffer, offset: number, value: number): void => {
     if (byteOrder === "big") target.writeUInt32BE(value >>> 0, offset);
@@ -285,12 +331,10 @@ export function encodePcap(
     // Split seconds from sub-seconds without ever multiplying an epoch-scale
     // millisecond value by 1e6, which would exceed Number.MAX_SAFE_INTEGER.
     let seconds = Math.floor(packet.timestampMs / 1000);
-    let subSeconds = Math.round(
-      (packet.timestampMs - seconds * 1000) * (subSecondsPerSecond / 1000),
-    );
-    if (subSeconds >= subSecondsPerSecond) {
+    let subSeconds = Math.round((packet.timestampMs - seconds * 1000) * (perSecond / 1000));
+    if (subSeconds >= perSecond) {
       seconds += 1;
-      subSeconds -= subSecondsPerSecond;
+      subSeconds -= perSecond;
     }
 
     const recordHeader = Buffer.alloc(PCAP_RECORD_HEADER_LENGTH);


### PR DESCRIPTION
Closes the one acceptance criterion of #465 that #600 left open: *"Raw Ethernet socket on configurable interface (eth0 default); filters ethertype 0x88B8"*. Until now nothing in this repository had ever captured a live frame.

## Approach

Live capture is done **out of process**, so there is no native addon, no `node-gyp` and no new npm dependency. `GooseLiveCaptureBackend` spawns a libpcap CLI tool that streams classic pcap on stdout:

```
dumpcap -i eth0 -P -q -s 65535 -w - -f '<bpf>'     # preferred
tcpdump -i eth0 -U -n -s 65535 -w - '<bpf>'        # fallback
```

libpcap opens the raw capture socket (`AF_PACKET`/`SOCK_RAW` on Linux, BPF devices on the BSDs) **inside the tool**, binds it to the configured interface, and attaches the EtherType filter as a kernel BPF program. Node reads the resulting pcap over a pipe. The privilege requirement therefore lands on the capture tool, not on the Node process, and the pcap machinery #600 already tested is reused.

`-P` (dumpcap) is mandatory — modern dumpcap defaults to pcapNG. `-U` (tcpdump) is mandatory — without packet-buffered output frames sit in a 4 KiB stdio buffer, which is unacceptable for a sub-4 ms protocol. `-s`/`-f` are placed after `-i` so they bind to that interface rather than acting as global defaults.

## What's new

**`pcap-stream.ts` — `PcapStreamDecoder`.** `parsePcap()` needs the whole capture in one Buffer; a pipe hands over arbitrary chunk boundaries. This decoder resumes correctly from a cut at **any** byte offset — inside the global header, inside a record header, inside packet data. It reuses `readPcapGlobalHeader` / the new `decodePcapRecordHeader` from `pcap.ts` (both byte orders, µs and ns magics) rather than duplicating the layout, flags snaplen truncation (`incl_len < orig_len`) so a cut-off GOOSE frame is rejected rather than half-decoded, and is **bounded**: an oversized `incl_len` is rejected before its body is buffered, and the undecodable residue is capped. A bound breach or framing error fails closed and stays failed — pcap has no resynchronisation marker.

**`live-backend.ts` — the backend.**
- `availability()` is truthful and never throws. It names an unsupported platform (Windows capture is Npcap-based and is not implemented here), or that no capture tool is installed, or the exact command it would run. It explicitly does **not** claim the process holds `CAP_NET_RAW` — only the kernel can answer that.
- `open()` spawns with an **argv array and no shell**, and resolves only once the pcap global header has been decoded. libpcap writes it when the capture handle is open, so `start()` reporting `"running"` means capture genuinely started rather than "we launched something".
- Failures are diagnosed distinctly: spawn `ENOENT` → "capture tool not found"; non-zero exit → the tool's stderr verbatim; permission denial → recognised and answered with the `setcap cap_net_raw,cap_net_admin+eip` / `wireshark`-group remedy; a bad interface name → called out as such; a silent tool → abandoned after a startup timeout.
- `close()` kills the child (SIGTERM → SIGKILL after a grace period), waits for it to be reaped, and is safe twice or when `open()` was never called. A bounded `process.on("exit")` hook — removed as soon as the child is reaped, so listeners never accumulate — covers a shutdown that forgets to call it.
- A non-Ethernet link type (`-i any` → `LINKTYPE_LINUX_SLL`) is refused explicitly.
- **Nothing is ever fabricated.** If capture cannot start there are no frames and no synthetic values.

**The VLAN-aware BPF filter.** `ether proto 0x88b8` alone is *wrong* for a substation bus: it compares at Ethernet offset 12, which on an 802.1Q frame holds the tag's TPID — the real EtherType has moved to offset 16. Since GOOSE is normally published on a dedicated priority-tagged VLAN, that filter silently drops exactly the traffic you subscribed to. The filter used is:

```
ether proto 0x88b8 or (vlan and ether proto 0x88b8)
```

Per `pcap-filter(7)` the first `vlan` in an expression re-bases every offset *after* it by 4 bytes, so the terms are not interchangeable — the untagged term must come first. Exactly one tag is unwrapped, matching what `readFrameEtherType()` and the frame parser decode (no QinQ). Every delivered frame is re-checked with `isGooseFrame()`, so a mis-set `GOOSE_CAPTURE_FILTER` cannot feed non-GOOSE traffic into the BER decoder.

## Configuration — default behaviour is unchanged

`GOOSE_CAPTURE=none|pcap|live` (Zod-validated) plus `GOOSE_CAPTURE_TOOL`, `GOOSE_CAPTURE_TOOL_PATH`, `GOOSE_CAPTURE_SNAPLEN`, `GOOSE_CAPTURE_FILTER`; `GOOSE_IFACE` is now genuinely used and still defaults to `eth0`. `GOOSE_PCAP_FILE` alone still selects replay, an environment with none of these still selects no capture at all, and **live capture is never chosen implicitly** — setting every other `GOOSE_CAPTURE_*` variable without `GOOSE_CAPTURE=live` still yields the null backend. `startGooseSubscriber()` also returns before constructing any backend when no subscriptions are configured.

## Tests (+86, 0 regressions)

`npx tsc --noEmit` exits 0. Full suite: **149 files / 3095 tests passing** (baseline on this host, measured on `origin/main` in a clean worktree: 147 files / 3009 tests — note this differs from the 152/3081 quoted in the tracking issue).

The hard part is proving live capture works without a substation. The backend is pointed at a **fake capture command** — `process.execPath -e <script>` emitting a known pcap byte stream on stdout — which exercises the real spawn → stdout stream → incremental decode → EtherType filter → frame handler → subscriber path. No module is mocked anywhere in this suite. Covered: multi-frame streaming at pathological chunk sizes, genuinely separate pipe chunks, both byte orders and the ns magic, **a VLAN-tagged frame delivered byte-identically with the QinQ boundary asserted**, truncated-frame rejection, non-GOOSE filtered out, the buffer bound during *and* after startup, `ENOENT`, non-zero exit with stderr surfaced, the permission-denied message, the startup timeout, `close()` reaping the child, double-close, reopen, no exit-listener accumulation, and `availability()` asserted truthfully on the actual host platform. The end-to-end case runs a `GooseSubscriber` over the fake command and asserts the tag updates and the existing Prometheus counters (`scada_goose_frames_received_total` +3, mean `goose_round_trip_us` inside the 4 ms budget).

The stream decoder is checked against `parsePcap()` for **every** single split point of a multi-packet capture, **every pair** of split points of a small one, and a byte-at-a-time feed.

## What is *not* verified

Stated plainly here and in `docs/protocols/iec61850-goose.md`:

- **No frame has ever been captured from a real IED or a real substation bus.** No such hardware is available. The live tests use a fake capture command; the code on this side of the pipe is real, the bus is not.
- The `dumpcap`/`tcpdump` argument vectors and the BPF filter have **not** been run against a real libpcap — CI has no capture privileges and no GOOSE traffic. They are written from the tools' documented behaviour. If a tool rejects the filter or an argument it exits and its stderr is surfaced verbatim; that path *is* tested. In particular the readiness signal assumes the tool flushes the pcap global header before the first packet; if it does not, a quiet bus would produce a spurious startup timeout (loud, not silent), and `startupTimeoutMs` is currently not exposed as an environment variable.
- Timing under real load is unmeasured. On the live backend `goose_round_trip_us` is publisher `t` → **kernel capture time**, deliberately excluding the tool's buffering, the pipe and the event loop; that semantic difference is documented.
- The committed replay capture remains synthetic.

The docs also cover the host requirements, how to grant `CAP_NET_RAW` (packaged `dpkg-reconfigure wireshark-common` route and `setcap`, plus systemd `AmbientCapabilities`), the VLAN reasoning, and the orphaned-child limitation under `SIGKILL`.

Nothing #600 delivered is regressed or weakened: the null backend still reports unavailable truthfully, pcap replay is untouched, and `pcap.ts`'s public API and tests are unchanged (it only gained a shared `decodePcapRecordHeader` that `parsePcap` now calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)