### PR TITLE
feat(nodes): persisted observed-liveness feed so the what-if simulator runs on real history (#456)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,12 +183,44 @@ BLUEPRINT_SAFETY_BINDINGS=
 # rather than being armed with a safe state it could not apply.
 BLUEPRINT_SAFE_STATE_ALLOW_OUTPUT_WRITES=false
 
+# Observed-liveness collector (Issue #456)
+# OFF by default. Set to exactly "true" (no truthy coercion) to poll every node
+# in ANCHOR_NODE_URLS above on a cadence and persist, per round, whether the
+# node answered and whether the chain height it reported advanced. Those rows
+# are the "actual history" the what-if slashing simulator replays a proposed
+# rule against, and they make GET /api/nodes/attestation-history serve
+# synthetic:false instead of 503.
+#
+# READ THIS BEFORE ENABLING. What is recorded is OBSERVED LIVENESS, not
+# consensus attestation. Consensus attestation duty history does not exist in
+# this build: the oxscada /status surface reports height, peers, mempool,
+# uptime ticks and Kuramoto phase and carries no per-slot duty outcome. For this
+# source:
+#   miss = the node did not answer that poll round
+#   hit  = it answered and the height it reported advanced
+#   late = it answered but the height did not advance (or it was the first
+#          observation, which cannot demonstrate progress)
+# Every API response states this in a machine-readable `observation` descriptor
+# and the UI renders it. Do not read a "miss" here as a missed duty.
+#
+# With this unset, no timer is armed, no poll happens, no row is written, and
+# the live endpoint fails closed exactly as before.
+VALIDATOR_LIVENESS_COLLECTOR_ENABLED=false
+# Poll cadence in ms. Clamped to 5000..3600000. Note that a cadence shorter than
+# the chain's block interval will legitimately produce "late" (no height
+# advance) observations.
+VALIDATOR_LIVENESS_POLL_INTERVAL_MS=60000
+# How long observations are kept before the collector prunes them, in ms.
+# Clamped to 3600000..2592000000. Default 604800000 = 7 days, which is the
+# longest window the visualizer offers — keeping more grows the table for no
+# operator benefit, keeping less silently shortens the 7d view.
+VALIDATOR_LIVENESS_RETENTION_MS=604800000
+
 # Slashing & Liveness Visualizer synthetic demo data (Issue #456)
-# This build has NO live per-validator attestation feed, so
-# GET /api/nodes/attestation-history fails closed with 503 and never returns
-# generated records. Setting this to exactly "true" additionally exposes
-# GET /api/nodes/attestation-history/demo, which serves seeded-PRNG output for
-# exercising the what-if slashing simulator. That data is FABRICATED — it is
-# labelled synthetic in the body, per validator and in response headers, and it
-# must never be enabled where an operator could act on it.
+# Independent of the collector above and unaffected by it. Setting this to
+# exactly "true" exposes GET /api/nodes/attestation-history/demo, which serves
+# seeded-PRNG output for exercising the what-if slashing simulator. That data is
+# FABRICATED — it is labelled synthetic in the body, per validator and in
+# response headers, and it must never be enabled where an operator could act on
+# it. The live endpoint never falls back to it, whatever this is set to.
 SLASHING_DEMO_DATA=false

--- a/client/src/pages/SlashingVisualizer.tsx
+++ b/client/src/pages/SlashingVisualizer.tsx
@@ -1,8 +1,10 @@
 /**
  * Slashing & Liveness Visualizer (issue #456).
  *
- * Per-validator attestation participation timeline (hits / misses / late) over a
- * selectable window (1h / 24h / 7d), with consecutive-miss "liveness fault" runs
+ * Per-validator participation timeline (hits / misses / late) over a selectable
+ * window (1h / 24h / 7d) — of whatever the loaded source measured, which in this
+ * build is observed liveness, not consensus attestation duties — with
+ * consecutive-miss "liveness fault" runs
  * highlighted, plus a "what-if" slashing-rule simulator. The operator types a
  * proposed rule (e.g. "slash 1% per miss after 10 in 1h"); the UI projects the
  * hypothetical penalties against the loaded history.
@@ -11,12 +13,19 @@
  * server state. All penalty math is delegated to the pure simulator in
  * ../lib/slashing-simulator so it can be unit-tested independently of the UI.
  *
- * PROVENANCE. There is no live attestation feed in this build (see
- * server/routes/nodes.ts). The page therefore starts by asking the LIVE
- * endpoint, and when that fails closed it says so plainly instead of drawing a
- * chart. Synthetic demo data must be requested deliberately, and whenever it is
- * loaded the page is covered in unmistakable "SYNTHETIC" markings: a sticky
- * banner, a per-validator badge, a watermarked timeline and a modified heading.
+ * PROVENANCE. The page starts by asking the LIVE endpoint, and when that fails
+ * closed it says so plainly instead of drawing a chart. Synthetic demo data
+ * must be requested deliberately, and whenever it is loaded the page is covered
+ * in unmistakable "SYNTHETIC" markings: a sticky banner, a per-validator badge,
+ * a watermarked timeline and a modified heading.
+ *
+ * SEMANTICS. Consensus attestation duty history is unavailable in this build.
+ * The live source it can serve is OBSERVED LIVENESS — whether each configured
+ * node answered a poll round and whether the height it reported advanced — so
+ * every live response carries a descriptor and this page renders it above the
+ * timelines. `hit` / `miss` / `late` are ambiguous words on their own, and an
+ * operator must never read "the node did not answer this poll round" as a
+ * missed consensus duty.
  */
 
 import React from "react";
@@ -27,7 +36,9 @@ import {
   type TimelineBucket,
 } from "../lib/slashing-simulator";
 import type {
+  AttestationSourceDescriptor,
   AttestationSourceUnavailableResponse,
+  LiveAttestationHistoryResponse,
   SimulationResult,
   SlashingRule,
   SyntheticAttestationHistoryResponse,
@@ -54,19 +65,16 @@ const C = {
 const LIVE_HISTORY_PATH = "/api/nodes/attestation-history";
 const DEMO_HISTORY_PATH = "/api/nodes/attestation-history/demo";
 
-/** Live payload shape (served only once a real feed is registered server-side). */
-interface LiveHistoryResponse {
-  synthetic: false;
-  demo: false;
-  provenance: "live";
-  source: string;
-  window: TimelineWindow;
-  validators: ValidatorHistory[];
-}
-
 /** What the page currently holds, discriminated by provenance. */
 type LoadedHistory =
-  | { kind: "live"; window: TimelineWindow; anchorMs: number; validators: ValidatorHistory[]; source: string }
+  | {
+      kind: "live";
+      window: TimelineWindow;
+      anchorMs: number;
+      validators: ValidatorHistory[];
+      source: string;
+      observation: AttestationSourceDescriptor;
+    }
   | {
       kind: "synthetic";
       window: TimelineWindow;
@@ -168,6 +176,99 @@ const SyntheticBanner: React.FC<{ notice: string; generator: string; seed: numbe
   </div>
 );
 
+/** Human-friendly cadence/retention rendering, e.g. "60s" / "7d". */
+function formatMs(ms: number | null): string {
+  if (ms === null) return "event-driven";
+  if (ms >= 24 * 60 * 60 * 1000) return `${(ms / (24 * 60 * 60 * 1000)).toFixed(0)}d`;
+  if (ms >= 60 * 60 * 1000) return `${(ms / (60 * 60 * 1000)).toFixed(0)}h`;
+  if (ms >= 1000) return `${(ms / 1000).toFixed(0)}s`;
+  return `${ms}ms`;
+}
+
+/**
+ * What the live source actually measured, and what each status means for it.
+ *
+ * This panel is not decoration. `miss` from the observed-liveness source means
+ * "the node did not answer this poll round" — it is NOT a missed consensus
+ * attestation duty, and nothing else on the page would tell an operator that.
+ */
+const ObservationSemantics: React.FC<{ descriptor: AttestationSourceDescriptor }> = ({
+  descriptor,
+}) => {
+  const isConsensus = descriptor.kind === "consensus-attestation";
+  return (
+    <div
+      data-testid="observation-descriptor"
+      style={{
+        backgroundColor: C.panel,
+        border: `1px solid ${isConsensus ? C.border : C.accent}`,
+        borderRadius: 8,
+        padding: 16,
+        marginBottom: 20,
+      }}
+    >
+      <div style={{ fontSize: 15, fontWeight: "bold", marginBottom: 6 }}>
+        Data source: <code>{descriptor.sourceId}</code> — {descriptor.kind}
+      </div>
+      <p style={{ color: C.muted, fontSize: 13, margin: "0 0 10px", lineHeight: 1.6 }}>
+        {descriptor.summary}
+      </p>
+      <div style={{ fontSize: 12, color: C.muted, marginBottom: 10 }}>
+        Measured by <code>{descriptor.method.transport}</code>{" "}
+        <code>{descriptor.method.endpoint}</code> every{" "}
+        <strong style={{ color: C.text }}>{formatMs(descriptor.method.pollIntervalMs)}</strong>
+        {" · "}fields <code>{descriptor.method.fields.join(", ")}</code>
+        {" · "}retained {formatMs(descriptor.method.retentionMs)}
+        {" · "}{descriptor.roundIdentifier.meaning}
+      </div>
+      <dl style={{ margin: 0, fontSize: 13, lineHeight: 1.6 }}>
+        {(
+          [
+            ["Hit", descriptor.statusSemantics.hit, C.hit],
+            ["Late", descriptor.statusSemantics.late, C.late],
+            ["Miss", descriptor.statusSemantics.miss, C.miss],
+          ] as const
+        ).map(([term, definition, color]) => (
+          <div key={term} style={{ display: "flex", gap: 10, marginBottom: 4 }}>
+            <dt
+              style={{
+                color,
+                fontWeight: "bold",
+                minWidth: 44,
+                flexShrink: 0,
+              }}
+            >
+              {term}
+            </dt>
+            <dd style={{ margin: 0, color: C.muted }}>{definition}</dd>
+          </div>
+        ))}
+      </dl>
+      {!descriptor.consensusAttestation.available && (
+        <div
+          data-testid="no-consensus-attestation"
+          style={{
+            marginTop: 10,
+            paddingTop: 10,
+            borderTop: `1px solid ${C.border}`,
+            fontSize: 12,
+            color: C.late,
+            lineHeight: 1.6,
+          }}
+        >
+          <strong>Consensus attestation duty history is not available.</strong>{" "}
+          {descriptor.consensusAttestation.note}
+        </div>
+      )}
+      {!descriptor.stake.available && (
+        <div style={{ marginTop: 8, fontSize: 12, color: C.muted, lineHeight: 1.6 }}>
+          {descriptor.stake.note}
+        </div>
+      )}
+    </div>
+  );
+};
+
 // --- per-validator card --------------------------------------------------------
 
 const ValidatorCard: React.FC<{
@@ -176,7 +277,22 @@ const ValidatorCard: React.FC<{
   rule: SlashingRule;
   anchorMs: number;
   synthetic: boolean;
-}> = ({ history, window, rule, anchorMs, synthetic }) => {
+  /**
+   * Whether `history.stake` is a measured value. The observed-liveness source
+   * has no stake to read, so absolute penalty amounts are suppressed rather
+   * than rendered as a confident "≈ 0 stake".
+   */
+  stakeAvailable: boolean;
+  /**
+   * True when the live source declared `kind: "observed-liveness"`.
+   *
+   * "Duties" and "slots" are CONSENSUS vocabulary. Applying them to poll
+   * observations would re-introduce, one line below the descriptor panel, the
+   * exact confusion that panel exists to prevent — so the card counts poll
+   * rounds when that is what the records are.
+   */
+  observedLiveness: boolean;
+}> = ({ history, window, rule, anchorMs, synthetic, stakeAvailable, observedLiveness }) => {
   // Restrict to the selected window, then project the rule (pure).
   const result: SimulationResult = React.useMemo(
     () => simulateRule(history, rule, window, anchorMs),
@@ -229,15 +345,23 @@ const ValidatorCard: React.FC<{
           )}
         </div>
         <div style={{ fontSize: 13, color: C.muted }}>
-          {synthetic ? "Notional stake" : "Stake"}:{" "}
-          <strong style={{ color: C.text }}>{history.stake.toLocaleString()}</strong>
+          {stakeAvailable ? (
+            <>
+              {synthetic ? "Notional stake" : "Stake"}:{" "}
+              <strong style={{ color: C.text }}>{history.stake.toLocaleString()}</strong>
+            </>
+          ) : (
+            <span data-testid="stake-not-observed">Stake: not observed</span>
+          )}
         </div>
       </div>
 
       {/* participation stats */}
       <div style={{ display: "flex", gap: 24, fontSize: 13, marginBottom: 12 }}>
         <span>Participation: <strong style={{ color: rateColor }}>{ratePct}%</strong></span>
-        <span style={{ color: C.muted }}>Duties: {summary.total}</span>
+        <span style={{ color: C.muted }}>
+          {observedLiveness ? "Poll rounds" : "Duties"}: {summary.total}
+        </span>
         <span style={{ color: C.hit }}>Hits: {summary.hits}</span>
         <span style={{ color: C.late }}>Late: {summary.late}</span>
         <span style={{ color: C.miss }}>Misses: {summary.misses}</span>
@@ -280,7 +404,8 @@ const ValidatorCard: React.FC<{
                 marginBottom: 4,
               }}
             >
-              {run.length} consecutive misses — slots {run.startSlot}…{run.endSlot}
+              {run.length} consecutive misses — {observedLiveness ? "poll rounds" : "slots"}{" "}
+              {run.startSlot}…{run.endSlot}
               {"  "}
               <span style={{ color: C.muted }}>
                 ({new Date(run.startTimestamp).toLocaleTimeString()} → {new Date(run.endTimestamp).toLocaleTimeString()})
@@ -306,9 +431,15 @@ const ValidatorCard: React.FC<{
           <span style={{ fontSize: 28, fontWeight: "bold", color: result.totalPenaltyPct > 0 ? C.miss : C.hit }}>
             {result.totalPenaltyPct.toFixed(2)}%
           </span>
-          <span style={{ fontSize: 14, color: C.muted }}>
-            ≈ {result.totalPenaltyAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })} stake
-          </span>
+          {stakeAvailable ? (
+            <span style={{ fontSize: 14, color: C.muted }}>
+              ≈ {result.totalPenaltyAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })} stake
+            </span>
+          ) : (
+            <span style={{ fontSize: 13, color: C.muted, fontStyle: "italic" }}>
+              absolute amount not computed — no stake was observed
+            </span>
+          )}
           <span style={{ fontSize: 13, color: C.muted }}>
             {result.penalties.filter((p) => p.penaltyPct > 0).length} penalised miss(es)
           </span>
@@ -384,7 +515,7 @@ const SlashingVisualizer: React.FC = () => {
           return;
         }
 
-        const body = (await res.json()) as LiveHistoryResponse;
+        const body = (await res.json()) as LiveAttestationHistoryResponse;
         if (cancelled) return;
         setUnavailable(null);
         setHistory({
@@ -397,6 +528,7 @@ const SlashingVisualizer: React.FC = () => {
           }, 0) || Date.now(),
           validators: body.validators,
           source: body.source,
+          observation: body.observation,
         });
       } catch (e: unknown) {
         if (!cancelled) {
@@ -429,6 +561,13 @@ const SlashingVisualizer: React.FC = () => {
 
   const isSynthetic = history?.kind === "synthetic";
   const anchorMs = history?.anchorMs ?? Date.now();
+  const descriptor = history?.kind === "live" ? history.observation : null;
+  // Synthetic profiles carry a notional stake; a live source only has one if it
+  // says so. Absent a claim, absolute amounts are not rendered.
+  const stakeAvailable = isSynthetic || (descriptor?.stake.available ?? false);
+  // Only an observed-liveness source counts poll rounds; a real duty feed (or
+  // the synthetic profiles, which imitate one) keeps the consensus wording.
+  const observedLiveness = descriptor?.kind === "observed-liveness";
 
   return (
     <div style={{ padding: 24, backgroundColor: C.bg, color: C.text, minHeight: "100vh" }}>
@@ -450,8 +589,9 @@ const SlashingVisualizer: React.FC = () => {
           )}
         </h1>
         <p style={{ color: C.muted, fontSize: 15, margin: 0 }}>
-          Per-validator attestation participation, liveness-fault detection, and a what-if
-          slashing-rule simulator. Read-only — nothing is slashed.
+          {descriptor && descriptor.kind === "observed-liveness"
+            ? "Per-validator OBSERVED LIVENESS, liveness-fault detection, and a what-if slashing-rule simulator. These records are poll observations, not consensus attestation duties. Read-only — nothing is slashed."
+            : "Per-validator attestation participation, liveness-fault detection, and a what-if slashing-rule simulator. Read-only — nothing is slashed."}
         </p>
       </div>
 
@@ -599,6 +739,9 @@ const SlashingVisualizer: React.FC = () => {
         </div>
       )}
 
+      {/* What the live source measured, and what each status means for it. */}
+      {!loading && !error && descriptor && <ObservationSemantics descriptor={descriptor} />}
+
       {!loading && !error && history && history.validators.length === 0 && (
         <div style={{ color: C.muted }}>No validators reported.</div>
       )}
@@ -614,6 +757,8 @@ const SlashingVisualizer: React.FC = () => {
             rule={rule}
             anchorMs={anchorMs}
             synthetic={isSynthetic}
+            stakeAvailable={stakeAvailable}
+            observedLiveness={observedLiveness}
           />
         ))}
 

--- a/client/src/pages/__tests__/SlashingVisualizer.test.tsx
+++ b/client/src/pages/__tests__/SlashingVisualizer.test.tsx
@@ -2,9 +2,13 @@
  * UI provenance tests for the Slashing & Liveness Visualizer (issue #456).
  *
  * The rejected implementation drew a chart from PRNG output with nothing in the
- * UI to say so. These tests assert the two user-visible halves of the fix:
+ * UI to say so. These tests assert the user-visible halves of the fix:
  *  - when the live source is unavailable the page says so and draws no chart,
- *  - when synthetic demo data is loaded the page is unmistakably marked.
+ *  - when synthetic demo data is loaded the page is unmistakably marked,
+ *  - when a live OBSERVED-LIVENESS source is served, the page states what was
+ *    measured and what `miss` means for it. That last one is not cosmetic: an
+ *    operator must never read "the node did not answer this poll round" as a
+ *    missed consensus attestation duty.
  */
 
 import React from "react";
@@ -14,6 +18,7 @@ import SlashingVisualizer from "../SlashingVisualizer";
 import {
   SYNTHETIC_ATTESTATION_NOTICE,
   type AttestationSourceUnavailableResponse,
+  type LiveAttestationHistoryResponse,
   type SyntheticAttestationHistoryResponse,
 } from "@shared/types/slashing";
 
@@ -69,6 +74,60 @@ function jsonResponse(body: unknown, status: number): Response {
   } as unknown as Response;
 }
 
+function liveBody(): LiveAttestationHistoryResponse {
+  return {
+    synthetic: false,
+    demo: false,
+    provenance: "live",
+    source: "oxscada-observed-liveness",
+    window: "24h",
+    observation: {
+      kind: "observed-liveness",
+      sourceId: "oxscada-observed-liveness",
+      summary:
+        "Observed liveness of each configured oxscada node: whether it answered " +
+        "each poll round, and whether the chain height it reported advanced.",
+      method: {
+        transport: "http-get",
+        endpoint: "/status",
+        fields: ["height", "uptime_ticks"],
+        pollIntervalMs: 60_000,
+        retentionMs: 7 * 24 * 60 * 60 * 1000,
+        maxRecordsPerQuery: 100_000,
+      },
+      statusSemantics: {
+        hit: "The node answered this poll round and the height it reported advanced.",
+        miss: "The node did not answer this poll round.",
+        late: "The node answered but the height it reported did not advance.",
+      },
+      roundIdentifier: {
+        field: "slot",
+        meaning: "Monotonic ordinal of the poll round — not a consensus slot.",
+      },
+      stake: {
+        available: false,
+        note: "No stake source exists in this build, so stake is reported as 0.",
+      },
+      consensusAttestation: {
+        available: false,
+        note: "The oxscada /status surface exposes no per-slot duty outcome.",
+      },
+    },
+    validators: [
+      {
+        validatorId: "10.0.0.11:9090",
+        label: "10.0.0.11:9090 (observed liveness)",
+        stake: 0,
+        records: [
+          { slot: 1, timestamp: ANCHOR - 120_000, status: "late", observedHeight: 900 },
+          { slot: 2, timestamp: ANCHOR - 60_000, status: "miss", observedHeight: null },
+          { slot: 3, timestamp: ANCHOR, status: "hit", observedHeight: 901 },
+        ],
+      },
+    ],
+  };
+}
+
 /** Route the page's two endpoints to canned responses. */
 function stubFetch(demoAvailable: boolean): void {
   vi.stubGlobal(
@@ -81,6 +140,11 @@ function stubFetch(demoAvailable: boolean): void {
       return jsonResponse(unavailableBody(demoAvailable), 503);
     }),
   );
+}
+
+/** Serve the live endpoint an observed-liveness payload. */
+function stubLiveFetch(): void {
+  vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(liveBody(), 200)));
 }
 
 afterEach(() => {
@@ -131,5 +195,58 @@ describe("SlashingVisualizer provenance", () => {
     // The unavailable panel is gone, and the simulator actually ran.
     expect(screen.queryByTestId("no-live-source")).toBeNull();
     expect(screen.getByText(/Aurora \(demo\)/)).toBeTruthy();
+  });
+});
+
+describe("SlashingVisualizer live observed-liveness semantics", () => {
+  it("states what was measured and what each status means", async () => {
+    stubLiveFetch();
+    render(<SlashingVisualizer />);
+
+    const panel = await screen.findByTestId("observation-descriptor");
+
+    // Which source, and what class of thing it measured.
+    expect(panel.textContent).toContain("oxscada-observed-liveness");
+    expect(panel.textContent).toContain("observed-liveness");
+    // How it was measured, and how often.
+    expect(panel.textContent).toContain("/status");
+    expect(panel.textContent).toContain("60s");
+    // The status definitions verbatim from the server — this is the line that
+    // stops a "miss" being read as a missed consensus duty.
+    expect(panel.textContent).toContain("The node did not answer this poll round.");
+    expect(panel.textContent).toContain("the height it reported did not advance");
+    // And the plain statement that duty history is still unavailable.
+    expect(
+      screen.getByTestId("no-consensus-attestation").textContent,
+    ).toContain("Consensus attestation duty history is not available");
+  });
+
+  it("counts poll rounds rather than consensus duties", async () => {
+    stubLiveFetch();
+    render(<SlashingVisualizer />);
+
+    await screen.findByTestId("observation-descriptor");
+
+    // "Duties" is consensus vocabulary. These records are poll observations, and
+    // saying "Duties" one line below the descriptor panel would re-introduce the
+    // exact confusion that panel exists to prevent.
+    expect(screen.getByText(/Poll rounds: 3/)).toBeTruthy();
+    expect(screen.queryByText(/Duties:/)).toBeNull();
+  });
+
+  it("renders the projection without a fabricated stake amount", async () => {
+    stubLiveFetch();
+    render(<SlashingVisualizer />);
+
+    await screen.findByTestId("observation-descriptor");
+
+    expect(screen.getByTestId("stake-not-observed").textContent).toBe("Stake: not observed");
+    expect(screen.getByText(/absolute amount not computed/)).toBeTruthy();
+    // The simulator still ran over the real records...
+    expect(screen.getByText(/10\.0\.0\.11:9090 \(observed liveness\)/)).toBeTruthy();
+    // ...and nothing is marked synthetic, because nothing here is.
+    expect(screen.queryByTestId("synthetic-data-banner")).toBeNull();
+    expect(screen.queryByTestId("synthetic-badge")).toBeNull();
+    expect(screen.queryByTestId("no-live-source")).toBeNull();
   });
 });

--- a/docs/api/attestation-history.md
+++ b/docs/api/attestation-history.md
@@ -11,48 +11,112 @@ Both endpoints require an operator API key via the `X-API-Key` header
 
 ---
 
-## There is no live attestation feed in this build
+## There is still no consensus attestation feed in this build
 
 This is stated plainly because the previous implementation of this endpoint
 served pseudo-random numbers as if they were measurements, and that was rejected
 under the repository's Integrity Rule.
 
-The tree was searched for a real per-validator attestation source. There is none:
+The tree was searched for a real per-validator **attestation duty** source. There
+is none, and nothing below changes that:
 
 | Candidate | Why it is not an attestation feed |
 |---|---|
-| `server/blockchain/validator-health.ts` | Real and tested, but polls the oxscada node `GET /status`, whose schema is `height` / `peers` / `mempool` / Kuramoto phase / `uptime_ticks`. No per-slot duty outcome. Keeps only the latest sample — no history. Not constructed anywhere in production code. |
+| `server/blockchain/validator-health.ts` | Real and tested, but polls the oxscada node `GET /status`, whose schema is `height` / `peers` / `mempool` / Kuramoto phase / `uptime_ticks`. No per-slot duty outcome. Keeps only the latest sample — no history. |
 | `server/blockchain.ts` | A declared stub: `isConnected()` returns `false`, `getBlockchainHealth()` reports `"Not implemented"`. Chain integration is opt-in via `ENABLE_BLOCKCHAIN` and exposes no attestation RPC. |
-| `shared/schema.ts` + `migrations/` | No attestations table. |
+| Cross-node state proxy (#454) | A point-in-time signed read of one state key. Not a per-slot duty log. |
 | `server/batch-anchoring.ts` | Anchors Merkle roots of **industrial events**, not validator duties. |
 
-Consequently the live endpoint fails closed, and the only history this build can
-produce is explicitly-requested synthetic demo data.
+## What this build *can* observe: observed liveness
+
+`server/blockchain/liveness-collector.ts` polls every node in
+`ANCHOR_NODE_URLS` on a cadence and persists the result of each round to
+`validator_liveness_observations` (migration `0012`). Each row is a real
+measurement taken at a real moment:
+
+| Status | Meaning **for this source** |
+|---|---|
+| `miss` | The node did not answer that poll round — transport failure, timeout, non-2xx, oversized body, or an unparseable `/status` payload. **Not** a missed consensus duty. |
+| `hit` | The node answered and the chain height it reported was strictly greater than the height of its previous observation. |
+| `late` | The node answered but the height did not advance, **or** this was its first observation so no previous height existed. Whether a stalled height indicates a fault depends on the node's block cadence versus the configured poll cadence. |
+
+Why this mapping: only `miss` is slashable in the simulator, and "did not answer
+at all" is the strongest liveness signal this build can observe — nothing weaker
+is mapped to it. `late` counts as participation but is flagged, which is exactly
+what "alive but showed no progress" deserves; mapping it to `miss` would
+manufacture penalties out of a fast poll interval. A first observation is `late`
+rather than `hit` because one sample demonstrates no progress, and a height
+regression is `late` rather than `miss` because the node did answer.
+
+`AttestationRecord.slot` is the **poll-round ordinal**, not a consensus slot. The
+chain height actually read is carried separately as `observedHeight` (`null` when
+the node did not answer). Height is not used as the round id because it is
+per-node, absent exactly on the rows that matter most for slashing, and can
+regress; the ordinal is resumed from `MAX(round_seq)` at startup so it stays
+monotonic across restarts.
+
+**Stake is not observed.** No stake source exists in this build, so
+`ValidatorHistory.stake` is `0`, the descriptor reports
+`stake.available: false`, and the UI shows the projected penalty as a percentage
+only rather than a confident "≈ 0 stake".
+
+**OFF by default.** With `VALIDATOR_LIVENESS_COLLECTOR_ENABLED` unset, no timer
+is armed, no poll happens, no row is written, and the live endpoint fails closed
+exactly as it did before. Retention defaults to 7 days (the longest window the
+UI offers) and is enforced after every round, so the table cannot grow without
+bound.
 
 ---
 
 ## `GET /api/nodes/attestation-history`
 
-Live, observed attestation history.
+Live, **observed** history from the registered source.
 
 **Query:** `window` (`1h` \| `24h` \| `7d`, default `24h`), optional `validatorId`.
 
-**200** — only when a live source has been registered with
-`registerLiveAttestationSource()` (nothing does today):
+**200** — when a live source has been registered with
+`registerLiveAttestationSource()`. The `observation` descriptor is **mandatory**:
+a source that will not declare what it measured cannot be served, because `miss`
+is otherwise indistinguishable from a missed consensus duty. The response also
+carries `X-Data-Provenance: live:<kind>`.
 
 ```json
 {
   "synthetic": false,
   "demo": false,
   "provenance": "live",
-  "source": "<source id>",
+  "source": "oxscada-observed-liveness",
   "window": "24h",
+  "observation": {
+    "kind": "observed-liveness",
+    "sourceId": "oxscada-observed-liveness",
+    "summary": "Observed liveness of each configured oxscada node: whether it answered each poll round, and whether the chain height it reported advanced. These are not consensus attestation duties.",
+    "method": {
+      "transport": "http-get",
+      "endpoint": "/status",
+      "fields": ["height", "uptime_ticks", "local_phase", "mean_phase", "node_id"],
+      "pollIntervalMs": 60000,
+      "retentionMs": 604800000,
+      "maxRecordsPerQuery": 100000
+    },
+    "statusSemantics": {
+      "hit": "The node answered this poll round and the chain height it reported was strictly greater than the height of its previous observation.",
+      "miss": "The node did not answer this poll round ... This is NOT a missed consensus attestation duty; no duty outcome is observable in this build.",
+      "late": "The node answered but the height it reported did not advance, or this was its first observation ..."
+    },
+    "roundIdentifier": { "field": "slot", "meaning": "Monotonic ordinal of the poll round ... not a consensus slot." },
+    "stake": { "available": false, "note": "No stake source exists in this build ..." },
+    "consensusAttestation": { "available": false, "note": "Consensus attestation duty history remains unavailable ..." }
+  },
   "validators": [ /* ValidatorHistory[] */ ]
 }
 ```
 
-**503** — the current behaviour of every deployment. The endpoint **never**
-substitutes generated records, not even when the demo flag is enabled:
+**502** — the registered source threw. A failing feed surfaces as a failure; it
+is never replaced with substituted data.
+
+**503** — no source is registered (the default deployment). The endpoint
+**never** substitutes generated records, not even when the demo flag is enabled:
 
 ```json
 {
@@ -71,12 +135,35 @@ substitutes generated records, not even when the demo flag is enabled:
 
 **400** on an invalid `window`. **401** without an operator key.
 
-### Wiring a real feed
+### Enabling the observed-liveness source
+
+```bash
+ANCHOR_NODE_URLS=http://10.0.0.11:9090,http://10.0.0.12:9090
+VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true
+# optional
+VALIDATOR_LIVENESS_POLL_INTERVAL_MS=60000     # clamped 5000..3600000
+VALIDATOR_LIVENESS_RETENTION_MS=604800000     # clamped 3600000..2592000000
+```
+
+`server/index.ts` calls `startValidatorLivenessCollector()` at boot. It primes
+the round ordinal and the per-node height baseline from the table before arming
+its timer, so history is continuous across restarts; if the store cannot be read
+it leaves the collector unarmed rather than writing from a wrong baseline.
+Failures are counted on `getValidatorLivenessCollectorStatus()` and exported as
+`scada_validator_liveness_*` metrics — a lost round is never silent.
+
+Run the collector on **one** replica. `round_seq` is a per-collector ordinal and
+the unique index on `(validator_id, round_seq)` assumes a single writer; inserts
+use `ON CONFLICT DO NOTHING` so a second writer is dropped rather than
+corrupting the ordering.
+
+### Wiring a real consensus attestation feed
 
 Implement `LiveAttestationSource` (`server/routes/nodes.ts`) over a source that
-**observed** the duty outcomes, and call `registerLiveAttestationSource()` once
-at startup. The live route then serves it with `synthetic: false` and no further
-change is needed. Do not point it at `server/demo/`.
+**observed** the duty outcomes, give it a descriptor with
+`kind: "consensus-attestation"`, and call `registerLiveAttestationSource()` once
+at startup. The live route and the UI serve it unchanged. Do not point it at
+`server/demo/`.
 
 ---
 
@@ -147,14 +234,41 @@ numbers — and offers a *Load synthetic demo data* button **only** when the ser
 reported `demo.available: true`. Loading demo data replaces the page chrome with
 the synthetic markings listed above.
 
+On a live `200` it renders the `observation` descriptor above the timelines: the
+source id and kind, what was polled and how often, the hit/miss/late definitions
+verbatim from the server, the "consensus attestation duty history is not
+available" statement, and — when `stake.available` is `false` — the projected
+penalty as a percentage only.
+
+When the descriptor's `kind` is `observed-liveness` the per-validator card also
+drops the consensus vocabulary: it counts **poll rounds** rather than "duties",
+and a consecutive-miss run is reported over **poll rounds** rather than "slots".
+Those words are the terms of art for consensus attestation, and using them one
+line below the descriptor panel would re-introduce the confusion the panel
+exists to prevent. A source that declares `kind: "consensus-attestation"` keeps
+the original wording.
+
 ## Tests
 
 - `server/__tests__/nodes-attestation-history-http.test.ts` — HTTP contract:
-  live fails closed (including with the demo flag on), demo is 404 by default,
+  live fails closed (including with the demo flag on), a registered source is
+  served with `synthetic: false` plus its descriptor, demo is 404 by default,
   labelling and headers when enabled, auth on both routes.
+- `server/blockchain/__tests__/liveness-collector.test.ts` — configuration
+  gating (inert by default), the status mapping for each of
+  reachable-and-advancing / unreachable / responded-but-stalled, lifecycle, and
+  a storage failure surfacing rather than being swallowed.
+- `server/blockchain/__tests__/liveness-collector-durability.test.ts` — against
+  a real SQLite database: observations persist and are read back across a
+  simulated restart, retention prunes beyond the window, window and
+  per-validator filtering, and an end-to-end case where the existing simulator
+  replays a rule over stored records and produces penalties.
 - `server/__tests__/nodes-history.test.ts` — the synthetic generator is
   deterministic, self-labelling, and replays through the simulator.
 - `client/src/lib/__tests__/slashing-simulator.test.ts` — the slashing/liveness
   math, including a 24h replay against a hand-computed expectation.
 - `client/src/pages/__tests__/SlashingVisualizer.test.tsx` — the UI never shows
-  synthetic data unmarked and never loads it without an explicit action.
+  synthetic data unmarked, never loads it without an explicit action, and
+  renders the live source's semantics descriptor.
+- `shared/__tests__/schema-parity.test.ts` — the observation table is defined
+  identically on Postgres and the SQLite dev fallback.

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -171,13 +171,24 @@ GET /api/nodes/attestation-history/demo?window=24h   # synthetic, opt-in
 Read-only history behind the Slashing & Liveness Visualizer. Both routes require
 an operator `X-API-Key`.
 
-This build has **no live attestation feed**, so the live route fails closed with
-`503 attestation_source_unavailable` and never substitutes generated records. The
-`/demo` route serves clearly-labelled synthetic PRNG output and is disabled
+This build has **no consensus attestation duty feed** — the oxscada `/status`
+surface exposes no per-slot duty outcome. What it can serve is an
+**observed-liveness** source: per poll round, whether each configured node
+answered and whether the height it reported advanced. It is OFF unless
+`VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true` with `ANCHOR_NODE_URLS` set; until
+then the live route fails closed with `503 attestation_source_unavailable` and
+never substitutes generated records.
+
+Every live 200 carries a mandatory `observation` descriptor stating what was
+polled, the cadence, and exactly what `hit` / `miss` / `late` mean — for this
+source `miss` means "the node did not answer this poll round", **not** a missed
+consensus duty.
+
+The `/demo` route serves clearly-labelled synthetic PRNG output and is disabled
 unless the server runs with `SLASHING_DEMO_DATA=true`.
 
 See [attestation-history.md](./attestation-history.md) for the full contract and
-for how to register a real feed.
+for how to register a real consensus attestation feed.
 
 ---
 

--- a/migrations/0012_validator_liveness_observations.sql
+++ b/migrations/0012_validator_liveness_observations.sql
@@ -1,0 +1,85 @@
+-- Migration: 0012_validator_liveness_observations
+-- Issue: #456 — [wave:2a] Slashing & Liveness Visualizer
+-- Description: Durable per-validator OBSERVED LIVENESS history: one row per
+--   configured oxscada node per poll round of the collector in
+--   server/blockchain/liveness-collector.ts. This is the "actual history" the
+--   what-if slashing simulator replays a proposed rule against.
+--
+-- ─── WHAT THIS TABLE DOES AND DOES NOT CONTAIN ───────────────────────────────
+--
+-- It contains LIVENESS OBSERVATIONS. It does NOT contain consensus attestation
+-- duty outcomes, because this build has no source for them: the oxscada node
+-- `GET /status` surface reports node_id, height, role, order_parameter,
+-- mean_phase, local_phase, peer_phases[], peers, mempool and uptime_ticks, and
+-- none of those is a per-slot duty result. No column here may ever be populated
+-- by computing, estimating, interpolating or randomising a duty outcome.
+--
+-- Each row asserts exactly one of:
+--
+--   miss — the collector polled `source_node_url` at `observed_at` and the node
+--          did not answer: transport failure, timeout, non-2xx, a body over the
+--          byte cap, or an unparseable /status shape. `detail` carries the
+--          bounded reason string.
+--   hit  — the node answered and `observed_height` was strictly greater than
+--          `previous_height`, the height recorded by the previous observation
+--          of the same validator.
+--   late — the node answered but `observed_height` did not advance (it was
+--          equal to, or below, `previous_height`), OR this is the first
+--          observation for that validator so there is no previous height to
+--          compare against. `detail` distinguishes the two cases.
+--
+-- Whether "did not advance" indicates a fault depends on the node's block
+-- cadence versus the operator-configured poll cadence; the API descriptor says
+-- so rather than implying a fault. When the node did not answer, every observed
+-- column is NULL — values are never carried forward from an earlier round.
+--
+-- ─── ROUND IDENTIFIER ────────────────────────────────────────────────────────
+--
+-- `round_seq` is a monotonic ordinal of poll rounds that actually happened,
+-- resumed from MAX(round_seq) at collector startup so it survives restarts. It
+-- is used rather than the chain height because height is per-node (so it cannot
+-- identify a fleet-wide round), is absent exactly when the node did not answer,
+-- and can regress. The real height is kept in `observed_height`, so choosing an
+-- ordinal loses nothing and keeps `miss` rows orderable.
+--
+-- SINGLE WRITER. The unique index assumes one collector process writes this
+-- table; inserts use ON CONFLICT DO NOTHING so a second writer is dropped
+-- rather than corrupting the ordering.
+--
+-- ─── RETENTION ───────────────────────────────────────────────────────────────
+--
+-- The collector prunes rows older than VALIDATOR_LIVENESS_RETENTION_MS (default
+-- 7 days — the longest window the UI offers) after every round, so the table
+-- cannot grow without bound. Nothing else writes it.
+-- Date: 2026-07-27
+
+CREATE TABLE IF NOT EXISTS validator_liveness_observations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- `host[:port][/path]` of the configured node URL. Derived offline, without
+  -- contacting the node, because the rows that matter most are the ones where
+  -- the node did not answer and therefore reported no node_id of its own.
+  validator_id VARCHAR(128) NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL,
+  round_seq BIGINT NOT NULL,
+  status VARCHAR(8) NOT NULL,
+  source_node_url VARCHAR(512) NOT NULL,
+  observed_height BIGINT,
+  previous_height BIGINT,
+  observed_uptime_ticks BIGINT,
+  reported_node_id VARCHAR(128),
+  local_phase DOUBLE PRECISION,
+  mean_phase DOUBLE PRECISION,
+  detail TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT validator_liveness_observations_status_check
+    CHECK (status IN ('hit', 'miss', 'late'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_validator_liveness_validator_round
+  ON validator_liveness_observations(validator_id, round_seq);
+
+-- Window queries (1h / 24h / 7d) and retention pruning both scan by time.
+CREATE INDEX IF NOT EXISTS idx_validator_liveness_observed_at
+  ON validator_liveness_observations(observed_at);
+CREATE INDEX IF NOT EXISTS idx_validator_liveness_validator_observed_at
+  ON validator_liveness_observations(validator_id, observed_at);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1784780408000,
       "tag": "0011_agent_marketplace",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1784780409000,
+      "tag": "0012_validator_liveness_observations",
+      "breakpoints": true
     }
   ]
 }

--- a/server/__tests__/nodes-attestation-history-http.test.ts
+++ b/server/__tests__/nodes-attestation-history-http.test.ts
@@ -21,12 +21,50 @@ import {
   nodesRoutes,
   registerLiveAttestationSource,
 } from "../routes/nodes";
+import {
+  getValidatorLivenessCollectorStatus,
+  loadLivenessCollectorConfig,
+  startValidatorLivenessCollector,
+  stopValidatorLivenessCollector,
+} from "../blockchain/liveness-collector";
 import { _resetControlPlaneAuthCache } from "../middleware/control-plane-auth";
 import type {
+  AttestationSourceDescriptor,
   AttestationSourceUnavailableResponse,
+  LiveAttestationHistoryResponse,
   SyntheticAttestationHistoryResponse,
   ValidatorHistory,
 } from "@shared/types/slashing";
+
+/**
+ * A descriptor is MANDATORY on a live source. `hit` / `miss` / `late` mean
+ * whatever the source measured, so a source that will not say what it measured
+ * cannot be served — see `LiveAttestationSource` in server/routes/nodes.ts.
+ */
+const TEST_DESCRIPTOR: AttestationSourceDescriptor = {
+  kind: "observed-liveness",
+  sourceId: "test-feed",
+  summary: "Test feed: whether the node answered each poll round.",
+  method: {
+    transport: "http-get",
+    endpoint: "/status",
+    fields: ["height"],
+    pollIntervalMs: 60_000,
+    retentionMs: 604_800_000,
+    maxRecordsPerQuery: 100_000,
+  },
+  statusSemantics: {
+    hit: "answered and height advanced",
+    miss: "did not answer this poll round",
+    late: "answered but height did not advance",
+  },
+  roundIdentifier: { field: "slot", meaning: "poll-round ordinal" },
+  stake: { available: false, note: "no stake source in this build" },
+  consensusAttestation: {
+    available: false,
+    note: "no per-slot duty outcome is observable in this build",
+  },
+};
 
 interface TestServer {
   server: Server;
@@ -134,6 +172,31 @@ describe("attestation history HTTP surface", () => {
       expect(body.demo.available).toBe(true);
     });
 
+    it("keeps failing closed when the observed-liveness collector is off", async () => {
+      // The collector is the only thing in the tree that registers a live
+      // source. With the default environment it must register NOTHING, so the
+      // route's fail-closed behaviour is byte-for-byte what it was before.
+      const config = loadLivenessCollectorConfig({});
+      expect(config.enabled).toBe(false);
+
+      const status = await startValidatorLivenessCollector({ config });
+      expect(status.enabled).toBe(false);
+      expect(status.running).toBe(false);
+      // Nothing was started, so there is no collector to report on.
+      expect(getValidatorLivenessCollectorStatus()).toBeNull();
+
+      const res = await get("/api/nodes/attestation-history?window=24h");
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as AttestationSourceUnavailableResponse;
+      expect(body.error).toBe("attestation_source_unavailable");
+      expect(body).not.toHaveProperty("validators");
+      // The reason names the opt-in, so the operator can act on it.
+      expect(body.reason).toContain("VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true");
+      expect(body.reason).toContain("Consensus attestation duty history is unavailable");
+
+      await stopValidatorLivenessCollector();
+    });
+
     it("rejects an invalid window before consulting any source", async () => {
       const res = await get("/api/nodes/attestation-history?window=3y");
       expect(res.status).toBe(400);
@@ -150,26 +213,44 @@ describe("attestation history HTTP surface", () => {
       ];
       registerLiveAttestationSource({
         id: "test-feed",
+        descriptor: TEST_DESCRIPTOR,
         history: async () => observed,
       });
 
       const res = await get("/api/nodes/attestation-history?window=24h");
       expect(res.status).toBe(200);
-      const body = (await res.json()) as {
-        synthetic: boolean;
-        provenance: string;
-        source: string;
-        validators: ValidatorHistory[];
-      };
+      const body = (await res.json()) as LiveAttestationHistoryResponse;
       expect(body.synthetic).toBe(false);
       expect(body.provenance).toBe("live");
       expect(body.source).toBe("test-feed");
       expect(body.validators).toEqual(observed);
     });
 
+    it("serves the source's semantics descriptor so a miss cannot be misread", async () => {
+      registerLiveAttestationSource({
+        id: "test-feed",
+        descriptor: TEST_DESCRIPTOR,
+        history: async () => [],
+      });
+
+      const res = await get("/api/nodes/attestation-history?window=1h");
+      expect(res.status).toBe(200);
+      // The provenance header names the KIND, not just "live": an
+      // observed-liveness feed is live data but is not consensus attestation.
+      expect(res.headers.get("x-data-provenance")).toBe("live:observed-liveness");
+
+      const body = (await res.json()) as LiveAttestationHistoryResponse;
+      expect(body.observation).toEqual(TEST_DESCRIPTOR);
+      expect(body.observation.kind).toBe("observed-liveness");
+      expect(body.observation.consensusAttestation.available).toBe(false);
+      expect(body.observation.statusSemantics.miss).toContain("did not answer");
+      expect(body.observation.method.pollIntervalMs).toBe(60_000);
+    });
+
     it("surfaces a failing source as an error rather than substituting data", async () => {
       registerLiveAttestationSource({
         id: "broken-feed",
+        descriptor: { ...TEST_DESCRIPTOR, sourceId: "broken-feed" },
         history: async () => {
           throw new Error("rpc timeout");
         },

--- a/server/blockchain/__tests__/liveness-collector-durability.test.ts
+++ b/server/blockchain/__tests__/liveness-collector-durability.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Observed-liveness durability, against a REAL database (issue #456).
+ *
+ * No mocked store here — the whole point of the table is that a 24h/7d window
+ * is meaningless if the history dies with the process. These tests run the
+ * collector and its live source against a file-backed SQLite database (the
+ * repository's development backend), close it, reopen it, and read the same
+ * observations back.
+ *
+ * Covered:
+ *   - observations persist and survive a simulated restart;
+ *   - a restarted collector resumes the round ordinal and the height baseline;
+ *   - retention prunes beyond the configured window;
+ *   - 1h / 24h / 7d window filtering and per-validator filtering;
+ *   - the ACCEPTANCE CRITERION: the existing, unmodified simulator
+ *     (`client/src/lib/slashing-simulator.ts`) evaluates an operator-typed rule
+ *     over records that came out of the store and produces penalties.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type * as StorageModule from "../../storage";
+import type { ValidatorLivenessObservationRecord } from "../../storage";
+import {
+  ObservedLivenessSource,
+  ValidatorLivenessCollector,
+  defaultLivenessObservationStore,
+  type LivenessCollectorConfig,
+} from "../liveness-collector";
+import { parseRulePhrase, simulateRule } from "../../../client/src/lib/slashing-simulator";
+import type { ValidatorHistory } from "@shared/types/slashing";
+
+const NODE_URL = "http://127.0.0.1:9490";
+const VALIDATOR_ID = "127.0.0.1:9490";
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+let storage: typeof StorageModule;
+let databaseDirectory: string;
+
+const originalEnv = {
+  forcePostgres: process.env.FORCE_POSTGRES,
+  sqlitePath: process.env.SQLITE_DATABASE_PATH,
+};
+
+function config(overrides: Partial<LivenessCollectorConfig> = {}): LivenessCollectorConfig {
+  return {
+    enabled: true,
+    reason: "test",
+    nodeUrls: [NODE_URL],
+    pollIntervalMs: MINUTE,
+    retentionMs: 7 * DAY,
+    timeoutMs: 1_000,
+    maxConcurrency: 1,
+    ...overrides,
+  };
+}
+
+/** Bounded-transport-shaped response carrying an oxscada `/status` payload. */
+function statusResponse(height: number): Response {
+  const text = JSON.stringify({
+    node_id: "node-liveness",
+    height,
+    role: "validator",
+    order_parameter: 0.99,
+    mean_phase: 1.2,
+    local_phase: 1.15,
+    peer_phases: [],
+    peers: 4,
+    mempool: 2,
+    uptime_ticks: height * 10,
+  });
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-length": String(text.length) }),
+    body: {
+      getReader() {
+        let done = false;
+        return {
+          async read() {
+            if (done) return { done: true, value: undefined };
+            done = true;
+            return { done: false, value: new TextEncoder().encode(text) };
+          },
+          async cancel() {
+            /* no-op */
+          },
+        };
+      },
+    },
+  } as unknown as Response;
+}
+
+/** Close and reopen the database — the closest thing to a process restart. */
+async function restartDatabase(): Promise<void> {
+  await storage.closeDatabase();
+  await storage.initializeDatabase();
+}
+
+async function clearObservations(): Promise<void> {
+  // Retention itself is the only delete path in production; using it here keeps
+  // the test from needing privileged SQL.
+  await storage.pruneValidatorLivenessObservations(Number.MAX_SAFE_INTEGER);
+}
+
+describe("observed-liveness durability (real SQLite)", () => {
+  beforeAll(async () => {
+    process.env.FORCE_POSTGRES = "false";
+    databaseDirectory = mkdtempSync(join(tmpdir(), "oxscada-liveness-"));
+    // File-backed, not :memory: — a restart must find the rows still there.
+    process.env.SQLITE_DATABASE_PATH = join(databaseDirectory, "liveness.sqlite");
+
+    storage = await import("../../storage");
+    await storage.initializeDatabase();
+    // Transforming + importing the server modules on a cold cache can exceed
+    // vitest's default 10s hook budget on Windows.
+  }, 60_000);
+
+  afterAll(async () => {
+    await storage.closeDatabase();
+    if (originalEnv.forcePostgres === undefined) delete process.env.FORCE_POSTGRES;
+    else process.env.FORCE_POSTGRES = originalEnv.forcePostgres;
+    if (originalEnv.sqlitePath === undefined) delete process.env.SQLITE_DATABASE_PATH;
+    else process.env.SQLITE_DATABASE_PATH = originalEnv.sqlitePath;
+    rmSync(databaseDirectory, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    await clearObservations();
+  });
+
+  it("persists observations and reads them back across a restart", async () => {
+    let clock = 1_800_000_000_000;
+    let height = 400;
+    const collector = new ValidatorLivenessCollector({
+      config: config(),
+      store: defaultLivenessObservationStore,
+      now: () => clock,
+      fetchImpl: async () => statusResponse(height),
+    });
+
+    await collector.runRound(); // baseline
+    clock += MINUTE;
+    height += 1;
+    await collector.runRound(); // advanced
+    await collector.stop();
+
+    const before = await storage.listValidatorLivenessObservations(0);
+    expect(before).toHaveLength(2);
+
+    await restartDatabase();
+
+    const after = await storage.listValidatorLivenessObservations(0);
+    expect(after).toHaveLength(2);
+    // Byte-for-byte the same observations, not a re-derivation.
+    expect(after.map((row) => row.status)).toEqual(["late", "hit"]);
+    expect(after.map((row) => row.roundSeq)).toEqual([1, 2]);
+    expect(after.map((row) => row.observedHeight)).toEqual([400, 401]);
+    expect(after.map((row) => row.observedAt.getTime())).toEqual([
+      1_800_000_000_000,
+      1_800_000_000_000 + MINUTE,
+    ]);
+    expect(after[1].previousHeight).toBe(400);
+    expect(after[0].sourceNodeUrl).toBe(NODE_URL);
+    expect(after[1].detail).toContain("400 -> 401");
+  });
+
+  it("resumes the round ordinal and height baseline in a fresh collector after a restart", async () => {
+    let clock = 1_800_000_000_000;
+    const first = new ValidatorLivenessCollector({
+      config: config(),
+      store: defaultLivenessObservationStore,
+      now: () => clock,
+      fetchImpl: async () => statusResponse(700),
+    });
+    await first.runRound();
+    clock += MINUTE;
+    await first.runRound();
+    await first.stop();
+
+    await restartDatabase();
+
+    clock += MINUTE;
+    const second = new ValidatorLivenessCollector({
+      config: config(),
+      store: defaultLivenessObservationStore,
+      now: () => clock,
+      fetchImpl: async () => statusResponse(701),
+    });
+    await second.runRound();
+    await second.stop();
+
+    const rows = await storage.listValidatorLivenessObservations(0);
+    expect(rows.map((row) => row.roundSeq)).toEqual([1, 2, 3]);
+    // The restarted collector did NOT treat the node as never-before-seen: it
+    // compared against the persisted height, so real progress is a hit.
+    expect(rows[2].previousHeight).toBe(700);
+    expect(rows[2].status).toBe("hit");
+  });
+
+  it("prunes observations beyond the retention window", async () => {
+    const now = 1_800_000_000_000;
+    const stale: ValidatorLivenessObservationRecord = {
+      validatorId: VALIDATOR_ID,
+      observedAt: new Date(now - 3 * HOUR),
+      roundSeq: 1,
+      status: "miss",
+      sourceNodeUrl: NODE_URL,
+      observedHeight: null,
+      previousHeight: null,
+      observedUptimeTicks: null,
+      reportedNodeId: null,
+      localPhase: null,
+      meanPhase: null,
+      detail: "no answer: timeout",
+    };
+    await storage.appendValidatorLivenessObservations([stale]);
+    expect(await storage.listValidatorLivenessObservations(0)).toHaveLength(1);
+
+    const collector = new ValidatorLivenessCollector({
+      // Retention of 1h; the stale row is 3h old.
+      config: config({ retentionMs: HOUR }),
+      store: defaultLivenessObservationStore,
+      now: () => now,
+      fetchImpl: async () => statusResponse(10),
+    });
+    await collector.runRound();
+    await collector.stop();
+
+    const rows = await storage.listValidatorLivenessObservations(0);
+    // Only the round just recorded survives; the table cannot grow unbounded.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].observedAt.getTime()).toBe(now);
+    expect(collector.status().rowsPruned).toBe(1);
+  });
+
+  it("filters by window and by validator", async () => {
+    const now = 1_800_000_000_000;
+    const other = "10.9.9.9:9090";
+    const row = (
+      validatorId: string,
+      sourceNodeUrl: string,
+      roundSeq: number,
+      agoMs: number,
+    ): ValidatorLivenessObservationRecord => ({
+      validatorId,
+      observedAt: new Date(now - agoMs),
+      roundSeq,
+      status: "hit",
+      sourceNodeUrl,
+      observedHeight: 100 + roundSeq,
+      previousHeight: 99 + roundSeq,
+      observedUptimeTicks: 1_000,
+      reportedNodeId: "node-x",
+      localPhase: 1,
+      meanPhase: 1,
+      detail: "height advanced",
+    });
+
+    await storage.appendValidatorLivenessObservations([
+      row(VALIDATOR_ID, NODE_URL, 1, 3 * DAY),
+      row(VALIDATOR_ID, NODE_URL, 2, 2 * HOUR),
+      row(VALIDATOR_ID, NODE_URL, 3, 30 * MINUTE),
+      row(other, "http://10.9.9.9:9090", 4, 10 * MINUTE),
+    ]);
+
+    const source = new ObservedLivenessSource(
+      defaultLivenessObservationStore,
+      config(),
+      () => now,
+    );
+
+    const oneHour = await source.history("1h");
+    expect(oneHour.flatMap((h) => h.records)).toHaveLength(2);
+
+    const oneDay = await source.history("24h");
+    expect(oneDay.flatMap((h) => h.records)).toHaveLength(3);
+
+    const sevenDays = await source.history("7d");
+    expect(sevenDays.flatMap((h) => h.records)).toHaveLength(4);
+    expect(sevenDays.map((h) => h.validatorId)).toEqual([other, VALIDATOR_ID]);
+
+    const filtered = await source.history("7d", VALIDATOR_ID);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].validatorId).toBe(VALIDATOR_ID);
+    expect(filtered[0].records.map((r) => r.slot)).toEqual([1, 2, 3]);
+  });
+
+  it("lets the EXISTING simulator project penalties from stored observations", async () => {
+    // ── Record a real outage: the node answers, then stops answering for eight
+    // poll rounds, then comes back. Every row below is written by the collector
+    // from a poll that actually happened.
+    const start = 1_800_000_000_000;
+    let clock = start;
+    let reachable = true;
+    let height = 900;
+
+    const collector = new ValidatorLivenessCollector({
+      config: config(),
+      store: defaultLivenessObservationStore,
+      now: () => clock,
+      fetchImpl: async () => {
+        if (!reachable) throw new Error("connect ECONNREFUSED 127.0.0.1:9490");
+        return statusResponse(height);
+      },
+    });
+
+    await collector.runRound(); // round 1: baseline -> late
+    reachable = false;
+    for (let i = 0; i < 8; i += 1) {
+      clock += MINUTE;
+      await collector.runRound(); // rounds 2..9: no answer -> miss
+    }
+    reachable = true;
+    clock += MINUTE;
+    height += 1;
+    await collector.runRound(); // round 10: answered and advanced -> hit
+    await collector.stop();
+
+    // ── Restart, then read the history back through the live source. Nothing
+    // in the projection below touches the collector's memory.
+    await restartDatabase();
+
+    const source = new ObservedLivenessSource(
+      defaultLivenessObservationStore,
+      config(),
+      () => clock,
+    );
+    const histories: ValidatorHistory[] = await source.history("1h");
+    expect(histories).toHaveLength(1);
+    const history = histories[0];
+    expect(history.records.map((r) => r.status)).toEqual([
+      "late",
+      "miss",
+      "miss",
+      "miss",
+      "miss",
+      "miss",
+      "miss",
+      "miss",
+      "miss",
+      "hit",
+    ]);
+
+    // ── The acceptance criterion: an operator types a rule, and the UNMODIFIED
+    // simulator projects hypothetical penalties against this actual history.
+    const rule = parseRulePhrase("slash 1% per miss after 2 in 1h");
+    expect(rule).not.toBeNull();
+
+    const result = simulateRule(history, { ...rule!, livenessRunThreshold: 3 }, "1h", clock);
+
+    expect(result.summary.total).toBe(10);
+    expect(result.summary.misses).toBe(8);
+    // Eight misses, the first two free: six penalised at 1% each.
+    expect(result.penalties).toHaveLength(6);
+    expect(result.totalPenaltyPct).toBeCloseTo(6, 10);
+    // The eight-round outage is a single consecutive-miss run.
+    expect(result.livenessFaults).toHaveLength(1);
+    expect(result.livenessFaults[0].length).toBe(8);
+    // Stake is NOT observed anywhere in this build, so the absolute amount is
+    // zero by construction. The percentage above is the real output; the API
+    // descriptor reports stake.available:false and the UI hides the amount.
+    expect(history.stake).toBe(0);
+    expect(result.totalPenaltyAmount).toBe(0);
+  });
+});

--- a/server/blockchain/__tests__/liveness-collector.test.ts
+++ b/server/blockchain/__tests__/liveness-collector.test.ts
@@ -1,0 +1,717 @@
+/**
+ * Observed-liveness collector: configuration gating, status mapping, lifecycle
+ * and failure handling (issue #456).
+ *
+ * The durability half — that observations survive a restart, that retention
+ * prunes, that window/validator filtering works, and that the existing
+ * simulator produces penalties from stored records — lives in
+ * ./liveness-collector-durability.test.ts against a real SQLite database.
+ *
+ * What is pinned here:
+ *   - with default env NOTHING is armed: no timer, no poll, no write;
+ *   - an unreachable node produces a `miss` OBSERVATION rather than throwing;
+ *   - the three mappings (answered+advanced / no answer / answered+stalled),
+ *     plus the two cases that must NOT be reported as `hit` or `miss`: a first
+ *     observation, and a height regression;
+ *   - `stop()` clears the timer and leaves nothing running;
+ *   - a storage failure is counted and surfaced, never swallowed.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  OBSERVED_LIVENESS_SOURCE_ID,
+  ObservedLivenessSource,
+  ValidatorLivenessCollector,
+  buildObservedLivenessDescriptor,
+  classifyObservation,
+  loadLivenessCollectorConfig,
+  observedValidatorId,
+  toValidatorHistories,
+  type LivenessObservationStore,
+} from "../liveness-collector";
+import type { ValidatorNodeView } from "@shared/types/services/validator-dashboard";
+import type { ValidatorLivenessObservationRecord } from "../../storage";
+
+// ─── Fakes ───────────────────────────────────────────────────────────────────
+
+/**
+ * In-memory store. Used ONLY for the non-durability assertions in this file;
+ * the persistence contract is proved against a real database elsewhere.
+ */
+class MemoryStore implements LivenessObservationStore {
+  rows: ValidatorLivenessObservationRecord[] = [];
+  appendCalls = 0;
+  pruneCalls: number[] = [];
+  failAppendWith: Error | null = null;
+  failPruneWith: Error | null = null;
+
+  async append(rows: readonly ValidatorLivenessObservationRecord[]): Promise<void> {
+    this.appendCalls += 1;
+    if (this.failAppendWith) throw this.failAppendWith;
+    this.rows.push(...rows.map((row) => ({ ...row })));
+  }
+
+  async since(
+    fromMs: number,
+    validatorId?: string,
+  ): Promise<ValidatorLivenessObservationRecord[]> {
+    return this.rows
+      .filter((row) => row.observedAt.getTime() >= fromMs)
+      .filter((row) => validatorId === undefined || row.validatorId === validatorId)
+      .sort((a, b) => a.roundSeq - b.roundSeq);
+  }
+
+  async prune(beforeMs: number): Promise<number> {
+    this.pruneCalls.push(beforeMs);
+    if (this.failPruneWith) throw this.failPruneWith;
+    const before = this.rows.length;
+    this.rows = this.rows.filter((row) => row.observedAt.getTime() >= beforeMs);
+    return before - this.rows.length;
+  }
+
+  async maxRoundSeq(): Promise<number> {
+    return this.rows.reduce((max, row) => Math.max(max, row.roundSeq), 0);
+  }
+
+  async latestHeights(): Promise<Array<{ validatorId: string; observedHeight: number }>> {
+    const latest = new Map<string, { roundSeq: number; observedHeight: number }>();
+    for (const row of this.rows) {
+      if (row.observedHeight === null) continue;
+      const current = latest.get(row.validatorId);
+      if (!current || row.roundSeq > current.roundSeq) {
+        latest.set(row.validatorId, {
+          roundSeq: row.roundSeq,
+          observedHeight: row.observedHeight,
+        });
+      }
+    }
+    return [...latest.entries()].map(([validatorId, entry]) => ({
+      validatorId,
+      observedHeight: entry.observedHeight,
+    }));
+  }
+}
+
+function statusPayload(height: number, nodeId = "node-1"): unknown {
+  return {
+    node_id: nodeId,
+    height,
+    role: "validator",
+    order_parameter: 0.97,
+    mean_phase: 1.1,
+    local_phase: 1.05,
+    peer_phases: [],
+    peers: 3,
+    mempool: 0,
+    uptime_ticks: height * 10,
+  };
+}
+
+/** Minimal fetch double matching the shared bounded transport's expectations. */
+function okResponse(body: unknown): Response {
+  const text = JSON.stringify(body);
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-length": String(text.length) }),
+    body: {
+      getReader() {
+        let done = false;
+        return {
+          async read() {
+            if (done) return { done: true, value: undefined };
+            done = true;
+            return { done: false, value: new TextEncoder().encode(text) };
+          },
+          async cancel() {
+            /* no-op */
+          },
+        };
+      },
+    },
+  } as unknown as Response;
+}
+
+function reachableView(height: number): ValidatorNodeView {
+  return {
+    label: "node:9090",
+    reachable: true,
+    error: null,
+    observedAt: 1_700_000_000_000,
+    status: {
+      nodeId: "node-1",
+      height,
+      role: "validator",
+      reportedOrderParameter: 0.97,
+      reportedMeanPhase: 1.1,
+      localPhase: 1.05,
+      peers: 3,
+      mempool: 0,
+      uptimeTicks: height * 10,
+      peerPhases: [],
+    },
+  };
+}
+
+function unreachableView(error: string): ValidatorNodeView {
+  return {
+    label: "node:9090",
+    reachable: false,
+    error,
+    observedAt: 1_700_000_000_000,
+    status: null,
+  };
+}
+
+// ─── Migration / dev-mode DDL alignment ──────────────────────────────────────
+
+describe("observed-liveness migration alignment", () => {
+  const COLUMNS = [
+    "validator_id",
+    "observed_at",
+    "round_seq",
+    "status",
+    "source_node_url",
+    "observed_height",
+    "previous_height",
+    "observed_uptime_ticks",
+    "reported_node_id",
+    "local_phase",
+    "mean_phase",
+    "detail",
+    "created_at",
+  ] as const;
+
+  it("creates every durable column and index in the Postgres migration", () => {
+    const sql = readFileSync(
+      new URL("../../../migrations/0012_validator_liveness_observations.sql", import.meta.url),
+      "utf8",
+    );
+
+    expect(sql).toContain("CREATE TABLE IF NOT EXISTS validator_liveness_observations");
+    for (const column of COLUMNS) {
+      expect(sql).toMatch(new RegExp(`\\b${column}\\b`));
+    }
+    expect(sql).toContain("UNIQUE INDEX IF NOT EXISTS idx_validator_liveness_validator_round");
+    expect(sql).toContain("idx_validator_liveness_observed_at");
+    expect(sql).toContain("idx_validator_liveness_validator_observed_at");
+    // The status vocabulary is constrained in the database, so a row this code
+    // cannot interpret cannot be written by anything else either.
+    expect(sql).toContain("CHECK (status IN ('hit', 'miss', 'late'))");
+  });
+
+  it("declares the same table for the SQLite development fallback", () => {
+    const storageSource = readFileSync(new URL("../../storage.ts", import.meta.url), "utf8");
+
+    expect(storageSource).toContain(
+      "CREATE TABLE IF NOT EXISTS validator_liveness_observations",
+    );
+    for (const column of COLUMNS) {
+      expect(storageSource).toMatch(new RegExp(`\\b${column}\\b`));
+    }
+    expect(storageSource).toContain("UNIQUE(validator_id, round_seq)");
+    expect(storageSource).toContain("CHECK (status IN ('hit', 'miss', 'late'))");
+    // Applied on every open, so the dev backend is usable without hand-seeding.
+    expect(storageSource).toContain("await sqliteExec(validatorLivenessSqliteSchema)");
+  });
+});
+
+// ─── Configuration gating ────────────────────────────────────────────────────
+
+describe("observed-liveness collector configuration", () => {
+  it("is disabled with an empty environment: the feature costs nothing by default", () => {
+    const config = loadLivenessCollectorConfig({});
+    expect(config.enabled).toBe(false);
+    expect(config.nodeUrls).toEqual([]);
+    expect(config.reason).toContain("VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true");
+  });
+
+  it("is disabled when the flag is not exactly 'true'", () => {
+    for (const value of ["1", "yes", "TRUE", "on", ""]) {
+      const config = loadLivenessCollectorConfig({
+        VALIDATOR_LIVENESS_COLLECTOR_ENABLED: value,
+        ANCHOR_NODE_URLS: "http://127.0.0.1:9090",
+      });
+      expect(config.enabled).toBe(false);
+    }
+  });
+
+  it("is disabled when opted in but no node is configured, and says so", () => {
+    const config = loadLivenessCollectorConfig({
+      VALIDATOR_LIVENESS_COLLECTOR_ENABLED: "true",
+    });
+    expect(config.enabled).toBe(false);
+    expect(config.reason).toContain("ANCHOR_NODE_URLS");
+  });
+
+  it("enables only with the exact flag plus at least one http(s) node", () => {
+    const config = loadLivenessCollectorConfig({
+      VALIDATOR_LIVENESS_COLLECTOR_ENABLED: "true",
+      ANCHOR_NODE_URLS: "http://127.0.0.1:9090,file:///etc/passwd",
+    });
+    expect(config.enabled).toBe(true);
+    // The non-http entry is dropped by the shared parser, not polled.
+    expect(config.nodeUrls).toEqual(["http://127.0.0.1:9090"]);
+  });
+
+  it("clamps cadence and retention rather than trusting the environment", () => {
+    const tooSmall = loadLivenessCollectorConfig({
+      VALIDATOR_LIVENESS_POLL_INTERVAL_MS: "1",
+      VALIDATOR_LIVENESS_RETENTION_MS: "1",
+    });
+    expect(tooSmall.pollIntervalMs).toBe(5_000);
+    expect(tooSmall.retentionMs).toBe(3_600_000);
+
+    const tooLarge = loadLivenessCollectorConfig({
+      VALIDATOR_LIVENESS_POLL_INTERVAL_MS: "999999999",
+      VALIDATOR_LIVENESS_RETENTION_MS: "999999999999",
+    });
+    expect(tooLarge.pollIntervalMs).toBe(3_600_000);
+    expect(tooLarge.retentionMs).toBe(30 * 24 * 60 * 60 * 1000);
+
+    const defaults = loadLivenessCollectorConfig({});
+    expect(defaults.pollIntervalMs).toBe(60_000);
+    // Default retention is the longest window the UI offers.
+    expect(defaults.retentionMs).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it("derives a validator id offline, so unanswered polls are still attributable", () => {
+    expect(observedValidatorId("http://10.0.0.12:9090")).toBe("10.0.0.12:9090");
+    expect(observedValidatorId("https://node.example:443/a")).toBe("node.example/a");
+    // Two nodes behind one host:port do not collide.
+    expect(observedValidatorId("http://h:9090/a")).not.toBe(
+      observedValidatorId("http://h:9090/b"),
+    );
+  });
+});
+
+// ─── Status mapping ──────────────────────────────────────────────────────────
+
+describe("observed-liveness status mapping", () => {
+  it("maps a node that answered and advanced to hit", () => {
+    const result = classifyObservation(reachableView(101), 100);
+    expect(result.status).toBe("hit");
+    expect(result.detail).toContain("100 -> 101");
+  });
+
+  it("maps a node that did not answer to miss, carrying the reason", () => {
+    const result = classifyObservation(unreachableView("connect ECONNREFUSED"), 100);
+    expect(result.status).toBe("miss");
+    expect(result.detail).toContain("no answer");
+    expect(result.detail).toContain("ECONNREFUSED");
+  });
+
+  it("maps a node that answered but stalled to late, not miss", () => {
+    const result = classifyObservation(reachableView(100), 100);
+    expect(result.status).toBe("late");
+    expect(result.detail).toContain("did not advance");
+  });
+
+  it("maps a height regression to late, because the node did answer", () => {
+    const result = classifyObservation(reachableView(90), 100);
+    // Calling this a `miss` would assert the node was unreachable, which is
+    // false. The regression stays visible in the detail and in the row.
+    expect(result.status).toBe("late");
+    expect(result.detail).toContain("previous 100");
+    expect(result.detail).toContain("observed 90");
+  });
+
+  it("maps a first observation to late, never hit: one sample shows no progress", () => {
+    const result = classifyObservation(reachableView(100), null);
+    expect(result.status).toBe("late");
+    expect(result.detail).toContain("baseline");
+  });
+});
+
+// ─── Lifecycle ───────────────────────────────────────────────────────────────
+
+describe("observed-liveness collector lifecycle", () => {
+  let store: MemoryStore;
+
+  beforeEach(() => {
+    store = new MemoryStore();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function collector(
+    options: { nodeUrls?: string[]; enabled?: boolean; now?: () => number } = {},
+  ): ValidatorLivenessCollector {
+    return new ValidatorLivenessCollector({
+      config: {
+        enabled: options.enabled ?? true,
+        reason: "test",
+        nodeUrls: options.nodeUrls ?? ["http://127.0.0.1:9090"],
+        pollIntervalMs: 60_000,
+        retentionMs: 7 * 24 * 60 * 60 * 1000,
+        timeoutMs: 1_000,
+        maxConcurrency: 2,
+      },
+      store,
+      now: options.now,
+      fetchImpl: async () => okResponse(statusPayload(1)),
+    });
+  }
+
+  it("arms no timer and writes nothing when the feature is disabled", async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const inert = collector({ enabled: false });
+
+    const status = await inert.start();
+
+    expect(status.enabled).toBe(false);
+    expect(status.running).toBe(false);
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(store.appendCalls).toBe(0);
+    expect(store.rows).toHaveLength(0);
+    setIntervalSpy.mockRestore();
+    await inert.stop();
+  });
+
+  it("arms exactly one timer however many times start() is called", async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const active = collector();
+
+    await active.start();
+    await active.start();
+    await active.start();
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(active.status().running).toBe(true);
+
+    await active.stop();
+    expect(active.status().running).toBe(false);
+    setIntervalSpy.mockRestore();
+  });
+
+  it("stop() clears the timer and leaves nothing running", async () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    const active = collector();
+
+    await active.start();
+    await active.stop();
+    await active.stop(); // idempotent
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(active.status().running).toBe(false);
+    clearIntervalSpy.mockRestore();
+  });
+
+  it("stop() awaits the round that is really running, not a skipped tick", async () => {
+    // A tick that lands while a slow round is still writing is SKIPPED and
+    // resolves immediately. If that no-op were what `stop()` awaited, `stop()`
+    // would return while an observation was still being written — and a caller
+    // that closed the database next would tear it out from under the write.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let writesCompleted = 0;
+    const slowStore = new MemoryStore();
+    const append = slowStore.append.bind(slowStore);
+    slowStore.append = async (rows) => {
+      await gate;
+      await append(rows);
+      writesCompleted += 1;
+    };
+
+    const slow = new ValidatorLivenessCollector({
+      config: {
+        enabled: true,
+        reason: "test",
+        nodeUrls: ["http://127.0.0.1:9090"],
+        pollIntervalMs: 60_000,
+        retentionMs: 7 * 24 * 60 * 60 * 1000,
+        timeoutMs: 1_000,
+        maxConcurrency: 1,
+      },
+      store: slowStore,
+      fetchImpl: async () => okResponse(statusPayload(7)),
+    });
+
+    const round = slow.runRound(); // blocks inside append
+    await slow.runRound(); // overlapping: skipped, resolves at once
+    expect(slow.status().roundsSkipped).toBe(1);
+
+    let stopReturned = false;
+    const stopped = slow.stop().then(() => {
+      stopReturned = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(writesCompleted).toBe(0);
+    expect(stopReturned).toBe(false);
+
+    release();
+    await stopped;
+    await round;
+    expect(stopReturned).toBe(true);
+    expect(writesCompleted).toBe(1);
+  });
+
+  it("records a miss observation for an unreachable node rather than throwing", async () => {
+    const failing = new ValidatorLivenessCollector({
+      config: {
+        enabled: true,
+        reason: "test",
+        nodeUrls: ["http://127.0.0.1:9099"],
+        pollIntervalMs: 60_000,
+        retentionMs: 7 * 24 * 60 * 60 * 1000,
+        timeoutMs: 1_000,
+        maxConcurrency: 1,
+      },
+      store,
+      fetchImpl: async () => {
+        throw new Error("connect ECONNREFUSED 127.0.0.1:9099");
+      },
+    });
+
+    // The point: this resolves. A dead fleet is data, not an exception.
+    await expect(failing.runRound()).resolves.toBeUndefined();
+
+    expect(store.rows).toHaveLength(1);
+    const row = store.rows[0];
+    expect(row.status).toBe("miss");
+    expect(row.validatorId).toBe("127.0.0.1:9099");
+    // Nothing is invented for a node that did not answer.
+    expect(row.observedHeight).toBeNull();
+    expect(row.observedUptimeTicks).toBeNull();
+    expect(row.reportedNodeId).toBeNull();
+    expect(row.localPhase).toBeNull();
+    expect(failing.status().observedMisses).toBe(1);
+    await failing.stop();
+  });
+
+  it("advances the round ordinal and the height baseline across rounds", async () => {
+    let height = 100;
+    const advancing = new ValidatorLivenessCollector({
+      config: {
+        enabled: true,
+        reason: "test",
+        nodeUrls: ["http://127.0.0.1:9090"],
+        pollIntervalMs: 60_000,
+        retentionMs: 7 * 24 * 60 * 60 * 1000,
+        timeoutMs: 1_000,
+        maxConcurrency: 1,
+      },
+      store,
+      fetchImpl: async () => okResponse(statusPayload(height)),
+    });
+
+    await advancing.runRound(); // baseline -> late
+    height = 101;
+    await advancing.runRound(); // advanced -> hit
+    await advancing.runRound(); // unchanged -> late
+
+    expect(store.rows.map((r) => r.status)).toEqual(["late", "hit", "late"]);
+    expect(store.rows.map((r) => r.roundSeq)).toEqual([1, 2, 3]);
+    expect(store.rows.map((r) => r.previousHeight)).toEqual([null, 100, 101]);
+    expect(store.rows.map((r) => r.observedHeight)).toEqual([100, 101, 101]);
+    await advancing.stop();
+  });
+
+  it("prunes beyond the retention window on every recorded round", async () => {
+    const now = 1_800_000_000_000;
+    const pruning = new ValidatorLivenessCollector({
+      config: {
+        enabled: true,
+        reason: "test",
+        nodeUrls: ["http://127.0.0.1:9090"],
+        pollIntervalMs: 60_000,
+        retentionMs: 3_600_000,
+        timeoutMs: 1_000,
+        maxConcurrency: 1,
+      },
+      store,
+      now: () => now,
+      fetchImpl: async () => okResponse(statusPayload(5)),
+    });
+
+    await pruning.runRound();
+
+    expect(store.pruneCalls).toEqual([now - 3_600_000]);
+    await pruning.stop();
+  });
+
+  it("surfaces a storage failure instead of swallowing it", async () => {
+    store.failAppendWith = new Error("database is locked");
+    const broken = collector();
+
+    await broken.runRound();
+
+    const status = broken.status();
+    expect(status.storageFailures).toBe(1);
+    expect(status.lastError).toContain("database is locked");
+    // The round is lost, not half-applied: nothing was recorded and the
+    // in-memory baseline was not advanced past a write that did not happen.
+    expect(status.roundsRecorded).toBe(0);
+    expect(store.rows).toHaveLength(0);
+    await broken.stop();
+  });
+
+  it("surfaces a retention failure without losing the recorded round", async () => {
+    store.failPruneWith = new Error("no such table");
+    const broken = collector();
+
+    await broken.runRound();
+
+    const status = broken.status();
+    expect(status.retentionFailures).toBe(1);
+    expect(status.lastError).toContain("no such table");
+    expect(status.roundsRecorded).toBe(1);
+    expect(store.rows).toHaveLength(1);
+    await broken.stop();
+  });
+
+  it("resumes the round ordinal and baseline from the store on restart", async () => {
+    store.rows.push({
+      validatorId: "127.0.0.1:9090",
+      observedAt: new Date(1_700_000_000_000),
+      roundSeq: 41,
+      status: "hit",
+      sourceNodeUrl: "http://127.0.0.1:9090",
+      observedHeight: 500,
+      previousHeight: 499,
+      observedUptimeTicks: 5000,
+      reportedNodeId: "node-1",
+      localPhase: 1,
+      meanPhase: 1,
+      detail: "height advanced 499 -> 500",
+    });
+
+    const restarted = new ValidatorLivenessCollector({
+      config: {
+        enabled: true,
+        reason: "test",
+        nodeUrls: ["http://127.0.0.1:9090"],
+        pollIntervalMs: 60_000,
+        retentionMs: 7 * 24 * 60 * 60 * 1000,
+        timeoutMs: 1_000,
+        maxConcurrency: 1,
+      },
+      store,
+      fetchImpl: async () => okResponse(statusPayload(501)),
+    });
+
+    await restarted.runRound();
+
+    const appended = store.rows[store.rows.length - 1];
+    // Ordinal continues from the stored high-water mark...
+    expect(appended.roundSeq).toBe(42);
+    // ...and the node is NOT treated as a never-before-seen baseline, so real
+    // progress across the restart is recorded as the hit it was.
+    expect(appended.previousHeight).toBe(500);
+    expect(appended.status).toBe("hit");
+    await restarted.stop();
+  });
+});
+
+// ─── Source shaping ──────────────────────────────────────────────────────────
+
+describe("observed-liveness source", () => {
+  it("declares its semantics, including that consensus attestation is unavailable", () => {
+    const descriptor = buildObservedLivenessDescriptor({
+      enabled: true,
+      reason: "test",
+      nodeUrls: ["http://127.0.0.1:9090"],
+      pollIntervalMs: 30_000,
+      retentionMs: 86_400_000,
+      timeoutMs: 1_000,
+      maxConcurrency: 1,
+    });
+
+    expect(descriptor.kind).toBe("observed-liveness");
+    expect(descriptor.sourceId).toBe(OBSERVED_LIVENESS_SOURCE_ID);
+    // The cadence and retention reported are the ones actually in force.
+    expect(descriptor.method.pollIntervalMs).toBe(30_000);
+    expect(descriptor.method.retentionMs).toBe(86_400_000);
+    expect(descriptor.method.endpoint).toBe("/status");
+    // A miss must be unmistakable.
+    expect(descriptor.statusSemantics.miss).toContain("did not answer this poll round");
+    expect(descriptor.statusSemantics.miss).toContain("NOT a missed consensus attestation");
+    expect(descriptor.consensusAttestation.available).toBe(false);
+    // Stake is not observed anywhere in this build, and the descriptor says so.
+    expect(descriptor.stake.available).toBe(false);
+    expect(descriptor.roundIdentifier.meaning).toContain("not a");
+  });
+
+  it("groups rows per validator, ordered by round, keeping the real height", () => {
+    const rows: ValidatorLivenessObservationRecord[] = [
+      {
+        validatorId: "b:9090",
+        observedAt: new Date(2_000),
+        roundSeq: 2,
+        status: "miss",
+        sourceNodeUrl: "http://b:9090",
+        observedHeight: null,
+        previousHeight: 10,
+        observedUptimeTicks: null,
+        reportedNodeId: null,
+        localPhase: null,
+        meanPhase: null,
+        detail: "no answer: timeout",
+      },
+      {
+        validatorId: "a:9090",
+        observedAt: new Date(1_000),
+        roundSeq: 1,
+        status: "hit",
+        sourceNodeUrl: "http://a:9090",
+        observedHeight: 11,
+        previousHeight: 10,
+        observedUptimeTicks: 110,
+        reportedNodeId: "node-a",
+        localPhase: 1,
+        meanPhase: 1,
+        detail: "height advanced 10 -> 11",
+      },
+    ];
+
+    const histories = toValidatorHistories(rows);
+
+    expect(histories.map((h) => h.validatorId)).toEqual(["a:9090", "b:9090"]);
+    // The label survives a screenshot without the JSON envelope.
+    expect(histories[0].label).toContain("observed liveness");
+    // Stake is not observed, so it is 0 and the descriptor tells consumers to
+    // ignore absolute amounts.
+    expect(histories[0].stake).toBe(0);
+    expect(histories[0].records[0]).toEqual({
+      slot: 1,
+      timestamp: 1_000,
+      status: "hit",
+      observedHeight: 11,
+    });
+    // A miss carries a null height — nothing is carried forward.
+    expect(histories[1].records[0].observedHeight).toBeNull();
+  });
+
+  it("reads the requested window from the store and substitutes nothing when empty", async () => {
+    const store = new MemoryStore();
+    const now = 1_800_000_000_000;
+    const source = new ObservedLivenessSource(
+      store,
+      {
+        enabled: true,
+        reason: "test",
+        nodeUrls: ["http://127.0.0.1:9090"],
+        pollIntervalMs: 60_000,
+        retentionMs: 7 * 24 * 60 * 60 * 1000,
+        timeoutMs: 1_000,
+        maxConcurrency: 1,
+      },
+      () => now,
+    );
+
+    const sinceSpy = vi.spyOn(store, "since");
+    const empty = await source.history("1h");
+
+    // An empty window is reported as an empty window.
+    expect(empty).toEqual([]);
+    expect(sinceSpy).toHaveBeenCalledWith(now - 3_600_000, undefined);
+    expect(source.id).toBe(OBSERVED_LIVENESS_SOURCE_ID);
+  });
+});

--- a/server/blockchain/liveness-collector.ts
+++ b/server/blockchain/liveness-collector.ts
@@ -1,0 +1,858 @@
+/**
+ * Observed-liveness collector and live source (issue #456).
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHAT THIS OBSERVES, AND WHAT IT DELIBERATELY DOES NOT
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * The Slashing & Liveness Visualizer's what-if simulator needs "actual history"
+ * to replay a proposed rule against. Consensus ATTESTATION DUTY OUTCOMES DO NOT
+ * EXIST IN THIS BUILD and cannot be manufactured: the oxscada node `GET /status`
+ * surface (`server/blockchain/validator-health.ts`) reports node_id, height,
+ * role, order_parameter, mean_phase, local_phase, peer_phases[], peers, mempool
+ * and uptime_ticks — no per-slot duty result of any kind. `server/blockchain.ts`
+ * is a declared stub. The cross-node state surface (#454) is a point-in-time
+ * signed read, not a duty log.
+ *
+ * So this module does not report attestation. It reports what CAN be truthfully
+ * observed by polling each configured node on a cadence and recording the result
+ * of every round:
+ *
+ *   - the node answered, or did not      (a genuine liveness observation)
+ *   - the height it reported advanced since the previous observation, or did not
+ *
+ * `uptime_ticks`, `local_phase`, `mean_phase` and the node's self-reported
+ * `node_id` are recorded alongside each row so the classification can be
+ * audited, but they do NOT drive it. An advancing `uptime_ticks` adds nothing
+ * over the fact that the node answered at all, and Kuramoto phase is a
+ * coherence measure with no defensible fault threshold here — inventing one
+ * would be exactly the kind of estimate this module refuses to make.
+ *
+ * Every row it writes is a real measurement taken at a real moment. Nothing is
+ * computed, estimated, interpolated or randomised — which is why registering it
+ * through `registerLiveAttestationSource()` is legitimate under that seam's
+ * contract, and why `synthetic: false` on the response is true.
+ *
+ * It is still NOT consensus attestation, so the name says "liveness" everywhere
+ * (source id, table, types, docs, UI) and every response carries a mandatory
+ * {@link AttestationSourceDescriptor} spelling out what each status means. If
+ * the node ever exposes a real duty log, implement it as a second source with
+ * `kind: "consensus-attestation"` — the seam, the route and the UI serve it
+ * unchanged.
+ *
+ * ── STATUS MAPPING, AND WHY ─────────────────────────────────────────────────
+ *
+ *   miss — the node did not answer this poll round (transport failure, timeout,
+ *          non-2xx, oversized body, or an unparseable /status shape).
+ *   hit  — the node answered AND the height it reported was strictly greater
+ *          than the height of its previous observation.
+ *   late — the node answered but the height did not advance, OR this is the
+ *          first observation for that node so there is no previous height to
+ *          compare against.
+ *
+ * The mapping is chosen to line up with how the simulator already treats the
+ * three statuses, so the projection means what an operator would expect:
+ *
+ *   - Only `miss` is slashable in `client/src/lib/slashing-simulator.ts`. "The
+ *     node did not answer at all" is the strongest liveness signal this build
+ *     can observe, and it is the one an operator would want a liveness rule to
+ *     bite on. Nothing weaker is mapped to `miss`.
+ *   - `late` counts as participation but is flagged. "Answered, but showed no
+ *     progress" is exactly that: the node is alive, yet it did not demonstrate
+ *     that the chain moved. It is not evidence of a fault on its own, because
+ *     whether a height should have advanced depends on the node's block cadence
+ *     versus the operator-configured poll cadence. Mapping it to `miss` would
+ *     manufacture penalties out of a fast poll interval.
+ *   - The FIRST observation of a node is `late`, never `hit`. A single sample
+ *     cannot demonstrate progress, and claiming a `hit` from it would be
+ *     asserting something that was not observed. The conservative direction is
+ *     the honest one; `detail` records that the row is a baseline.
+ *   - A height REGRESSION is also `late`, not `miss` — the node answered, so
+ *     calling it a miss would be false. The regression is visible in the row's
+ *     `previous_height` / `observed_height` and in `detail`.
+ *
+ * ── BOUNDING AND GATING ─────────────────────────────────────────────────────
+ *
+ * Outbound requests reuse the bounded transport that already backs
+ * `GET /api/validators` (`./validator-dashboard`): the same URL parsing, node
+ * cap, per-request timeout covering the body read, response byte cap,
+ * concurrency limit and one-attempt-no-retry policy. There is no second fetch
+ * path.
+ *
+ * OFF BY DEFAULT. Nothing is armed unless `VALIDATOR_LIVENESS_COLLECTOR_ENABLED`
+ * is exactly `"true"` AND `ANCHOR_NODE_URLS` names at least one node. With no
+ * new environment set, no timer exists, no poll happens, no row is written, and
+ * `GET /api/nodes/attestation-history` keeps failing closed with 503 exactly as
+ * before.
+ */
+
+import pino from "pino";
+import {
+  MAX_NODES,
+  loadValidatorDashboardConfig,
+  mapWithConcurrency,
+  parseNodeUrls,
+  pollNodeStatus,
+  type DashboardFetch,
+} from "./validator-dashboard";
+import type { ValidatorNodeView } from "@shared/types/services/validator-dashboard";
+import {
+  MAX_LIVENESS_OBSERVATION_ROWS,
+  appendValidatorLivenessObservations,
+  getLatestValidatorLivenessHeights,
+  getValidatorLivenessRoundSeqHighWaterMark,
+  listValidatorLivenessObservations,
+  pruneValidatorLivenessObservations,
+  type ValidatorLivenessObservationRecord,
+} from "../storage";
+import {
+  clearLiveAttestationSource,
+  registerLiveAttestationSource,
+  type LiveAttestationSource,
+} from "../routes/nodes";
+import {
+  WINDOW_MS,
+  type AttestationSourceDescriptor,
+  type AttestationStatus,
+  type TimelineWindow,
+  type ValidatorHistory,
+} from "@shared/types/slashing";
+import { registry } from "../metrics/prometheus";
+
+const logger = pino({ name: "validator-liveness-collector" });
+
+// ─── Identity ────────────────────────────────────────────────────────────────
+
+/**
+ * Stable id of this source. The word "liveness" is load-bearing: it is what the
+ * operator sees in the response `source` field and in the UI.
+ */
+export const OBSERVED_LIVENESS_SOURCE_ID = "oxscada-observed-liveness";
+
+/** Longest column width the observation table accepts for a validator id. */
+const MAX_VALIDATOR_ID_LENGTH = 128;
+
+/**
+ * Identity of a polled endpoint: `host[:port][/path]` of the configured URL.
+ *
+ * Derived OFFLINE, without contacting the node, because the observations that
+ * matter most are the ones where the node did not answer and therefore reported
+ * no `node_id` of its own. Using the node's self-reported id would leave every
+ * `miss` row unattributable.
+ *
+ * Scheme-less by the same reasoning as `nodeLabel` in ./validator-dashboard: the
+ * id reaches the browser, so it identifies a node for troubleshooting without
+ * handing the browser something it could fetch. The path is retained so two
+ * nodes behind one host:port do not collide.
+ */
+export function observedValidatorId(nodeUrl: string): string {
+  let raw: string;
+  try {
+    const parsed = new URL(nodeUrl);
+    raw = `${parsed.host}${parsed.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    raw = nodeUrl;
+  }
+  return raw.slice(0, MAX_VALIDATOR_ID_LENGTH);
+}
+
+// ─── Configuration ───────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS_DEFAULT = 60_000;
+const POLL_INTERVAL_MS_MIN = 5_000;
+const POLL_INTERVAL_MS_MAX = 3_600_000;
+
+/**
+ * Default retention equals the longest window the UI offers (7d). Keeping more
+ * than the UI can ask for would grow the table for no operator benefit; keeping
+ * less would silently shorten the 7d view.
+ */
+const RETENTION_MS_DEFAULT = 7 * 24 * 60 * 60 * 1000;
+const RETENTION_MS_MIN = 60 * 60 * 1000;
+const RETENTION_MS_MAX = 30 * 24 * 60 * 60 * 1000;
+
+export interface LivenessCollectorConfig {
+  /** True only when explicitly opted in AND at least one node is configured. */
+  enabled: boolean;
+  /** Operator-readable statement of the enabled/disabled decision. */
+  reason: string;
+  nodeUrls: string[];
+  pollIntervalMs: number;
+  retentionMs: number;
+  timeoutMs: number;
+  maxConcurrency: number;
+}
+
+function clampInt(raw: string | undefined, fallback: number, min: number, max: number): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(value)));
+}
+
+/**
+ * Read the collector configuration from the environment. Pure in `env`.
+ *
+ * The opt-in must be exactly the string `"true"`: there is no truthy coercion,
+ * so a stray `1` / `yes` / `on` cannot start writing observation rows.
+ */
+export function loadLivenessCollectorConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): LivenessCollectorConfig {
+  const dashboard = loadValidatorDashboardConfig(env);
+  const nodeUrls = parseNodeUrls(env.ANCHOR_NODE_URLS);
+  const optedIn = env.VALIDATOR_LIVENESS_COLLECTOR_ENABLED === "true";
+
+  let reason: string;
+  if (!optedIn) {
+    reason =
+      "disabled — set VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true to record observed liveness";
+  } else if (nodeUrls.length === 0) {
+    // Opted in but nothing to poll. Fail closed and say so rather than arming a
+    // timer that would record nothing.
+    reason =
+      "disabled — VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true but ANCHOR_NODE_URLS names no http(s) node";
+  } else {
+    reason = `enabled — polling ${nodeUrls.length} node(s) (cap ${MAX_NODES})`;
+  }
+
+  return {
+    enabled: optedIn && nodeUrls.length > 0,
+    reason,
+    nodeUrls,
+    pollIntervalMs: clampInt(
+      env.VALIDATOR_LIVENESS_POLL_INTERVAL_MS,
+      POLL_INTERVAL_MS_DEFAULT,
+      POLL_INTERVAL_MS_MIN,
+      POLL_INTERVAL_MS_MAX,
+    ),
+    retentionMs: clampInt(
+      env.VALIDATOR_LIVENESS_RETENTION_MS,
+      RETENTION_MS_DEFAULT,
+      RETENTION_MS_MIN,
+      RETENTION_MS_MAX,
+    ),
+    timeoutMs: dashboard.timeoutMs,
+    maxConcurrency: dashboard.maxConcurrency,
+  };
+}
+
+// ─── Storage seam ────────────────────────────────────────────────────────────
+
+/**
+ * Persistence the collector needs. Backed by `server/storage.ts` in production
+ * (both Postgres and the SQLite dev fallback); injectable so the collector can
+ * be driven against a real database in tests without a composition root.
+ */
+export interface LivenessObservationStore {
+  append(rows: readonly ValidatorLivenessObservationRecord[]): Promise<void>;
+  since(
+    fromMs: number,
+    validatorId?: string,
+  ): Promise<ValidatorLivenessObservationRecord[]>;
+  prune(beforeMs: number): Promise<number>;
+  maxRoundSeq(): Promise<number>;
+  latestHeights(): Promise<Array<{ validatorId: string; observedHeight: number }>>;
+}
+
+export const defaultLivenessObservationStore: LivenessObservationStore = {
+  append: appendValidatorLivenessObservations,
+  since: listValidatorLivenessObservations,
+  prune: pruneValidatorLivenessObservations,
+  maxRoundSeq: getValidatorLivenessRoundSeqHighWaterMark,
+  latestHeights: getLatestValidatorLivenessHeights,
+};
+
+// ─── Classification (pure) ───────────────────────────────────────────────────
+
+export interface ObservationClassification {
+  status: AttestationStatus;
+  /** Bounded, human-readable justification stored alongside the row. */
+  detail: string;
+}
+
+/**
+ * Classify one polled node view against the height of its previous observation.
+ *
+ * PURE — it reads only its arguments. See the module header for the reasoning
+ * behind each branch. `previousHeight` is `null` when this validator has never
+ * been observed answering; that produces a `late` baseline rather than a `hit`,
+ * because a single sample demonstrates no progress.
+ */
+export function classifyObservation(
+  view: ValidatorNodeView,
+  previousHeight: number | null,
+): ObservationClassification {
+  if (!view.reachable || view.status === null) {
+    return {
+      status: "miss",
+      detail: `no answer: ${view.error ?? "unknown transport failure"}`.slice(0, 240),
+    };
+  }
+
+  const height = view.status.height;
+  if (previousHeight === null) {
+    return {
+      status: "late",
+      detail:
+        `baseline: answered at height ${height}; no previous observation to ` +
+        "compare against, so progress was not demonstrated",
+    };
+  }
+  if (height > previousHeight) {
+    return {
+      status: "hit",
+      detail: `height advanced ${previousHeight} -> ${height}`,
+    };
+  }
+  return {
+    status: "late",
+    detail:
+      `answered, but height did not advance (previous ${previousHeight}, ` +
+      `observed ${height})`,
+  };
+}
+
+// ─── Metrics ─────────────────────────────────────────────────────────────────
+
+const livenessRoundsTotal = registry.counter(
+  "validator_liveness_rounds_total",
+  "Poll rounds whose observations were successfully persisted",
+);
+const livenessObservationsTotal = registry.counter(
+  "validator_liveness_observations_total",
+  "Liveness observations persisted, by recorded status",
+  ["status"],
+);
+const livenessStorageFailuresTotal = registry.counter(
+  "validator_liveness_storage_failures_total",
+  "Poll rounds whose observations could not be persisted",
+);
+const livenessRetentionFailuresTotal = registry.counter(
+  "validator_liveness_retention_failures_total",
+  "Retention prunes that failed",
+);
+const livenessRowsPrunedTotal = registry.counter(
+  "validator_liveness_rows_pruned_total",
+  "Observation rows deleted by retention",
+);
+const livenessCollectorRunning = registry.gauge(
+  "validator_liveness_collector_running",
+  "Whether the observed-liveness collector has a poll timer armed (1/0)",
+);
+
+// ─── Collector ───────────────────────────────────────────────────────────────
+
+export interface LivenessCollectorStatus {
+  enabled: boolean;
+  /** Whether a poll timer is currently armed. */
+  running: boolean;
+  reason: string;
+  sourceId: string;
+  nodeCount: number;
+  pollIntervalMs: number;
+  retentionMs: number;
+  /** Rounds whose observations were persisted. */
+  roundsRecorded: number;
+  /** Rounds skipped because the previous round was still in flight. */
+  roundsSkipped: number;
+  /** Observations recorded as `miss` (the node did not answer). */
+  observedMisses: number;
+  /** Rounds whose observations could NOT be persisted. */
+  storageFailures: number;
+  retentionFailures: number;
+  rowsPruned: number;
+  lastRoundAt: number | null;
+  /** Most recent failure message, retained so a failure is not invisible. */
+  lastError: string | null;
+}
+
+export interface LivenessCollectorDeps {
+  config?: LivenessCollectorConfig;
+  store?: LivenessObservationStore;
+  /** Injectable transport, forwarded to the shared bounded poller. */
+  fetchImpl?: DashboardFetch;
+  /** Injectable clock so cadence and retention are testable without sleeping. */
+  now?: () => number;
+}
+
+/**
+ * Polls the configured nodes on a cadence and persists one observation per node
+ * per round.
+ *
+ * Lifecycle contract:
+ *   - `start()` is idempotent; calling it twice arms exactly one timer.
+ *   - `stop()` clears the timer and awaits any round still in flight, so a test
+ *     that stops the collector leaves nothing running and nothing writing.
+ *   - a failing node degrades to a `miss` observation; it never throws out of a
+ *     round (the shared `pollNodeStatus` never throws by construction).
+ *   - a storage failure is logged, counted, exposed on `status()` and exported
+ *     as a Prometheus counter — never silently swallowed.
+ */
+export class ValidatorLivenessCollector {
+  private readonly config: LivenessCollectorConfig;
+  private readonly store: LivenessObservationStore;
+  private readonly fetchImpl: DashboardFetch | undefined;
+  private readonly now: () => number;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  /** The round currently executing, retained so `stop()` can await it. */
+  private inFlight: Promise<void> | null = null;
+  /** Guard against a timer firing while the previous round is still running. */
+  private inFlightRound = false;
+  private primed = false;
+  private nextRoundSeq = 1;
+  /** Last height actually observed per validator; seeded from the store. */
+  private readonly lastHeight = new Map<string, number>();
+
+  private roundsRecorded = 0;
+  private roundsSkipped = 0;
+  private observedMisses = 0;
+  private storageFailures = 0;
+  private retentionFailures = 0;
+  private rowsPruned = 0;
+  private lastRoundAt: number | null = null;
+  private lastError: string | null = null;
+
+  constructor(deps: LivenessCollectorDeps = {}) {
+    this.config = deps.config ?? loadLivenessCollectorConfig();
+    this.store = deps.store ?? defaultLivenessObservationStore;
+    this.fetchImpl = deps.fetchImpl;
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  getConfig(): LivenessCollectorConfig {
+    return this.config;
+  }
+
+  status(): LivenessCollectorStatus {
+    return {
+      enabled: this.config.enabled,
+      running: this.timer !== null,
+      reason: this.config.reason,
+      sourceId: OBSERVED_LIVENESS_SOURCE_ID,
+      nodeCount: this.config.nodeUrls.length,
+      pollIntervalMs: this.config.pollIntervalMs,
+      retentionMs: this.config.retentionMs,
+      roundsRecorded: this.roundsRecorded,
+      roundsSkipped: this.roundsSkipped,
+      observedMisses: this.observedMisses,
+      storageFailures: this.storageFailures,
+      retentionFailures: this.retentionFailures,
+      rowsPruned: this.rowsPruned,
+      lastRoundAt: this.lastRoundAt,
+      lastError: this.lastError,
+    };
+  }
+
+  /**
+   * Prime the round ordinal and the per-validator height baseline from the
+   * store. Runs once. Doing this BEFORE the first round is what makes the
+   * history continuous across a restart: without it the collector would reuse
+   * round ordinals already in the window and would treat every node as a
+   * never-before-seen baseline.
+   */
+  private async prime(): Promise<void> {
+    if (this.primed) return;
+    const [highWaterMark, heights] = await Promise.all([
+      this.store.maxRoundSeq(),
+      this.store.latestHeights(),
+    ]);
+    this.nextRoundSeq = highWaterMark + 1;
+    for (const entry of heights) {
+      this.lastHeight.set(entry.validatorId, entry.observedHeight);
+    }
+    this.primed = true;
+  }
+
+  /**
+   * Arm the poll timer. Idempotent, and a no-op when the feature is not opted
+   * in. Priming happens before the timer is armed, so a store that cannot be
+   * read leaves the collector unarmed rather than writing from a wrong baseline.
+   */
+  async start(): Promise<LivenessCollectorStatus> {
+    if (this.timer !== null) return this.status();
+    if (!this.config.enabled) {
+      logger.info({ reason: this.config.reason }, "observed-liveness collector not started");
+      return this.status();
+    }
+
+    await this.prime();
+
+    this.timer = setInterval(() => {
+      // `runRound()` publishes the round it actually starts on `this.inFlight`,
+      // so `stop()` awaits a timer-fired round too, not just the first one.
+      // Assigning the returned promise here instead would be wrong: a tick that
+      // lands while a slow round is still running is SKIPPED and resolves
+      // immediately, which would overwrite the real round's promise and let
+      // `stop()` return while that round was still writing.
+      void this.runRoundSafely();
+    }, this.config.pollIntervalMs);
+    // Never keep the process alive just to poll.
+    this.timer.unref?.();
+    livenessCollectorRunning.set(1);
+
+    logger.info(
+      {
+        nodes: this.config.nodeUrls.length,
+        pollIntervalMs: this.config.pollIntervalMs,
+        retentionMs: this.config.retentionMs,
+        nextRoundSeq: this.nextRoundSeq,
+      },
+      "observed-liveness collector started (liveness observations only — not consensus attestation)",
+    );
+
+    // Record a first round immediately, but do not block startup on it.
+    // `runRound()` retains it on `this.inFlight` so `stop()` can await it.
+    void this.runRoundSafely();
+    return this.status();
+  }
+
+  /** Clear the timer and await any in-flight round. Idempotent. */
+  async stop(): Promise<void> {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    livenessCollectorRunning.set(0);
+    const pending = this.inFlight;
+    this.inFlight = null;
+    if (pending) await pending;
+  }
+
+  private runRoundSafely(): Promise<void> {
+    return this.runRound().catch((err: unknown) => {
+      // runRound already handles poll and storage failures; reaching here means
+      // something unexpected, which must still not kill the timer.
+      const message = err instanceof Error ? err.message : String(err);
+      this.lastError = message;
+      logger.error({ err: message }, "observed-liveness round failed unexpectedly");
+    });
+  }
+
+  /**
+   * Poll every configured node once and persist one observation each.
+   *
+   * Public so tests can drive rounds deterministically instead of waiting on a
+   * timer. Overlapping invocations are skipped rather than queued: a fleet that
+   * is slower than the poll interval must not accumulate rounds.
+   */
+  async runRound(): Promise<void> {
+    if (this.inFlightRound) {
+      this.roundsSkipped += 1;
+      return;
+    }
+    this.inFlightRound = true;
+    // Publish the round that is actually starting, so `stop()` awaits THIS one.
+    // A skipped tick returns above without touching `inFlight`, so it can never
+    // mask a round that is still writing.
+    const running = this.executeRound();
+    // `stop()` must not reject just because a round did — failures are already
+    // counted, logged and exported — so what it awaits is a settled-either-way
+    // view of the same round. `await running` below still propagates to a test
+    // that drives rounds directly.
+    this.inFlight = running.then(
+      () => undefined,
+      () => undefined,
+    );
+    await running;
+  }
+
+  private async executeRound(): Promise<void> {
+    try {
+      await this.prime();
+      await this.collectAndPersist();
+    } finally {
+      this.inFlightRound = false;
+    }
+  }
+
+  private async collectAndPersist(): Promise<void> {
+    const roundSeq = this.nextRoundSeq;
+    this.nextRoundSeq += 1;
+    const observedAtMs = this.now();
+    const observedAt = new Date(observedAtMs);
+
+    const views = await mapWithConcurrency(
+      this.config.nodeUrls,
+      this.config.maxConcurrency,
+      (nodeUrl) =>
+        pollNodeStatus(nodeUrl, {
+          timeoutMs: this.config.timeoutMs,
+          fetchImpl: this.fetchImpl,
+          now: this.now,
+        }),
+    );
+
+    const rows: ValidatorLivenessObservationRecord[] = views.map((view, index) => {
+      const nodeUrl = this.config.nodeUrls[index];
+      const validatorId = observedValidatorId(nodeUrl);
+      const previousHeight = this.lastHeight.get(validatorId) ?? null;
+      const { status, detail } = classifyObservation(view, previousHeight);
+      const observed = view.status;
+      return {
+        validatorId,
+        observedAt,
+        roundSeq,
+        status,
+        sourceNodeUrl: nodeUrl,
+        // Absent observations stay absent: nothing is carried forward from an
+        // earlier round when the node did not answer.
+        observedHeight: observed ? observed.height : null,
+        previousHeight,
+        observedUptimeTicks: observed ? observed.uptimeTicks : null,
+        reportedNodeId: observed ? observed.nodeId.slice(0, 128) : null,
+        localPhase: observed ? observed.localPhase : null,
+        meanPhase: observed ? observed.reportedMeanPhase : null,
+        detail,
+      };
+    });
+
+    try {
+      await this.store.append(rows);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.storageFailures += 1;
+      this.lastError = message;
+      livenessStorageFailuresTotal.inc();
+      logger.error(
+        { err: message, roundSeq, rows: rows.length },
+        "observed-liveness observations could not be persisted; this round is lost",
+      );
+      return;
+    }
+
+    // Advance the in-memory baseline only after a successful write, so it can
+    // never drift from what the table actually holds.
+    for (const row of rows) {
+      if (row.observedHeight !== null) {
+        this.lastHeight.set(row.validatorId, row.observedHeight);
+      }
+      livenessObservationsTotal.inc({ status: row.status });
+      if (row.status === "miss") this.observedMisses += 1;
+    }
+    this.roundsRecorded += 1;
+    this.lastRoundAt = observedAtMs;
+    livenessRoundsTotal.inc();
+
+    await this.pruneRetention(observedAtMs);
+  }
+
+  /** Enforce retention so the table cannot grow without bound. */
+  private async pruneRetention(nowMs: number): Promise<void> {
+    try {
+      const deleted = await this.store.prune(nowMs - this.config.retentionMs);
+      if (deleted > 0) {
+        this.rowsPruned += deleted;
+        livenessRowsPrunedTotal.inc({}, deleted);
+        logger.debug({ deleted }, "pruned observed-liveness rows beyond retention");
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.retentionFailures += 1;
+      this.lastError = message;
+      livenessRetentionFailuresTotal.inc();
+      logger.error({ err: message }, "observed-liveness retention prune failed");
+    }
+  }
+}
+
+// ─── Live source ─────────────────────────────────────────────────────────────
+
+/**
+ * Placeholder stake for observed-liveness histories.
+ *
+ * There is NO stake source in this build — `/status` reports no balance and no
+ * staking contract is read anywhere — so a stake figure here would be invented.
+ * It is reported as 0 and the descriptor declares `stake.available: false`, and
+ * the UI renders the penalty as a percentage only. The percentage is the real
+ * output of the simulator; the absolute amount is not computable and is not
+ * pretended to be.
+ */
+const STAKE_NOT_OBSERVED = 0;
+
+/**
+ * Group observation rows into the per-validator shape the simulator consumes.
+ * PURE. Records come out ascending by round ordinal (and therefore by time).
+ */
+export function toValidatorHistories(
+  rows: readonly ValidatorLivenessObservationRecord[],
+): ValidatorHistory[] {
+  const byId = new Map<string, ValidatorHistory>();
+  for (const row of rows) {
+    let history = byId.get(row.validatorId);
+    if (!history) {
+      history = {
+        validatorId: row.validatorId,
+        // The suffix survives a screenshot or a copy/paste out of the JSON, the
+        // same reasoning as the demo feed's "(demo)".
+        label: `${row.validatorId} (observed liveness)`,
+        stake: STAKE_NOT_OBSERVED,
+        records: [],
+      };
+      byId.set(row.validatorId, history);
+    }
+    history.records.push({
+      slot: row.roundSeq,
+      timestamp: row.observedAt.getTime(),
+      status: row.status,
+      observedHeight: row.observedHeight,
+    });
+  }
+
+  const histories = [...byId.values()];
+  histories.sort((a, b) => a.validatorId.localeCompare(b.validatorId));
+  for (const history of histories) {
+    history.records.sort((a, b) => a.slot - b.slot);
+  }
+  return histories;
+}
+
+/**
+ * Build the mandatory semantics declaration served with every live response.
+ * Pure in its configuration, so the descriptor cannot drift from the cadence
+ * and retention actually in force.
+ */
+export function buildObservedLivenessDescriptor(
+  config: LivenessCollectorConfig,
+): AttestationSourceDescriptor {
+  return {
+    kind: "observed-liveness",
+    sourceId: OBSERVED_LIVENESS_SOURCE_ID,
+    summary:
+      "Observed liveness of each configured oxscada node: whether it answered " +
+      "each poll round, and whether the chain height it reported advanced. " +
+      "These are not consensus attestation duties.",
+    method: {
+      transport: "http-get",
+      endpoint: "/status",
+      fields: ["height", "uptime_ticks", "local_phase", "mean_phase", "node_id"],
+      pollIntervalMs: config.pollIntervalMs,
+      retentionMs: config.retentionMs,
+      maxRecordsPerQuery: MAX_LIVENESS_OBSERVATION_ROWS,
+    },
+    statusSemantics: {
+      hit:
+        "The node answered this poll round and the chain height it reported was " +
+        "strictly greater than the height of its previous observation.",
+      miss:
+        "The node did not answer this poll round — transport failure, timeout, " +
+        "non-2xx response, oversized body, or an unparseable /status payload. " +
+        "This is NOT a missed consensus attestation duty; no duty outcome is " +
+        "observable in this build.",
+      late:
+        "The node answered but the height it reported did not advance, or this " +
+        "was its first observation so no previous height existed to compare " +
+        "against. Whether a stalled height indicates a fault depends on the " +
+        "node's block cadence versus the configured poll cadence.",
+    },
+    roundIdentifier: {
+      field: "slot",
+      meaning:
+        "Monotonic ordinal of the poll round that produced the record — not a " +
+        "consensus slot. The chain height actually read is carried separately " +
+        "as `observedHeight`, and is null when the node did not answer.",
+    },
+    stake: {
+      available: false,
+      note:
+        "No stake source exists in this build, so stake is reported as 0 and " +
+        "absolute penalty amounts are not computed. Projected penalties are " +
+        "meaningful as a percentage of stake only.",
+    },
+    consensusAttestation: {
+      available: false,
+      note:
+        "Consensus attestation duty history remains unavailable: the oxscada " +
+        "/status surface exposes no per-slot duty outcome and nothing else in " +
+        "this build records one. If a node ever exposes a duty log, it can be " +
+        "served through this same seam with kind 'consensus-attestation' and " +
+        "no route or UI change.",
+    },
+  };
+}
+
+/**
+ * The registered live source. Reads persisted observations for the requested
+ * window; it computes no outcome of its own and substitutes nothing when the
+ * table is empty (an empty window is reported as an empty window).
+ */
+export class ObservedLivenessSource implements LiveAttestationSource {
+  readonly id = OBSERVED_LIVENESS_SOURCE_ID;
+  readonly descriptor: AttestationSourceDescriptor;
+
+  constructor(
+    private readonly store: LivenessObservationStore,
+    config: LivenessCollectorConfig,
+    private readonly now: () => number = () => Date.now(),
+  ) {
+    this.descriptor = buildObservedLivenessDescriptor(config);
+  }
+
+  async history(
+    window: TimelineWindow,
+    validatorId?: string,
+  ): Promise<ValidatorHistory[]> {
+    const fromMs = this.now() - WINDOW_MS[window];
+    const rows = await this.store.since(fromMs, validatorId);
+    if (rows.length >= MAX_LIVENESS_OBSERVATION_ROWS) {
+      logger.warn(
+        { window, rows: rows.length, cap: MAX_LIVENESS_OBSERVATION_ROWS },
+        "observed-liveness window hit the row cap; the oldest part of the window is not included",
+      );
+    }
+    return toValidatorHistories(rows);
+  }
+}
+
+// ─── Composition root ────────────────────────────────────────────────────────
+
+let activeCollector: ValidatorLivenessCollector | null = null;
+
+export type StartLivenessCollectorOptions = LivenessCollectorDeps;
+
+/**
+ * Start the collector and, only if it actually started, register its source so
+ * `GET /api/nodes/attestation-history` serves it with `synthetic: false`.
+ *
+ * With no new environment set this returns a disabled status, registers
+ * nothing, and the live route keeps failing closed with 503.
+ */
+export async function startValidatorLivenessCollector(
+  options: StartLivenessCollectorOptions = {},
+): Promise<LivenessCollectorStatus> {
+  if (activeCollector) return activeCollector.status();
+
+  const config = options.config ?? loadLivenessCollectorConfig();
+  const collector = new ValidatorLivenessCollector({ ...options, config });
+  if (!config.enabled) {
+    logger.info({ reason: config.reason }, "observed-liveness collector disabled");
+    return collector.status();
+  }
+
+  const status = await collector.start();
+  activeCollector = collector;
+
+  const store = options.store ?? defaultLivenessObservationStore;
+  registerLiveAttestationSource(
+    new ObservedLivenessSource(store, config, options.now ?? (() => Date.now())),
+  );
+  logger.info(
+    { source: OBSERVED_LIVENESS_SOURCE_ID },
+    "registered observed-liveness source for GET /api/nodes/attestation-history",
+  );
+  return status;
+}
+
+/** Stop the collector and unregister its source. Safe to call when never started. */
+export async function stopValidatorLivenessCollector(): Promise<void> {
+  const collector = activeCollector;
+  activeCollector = null;
+  if (collector) await collector.stop();
+  clearLiveAttestationSource();
+}
+
+/** Current collector status, or null when nothing was started. */
+export function getValidatorLivenessCollectorStatus(): LivenessCollectorStatus | null {
+  return activeCollector ? activeCollector.status() : null;
+}

--- a/server/blueprint/__tests__/production-safety.test.ts
+++ b/server/blueprint/__tests__/production-safety.test.ts
@@ -63,6 +63,7 @@ describe("safe-state audit migration alignment", () => {
       { idx: 6, tag: "0009_blueprint_safe_state_log" },
       { idx: 7, tag: "0010_pid_tuning_audit" },
       { idx: 8, tag: "0011_agent_marketplace" },
+      { idx: 9, tag: "0012_validator_liveness_observations" },
     ]);
     // `when` must stay monotonic so drizzle-kit orders the journal correctly.
     const timestamps = journal.entries.map((e) => e.when);

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,9 @@ import { startBlueprintControlLoop } from "./blueprint/control-loop";
 // Blueprint watchdog / safe-state composition root (#459). Off unless the
 // deployment supplies BLUEPRINT_SAFETY_BINDINGS[_FILE].
 import { blueprintSafetyHost } from "./blueprint/safety-host";
+// Observed-liveness collector (#456). Off unless
+// VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true and ANCHOR_NODE_URLS is set.
+import { startValidatorLivenessCollector } from "./blockchain/liveness-collector";
 
 // Re-export log for backward compatibility
 export { log } from "./logger";
@@ -251,6 +254,26 @@ registerSwaggerRoutes(app, gatewayConfig);
       // the resulting state is always reported by /api/blueprint-safe-state.
       const safetyStatus = blueprintSafetyHost.start();
       log(`Blueprint safety host: ${safetyStatus.state} — ${safetyStatus.reason}`);
+
+      // Observed-liveness collector (#456) — OFF unless
+      // VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true and ANCHOR_NODE_URLS names at
+      // least one node. It polls each node's /status on a cadence and persists
+      // whether the node answered and whether the height it reported advanced.
+      // That is observed liveness, NOT consensus attestation duty history —
+      // which this build still cannot report. When it starts, it registers the
+      // live source behind GET /api/nodes/attestation-history; when it does
+      // not, that route keeps failing closed with 503.
+      try {
+        const livenessStatus = await startValidatorLivenessCollector();
+        log(
+          `Observed-liveness collector: ${livenessStatus.reason}` +
+            (livenessStatus.enabled
+              ? ` (source ${livenessStatus.sourceId}; observed liveness only, not consensus attestation)`
+              : ""),
+        );
+      } catch (err) {
+        logError(err, "Observed-liveness collector failed to start — no source registered");
+      }
 
       // Start periodic health monitoring (every 30 s)
       healthManager.startPeriodicCheck(30_000);

--- a/server/routes/nodes.ts
+++ b/server/routes/nodes.ts
@@ -109,7 +109,9 @@ import {
   type ValidatorStateWatermarkRecord,
 } from "../storage";
 import type {
+  AttestationSourceDescriptor,
   AttestationSourceUnavailableResponse,
+  LiveAttestationHistoryResponse,
   SyntheticAttestationHistoryResponse,
   TimelineWindow,
   ValidatorHistory,
@@ -752,36 +754,50 @@ function handleClientError(err: unknown, res: Response, nodeId: string, key: str
  * Backs the Slashing & Liveness Visualizer. Read-only: this router never writes
  * and never slashes anything.
  *
- * ── WHY THERE IS NO LIVE ATTESTATION FEED HERE ──────────────────────────────
+ * ── CONSENSUS ATTESTATION DUTY HISTORY REMAINS UNAVAILABLE ──────────────────
  *
  * PR #514 originally served a seeded PRNG from `GET /api/nodes/history` as
  * though it were attestation history. That was rejected, correctly: it violates
- * the repository Integrity Rule ("NO fabricated data"). Before rewriting it the
- * tree was searched for a real source, and there is none:
+ * the repository Integrity Rule ("NO fabricated data"). The tree was searched
+ * for a real per-slot duty source, and there is still none:
  *
  *   - `server/blockchain/validator-health.ts` is a real, tested monitor, but it
  *     polls the oxscada node `GET /status` surface, whose schema
  *     (height / peers / mempool / Kuramoto phase / uptime_ticks) carries no
  *     per-slot attestation duty outcome at all. It also keeps only the latest
- *     sample — there is no history — and it is not constructed anywhere in
- *     production code, only in its own test.
+ *     sample — there is no history.
  *   - `server/blockchain.ts` is a declared stub: `isConnected()` returns false
  *     and `getBlockchainHealth()` reports "Not implemented". Chain integration
  *     is opt-in via ENABLE_BLOCKCHAIN and there is no attestation RPC behind it.
  *   - The cross-node state surface above proxies a validator's view of a state
  *     key. It is a point-in-time signed read, not a per-slot duty log, so it
  *     cannot answer "did validator N attest in slot S?" either.
- *   - Neither `shared/schema.ts` nor any migration has an attestations table,
- *     and the batch-anchoring pipeline anchors Merkle roots of industrial
- *     events — not validator duties.
+ *   - The batch-anchoring pipeline anchors Merkle roots of industrial events —
+ *     not validator duties.
  *
- * So this build genuinely cannot report attestation history. Rather than fake
- * it, the endpoints are split by provenance:
+ * That has not changed and is not papered over anywhere.
+ *
+ * ── WHAT THIS BUILD *CAN* OBSERVE, AND DOES ─────────────────────────────────
+ *
+ * `server/blockchain/liveness-collector.ts` polls each configured node's
+ * `/status` on a cadence and persists the result of every round: whether the
+ * node answered, and whether the height it reported advanced. That is real
+ * observed data about a validator at a real moment in time, so it satisfies the
+ * `LiveAttestationSource` contract below and is served with `synthetic: false`.
+ * It is NOT consensus attestation, so it is named "observed liveness"
+ * everywhere and every response carries a mandatory descriptor stating exactly
+ * what `hit` / `miss` / `late` mean for it. The collector is OFF unless
+ * `VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true`; with no source registered this
+ * route behaves exactly as it did before — 503, never generated records.
+ *
+ * The endpoints are split by provenance:
  *
  *   GET /api/nodes/attestation-history
- *       The live endpoint. Fails closed with HTTP 503 and a machine-readable
- *       `attestation_source_unavailable` body while no feed exists. It never
- *       falls back to synthetic records.
+ *       The live endpoint. Serves a registered observed source with
+ *       `synthetic: false` plus its semantics descriptor. With no registered
+ *       source it fails closed with HTTP 503 and a machine-readable
+ *       `attestation_source_unavailable` body. It never falls back to
+ *       synthetic records, and a failing source surfaces as 502.
  *
  *   GET /api/nodes/attestation-history/demo
  *       Explicitly-synthetic demo data for exercising the (real, unit-tested)
@@ -790,9 +806,7 @@ function handleClientError(err: unknown, res: Response, nodeId: string, key: str
  *       carries the canonical notice string, and sets `X-Data-Provenance:
  *       synthetic` plus an RFC 9111 `Warning: 199` header.
  *
- * When a real feed lands, register it with `registerLiveAttestationSource()`
- * below and the live route serves it with `synthetic: false`. Do not point the
- * live route at `server/demo/`.
+ * Do not point the live route at `server/demo/`.
  */
 const attestationRouter = Router();
 
@@ -806,15 +820,23 @@ export const DEMO_ENV_FLAG = "SLASHING_DEMO_DATA=true";
 // ---------------------------------------------------------------------------
 
 /**
- * A live per-validator attestation feed.
+ * A live per-validator feed.
  *
  * `history` must return records that were OBSERVED. An implementation that
  * computes, estimates, interpolates or randomises duty outcomes is not a live
  * source and must not be registered here.
+ *
+ * `descriptor` is MANDATORY. `hit` / `miss` / `late` are generic words whose
+ * meaning depends entirely on what the source measured, and an operator must
+ * never be able to read an observed-liveness `miss` ("the node did not answer
+ * this poll round") as a missed consensus duty. A source that will not state
+ * its own semantics cannot be served.
  */
 export interface LiveAttestationSource {
-  /** Stable identifier reported to operators, e.g. "oxscada-rpc". */
+  /** Stable identifier reported to operators, e.g. "oxscada-observed-liveness". */
   readonly id: string;
+  /** Machine-readable declaration of what was measured and what each status means. */
+  readonly descriptor: AttestationSourceDescriptor;
   history(
     window: TimelineWindow,
     validatorId?: string,
@@ -824,16 +846,16 @@ export interface LiveAttestationSource {
 /**
  * The registered live source, if any.
  *
- * Nothing in this repository registers one today — see the section header — so
- * the live route reports "unavailable". This is an empty registry, not a stub
- * implementation: the moment a real feed calls
- * `registerLiveAttestationSource()` at startup, the live route serves it.
+ * This is an empty registry, not a stub implementation. On a default
+ * deployment nothing registers a source and the live route reports
+ * "unavailable"; the observed-liveness collector registers one at startup when
+ * it is explicitly enabled.
  */
 let liveAttestationSource: LiveAttestationSource | undefined;
 
 /**
- * Wire a real observed-attestation feed into the live route. Intended to be
- * called once during server startup by whatever module owns the feed.
+ * Wire an observed feed into the live route. Intended to be called once during
+ * server startup by whatever module owns the feed.
  */
 export function registerLiveAttestationSource(
   source: LiveAttestationSource,
@@ -855,11 +877,27 @@ export function isDemoDataEnabled(): boolean {
   return process.env.SLASHING_DEMO_DATA === "true";
 }
 
+/**
+ * Why the live route is answering 503 on THIS deployment.
+ *
+ * Two separate facts, kept separate on purpose:
+ *   1. Consensus attestation duty history is unavailable in this build, full
+ *      stop. The oxscada /status surface exposes no per-slot duty outcome and
+ *      nothing else records one. That is a property of the build.
+ *   2. The observed-liveness source that this build *can* serve is not running
+ *      here, because it is opt-in. That is a property of the deployment, and it
+ *      is the one an operator can act on.
+ */
 const NO_LIVE_SOURCE_REASON =
-  "No live attestation feed is compiled into this build. The oxscada node " +
-  "/status surface reports height, peers, mempool and Kuramoto phase but no " +
-  "per-slot attestation duty outcome, and nothing in this repository persists " +
-  "per-validator duty history.";
+  "No live source is registered on this deployment. Consensus attestation duty " +
+  "history is unavailable in this build at all: the oxscada node /status " +
+  "surface reports height, peers, mempool, uptime ticks and Kuramoto phase but " +
+  "no per-slot attestation duty outcome, and nothing in this repository records " +
+  "one. An observed-liveness feed IS available — it records, per poll round, " +
+  "whether each configured node answered and whether the height it reported " +
+  "advanced — but it is opt-in: set VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true " +
+  "and configure ANCHOR_NODE_URLS. Observed liveness is not consensus " +
+  "attestation and is labelled as such wherever it is served.";
 
 function unavailableBody(): AttestationSourceUnavailableResponse {
   return {
@@ -901,8 +939,12 @@ const DemoHistoryQuerySchema = HistoryQuerySchema.extend({
 /**
  * GET /api/nodes/attestation-history?window=24h[&validatorId=...]
  *
- * Live per-validator attestation history. Read-only. Returns 503 while no live
- * source is wired — never synthetic records.
+ * Live per-validator history from the registered observed source. Read-only.
+ * Returns 503 while no live source is wired — never synthetic records.
+ *
+ * The response always carries the source's `observation` descriptor, so a
+ * consumer can tell an observed-liveness `miss` ("the node did not answer this
+ * poll round") from a consensus duty miss without out-of-band knowledge.
  */
 attestationRouter.get(
   "/attestation-history",
@@ -924,14 +966,21 @@ attestationRouter.get(
     const { window, validatorId } = parsed.data;
     try {
       const validators = await source.history(window, validatorId);
-      return res.json({
+      const descriptor: AttestationSourceDescriptor = source.descriptor;
+      const body: LiveAttestationHistoryResponse = {
         synthetic: false,
         demo: false,
         provenance: "live",
         source: source.id,
         window,
+        observation: descriptor,
         validators,
-      });
+      };
+      // Provenance survives body truncation, proxying and logging. `live` here
+      // means observed — it does not mean consensus attestation, which the
+      // descriptor's `kind` states explicitly.
+      res.setHeader("X-Data-Provenance", `live:${descriptor.kind}`);
+      return res.json(body);
     } catch (err) {
       // A failing feed must surface as a failure, never as substituted data.
       return res.status(502).json({

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2,7 +2,7 @@
  * Storage/Database module with SQLite fallback for development
  */
 import { drizzle as drizzlePostgres } from 'drizzle-orm/node-postgres';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, gte } from 'drizzle-orm';
 import { Client } from 'pg';
 import { Database } from 'sqlite3';
 import * as schema from '@shared/schema';
@@ -250,6 +250,44 @@ CREATE INDEX IF NOT EXISTS idx_validator_pubkeys_node_active
   ON validator_pubkeys(node_id, active);
 `;
 
+/**
+ * Observed-liveness observation history for the development SQLite database
+ * (#456). Mirrors `migrations/0012_validator_liveness_observations.sql`.
+ *
+ * A 24h/7d window is meaningless if the history dies with the process, so the
+ * collector's output has to be durable on BOTH dialects — otherwise the
+ * what-if slashing simulator would be replaying rules against whatever happened
+ * since the last restart while claiming a 7-day window.
+ *
+ * This table holds LIVENESS OBSERVATIONS (did the node answer this poll round;
+ * did the height it reported advance), never consensus attestation duty
+ * outcomes — this build has no source for those. See the migration for the full
+ * per-status semantics.
+ */
+const validatorLivenessSqliteSchema = `
+CREATE TABLE IF NOT EXISTS validator_liveness_observations (
+  id TEXT PRIMARY KEY,
+  validator_id TEXT NOT NULL,
+  observed_at INTEGER NOT NULL,
+  round_seq INTEGER NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('hit', 'miss', 'late')),
+  source_node_url TEXT NOT NULL,
+  observed_height INTEGER,
+  previous_height INTEGER,
+  observed_uptime_ticks INTEGER,
+  reported_node_id TEXT,
+  local_phase REAL,
+  mean_phase REAL,
+  detail TEXT,
+  created_at INTEGER NOT NULL,
+  UNIQUE(validator_id, round_seq)
+);
+CREATE INDEX IF NOT EXISTS idx_validator_liveness_observed_at
+  ON validator_liveness_observations(observed_at);
+CREATE INDEX IF NOT EXISTS idx_validator_liveness_validator_observed_at
+  ON validator_liveness_observations(validator_id, observed_at);
+`;
+
 function toSnakeCase(value: string): string {
   return value.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 }
@@ -274,6 +312,21 @@ function sqliteExec(sqlText: string): Promise<void> {
 function sqliteRun(sqlText: string, parameters: unknown[] = []): Promise<void> {
   return new Promise((resolve, reject) => {
     requireSqliteClient().run(sqlText, parameters, (error) => error ? reject(error) : resolve());
+  });
+}
+
+/**
+ * `sqliteRun` variant that reports how many rows the statement touched.
+ * sqlite3 exposes that only as `this.changes` inside a non-arrow callback, so
+ * this cannot reuse `sqliteRun`. Used by retention pruning, which has to be
+ * able to report what it deleted rather than pruning blind.
+ */
+function sqliteRunWithChanges(sqlText: string, parameters: unknown[] = []): Promise<number> {
+  return new Promise((resolve, reject) => {
+    requireSqliteClient().run(sqlText, parameters, function (this: { changes: number }, error) {
+      if (error) reject(error);
+      else resolve(this.changes);
+    });
   });
 }
 
@@ -389,6 +442,7 @@ async function openSqliteDatabase(databasePath: string): Promise<void> {
   });
   await sqliteExec(blueprintSqliteSchema);
   await sqliteExec(validatorRegistrySqliteSchema);
+  await sqliteExec(validatorLivenessSqliteSchema);
 }
 
 export const initializeDatabase = async () => {
@@ -1047,6 +1101,278 @@ export const recordValidatorStateWatermark = async (
     );
   }
   return current;
+};
+
+// ─── Observed liveness observations (#456) ───────────────────────────────────
+//
+// Durable per-validator liveness history for the Slashing & Liveness
+// Visualizer's what-if simulator. Written only by
+// `server/blockchain/liveness-collector.ts`; read only by its live
+// attestation source. Postgres schema: migrations/0012_validator_liveness_observations.sql.
+// SQLite schema: `validatorLivenessSqliteSchema` above, applied on every open.
+//
+// These rows record whether a configured node ANSWERED a poll round and whether
+// the chain height it reported ADVANCED. They are not consensus attestation
+// duty outcomes and must never be populated from a computed or estimated one.
+
+/** One observation row, as stored and as read back. */
+export interface ValidatorLivenessObservationRecord {
+  /** `host[:port][/path]` of the configured node URL. */
+  validatorId: string;
+  observedAt: Date;
+  /** Monotonic poll-round ordinal (see the migration for why not chain height). */
+  roundSeq: number;
+  status: 'hit' | 'miss' | 'late';
+  sourceNodeUrl: string;
+  /** NULL when the node did not answer. Never carried forward. */
+  observedHeight: number | null;
+  previousHeight: number | null;
+  observedUptimeTicks: number | null;
+  reportedNodeId: string | null;
+  localPhase: number | null;
+  meanPhase: number | null;
+  detail: string | null;
+}
+
+/**
+ * Hard cap on rows returned by one `listValidatorLivenessObservations` call, so
+ * a 7d window over a large fleet cannot pull an unbounded result set into
+ * memory. The NEWEST rows win: when the cap bites, the older part of the window
+ * is simply absent. It is never summarised, downsampled or synthesised — the
+ * API descriptor reports the cap so a short timeline is explicable.
+ */
+export const MAX_LIVENESS_OBSERVATION_ROWS = 100_000;
+
+function toLivenessObservationRecord(
+  row: Record<string, unknown>,
+): ValidatorLivenessObservationRecord {
+  const num = (value: unknown): number | null =>
+    value === null || value === undefined ? null : Number(value);
+  const str = (value: unknown): string | null =>
+    value === null || value === undefined ? null : String(value);
+  const status = String(row.status);
+  if (status !== 'hit' && status !== 'miss' && status !== 'late') {
+    // The column is CHECK-constrained on both dialects, so this can only fire
+    // if the table was written outside this module. Fail loudly: a status this
+    // code cannot interpret must not be silently coerced into a duty outcome.
+    throw new Error(`Unknown liveness observation status "${status}"`);
+  }
+  return {
+    validatorId: String(row.validatorId),
+    observedAt: row.observedAt instanceof Date
+      ? row.observedAt
+      : new Date(Number(row.observedAt)),
+    roundSeq: Number(row.roundSeq),
+    status,
+    sourceNodeUrl: String(row.sourceNodeUrl),
+    observedHeight: num(row.observedHeight),
+    previousHeight: num(row.previousHeight),
+    observedUptimeTicks: num(row.observedUptimeTicks),
+    reportedNodeId: str(row.reportedNodeId),
+    localPhase: num(row.localPhase),
+    meanPhase: num(row.meanPhase),
+    detail: str(row.detail),
+  };
+}
+
+/**
+ * Append one poll round's observations.
+ *
+ * Conflicts on (validator_id, round_seq) are ignored rather than raising: the
+ * unique index assumes a single collector process, and a duplicate can only
+ * mean a second writer or a retried round. Dropping the duplicate keeps the
+ * ordering intact; it never overwrites an observation that was already made.
+ */
+export const appendValidatorLivenessObservations = async (
+  rows: readonly ValidatorLivenessObservationRecord[],
+): Promise<void> => {
+  if (rows.length === 0) return;
+
+  await withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      const now = Date.now();
+      const placeholders = rows.map(() => '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)').join(', ');
+      const parameters: unknown[] = [];
+      for (const row of rows) {
+        parameters.push(
+          randomUUID(),
+          row.validatorId,
+          row.observedAt.getTime(),
+          row.roundSeq,
+          row.status,
+          row.sourceNodeUrl,
+          row.observedHeight,
+          row.previousHeight,
+          row.observedUptimeTicks,
+          row.reportedNodeId,
+          row.localPhase,
+          row.meanPhase,
+          row.detail,
+          now,
+        );
+      }
+      await sqliteRun(
+        `INSERT OR IGNORE INTO validator_liveness_observations
+           (id, validator_id, observed_at, round_seq, status, source_node_url,
+            observed_height, previous_height, observed_uptime_ticks,
+            reported_node_id, local_phase, mean_phase, detail, created_at)
+         VALUES ${placeholders}`,
+        parameters,
+      );
+      return;
+    }
+
+    await requireDatabase()
+      .insert(schema.validatorLivenessObservations)
+      .values(rows.map((row) => ({
+        validatorId: row.validatorId,
+        observedAt: row.observedAt,
+        roundSeq: row.roundSeq,
+        status: row.status,
+        sourceNodeUrl: row.sourceNodeUrl,
+        observedHeight: row.observedHeight,
+        previousHeight: row.previousHeight,
+        observedUptimeTicks: row.observedUptimeTicks,
+        reportedNodeId: row.reportedNodeId,
+        localPhase: row.localPhase,
+        meanPhase: row.meanPhase,
+        detail: row.detail,
+      })))
+      .onConflictDoNothing();
+  });
+};
+
+/**
+ * Observations at or after `fromMs`, chronologically ascending, optionally for
+ * one validator. Bounded by {@link MAX_LIVENESS_OBSERVATION_ROWS}: the query
+ * takes the NEWEST rows and the caller receives them oldest-first.
+ */
+export const listValidatorLivenessObservations = async (
+  fromMs: number,
+  validatorId?: string,
+  limit: number = MAX_LIVENESS_OBSERVATION_ROWS,
+): Promise<ValidatorLivenessObservationRecord[]> => {
+  const cap = Math.max(1, Math.min(Math.trunc(limit), MAX_LIVENESS_OBSERVATION_ROWS));
+
+  return withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      const parameters: unknown[] = [fromMs];
+      let where = 'observed_at >= ?';
+      if (validatorId !== undefined) {
+        where += ' AND validator_id = ?';
+        parameters.push(validatorId);
+      }
+      parameters.push(cap);
+      const rows = await sqliteAll(
+        `SELECT * FROM validator_liveness_observations
+         WHERE ${where}
+         ORDER BY observed_at DESC, round_seq DESC
+         LIMIT ?`,
+        parameters,
+      );
+      return rows
+        .map((row) => toLivenessObservationRecord(decodeSqliteRow(row)))
+        .reverse();
+    }
+
+    const table = schema.validatorLivenessObservations;
+    const predicate = validatorId === undefined
+      ? gte(table.observedAt, new Date(fromMs))
+      : and(gte(table.observedAt, new Date(fromMs)), eq(table.validatorId, validatorId));
+    const rows = await requireDatabase()
+      .select()
+      .from(table)
+      .where(predicate)
+      .orderBy(desc(table.observedAt), desc(table.roundSeq))
+      .limit(cap);
+    return (rows as Record<string, unknown>[])
+      .map(toLivenessObservationRecord)
+      .reverse();
+  });
+};
+
+/**
+ * Delete observations older than `beforeMs`. Returns the number of rows
+ * removed so the caller can report retention rather than prune blind.
+ */
+export const pruneValidatorLivenessObservations = async (
+  beforeMs: number,
+): Promise<number> => {
+  return withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      return sqliteRunWithChanges(
+        'DELETE FROM validator_liveness_observations WHERE observed_at < ?',
+        [beforeMs],
+      );
+    }
+    if (!pgClient) throw new Error('PostgreSQL client is not initialized');
+    const result = await pgClient.query(
+      'DELETE FROM validator_liveness_observations WHERE observed_at < $1',
+      [new Date(beforeMs).toISOString()],
+    );
+    return result.rowCount ?? 0;
+  });
+};
+
+/**
+ * Highest `round_seq` ever written, or 0 when the table is empty. The collector
+ * resumes from this on startup so the round ordinal stays monotonic across
+ * restarts instead of colliding with rows already in the window.
+ */
+export const getValidatorLivenessRoundSeqHighWaterMark = async (): Promise<number> => {
+  return withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      const rows = await sqliteAll(
+        'SELECT MAX(round_seq) AS max_round_seq FROM validator_liveness_observations',
+      );
+      const value = rows[0]?.max_round_seq;
+      return value === null || value === undefined ? 0 : Number(value);
+    }
+    if (!pgClient) throw new Error('PostgreSQL client is not initialized');
+    const result = await pgClient.query<{ max_round_seq: string | null }>(
+      'SELECT MAX(round_seq) AS max_round_seq FROM validator_liveness_observations',
+    );
+    const value = result.rows[0]?.max_round_seq;
+    return value === null || value === undefined ? 0 : Number(value);
+  });
+};
+
+/**
+ * The most recent height actually observed for each validator, used to seed the
+ * collector's height-progress comparison after a restart. Only rows that carry
+ * a height are considered, so a run of unanswered polls does not erase the last
+ * real reading — and nothing is invented for a validator that has never
+ * answered (it is simply absent, and its next observation is a baseline).
+ */
+export const getLatestValidatorLivenessHeights = async (): Promise<
+  Array<{ validatorId: string; observedHeight: number }>
+> => {
+  const sqlText = `
+    SELECT o.validator_id AS validator_id, o.observed_height AS observed_height
+    FROM validator_liveness_observations o
+    WHERE o.observed_height IS NOT NULL
+      AND o.round_seq = (
+        SELECT MAX(i.round_seq)
+        FROM validator_liveness_observations i
+        WHERE i.validator_id = o.validator_id AND i.observed_height IS NOT NULL
+      )
+  `;
+
+  return withStorageLock(async () => {
+    if (dbType !== 'postgres') {
+      const rows = await sqliteAll(sqlText);
+      return rows.map((row) => ({
+        validatorId: String(row.validator_id),
+        observedHeight: Number(row.observed_height),
+      }));
+    }
+    if (!pgClient) throw new Error('PostgreSQL client is not initialized');
+    const result = await pgClient.query<{ validator_id: string; observed_height: string }>(sqlText);
+    return result.rows.map((row) => ({
+      validatorId: String(row.validator_id),
+      observedHeight: Number(row.observed_height),
+    }));
+  });
 };
 // ─── Blueprint safe-state audit trail (#459) ────────────────────────────────
 // The watchdog's safe-state transitions must be durable on BOTH dialects. The

--- a/shared/__tests__/schema-parity.test.ts
+++ b/shared/__tests__/schema-parity.test.ts
@@ -7,6 +7,7 @@ import {
   validatorNodes as pgValidatorNodes,
   validatorPubkeys as pgValidatorPubkeys,
   validatorStateWatermarks as pgValidatorStateWatermarks,
+  validatorLivenessObservations as pgValidatorLivenessObservations,
   blueprintSafeStateLog as pgBlueprintSafeStateLog,
   pidTuningAudit as pgPidTuningAudit,
 } from '../schema';
@@ -16,6 +17,7 @@ import {
   validatorNodes as sqliteValidatorNodes,
   validatorPubkeys as sqliteValidatorPubkeys,
   validatorStateWatermarks as sqliteValidatorStateWatermarks,
+  validatorLivenessObservations as sqliteValidatorLivenessObservations,
   blueprintSafeStateLog as sqliteBlueprintSafeStateLog,
   pidTuningAudit as sqlitePidTuningAudit,
 } from '../schema-sqlite';
@@ -55,6 +57,15 @@ const cases = [
     name: 'validator_state_watermarks',
     pg: pgValidatorStateWatermarks,
     sqlite: sqliteValidatorStateWatermarks,
+  },
+  // #456: the observed-liveness history the what-if slashing simulator replays
+  // rules against. A column present on only one dialect would silently drop
+  // part of an observation record — and an observation that cannot be audited
+  // is indistinguishable from an invented one.
+  {
+    name: 'validator_liveness_observations',
+    pg: pgValidatorLivenessObservations,
+    sqlite: sqliteValidatorLivenessObservations,
   },
   {
     name: 'blueprint_safe_state_log',

--- a/shared/schema-sqlite.ts
+++ b/shared/schema-sqlite.ts
@@ -332,6 +332,36 @@ export const validatorStateWatermarks = sqliteTable("validator_state_watermarks"
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
 });
 
+// ─── Observed Liveness Observations (#456) ───────────────────────────────────
+// Dev-mode parity with the Postgres table in `shared/schema.ts`, created in
+// production by migrations/0012_validator_liveness_observations.sql. The
+// physical SQLite DDL lives in `validatorLivenessSqliteSchema` (server/storage.ts)
+// and is applied on every open. Kept in sync by
+// `shared/__tests__/schema-parity.test.ts`.
+//
+// This table records OBSERVED LIVENESS — whether each configured node answered
+// a poll round and whether the chain height it reported advanced. It does NOT
+// record consensus attestation duty outcomes; this build has no source for
+// those. See the Postgres definition for the full per-status semantics.
+//
+// timestamptz → integer timestamp, bigint → integer, double precision → real.
+export const validatorLivenessObservations = sqliteTable("validator_liveness_observations", {
+  id: text("id").primaryKey(),
+  validatorId: text("validator_id").notNull(),
+  observedAt: integer("observed_at", { mode: "timestamp" }).notNull(),
+  roundSeq: integer("round_seq").notNull(),
+  status: text("status").notNull(),
+  sourceNodeUrl: text("source_node_url").notNull(),
+  observedHeight: integer("observed_height"),
+  previousHeight: integer("previous_height"),
+  observedUptimeTicks: integer("observed_uptime_ticks"),
+  reportedNodeId: text("reported_node_id"),
+  localPhase: real("local_phase"),
+  meanPhase: real("mean_phase"),
+  detail: text("detail"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+});
+
 // ─── Blueprint Safe-State audit trail (#459) ─────────────────────────────────
 // Dev-mode parity with the Postgres table in `shared/schema.ts`, which is
 // created in production by migrations/0009_blueprint_safe_state_log.sql. The

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -26,6 +26,7 @@ import {
   integer,
   bigint,
   real,
+  doublePrecision,
   jsonb,
   pgEnum,
   index,
@@ -615,6 +616,75 @@ export const validatorStateWatermarks = pgTable("validator_state_watermarks", {
   nodeKeyIdx: uniqueIndex("idx_validator_state_watermarks_node_key").on(table.nodeId, table.stateKey),
 }));
 
+// ─── Observed Liveness Observations (#456) ───────────────────────────────────
+//
+// One row per configured node per poll round of the observed-liveness collector
+// (`server/blockchain/liveness-collector.ts`). This is the durable history the
+// Slashing & Liveness Visualizer's what-if simulator replays a proposed rule
+// against.
+//
+// READ THE COLUMN NAMES LITERALLY. This table records LIVENESS OBSERVATIONS, not
+// consensus attestation duty outcomes. The oxscada `/status` surface reports
+// height / peers / mempool / Kuramoto phase / uptime_ticks and carries no
+// per-slot duty outcome whatsoever, so no such outcome can be stored here. What
+// each row asserts is exactly:
+//
+//   miss — the collector polled `source_node_url` at `observed_at` and the node
+//          did not answer (transport failure, non-2xx, oversized body, or an
+//          unparseable /status shape). `detail` carries the bounded reason.
+//   hit  — the node answered and `observed_height` was strictly greater than
+//          `previous_height` (the height stored by the previous observation).
+//   late — the node answered but `observed_height` did not advance, OR this is
+//          the first observation for the validator and there is no previous
+//          height to compare against (`detail` distinguishes the two).
+//
+// Nothing is interpolated. When the node did not answer, `observed_height`,
+// `observed_uptime_ticks`, `reported_node_id`, `local_phase` and `mean_phase`
+// are NULL — never carried forward from an earlier round.
+//
+// SINGLE WRITER. `round_seq` is a per-collector monotonic ordinal (see the
+// column comment) and the unique index below assumes one collector process
+// writes this table. Running two would conflict on (validator_id, round_seq);
+// inserts use ON CONFLICT DO NOTHING so the loser is dropped rather than
+// corrupting the ordering.
+export const validatorLivenessObservations = pgTable("validator_liveness_observations", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  // Stable identity of the polled endpoint: `host[:port][/path]` of the
+  // configured URL, derived WITHOUT contacting the node. It has to be derivable
+  // offline because the most important rows are the ones where the node did not
+  // answer and therefore reported no node_id of its own.
+  validatorId: varchar("validator_id", { length: 128 }).notNull(),
+  observedAt: timestamp("observed_at", { withTimezone: true }).notNull(),
+  // Monotonic ordinal of the poll round that produced this row. Deliberately
+  // NOT the chain height: height is per-node (so it cannot identify a
+  // fleet-wide round), it is absent exactly when the node did not answer (the
+  // rows that matter most for slashing), and it can regress. `round_seq` counts
+  // poll rounds that actually happened and is resumed from MAX(round_seq) at
+  // startup so it stays monotonic across restarts. The real height is kept in
+  // `observed_height` so no information is lost.
+  roundSeq: bigint("round_seq", { mode: "number" }).notNull(),
+  // 'hit' | 'miss' | 'late', with the meanings spelled out in the block above.
+  status: varchar("status", { length: 8 }).notNull(),
+  // Exact URL polled, for audit. Not returned to the browser.
+  sourceNodeUrl: varchar("source_node_url", { length: 512 }).notNull(),
+  observedHeight: bigint("observed_height", { mode: "number" }),
+  previousHeight: bigint("previous_height", { mode: "number" }),
+  observedUptimeTicks: bigint("observed_uptime_ticks", { mode: "number" }),
+  reportedNodeId: varchar("reported_node_id", { length: 128 }),
+  localPhase: doublePrecision("local_phase"),
+  meanPhase: doublePrecision("mean_phase"),
+  // Bounded, human-readable reason for the recorded status.
+  detail: text("detail"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  validatorRoundIdx: uniqueIndex("idx_validator_liveness_validator_round")
+    .on(table.validatorId, table.roundSeq),
+  // Window queries (1h / 24h / 7d) and retention pruning both scan by time.
+  observedAtIdx: index("idx_validator_liveness_observed_at").on(table.observedAt),
+  validatorObservedAtIdx: index("idx_validator_liveness_validator_observed_at")
+    .on(table.validatorId, table.observedAt),
+}));
+
 // ─── Modbus Register Map (Issue #462: Modbus TCP Server Mode) ────────────────
 //
 // Per-site mapping of 0xSCADA tags to Modbus addresses so standard Modbus
@@ -811,6 +881,7 @@ export const insertControllerSchema = createInsertSchema(controllers);
 export const insertValidatorNodeSchema = createInsertSchema(validatorNodes);
 export const insertValidatorPubkeySchema = createInsertSchema(validatorPubkeys);
 export const insertValidatorStateWatermarkSchema = createInsertSchema(validatorStateWatermarks);
+export const insertValidatorLivenessObservationSchema = createInsertSchema(validatorLivenessObservations);
 export const insertModbusRegisterMapSchema = createInsertSchema(modbusRegisterMap);
 
 // Type exports
@@ -852,6 +923,8 @@ export type ValidatorStateWatermark = typeof validatorStateWatermarks.$inferSele
 export type InsertValidatorNode = typeof validatorNodes.$inferInsert;
 export type InsertValidatorPubkey = typeof validatorPubkeys.$inferInsert;
 export type InsertValidatorStateWatermark = typeof validatorStateWatermarks.$inferInsert;
+export type ValidatorLivenessObservationRow = typeof validatorLivenessObservations.$inferSelect;
+export type InsertValidatorLivenessObservationRow = typeof validatorLivenessObservations.$inferInsert;
 export type ModbusRegisterMapRow = typeof modbusRegisterMap.$inferSelect;
 export type InsertModbusRegisterMapRow = typeof modbusRegisterMap.$inferInsert;
 export type PidTuningAuditRow = typeof pidTuningAudit.$inferSelect;

--- a/shared/types/slashing.ts
+++ b/shared/types/slashing.ts
@@ -6,33 +6,62 @@
  * that BOTH the server endpoints and the client simulator/UI share a single
  * source of truth.
  *
- * PROVENANCE IS PART OF THE CONTRACT. This repository has NO live per-validator
- * attestation feed (see server/routes/nodes.ts for the full investigation), so
- * the only history this build can produce is explicitly-requested synthetic demo
- * data. Every transport envelope therefore carries a `synthetic` discriminant
- * and, when synthetic, a human-readable `notice`. Consumers must branch on
- * `synthetic` before presenting anything to an operator.
+ * PROVENANCE IS PART OF THE CONTRACT. Every transport envelope carries a
+ * `synthetic` discriminant and, when synthetic, a human-readable `notice`.
+ * Consumers must branch on `synthetic` before presenting anything to an
+ * operator.
+ *
+ * SEMANTICS ARE ALSO PART OF THE CONTRACT. `hit` / `miss` / `late` are generic
+ * words, and what they actually mean depends entirely on what the source
+ * measured. This build has NO consensus attestation duty feed — the oxscada
+ * node exposes no per-slot duty outcome (see server/routes/nodes.ts). The live
+ * source it *can* offer is an observed-liveness feed: whether each configured
+ * node answered a poll round and whether the chain height it reported advanced.
+ * That is real observed data, but it is NOT consensus attestation, so every
+ * live envelope carries an {@link AttestationSourceDescriptor} stating exactly
+ * what was measured and exactly what each status means for that source. An
+ * operator must never be able to read one of these `miss` values as a missed
+ * consensus duty.
  */
 
 /**
- * Outcome of a single attestation duty for one validator at one slot.
- * - `hit`     : the validator attested correctly and on time.
- * - `miss`    : the validator failed to attest (liveness fault contributor).
- * - `late`    : the validator attested but outside the inclusion window. Treated
- *               as a participation hit but flagged so the UI can distinguish it.
+ * Outcome recorded for one validator at one point in a source's record series.
+ *
+ * The canonical consensus reading is:
+ * - `hit`  : the validator attested correctly and on time.
+ * - `miss` : the validator failed to attest (liveness fault contributor).
+ * - `late` : the validator attested but outside the inclusion window. Treated
+ *            as a participation hit but flagged so the UI can distinguish it.
+ *
+ * NO SOURCE IN THIS BUILD MEASURES THAT. A source must declare its own mapping
+ * in {@link AttestationSourceDescriptor.statusSemantics}; the three labels above
+ * describe the *slashing model's* treatment of each status (only `miss` is
+ * slashable; `late` counts as participation), not a claim about what any
+ * particular feed observed.
  */
 export type AttestationStatus = "hit" | "miss" | "late";
 
 /**
- * A single attestation duty record. One per assigned slot per validator.
+ * A single record. One per validator per round of whatever the source measures.
  */
 export interface AttestationRecord {
-  /** Slot index this duty was assigned for (monotonically increasing). */
+  /**
+   * Round identifier. Monotonically increasing per validator and consistent
+   * with `timestamp` ordering. Its meaning is source-specific and is declared
+   * in {@link AttestationSourceDescriptor.roundIdentifier}.
+   */
   slot: number;
-  /** Unix epoch milliseconds at which the slot occurred. */
+  /** Unix epoch milliseconds at which the round occurred. */
   timestamp: number;
-  /** Outcome of the duty. */
+  /** Outcome of the round. */
   status: AttestationStatus;
+  /**
+   * Chain height the source actually read for this record, when it has one.
+   * `null` means the source had no answer this round (so no height exists);
+   * omitted entirely by sources that do not read a height at all. Never
+   * carried forward from a previous round — an absent observation stays absent.
+   */
+  observedHeight?: number | null;
 }
 
 /**
@@ -111,6 +140,98 @@ export interface SyntheticAttestationHistoryResponse {
   /** Wall-clock anchor (ms) the synthetic slots were laid out backwards from. */
   readonly anchorMs: number;
   readonly validators: SyntheticValidatorHistory[];
+}
+
+// ---------------------------------------------------------------------------
+// Live source semantics
+// ---------------------------------------------------------------------------
+
+/**
+ * What a live source actually measured.
+ *
+ * - `consensus-attestation` : per-slot validator duty outcomes from consensus.
+ *                             NOTHING IN THIS BUILD PRODUCES THIS.
+ * - `observed-liveness`     : whether the node answered a poll and whether the
+ *                             chain height it reported advanced. Real observed
+ *                             data about node availability and progress; it is
+ *                             not a duty log and cannot be read as one.
+ */
+export type ObservationKind = "consensus-attestation" | "observed-liveness";
+
+/** Plain-language definition of each status, as produced by ONE source. */
+export interface ObservationStatusSemantics {
+  readonly hit: string;
+  readonly miss: string;
+  readonly late: string;
+}
+
+/**
+ * Machine-readable declaration of a live source's semantics. Mandatory: a
+ * source may not be served without stating what it measured, because `miss` is
+ * otherwise indistinguishable from a missed consensus duty.
+ */
+export interface AttestationSourceDescriptor {
+  /** What class of thing was measured. */
+  readonly kind: ObservationKind;
+  /** Stable id of the source that produced the records. */
+  readonly sourceId: string;
+  /** One-sentence operator-readable statement of what was measured. */
+  readonly summary: string;
+  /** How the measurement was taken. */
+  readonly method: {
+    /** e.g. "http-get". */
+    readonly transport: string;
+    /** Endpoint polled, e.g. "/status". */
+    readonly endpoint: string;
+    /** Response fields the source reads and records. */
+    readonly fields: readonly string[];
+    /** Poll cadence in ms; `null` for event-driven sources. */
+    readonly pollIntervalMs: number | null;
+    /** How long records are retained before pruning, in ms. */
+    readonly retentionMs: number;
+    /**
+     * Hard cap on records returned for one query. When a window holds more
+     * than this, the NEWEST records are returned and the older part of the
+     * window is absent rather than summarised.
+     */
+    readonly maxRecordsPerQuery: number;
+  };
+  /** Exactly what `hit` / `miss` / `late` mean for THIS source. */
+  readonly statusSemantics: ObservationStatusSemantics;
+  /** What `AttestationRecord.slot` identifies for this source. */
+  readonly roundIdentifier: {
+    readonly field: string;
+    readonly meaning: string;
+  };
+  /**
+   * Whether `ValidatorHistory.stake` is a measured value. When `false` the
+   * stake figure is a placeholder and absolute penalty amounts are meaningless;
+   * consumers must show the percentage only.
+   */
+  readonly stake: {
+    readonly available: boolean;
+    readonly note: string;
+  };
+  /**
+   * Whether the records are consensus attestation duty outcomes. `false` for
+   * every source this build ships; `note` says so in operator-readable terms.
+   */
+  readonly consensusAttestation: {
+    readonly available: boolean;
+    readonly note: string;
+  };
+}
+
+/** Envelope returned by the live attestation-history endpoint when a source is registered. */
+export interface LiveAttestationHistoryResponse {
+  readonly synthetic: false;
+  readonly demo: false;
+  readonly provenance: "live";
+  readonly source: string;
+  readonly window: TimelineWindow;
+  /** Mandatory semantics declaration — see {@link AttestationSourceDescriptor}. */
+  readonly observation: AttestationSourceDescriptor;
+  readonly validators: ValidatorHistory[];
 }
 
 /**


### PR DESCRIPTION
Split out per your note on #456: *"That feed is the remaining work, and it is a different-sized job than this issue was scoped for; probably worth splitting out."*

Your status comment is accurate about `main` as it stands. #608 merged at its first commit (`0112117b3`) only — the feed commit I'd pushed to that branch didn't make the merge, so `main` today has no `liveness-collector.ts` and no migration `0012`, and `/api/nodes/attestation-history` still 503s. This PR is that commit, cherry-picked onto current `main` (clean, no conflicts).

## What it does

Adds a real, persisted, per-validator observation feed and registers it through the `registerLiveAttestationSource()` seam #608 left. The live route then serves `synthetic: false`.

**It does not invent duty outcomes.** Your analysis of why no attestation source exists is unchanged and still correct: `/status` carries no per-slot duty outcome, `blockchain.ts` has no attestation RPC, the cross-node surface is a point-in-time read, and there was no table. So this feed records only what is genuinely observable by polling `/status` on a cadence — **did the node answer, and did the height it reported advance**. Those are measurements at real moments, which is what makes `synthetic: false` truthful and registration legitimate under the seam's own doc comment.

It is **observed liveness, not consensus attestation**, and it says so everywhere — source id, table name, types, docs, UI. The 200 carries a mandatory descriptor:

```
X-Data-Provenance: live:observed-liveness
observation.kind = "observed-liveness"
observation.statusSemantics.miss =
  "The node did not answer this poll round — transport failure, timeout, non-2xx,
   oversized body, or an unparseable /status payload. This is NOT a missed
   consensus attestation duty; no duty outcome is observable in this build."
observation.consensusAttestation = { available: false, note: "..." }
```

## Status mapping, and two places I chose the conservative reading

- **miss** — the node did not answer this poll round.
- **hit** — it answered *and* its reported height strictly advanced.
- **late** — it answered but the height did not advance, or this is its first observation.

A stalled height is deliberately **not** a `miss`: whether a height *should* have advanced depends on the node's block cadence versus the operator's poll cadence, so slashing on it would manufacture penalties out of a fast poll interval. A first observation is `late`, never `hit` — one sample demonstrates no progress, and calling it a hit would assert something unobserved. A height regression is `late`, not `miss`, because the node did answer.

`uptime_ticks` and Kuramoto phase are recorded for audit but do **not** drive classification — there is no defensible fault threshold for phase here, and inventing one would be exactly the estimate this module refuses to make.

**Round identifier is a poll-round ordinal, not chain height.** Height is per-node so it cannot identify a fleet-wide round, it is absent precisely on `miss` rows (the ones that matter for slashing), and it can regress. Real height is still persisted and exposed as `observedHeight`, `null` when the node did not answer.

**Stake** has no source in this build, so it is `0`, the descriptor declares `stake.available: false`, and the UI renders "not observed" rather than a confident zero.

## The criterion, proven rather than asserted

`liveness-collector-durability.test.ts` runs a real file-backed SQLite DB: the collector polls a node that answers, then refuses connections for eight rounds (the double throws `connect ECONNREFUSED`, so the `miss` rows come from a genuine transport failure), then answers at a higher height. The DB is **closed and reopened**, read back through the production source, and `parseRulePhrase("slash 1% per miss after 2 in 1h")` — your issue's own phrasing — feeds the **unmodified** `simulateRule`:

```
statuses      [late, miss×8, hit]
total 10  misses 8  penaltyEvents 6  totalPenaltyPct 6  livenessFaults 1  runLen 8
```

## Safety and bounding

- **Off by default.** `VALIDATOR_LIVENESS_COLLECTOR_ENABLED` must be exactly `"true"` *and* `ANCHOR_NODE_URLS` must name a node. With no new env: no timer, no poll, no row, and the 503 path byte-for-byte unchanged (pinned by a test).
- Reuses #606's bounded transport (`pollNodeStatus`, `mapWithConcurrency`, `MAX_NODES`, `MAX_RESPONSE_BYTES`) — no second fetch path.
- Retention defaults to 7d (the longest UI window), clamped and enforced after each recorded round.
- Reads capped at 100k rows, newest-wins, never summarised.
- `stop()` clears the timer and awaits the round that is really running.
- Storage failures are counted, logged, and exported as `scada_validator_liveness_*`.

The synthetic demo route, its `SLASHING_DEMO_DATA` gate, its labelling, `synthetic-attestations.ts` and `slashing-simulator.ts` are **byte-identical** — verified with an empty diff.

## Verification

`npx tsc --noEmit` exits 0. Full suite on this branch: **160 files / 3254 tests passing**, 2 files + 5 tests skipped.

## Known gaps

- **Postgres is unverified.** Migration `0012` has never executed and the Postgres branches of the storage helpers are untested — SQLite only. The schema-parity test is also **name-level only**: it compares column names, not types or nullability, so a dialect divergence would pass green.
- Never run against a real oxscada node. Node-side schema drift would surface as `bad shape` → `miss` observations, which would look like an outage rather than a parse failure.
- Single-writer is documented but not enforced: `onConflictDoNothing` on unique `(validator_id, round_seq)` means two collector replicas silently drop the loser's observation.
- Retention prunes only after a successfully recorded round.
- `AttestationRecord.slot` keeps its consensus-sounding JSON key for a poll-round ordinal; mitigated by the mandatory descriptor rather than renaming the shared type and churning the deliberately untouched simulator.

Refs #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)
