### PR TITLE
feat(nlquery): scoped, bounded natural-language process query (#216)

### DIFF
--- a/client/src/pages/intelligence.tsx
+++ b/client/src/pages/intelligence.tsx
@@ -28,8 +28,8 @@ interface TabDefinition {
 
 interface TabContent {
   heading: string;
-  /** Server contract for this capability: 501 unbuilt, 410 moved. */
-  status: 'not-implemented' | 'moved';
+  /** Server contract: 501 unbuilt, 410 moved, or served on this path. */
+  status: 'not-implemented' | 'moved' | 'implemented';
   /** What the legacy /api/intelligence path now returns. */
   legacyPath: string;
   summary: string;
@@ -46,14 +46,23 @@ const TABS: readonly TabDefinition[] = [
 const CONTENT: Record<TabKey, TabContent> = {
   'nl-query': {
     heading: 'Natural language query',
-    status: 'not-implemented',
+    status: 'implemented',
     legacyPath: 'POST /api/intelligence/nlquery',
     summary:
-      'Not implemented. No natural-language query engine is wired to this '
-      + 'service, so there is nothing to display here. The endpoint returns '
-      + '501 with { error: "not_implemented" } rather than a placeholder '
-      + 'answer.',
-    endpoints: [],
+      'Implemented (#216), and served on this path rather than moved. A regex '
+      + 'intent grammar resolves tag names against the historian, the live tag '
+      + 'stream, and the alarm-correlation engine; when it cannot identify a '
+      + 'tag or reach a store it says so instead of returning a number. Access '
+      + 'requires the nlquery.read control-plane scope — a read scope, because '
+      + 'the POST carries the question in the body but mutates nothing. '
+      + 'Execution is bounded (query length, wall-clock timeout, result and '
+      + 'scan caps) and any truncation is reported in the response. Query '
+      + 'history is process-local and lost on restart. This page issues no '
+      + 'query itself and displays no plant data.',
+    endpoints: [
+      'POST /api/intelligence/nlquery',
+      'GET /api/intelligence/nlquery/history',
+    ],
   },
   predictive: {
     heading: 'Predictive maintenance',
@@ -93,11 +102,13 @@ const CONTENT: Record<TabKey, TabContent> = {
 const STATUS_LABEL: Record<TabContent['status'], string> = {
   'not-implemented': 'Not implemented',
   moved: 'Moved — this path returns 410',
+  implemented: 'Implemented — requires nlquery.read',
 };
 
 const STATUS_COLOR: Record<TabContent['status'], string> = {
   'not-implemented': '#ef4444',
   moved: '#f59e0b',
+  implemented: '#86efac',
 };
 
 const Intelligence: React.FC = () => {
@@ -167,9 +178,16 @@ const Intelligence: React.FC = () => {
           }}
         >
           <h3 style={{ fontSize: 14, marginTop: 0, marginBottom: 8, color: '#888' }}>
-            Legacy path
+            {content.status === 'implemented' ? 'Served on this path' : 'Legacy path'}
           </h3>
-          <code style={{ fontSize: 13, color: '#f87171' }}>{content.legacyPath}</code>
+          <code
+            style={{
+              fontSize: 13,
+              color: content.status === 'implemented' ? '#86efac' : '#f87171',
+            }}
+          >
+            {content.legacyPath}
+          </code>
         </div>
 
         {content.endpoints.length > 0 && (

--- a/docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md
+++ b/docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md
@@ -1,0 +1,229 @@
+# ADR-0027: Natural-Language Process Query — Read Scope and Bounded Execution
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Date | 2026-07-28 |
+| Author | Neel Modha |
+| Refines | ADR-0013 [13.5], ADR-0026 |
+| Issue | [#216](https://github.com/NickFlach/0xSCADA/issues/216) |
+
+## Context
+
+### The ADR-0013 citation
+
+Issue #216's review noted that the cited `ADR-0013` "does not exist in
+`docs/adr`". That is accurate about the directory and misleading about the
+document. **ADR-0013 exists**, as
+[`docs/decisions/ADR-0013-autonomous-agent-architecture.md`](../decisions/ADR-0013-autonomous-agent-architecture.md)
+— Status *Accepted*, dated 2026-02-15 — and it is cited 87 times on `main` at
+commit `0aec4ec99` by the whole `[13.x]` intelligence series (predictive maintenance
+13.1, alarm correlation 13.2, digital twin 13.3, PID tuning 13.4, this feature
+13.5, marketplace 13.6). The repository keeps ADRs in two directories,
+`docs/adr/` and `docs/decisions/`, and the reviewer checked the one that does
+not hold it.
+
+So the citation is not dangling and does not need to be removed. What it needed
+was a correct path, which the code comments now carry. This ADR is the
+route-level contract that the review actually asked for: it records the
+decisions #216 makes that ADR-0013 does not specify.
+
+[`ADR-0026: Autonomous Agent Security and Integration Contract`](./ADR-0026-autonomous-agent-security-contract.md)
+already names this module — "NL query | **Authenticated question** | Structured
+process-data answer" — and lists Authentication and Authorization among its open
+compliance gaps. This ADR closes those two rows for this surface.
+
+### What went wrong the first time
+
+The previous attempt at #216 was reviewed as "PARTIAL but clean on security".
+The security properties it got right are preserved verbatim below. What it got
+wrong, and what this decision addresses:
+
+- `requireAuth` on the new routes was a no-op — an unauthenticated read path.
+- Nothing bounded execution. Operator text drove an O(tags x tokens) scan with
+  no cap, no timeout, and no result limit.
+- The engine answered from an in-memory demo store, not from real process data.
+- The `LLMBackend` interface was dead code: injected, never wired, never called.
+- Query history lived in an unbounded process-local `Map` with no statement
+  anywhere that it was not durable.
+
+## Decision
+
+### 1. Both routes require the `nlquery.read` scope
+
+`POST /api/intelligence/nlquery` and `GET /api/intelligence/nlquery/history`
+each carry a route-local
+`requireControlPlaneAccess({ scopes: ["nlquery.read"] })` guard, following the
+#576 pattern used by `/api/validators` and `/api/predictive`.
+
+**`POST /nlquery` is a POST but semantically a READ, and must not require or
+imply write privilege.** It is a POST for transport reasons only: the question
+is operator free text, and a free-text query string lands in access logs, proxy
+logs, and browser history. The handler reads the historian, the tag stream, and
+the alarm-correlation engine; it writes nothing, anywhere.
+
+Two consequences follow, and both are asserted in
+`server/routes/__tests__/nlquery-auth.test.ts`:
+
+- a credential holding **only** `nlquery.read` can ask questions;
+- a credential holding `write` but not `nlquery.read` is **rejected with 403**.
+  Write access is neither required nor sufficient.
+
+The second half needs help from the gateway. `mutationAuthorizationMiddleware`
+applies `DEFAULT_MUTATION_POLICY` (scope `write`) to every mutating `/api`
+request, and a POST is mutating by method. Left alone, that floor would demand
+`write` for a read-only route — locking read-only operators out and implying a
+control privilege the route never exercises. `control-route-policy.ts` therefore
+carries an explicit `nl-query-read` entry mapping `/api/intelligence/nlquery` to
+`["nlquery.read"]`, so the gateway floor and the route-local guard agree.
+
+The full matrix — anonymous → 401, unknown credential → 401, valid credential
+with the wrong scope → 403, correct scope → 200, admin → 200 — is tested per
+route, along with credential-in-query-string rejection and guard-before-validation
+ordering.
+
+### 2. Execution is bounded
+
+Every bound is a named constant in `server/services/nlquery/limits.ts` and each
+has a test in `server/services/nlquery/__tests__/nl-query-bounds.test.ts` that
+proves the bound holds.
+
+| Constant | Value | Bounds | On breach |
+| --- | --- | --- | --- |
+| `MAX_QUERY_LENGTH` | 512 chars | Input size | **400, never truncated** |
+| `QUERY_TIMEOUT_MS` | 2 000 ms | Wall clock per query | Explicit timeout answer, `success: false` |
+| `MAX_RESOLVER_CANDIDATE_TAGS` | 2 000 | Tags scored (the O(tags x tokens) bound) | `searchTruncated`; a miss is reported as "not found among the tags I examined" |
+| `MAX_HISTORY_SAMPLES` | 5 000 | Historian rows per trend | `truncation.historySamples`; answer says the aggregate covers the subset |
+| `MAX_TREND_WINDOW_MS` | 7 days | Trend window | Clamped, `truncation.timeRange` set and stated |
+| `MAX_ALARM_SCAN` | 500 | Alarms fetched | `scanTruncated`; never a bare all-clear |
+| `MAX_RESULT_ITEMS` | 50 | List items serialised | `truncation.resultItems`; true total still reported |
+| `MAX_HISTORY_ENTRIES` | 100 | Query-history ring buffer | Oldest evicted |
+| `MAX_HISTORY_PAGE` | 50 | History rows per response | 400 |
+
+Two properties are deliberate:
+
+- **Over-long input is rejected, not truncated.** Silently answering a question
+  the operator did not finish asking is precisely the failure this surface must
+  not have.
+- **Truncation is reported, never silent.** Every response carries a
+  `truncation` object, and the natural-language answer states the caveat in
+  words. A capped tag count is rendered as `2000+`, not as the site's total.
+
+On the timeout: `Promise.race` bounds the *response*, not the work — a promise
+cannot be cancelled in JavaScript, so an in-flight query runs to completion.
+That residual work is bounded independently, because every port read pushes an
+explicit row cap down to the store as a SQL `LIMIT`. A timed-out query cannot
+leave unbounded work behind it. The code says this plainly rather than claiming
+cancellation it does not perform.
+
+### 3. The engine reads real data, behind a narrow injectable port
+
+`NLQueryDataPort` has four methods, each taking an explicit cap.
+`ProcessDataPort` implements it over the three stores that exist on `main`:
+
+- **Tag catalogue and history** — the `historian_data` table, via Drizzle.
+  There is no dedicated tag table in `shared/schema.ts`; the tag id space is
+  defined by what the historian recorded, the same projection
+  `server/protocols/opcua-server/runtime.ts` uses for its UA address space.
+- **Latest values** — `tagStreamServer.getLatestValues()`, the live stream the
+  gateway scan loop and the field simulator already publish to. A live sample
+  is preferred over the newest historian row because it is fresher, and each
+  reading records which source it came from so the answer can cite provenance.
+- **Active alarms** — `alarmCorrelationService.engine`, over alarms actually
+  ingested through `/api/alarm-correlation`.
+
+**No SQL is constructed from operator text.** Every query is a Drizzle
+query-builder expression with bound parameters; the operator's string reaches a
+parameter slot and never the statement. There is no `eval` and no dynamic
+`RegExp` built from input.
+
+**When data is unavailable, the engine says so.** Reads return
+`PortResult<T>`, so `available: false` ("could not consult the store") stays
+distinct from `available: true, value: null` ("consulted, nothing recorded").
+Collapsing those would let an outage read to an operator as a quiet process.
+The honest-refusal cases are:
+
+- the historian is Postgres-only, and the SQLite development fallback has no
+  `historian_data` table — reported, not faked;
+- `status` reports the last recorded value and its age, and states that no
+  equipment state model is configured, rather than inventing a
+  running/stopped verdict;
+- a comparison with one missing reading reports the gap; a null is never
+  coerced to 0;
+- an unresolved alarm scope reports the total active count and explicitly does
+  **not** read as an all-clear.
+
+### 4. No LLM backend ships — the interface is deleted
+
+The previous attempt shipped an `LLMBackend` interface with `parseQuery` and
+`formatAnswer`. It is **removed**, not re-homed behind a flag.
+
+The decisive reason is `formatAnswer`. It allowed a language model to rewrite
+an operator-facing process answer wholesale. A model doing that can emit a
+number no sensor produced, and no amount of output validation catches a
+plausible-looking wrong reading. On a SCADA surface that is the worst available
+failure mode, and it is exactly what this repository's integrity rule forbids.
+
+`parseQuery` is safer in principle but was still dead code by the review's own
+finding: injected, wired by nothing, exercised only by fakes. It also buys no
+extensibility that the module boundary does not already provide — `parseIntent`
+is a pure `(query, nowMs) => QueryIntent` function, and anyone adding a
+different parsing strategy replaces that one call. Shipping an unused interface
+to advertise a seam that already exists is cost without benefit.
+
+Issue #216 asks for a "pluggable LLM backend interface". That framing predates
+the operator-safety review, and where the two conflict the safety constraint
+wins. **No language model is imported, constructed, or called anywhere in this
+feature; no API key is read; no network dependency is added.** The extension
+point, if one is ever wanted, is `parser.ts`.
+
+### 5. History is process-local, bounded, and says so
+
+Query history is a bounded ring buffer of `MAX_HISTORY_ENTRIES` results held in
+the API process. It is **not** persisted, and this is a decision rather than an
+omission:
+
+- **This surface performs no mutation, so there is nothing to audit durably.**
+  ADR-0026's durability requirement covers "pending approvals and audit
+  records". A read query creates neither. Control-plane audit lives in
+  `audit_logs` and is untouched.
+- **Persisting results would create a second source of truth for process
+  values.** A `QueryResult` embeds the readings that answered it. Writing those
+  to a new table would put a durable, unversioned, retention-policy-free copy
+  of process data outside the historian — with the historian's values reachable
+  by two paths that can disagree. For a SCADA system that is a worse outcome
+  than losing a convenience list on restart.
+- **Free-text operator questions are a data-retention surface** we should not
+  create without a retention policy, and #216 does not define one.
+
+The obligation that comes with this choice is disclosure, and it is met in
+three places: `GET /nlquery/history` returns
+`persistence: "process-local"` plus a `persistenceNote` stating the history is
+"lost on restart and is not shared across replicas or persisted to the
+database"; every query response carries `historyPersistence`; and the service
+module documents it. No migration is added, so `migrations/meta/_journal.json`
+is untouched.
+
+## Consequences
+
+- Read-only operators can query process data with a credential that grants no
+  write capability anywhere in the system.
+- A large site degrades honestly: answers arrive capped and labelled rather
+  than slowly or not at all.
+- The engine answers fewer questions than a fabricating one would, and says so
+  when it cannot answer. That is the intended trade.
+- Restarting the API loses recent query history. Accepted, disclosed, and
+  reversible: if a durable history is later wanted, it is an additive table plus
+  a migration, and the port boundary means the engine does not change.
+- Anyone wanting model-assisted parsing must revisit this ADR rather than
+  filling in a waiting interface.
+
+## Compliance with ADR-0026
+
+| ADR-0026 row | Status on this surface |
+| --- | --- |
+| Authentication | **Closed here.** Both routes fail closed for anonymous and unknown credentials; tested. |
+| Authorization | **Closed here.** Least-privilege read scope, distinct from `write`, enforced at both the route and the gateway floor; both directions tested. |
+| Authenticated identity | N/A — no actor is recorded, because nothing is mutated. |
+| Durable approvals | N/A — no approvals, no mutations. History durability is addressed in §5. |
+| Physical actuation | N/A — read-only surface. |

--- a/server/middleware/control-route-policy.ts
+++ b/server/middleware/control-route-policy.ts
@@ -112,6 +112,20 @@ export const CONTROL_ROUTE_POLICIES: readonly ControlRoutePolicy[] = Object.free
     description: "Change classification rules or trigger recalibration.",
   },
   {
+    id: "nl-query-read",
+    pathPrefix: "/api/intelligence/nlquery",
+    scopes: Object.freeze(["nlquery.read"]),
+    description:
+      "Ask a natural-language process question (#216). This is a POST for "
+      + "transport reasons only — the question is free text that must not land "
+      + "in a URL, and therefore in access logs, proxy logs, and browser "
+      + "history — but it is semantically a READ and mutates nothing. Without "
+      + "this entry the default mutation policy would demand `write`, which "
+      + "would both lock read-only operators out of a read surface and imply a "
+      + "control privilege the route neither needs nor exercises. The "
+      + "route-local guard enforces the same `nlquery.read` scope.",
+  },
+  {
     id: "digital-twin-control",
     pathPrefix: "/api/intelligence/digitaltwin/operate",
     scopes: Object.freeze(["control.write"]),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -27,6 +27,7 @@ import { tuningRoutes } from "./routes/tuning";
 import { tuningService } from "./services/tuning";
 import { marketplaceRoutes } from "./routes/marketplace";
 import { marketplaceService } from "./services/marketplace";
+import { nlQueryService } from "./services/nlquery";
 import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
@@ -184,6 +185,16 @@ export async function registerRoutes(
   // publish path checks plugin ownership against the loaded registry, and an
   // ownership check against an unhydrated registry would authorize a hijack.
   await marketplaceService.initialize();
+
+  // Mark the NL query service live here — services/initializeServices() has no
+  // callers at startup (#216). There is nothing to subscribe or schedule: the
+  // engine reads the historian, the live tag stream, and the alarm-correlation
+  // engine at query time rather than keeping a shadow copy of process data, so
+  // initialize() only flips the health flag.
+  void nlQueryService.initialize();
+  httpServer.once("close", () => {
+    void nlQueryService.shutdown();
+  });
 
   // WebSocket metrics endpoint. The legacy event-stream server was removed;
   // only the tag and unified streams report (#446, #479).

--- a/server/routes/__tests__/intelligence-contract.test.ts
+++ b/server/routes/__tests__/intelligence-contract.test.ts
@@ -12,6 +12,14 @@
  * same test server so the "the working APIs still work" half of the contract is
  * exercised rather than assumed.
  *
+ * Update (#216): POST /nlquery and GET /nlquery/history are no longer 501 —
+ * the engine was built, so they serve real answers behind a `nlquery.read`
+ * guard. They moved out of the 501 table into their own block below, which
+ * pins the property that actually matters for them: with no database and no
+ * live tag stream in this harness, they must REFUSE rather than produce a
+ * reading. The anti-fabrication assertions apply to them as much as to the
+ * refusals.
+ *
  * Harness pattern follows predictive-contract.test.ts: port-0 express server,
  * API_KEYS env, x-api-key header. No DB, no network, no new dependencies.
  */
@@ -55,10 +63,11 @@ async function api(method: string, path: string, body?: unknown): Promise<ApiRes
 }
 
 beforeAll(async () => {
-  // A single privileged key satisfies the guards on the real routers. The
-  // intelligence router carries no per-route control-plane guard of its own,
-  // which is precisely why its handlers must not serve engine data (see the
-  // module comment there).
+  // A single privileged key satisfies the guards on the real routers and the
+  // `nlquery.read` guard on the two implemented routes. Every OTHER handler on
+  // the intelligence router still carries no control-plane guard, which is
+  // precisely why those handlers must not serve engine data (see the module
+  // comment there).
   process.env.API_KEYS = `${KEY}:intelligence-contract-tester:*`;
   _resetControlPlaneAuthCache();
 
@@ -114,8 +123,9 @@ function expectNoFabricatedMeasurements(body: Record<string, unknown>): void {
 // ── Endpoints with no implementation anywhere on main → 501 ────────────────
 
 const NOT_IMPLEMENTED: ReadonlyArray<readonly [string, string, unknown]> = [
-  ["POST", "/api/intelligence/nlquery", { query: "Show me pump efficiency trends" }],
-  ["GET", "/api/intelligence/nlquery/history", undefined],
+  // The two /nlquery routes previously listed here are now implemented (#216)
+  // and are covered by their own contract block below, plus the auth matrix in
+  // nlquery-auth.test.ts.
   [
     "POST",
     "/api/intelligence/ml/pipeline",
@@ -223,6 +233,73 @@ describe("no intelligence endpoint returns a value that varies between calls", (
     const b = await api("GET", "/api/intelligence/maintenance/insights/TANK-203");
     expect(b.text).toBe(a.text);
     expect(a.status).toBe(410);
+  });
+});
+
+// ── The implemented NL query surface (#216) ────────────────────────────────
+
+describe("nlquery answers from real data or refuses — never fabricates", () => {
+  it("POST /nlquery refuses honestly when no process data store is reachable", async () => {
+    // This harness has no database and no live tag stream, which is exactly
+    // the condition under which a fabricating implementation would invent a
+    // number. The engine must instead report that it could not read.
+    const res = await api("POST", "/api/intelligence/nlquery", {
+      query: "What is the pressure in tank 3?",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.json.success).toBe(false);
+    const answer = res.json.answer as string;
+    expect(typeof answer).toBe("string");
+    // No digit-bearing reading may appear in a refusal.
+    expect(answer).not.toMatch(/\bis -?\d+(\.\d+)?\b/);
+    expect(res.json.parsedBy).toBe("regex");
+    // The refusal names WHY it could not read, rather than degrading to a
+    // generic error: an operator must be able to tell an outage from a quiet
+    // process. `getDatabase()` throws when uninitialized, so this also pins
+    // that the port converts that throw into a reason instead of letting it
+    // escape into the engine's generic failure branch.
+    expect(answer).toMatch(/tag catalogue/i);
+    expect(answer).toMatch(/Database not initialized/i);
+    expect(answer).not.toMatch(/process data store returned an error/i);
+  });
+
+  it("reports the same refusal on repeated calls — no PRNG in the answer", async () => {
+    const body = { query: "What is the pressure in tank 3?" };
+    const [first, second, third] = await Promise.all([
+      api("POST", "/api/intelligence/nlquery", body),
+      api("POST", "/api/intelligence/nlquery", body),
+      api("POST", "/api/intelligence/nlquery", body),
+    ]);
+    // `id`, `timestamp` and `durationMs` legitimately differ per call, so the
+    // whole body cannot be byte-compared. The ANSWER is the operator-facing
+    // payload and must be stable for a stable question.
+    expect(second.json.answer).toBe(first.json.answer);
+    expect(third.json.answer).toBe(first.json.answer);
+    expect(second.json.success).toBe(first.json.success);
+  });
+
+  it("rejects an over-long question with 400 instead of truncating it", async () => {
+    const res = await api("POST", "/api/intelligence/nlquery", {
+      query: "x".repeat(100_000),
+    });
+    expect(res.status).toBe(400);
+    expect(res.json.error).toBe("invalid_request");
+  });
+
+  it("GET /nlquery/history states plainly that history is not persisted", async () => {
+    const res = await api("GET", "/api/intelligence/nlquery/history");
+    expect(res.status).toBe(200);
+    expect(res.json.persistence).toBe("process-local");
+    expect(res.json.persistenceNote as string).toMatch(/lost on restart/i);
+    expect(Array.isArray(res.json.history)).toBe(true);
+  });
+
+  it("history records the queries this suite just ran, bounded", async () => {
+    const res = await api("GET", "/api/intelligence/nlquery/history?limit=5");
+    expect(res.status).toBe(200);
+    const history = res.json.history as unknown[];
+    expect(history.length).toBeLessThanOrEqual(5);
   });
 });
 

--- a/server/routes/__tests__/nlquery-auth.test.ts
+++ b/server/routes/__tests__/nlquery-auth.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Authorization contract for the natural-language process query surface (#216).
+ *
+ * The maintainer review of the previous attempt found `requireAuth` was a
+ * no-op on the new routes. Both routes now carry
+ * `requireControlPlaneAccess({ scopes: ["nlquery.read"] })`, and this file is
+ * the proof: the full matrix — anonymous, unknown credential, valid credential
+ * with the wrong scope, correct scope, admin — is asserted per route.
+ *
+ * The scope is a READ scope by design. `POST /nlquery` is a POST only because
+ * the question travels in the body; it mutates nothing. Two assertions below
+ * pin that decision in both directions, so a later refactor cannot quietly
+ * turn a read surface into a write-privileged one:
+ *
+ *   - a key holding ONLY `nlquery.read` succeeds (read access is sufficient);
+ *   - a key holding `write` but not `nlquery.read` is rejected with 403
+ *     (write access is neither required nor sufficient).
+ *
+ * Contract: docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import express from 'express';
+import { createServer, type Server } from 'node:http';
+
+import { _resetControlPlaneAuthCache } from '../../middleware/control-plane-auth';
+import {
+  CONTROL_ROUTE_POLICIES,
+  mutationPolicyFor,
+} from '../../middleware/control-route-policy';
+import { MAX_QUERY_LENGTH } from '../../services/nlquery';
+import { intelligenceRoutes } from '../intelligence';
+
+let server: Server;
+let baseUrl: string;
+
+const originalApiKeys = process.env.API_KEYS;
+
+const QUERY_PATH = '/api/intelligence/nlquery';
+const HISTORY_PATH = '/api/intelligence/nlquery/history';
+
+function ask(headers: Record<string, string> = {}, query = 'What tags are available?') {
+  return fetch(`${baseUrl}${QUERY_PATH}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify({ query }),
+  });
+}
+
+function history(headers: Record<string, string> = {}) {
+  return fetch(`${baseUrl}${HISTORY_PATH}`, { headers });
+}
+
+beforeAll(async () => {
+  process.env.API_KEYS = [
+    'nlquery-key:nlquery-reader:nlquery.read',
+    // Holds a broad write grant but NOT nlquery.read — proves the read scope
+    // is required and that `write` does not imply it.
+    'writer-key:generic-writer:write',
+    // A valid credential for an unrelated service.
+    'other-key:other-service:twin.read',
+    'admin-key:platform-admin:admin',
+  ].join(',');
+  _resetControlPlaneAuthCache();
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/intelligence', intelligenceRoutes);
+
+  await new Promise<void>((resolve) => {
+    server = createServer(app);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      baseUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  if (originalApiKeys === undefined) delete process.env.API_KEYS;
+  else process.env.API_KEYS = originalApiKeys;
+  _resetControlPlaneAuthCache();
+});
+
+describe('POST /api/intelligence/nlquery authorization', () => {
+  it('fails closed for an anonymous caller', async () => {
+    expect((await ask()).status).toBe(401);
+  });
+
+  it('rejects an unknown credential', async () => {
+    expect((await ask({ 'x-api-key': 'not-a-key' })).status).toBe(401);
+  });
+
+  it('rejects a credential from an unrelated service', async () => {
+    expect((await ask({ 'x-api-key': 'other-key' })).status).toBe(403);
+  });
+
+  it('rejects a generic write credential — write does not imply nlquery.read', async () => {
+    expect((await ask({ 'x-api-key': 'writer-key' })).status).toBe(403);
+  });
+
+  it('allows the nlquery.read scope', async () => {
+    expect((await ask({ 'x-api-key': 'nlquery-key' })).status).toBe(200);
+  });
+
+  it('allows an admin credential', async () => {
+    expect((await ask({ 'x-api-key': 'admin-key' })).status).toBe(200);
+  });
+
+  it('rejects a credential passed in the query string', async () => {
+    const res = await fetch(`${baseUrl}${QUERY_PATH}?api_key=nlquery-key`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: 'What tags are available?' }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('authorizes before validating the body, so an unauthenticated caller learns nothing', async () => {
+    // An over-long query is a 400 for an authorized caller; anonymous must
+    // still be 401, i.e. the guard runs first.
+    const res = await fetch(`${baseUrl}${QUERY_PATH}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: 'x'.repeat(MAX_QUERY_LENGTH + 1) }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/intelligence/nlquery/history authorization', () => {
+  it('fails closed for an anonymous caller', async () => {
+    expect((await history()).status).toBe(401);
+  });
+
+  it('rejects an unknown credential', async () => {
+    expect((await history({ 'x-api-key': 'not-a-key' })).status).toBe(401);
+  });
+
+  it('rejects a credential from an unrelated service', async () => {
+    expect((await history({ 'x-api-key': 'other-key' })).status).toBe(403);
+  });
+
+  it('rejects a generic write credential', async () => {
+    expect((await history({ 'x-api-key': 'writer-key' })).status).toBe(403);
+  });
+
+  it('allows the nlquery.read scope', async () => {
+    expect((await history({ 'x-api-key': 'nlquery-key' })).status).toBe(200);
+  });
+
+  it('allows an admin credential', async () => {
+    expect((await history({ 'x-api-key': 'admin-key' })).status).toBe(200);
+  });
+});
+
+describe('gateway mutation policy for the nlquery prefix', () => {
+  it('maps POST /nlquery to the nlquery.read scope, not the default write policy', () => {
+    const policy = mutationPolicyFor('POST', QUERY_PATH);
+    expect(policy?.id).toBe('nl-query-read');
+    expect(policy?.scopes).toEqual(['nlquery.read']);
+    // The point of the entry: without it the default policy would demand
+    // `write` for a route that mutates nothing.
+    expect(policy?.scopes).not.toContain('write');
+  });
+
+  it('registers the policy in the central inventory', () => {
+    const entry = CONTROL_ROUTE_POLICIES.find((p) => p.id === 'nl-query-read');
+    expect(entry).toBeDefined();
+    expect(entry?.pathPrefix).toBe('/api/intelligence/nlquery');
+  });
+
+  it('leaves GET /nlquery/history outside the mutation policy entirely', () => {
+    // It is a GET: the mutation inventory must not claim it, and the
+    // route-local guard is what protects it (asserted above).
+    expect(mutationPolicyFor('GET', HISTORY_PATH)).toBeUndefined();
+  });
+});

--- a/server/routes/intelligence.ts
+++ b/server/routes/intelligence.ts
@@ -1,7 +1,14 @@
 /**
  * Legacy /api/intelligence surface.
  *
- * Issue #216 (ADR-0013 [13.5]) review: this router shipped as a demo scaffold
+ * ADR-0013 [13.5] is docs/decisions/ADR-0013-autonomous-agent-architecture.md
+ * (Accepted, 2026-02-15). The #216 review reported it missing because it
+ * checked docs/adr/, which is not where this repository keeps it. The
+ * route-level contract for the nlquery pair below — read scope, bounds, data
+ * sources, and the decisions on the LLM seam and history durability — is
+ * docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md.
+ *
+ * Issue #216 review: this router shipped as a demo scaffold
  * and every handler fabricated its payload — PRNG-generated risk and health
  * "scores" on a 0..100 scale, hardcoded maintenance recommendations, invented
  * 2024 failure dates, canned ML accuracy figures. It was mounted next to the real
@@ -11,14 +18,23 @@
  * measurement is a safety hazard, and it violates the repository integrity
  * rule ("NO shortcuts, fake data, or false claims").
  *
- * No handler here produces data any more. Each returns an explicit,
- * machine-readable refusal:
+ * Every handler here except the two natural-language query routes returns an
+ * explicit, machine-readable refusal:
  *
  *   410 Gone             `error: "endpoint_retired"` — the capability is
  *                        implemented, on another router. The body carries the
  *                        replacement endpoints and the scopes they require.
  *   501 Not Implemented  `error: "not_implemented"` — nothing on `main`
  *                        implements this capability at all.
+ *
+ * `POST /nlquery` and `GET /nlquery/history` are the exception: #216 built the
+ * capability, so they now serve real answers read from the historian, the live
+ * tag stream, and the alarm-correlation engine. Unlike the mock they replace,
+ * they carry a route-local `requireControlPlaneAccess({ scopes: ["nlquery.read"] })`
+ * guard — which is precisely the property whose absence is the reason the rest
+ * of this router refuses to proxy rather than delegating. Their execution is
+ * bounded (input length, wall-clock timeout, result and scan caps), and when
+ * they cannot reach data they say so instead of producing a number.
  *
  * Why refuse rather than proxy to the real engines: every handler on
  * `/api/predictive` and `/api/twin` carries a per-route
@@ -42,7 +58,20 @@
  */
 
 import { Router } from "express";
-import type { Response } from "express";
+import type { Request, RequestHandler, Response } from "express";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error/v3";
+import { requireControlPlaneAccess } from "../middleware/control-plane-auth";
+import {
+  exampleQueries,
+  nlQueryService,
+  MAX_HISTORY_ENTRIES,
+  MAX_HISTORY_PAGE,
+  MAX_QUERY_LENGTH,
+  MAX_RESOLVER_CANDIDATE_TAGS,
+  MAX_RESULT_ITEMS,
+  QUERY_TIMEOUT_MS,
+} from "../services/nlquery";
 
 const router = Router();
 
@@ -110,29 +139,125 @@ const TWIN_REPLACEMENT: Replacement = {
 };
 
 // ── Natural-language query (ADR-0013 [13.5], #216) ─────────────────────────
-// Not implemented on main. The former handler echoed the request back as an
-// "interpretation", returned `results: []`, and appended two fixed
-// "suggestions" — it never reached a data source.
+//
+// These two routes are the one implemented surface on this router. They
+// replace the 501 stubs that stood here while the capability did not exist:
+// the engine now reads the historian (`historian_data`), the live tag stream,
+// and the alarm-correlation engine, and refuses to answer when it cannot.
+//
+// AUTHORIZATION (#576 pattern). Both routes require `nlquery.read`, a READ
+// scope. `POST /nlquery` is a POST for transport reasons only — the question
+// is free text that would otherwise sit in a URL, and therefore in access
+// logs, proxy logs, and browser history — and it mutates nothing. It must
+// therefore never require or imply write privilege: a key holding only
+// `nlquery.read` can ask questions, and a key holding `write` (but not
+// `nlquery.read`) cannot. That second half matters, because the gateway's
+// default mutation policy would otherwise treat this POST as a generic write;
+// `server/middleware/control-route-policy.ts` carries an explicit
+// `nl-query-read` entry so the gateway floor for this prefix is the read
+// scope rather than `write`.
+//
+// Rationale and the full bounds table: docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md.
 
-router.post("/nlquery", (_req, res) => {
-  notImplemented(
-    res,
-    "Natural-language process query is not implemented. The previous handler "
-      + "echoed the submitted query back as an interpretation with an empty "
-      + "result set; it queried no tags, events, or historian data. Query the "
-      + "typed APIs directly (for example GET /api/predictive/alerts or "
-      + "GET /api/v2/events) until this is built.",
-  );
+const requireNlQueryRead = requireControlPlaneAccess({ scopes: ["nlquery.read"] });
+
+/** Express 4 does not catch async rejections — wrap every async handler. */
+function asyncHandler(
+  fn: (req: Request, res: Response) => Promise<unknown>,
+): RequestHandler {
+  return (req, res) => {
+    fn(req, res).catch((error) => {
+      if (!res.headersSent) {
+        res.status(500).json({ error: "Internal error" });
+      }
+      console.error("[nlquery] handler error:", error);
+    });
+  };
+}
+
+/**
+ * Over-long input is REJECTED, not truncated. Answering a question the
+ * operator did not finish asking is the failure mode this surface must not
+ * have, so a 400 that names the limit is the only safe response.
+ */
+const NlQuerySchema = z.object({
+  query: z.string().min(1).max(MAX_QUERY_LENGTH),
 });
 
-router.get("/nlquery/history", (_req, res) => {
-  notImplemented(
-    res,
-    "Natural-language query history is not implemented. No query history is "
-      + "recorded anywhere in this service; the previous handler returned one "
-      + "hardcoded example row stamped with the current time.",
-  );
+const HistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(MAX_HISTORY_PAGE).default(MAX_HISTORY_PAGE),
 });
+
+/** The bounds every response advertises, so a caller can see what shaped it. */
+const NLQUERY_LIMITS = Object.freeze({
+  maxQueryLength: MAX_QUERY_LENGTH,
+  queryTimeoutMs: QUERY_TIMEOUT_MS,
+  maxResolverCandidateTags: MAX_RESOLVER_CANDIDATE_TAGS,
+  maxResultItems: MAX_RESULT_ITEMS,
+  maxHistoryEntries: MAX_HISTORY_ENTRIES,
+});
+
+/**
+ * Stated on every history response and on each query result. History is a
+ * bounded in-process ring buffer: it is lost on restart and is not shared
+ * between replicas. Saying so is part of the contract — an operator must not
+ * mistake this for a durable audit trail (control-plane audit lives in
+ * `audit_logs`, and this surface performs no mutation to audit).
+ */
+const HISTORY_PERSISTENCE = "process-local" as const;
+const HISTORY_PERSISTENCE_NOTE =
+  "Query history is held in a bounded in-memory ring buffer in this process. "
+  + "It is lost on restart and is not shared across replicas or persisted to "
+  + "the database.";
+
+router.post(
+  "/nlquery",
+  requireNlQueryRead,
+  asyncHandler(async (req, res) => {
+    const parsed = NlQuerySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: "invalid_request",
+        detail: fromZodError(parsed.error).message,
+        limits: NLQUERY_LIMITS,
+        examples: exampleQueries(),
+      });
+      return;
+    }
+
+    const result = await nlQueryService.engine.execute(parsed.data.query);
+    res.json({
+      ...result,
+      limits: NLQUERY_LIMITS,
+      historyPersistence: HISTORY_PERSISTENCE,
+    });
+  }),
+);
+
+router.get(
+  "/nlquery/history",
+  requireNlQueryRead,
+  asyncHandler(async (req, res) => {
+    const parsed = HistoryQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: "invalid_request",
+        detail: fromZodError(parsed.error).message,
+        limits: NLQUERY_LIMITS,
+      });
+      return;
+    }
+
+    const history = nlQueryService.engine.getHistory(parsed.data.limit);
+    res.json({
+      history,
+      count: history.length,
+      persistence: HISTORY_PERSISTENCE,
+      persistenceNote: HISTORY_PERSISTENCE_NOTE,
+      limits: NLQUERY_LIMITS,
+    });
+  }),
+);
 
 // ── Predictive maintenance — superseded by /api/predictive (#212) ──────────
 // The former handlers returned a PRNG draw scaled to 0..100 as `riskScore` and

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -84,6 +84,12 @@ export { tuningService } from './tuning';
 export * from './marketplace';
 export { marketplaceService } from './marketplace';
 
+// ── NL Process Query Service (ADR-0013 [13.5], #216) ─────────────────────────
+// Exported by name rather than with `export *`: the module's public surface
+// includes generic bound names (MAX_RESULT_ITEMS, tokenize, ...) that would be
+// ambiguous re-exports from a barrel this wide.
+export { NLQueryService, nlQueryService } from './nlquery';
+
 /**
  * Initialize all services
  * 

--- a/server/services/nlquery/__tests__/nl-query-bounds.test.ts
+++ b/server/services/nlquery/__tests__/nl-query-bounds.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Bounded-execution proofs for the NL process query surface (#216).
+ *
+ * The rebuild brief requires that "query execution should be bounded (result
+ * caps, timeouts) before this surface returns". Every named constant in
+ * `server/services/nlquery/limits.ts` gets a test here that proves the bound
+ * actually holds — not that the constant exists.
+ *
+ * Contract: docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import express from 'express';
+import { createServer, type Server } from 'node:http';
+
+import type {
+  ActiveAlarmPage,
+  HistorySlice,
+  NLQueryDataPort,
+  PortResult,
+  TagCatalogue,
+  TagReading,
+} from '@shared/types/nl-query';
+import { _resetControlPlaneAuthCache } from '../../../middleware/control-plane-auth';
+import { intelligenceRoutes } from '../../../routes/intelligence';
+import { NLQueryEngine } from '../engine';
+import {
+  MAX_ALARM_SCAN,
+  MAX_HISTORY_ENTRIES,
+  MAX_HISTORY_PAGE,
+  MAX_HISTORY_SAMPLES,
+  MAX_QUERY_LENGTH,
+  MAX_RESOLVER_CANDIDATE_TAGS,
+  MAX_RESULT_ITEMS,
+  MAX_TREND_WINDOW_MS,
+  QUERY_TIMEOUT_MS,
+} from '../limits';
+import { parseIntent } from '../parser';
+
+/** Records the caps the engine actually pushes down to the port. */
+interface RecordedCalls {
+  listTagsLimit: number[];
+  historyMaxSamples: number[];
+  alarmLimit: number[];
+}
+
+interface FakePortOptions {
+  tags?: string[];
+  catalogueTruncated?: boolean;
+  history?: TagReading[];
+  historyTruncated?: boolean;
+  alarms?: ActiveAlarmPage['alarms'];
+  alarmsTruncated?: boolean;
+  latest?: TagReading | null;
+  /** Delay every read by this many ms, to exercise the timeout. */
+  delayMs?: number;
+}
+
+function fakePort(options: FakePortOptions = {}): {
+  port: NLQueryDataPort;
+  calls: RecordedCalls;
+} {
+  const calls: RecordedCalls = {
+    listTagsLimit: [],
+    historyMaxSamples: [],
+    alarmLimit: [],
+  };
+  const wait = async (): Promise<void> => {
+    if (options.delayMs) {
+      await new Promise((resolve) => setTimeout(resolve, options.delayMs));
+    }
+  };
+
+  const port: NLQueryDataPort = {
+    async listTags(limit): Promise<PortResult<TagCatalogue>> {
+      calls.listTagsLimit.push(limit);
+      await wait();
+      const tags = options.tags ?? [];
+      return {
+        available: true,
+        value: {
+          tagIds: tags.slice(0, limit),
+          truncated: options.catalogueTruncated ?? tags.length > limit,
+        },
+      };
+    },
+    async readLatest(): Promise<PortResult<TagReading | null>> {
+      await wait();
+      return { available: true, value: options.latest ?? null };
+    },
+    async readHistory(_tagId, _start, _end, maxSamples): Promise<PortResult<HistorySlice>> {
+      calls.historyMaxSamples.push(maxSamples);
+      await wait();
+      return {
+        available: true,
+        value: {
+          samples: options.history ?? [],
+          truncated: options.historyTruncated ?? false,
+        },
+      };
+    },
+    async listActiveAlarms(limit): Promise<PortResult<ActiveAlarmPage>> {
+      calls.alarmLimit.push(limit);
+      await wait();
+      return {
+        available: true,
+        value: {
+          alarms: options.alarms ?? [],
+          truncated: options.alarmsTruncated ?? false,
+        },
+      };
+    },
+  };
+  return { port, calls };
+}
+
+function reading(tagId: string, value: number, timestamp: number): TagReading {
+  return { tagId, value, timestamp, source: 'historian' };
+}
+
+// ── MAX_QUERY_LENGTH ───────────────────────────────────────────────────────
+
+describe('MAX_QUERY_LENGTH', () => {
+  let server: Server;
+  let baseUrl: string;
+  const originalApiKeys = process.env.API_KEYS;
+  const auth = { 'x-api-key': 'nlq-key', 'content-type': 'application/json' };
+
+  beforeAll(async () => {
+    process.env.API_KEYS = 'nlq-key:nlq-reader:nlquery.read';
+    _resetControlPlaneAuthCache();
+    const app = express();
+    app.use(express.json({ limit: '256kb' }));
+    app.use('/api/intelligence', intelligenceRoutes);
+    await new Promise<void>((resolve) => {
+      server = createServer(app);
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+        const port = typeof address === 'object' && address ? address.port : 0;
+        baseUrl = `http://127.0.0.1:${port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (originalApiKeys === undefined) delete process.env.API_KEYS;
+    else process.env.API_KEYS = originalApiKeys;
+    _resetControlPlaneAuthCache();
+  });
+
+  it('accepts a query exactly at the limit', async () => {
+    const res = await fetch(`${baseUrl}/api/intelligence/nlquery`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify({ query: `show ${'a'.repeat(MAX_QUERY_LENGTH - 5)}` }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects one character over the limit with 400 — and does NOT truncate', async () => {
+    const oversized = 'x'.repeat(MAX_QUERY_LENGTH + 1);
+    const res = await fetch(`${baseUrl}/api/intelligence/nlquery`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify({ query: oversized }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; limits: { maxQueryLength: number } };
+    expect(body.error).toBe('invalid_request');
+    expect(body.limits.maxQueryLength).toBe(MAX_QUERY_LENGTH);
+  });
+
+  it('rejects an empty query rather than answering a question nobody asked', async () => {
+    const res = await fetch(`${baseUrl}/api/intelligence/nlquery`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify({ query: '' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('caps GET /nlquery/history at MAX_HISTORY_PAGE', async () => {
+    const res = await fetch(
+      `${baseUrl}/api/intelligence/nlquery/history?limit=${MAX_HISTORY_PAGE + 1}`,
+      { headers: { 'x-api-key': 'nlq-key' } },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('reports history as process-local, not persisted', async () => {
+    const res = await fetch(`${baseUrl}/api/intelligence/nlquery/history`, {
+      headers: { 'x-api-key': 'nlq-key' },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { persistence: string; persistenceNote: string };
+    expect(body.persistence).toBe('process-local');
+    expect(body.persistenceNote).toMatch(/lost on restart/i);
+  });
+});
+
+// ── QUERY_TIMEOUT_MS ───────────────────────────────────────────────────────
+
+describe('QUERY_TIMEOUT_MS', () => {
+  it('returns an explicit, unsuccessful timeout answer rather than hanging', async () => {
+    const { port } = fakePort({ tags: ['TANK-3.PRESSURE'], delayMs: 200 });
+    const engine = new NLQueryEngine({ dataPort: port, timeoutMs: 20 });
+
+    const result = await engine.execute('What is the pressure in tank 3?');
+
+    expect(result.success).toBe(false);
+    expect(result.answer).toMatch(/time limit/i);
+    expect(result.data).toMatchObject({ timedOut: true, timeoutMs: 20 });
+    // The critical property: no value is reported when the read did not finish.
+    expect(result.answer).not.toMatch(/\bis \d/);
+  });
+
+  it('does not time out a fast query', async () => {
+    const { port } = fakePort({ tags: ['TANK-3.PRESSURE'] });
+    const engine = new NLQueryEngine({ dataPort: port, timeoutMs: 1_000 });
+    const result = await engine.execute('What tags are available?');
+    expect(result.success).toBe(true);
+    expect(result.data).not.toHaveProperty('timedOut');
+  });
+
+  it('defaults to the documented QUERY_TIMEOUT_MS', () => {
+    expect(QUERY_TIMEOUT_MS).toBe(2_000);
+  });
+});
+
+// ── The bound VALUES themselves ────────────────────────────────────────────
+
+/**
+ * Every other test in this file states its expectation in terms of the
+ * constant it is testing, which proves the mechanism but not the magnitude:
+ * raising MAX_RESOLVER_CANDIDATE_TAGS to ten million would keep them all
+ * green while unbounding the surface in practice. Pin the literals too, so
+ * loosening a bound has to be a deliberate, reviewable edit to this list.
+ */
+describe('documented bound values', () => {
+  it.each([
+    ['MAX_QUERY_LENGTH', MAX_QUERY_LENGTH, 512],
+    ['QUERY_TIMEOUT_MS', QUERY_TIMEOUT_MS, 2_000],
+    ['MAX_RESOLVER_CANDIDATE_TAGS', MAX_RESOLVER_CANDIDATE_TAGS, 2_000],
+    ['MAX_HISTORY_SAMPLES', MAX_HISTORY_SAMPLES, 5_000],
+    ['MAX_TREND_WINDOW_MS', MAX_TREND_WINDOW_MS, 7 * 24 * 60 * 60 * 1_000],
+    ['MAX_RESULT_ITEMS', MAX_RESULT_ITEMS, 50],
+    ['MAX_ALARM_SCAN', MAX_ALARM_SCAN, 500],
+    ['MAX_HISTORY_ENTRIES', MAX_HISTORY_ENTRIES, 100],
+    ['MAX_HISTORY_PAGE', MAX_HISTORY_PAGE, 50],
+  ])('%s is %i', (_name, actual, expected) => {
+    expect(actual).toBe(expected);
+  });
+
+  it('never lets a page exceed the ring it pages over', () => {
+    expect(MAX_HISTORY_PAGE).toBeLessThanOrEqual(MAX_HISTORY_ENTRIES);
+  });
+
+  it('scans more alarms than it serialises, so the reported total is real', () => {
+    expect(MAX_ALARM_SCAN).toBeGreaterThan(MAX_RESULT_ITEMS);
+  });
+});
+
+// ── MAX_RESOLVER_CANDIDATE_TAGS ────────────────────────────────────────────
+
+describe('MAX_RESOLVER_CANDIDATE_TAGS', () => {
+  it('asks the port for at most the candidate cap — the O(tags x tokens) bound', async () => {
+    const { port, calls } = fakePort({ tags: ['A.B'] });
+    const engine = new NLQueryEngine({ dataPort: port });
+    await engine.execute('What is the pressure in tank 3?');
+    expect(calls.listTagsLimit).toEqual([MAX_RESOLVER_CANDIDATE_TAGS]);
+  });
+
+  it('scores no more tags than the cap even when the site has far more', async () => {
+    const many = Array.from(
+      { length: MAX_RESOLVER_CANDIDATE_TAGS + 500 },
+      (_v, i) => `TANK-${i}.PRESSURE`,
+    );
+    const { port } = fakePort({ tags: many });
+    const engine = new NLQueryEngine({ dataPort: port });
+
+    const result = await engine.execute('What tags are available?');
+
+    expect(result.data.count).toBe(MAX_RESOLVER_CANDIDATE_TAGS);
+    expect(result.truncation.tagCatalogue).toBe(true);
+    expect(result.data.countIsCapped).toBe(true);
+    // The count must be presented as a floor, not as the site's tag total.
+    expect(result.answer).toMatch(/capped/i);
+  });
+
+  it('re-applies the candidate cap when a port ignores the limit it was given', async () => {
+    // Defence in depth: the resolver's O(tags x tokens) scoring is the only CPU
+    // bound on this path, so the engine must not depend on every port
+    // implementation having honoured the cap it was passed.
+    const overRun = Array.from(
+      { length: MAX_RESOLVER_CANDIDATE_TAGS + 5_000 },
+      (_v, i) => `TANK-${i}.PRESSURE`,
+    );
+    const engine = new NLQueryEngine({
+      dataPort: {
+        listTags: async () => ({
+          available: true,
+          // Deliberately ignores `limit` and reports itself un-truncated.
+          value: { tagIds: overRun, truncated: false },
+        }),
+        readLatest: async () => ({ available: true, value: null }),
+        readHistory: async () => ({
+          available: true,
+          value: { samples: [], truncated: false },
+        }),
+        listActiveAlarms: async () => ({
+          available: true,
+          value: { alarms: [], truncated: false },
+        }),
+      },
+    });
+
+    const result = await engine.execute('What tags are available?');
+
+    expect(result.data.count).toBe(MAX_RESOLVER_CANDIDATE_TAGS);
+    expect(result.truncation.tagCatalogue).toBe(true);
+    expect(result.answer).toMatch(/capped/i);
+  });
+
+  it('says a miss under truncation is not proof the tag does not exist', async () => {
+    const { port } = fakePort({ tags: ['UNRELATED.TAG'], catalogueTruncated: true });
+    const engine = new NLQueryEngine({ dataPort: port });
+
+    const result = await engine.execute('What is the pressure in tank 3?');
+
+    expect(result.success).toBe(false);
+    expect(result.resolved[0].searchTruncated).toBe(true);
+    expect(result.answer).toMatch(/does not mean the tag does not exist/i);
+  });
+});
+
+// ── MAX_HISTORY_SAMPLES ────────────────────────────────────────────────────
+
+describe('MAX_HISTORY_SAMPLES', () => {
+  it('pushes the sample cap down to the port', async () => {
+    const { port, calls } = fakePort({
+      tags: ['TANK-3.PRESSURE'],
+      history: [reading('TANK-3.PRESSURE', 1, 1_000)],
+    });
+    const engine = new NLQueryEngine({ dataPort: port });
+    await engine.execute('trend of TANK-3.PRESSURE');
+    expect(calls.historyMaxSamples).toEqual([MAX_HISTORY_SAMPLES]);
+  });
+
+  it('reports sample truncation explicitly instead of silently trimming', async () => {
+    const samples = Array.from({ length: 10 }, (_v, i) =>
+      reading('TANK-3.PRESSURE', i, 1_000 + i),
+    );
+    const { port } = fakePort({
+      tags: ['TANK-3.PRESSURE'],
+      history: samples,
+      historyTruncated: true,
+    });
+    const engine = new NLQueryEngine({ dataPort: port });
+
+    const result = await engine.execute('trend of TANK-3.PRESSURE');
+
+    expect(result.success).toBe(true);
+    expect(result.truncation.historySamples).toBe(true);
+    expect(result.data.sampleCapReached).toBe(true);
+    expect(result.answer).toMatch(/sample cap/i);
+    // The aggregate must be described as covering the subset, not the window.
+    expect(result.answer).toMatch(/not the whole window/i);
+  });
+});
+
+// ── MAX_TREND_WINDOW_MS ────────────────────────────────────────────────────
+
+describe('MAX_TREND_WINDOW_MS', () => {
+  it('clamps an over-long trend window and flags the clamp', () => {
+    const now = 1_800_000_000_000;
+    const intent = parseIntent('trend of TANK-3.PRESSURE over the last 3650 days', now);
+
+    expect(intent.type).toBe('trend');
+    expect(intent.timeRangeClamped).toBe(true);
+    expect(intent.timeRange).toBeDefined();
+    expect(now - (intent.timeRange?.start ?? 0)).toBe(MAX_TREND_WINDOW_MS);
+  });
+
+  it('leaves a window inside the maximum unclamped', () => {
+    const now = 1_800_000_000_000;
+    const intent = parseIntent('trend of TANK-3.PRESSURE over the last 2 hours', now);
+    expect(intent.timeRangeClamped).toBe(false);
+    expect(now - (intent.timeRange?.start ?? 0)).toBe(2 * 3_600_000);
+  });
+
+  it('surfaces the clamp in the answer', async () => {
+    const { port } = fakePort({
+      tags: ['TANK-3.PRESSURE'],
+      history: [
+        reading('TANK-3.PRESSURE', 1, 1_000),
+        reading('TANK-3.PRESSURE', 3, 2_000),
+      ],
+    });
+    const engine = new NLQueryEngine({ dataPort: port });
+
+    const result = await engine.execute('trend of TANK-3.PRESSURE over the last 400 days');
+
+    expect(result.truncation.timeRange).toBe(true);
+    expect(result.answer).toMatch(/clamped/i);
+  });
+});
+
+// ── MAX_RESULT_ITEMS / MAX_ALARM_SCAN ──────────────────────────────────────
+
+describe('MAX_RESULT_ITEMS', () => {
+  it('caps the serialized tag list and reports the truncation', async () => {
+    const tags = Array.from({ length: MAX_RESULT_ITEMS + 25 }, (_v, i) => `T-${i}.V`);
+    const { port } = fakePort({ tags, catalogueTruncated: false });
+    const engine = new NLQueryEngine({ dataPort: port });
+
+    const result = await engine.execute('What tags are available?');
+
+    expect((result.data.tags as string[]).length).toBe(MAX_RESULT_ITEMS);
+    // The true total is still reported — only the listing is capped.
+    expect(result.data.count).toBe(MAX_RESULT_ITEMS + 25);
+    expect(result.truncation.resultItems).toBe(true);
+    expect(result.answer).toMatch(new RegExp(`showing ${MAX_RESULT_ITEMS}`));
+  });
+
+  it('caps the serialized alarm list and reports the true total', async () => {
+    const alarms = Array.from({ length: MAX_RESULT_ITEMS + 10 }, (_v, i) => ({
+      id: `A-${i}`,
+      name: `ALARM-${i}`,
+      tagId: `T-${i}.V`,
+      severity: 'high',
+      state: 'active',
+      message: 'test',
+      timestamp: 1_000 + i,
+    }));
+    const { port } = fakePort({ alarms });
+    const engine = new NLQueryEngine({ dataPort: port });
+
+    const result = await engine.execute('any active alarms?');
+
+    expect((result.data.alarms as unknown[]).length).toBe(MAX_RESULT_ITEMS);
+    expect(result.data.total).toBe(MAX_RESULT_ITEMS + 10);
+    expect(result.truncation.resultItems).toBe(true);
+  });
+
+  it('pushes MAX_ALARM_SCAN down to the port', async () => {
+    const { port, calls } = fakePort({ alarms: [] });
+    const engine = new NLQueryEngine({ dataPort: port });
+    await engine.execute('any active alarms?');
+    expect(calls.alarmLimit).toEqual([MAX_ALARM_SCAN]);
+  });
+
+  it('never reports a bare all-clear when the alarm scan was truncated', async () => {
+    const { port } = fakePort({ alarms: [], alarmsTruncated: true });
+    const engine = new NLQueryEngine({ dataPort: port });
+
+    const result = await engine.execute('any active alarms?');
+
+    // "No active alarms." full stop would be a dangerous claim here.
+    expect(result.answer).toMatch(/beyond that cap/i);
+  });
+});
+
+// ── MAX_HISTORY_ENTRIES ────────────────────────────────────────────────────
+
+describe('MAX_HISTORY_ENTRIES', () => {
+  it('bounds the in-memory history ring buffer', async () => {
+    const { port } = fakePort({ tags: ['A.B'] });
+    const engine = new NLQueryEngine({ dataPort: port, maxHistory: 5 });
+
+    for (let i = 0; i < 20; i++) {
+      await engine.execute(`What tags are available? ${i}`);
+    }
+
+    const history = engine.getHistory(1_000);
+    expect(history.length).toBe(5);
+    // Newest first, and the oldest entries are gone.
+    expect(history[0].query).toContain('19');
+    expect(history.map((h) => h.query).some((q) => q.includes(' 0'))).toBe(false);
+  });
+
+  it('never returns more than the ring size even when asked for more', async () => {
+    const { port } = fakePort({ tags: ['A.B'] });
+    const engine = new NLQueryEngine({ dataPort: port, maxHistory: 3 });
+    await engine.execute('What tags are available?');
+    expect(engine.getHistory(Number.MAX_SAFE_INTEGER).length).toBeLessThanOrEqual(3);
+  });
+
+  it('uses the documented default ring size', () => {
+    expect(MAX_HISTORY_ENTRIES).toBe(100);
+  });
+});

--- a/server/services/nlquery/__tests__/nl-query.test.ts
+++ b/server/services/nlquery/__tests__/nl-query.test.ts
@@ -1,0 +1,542 @@
+/**
+ * NL process query — grammar, resolution, and answer-integrity tests (#216).
+ *
+ * The maintainer review praised three properties of the previous attempt and
+ * asked that they be carried forward rather than rewritten: the ordered
+ * 6-intent regex grammar, the token-overlap tag scoring, and a resolver that
+ * refuses to guess between ambiguous tags. Those are pinned here.
+ *
+ * The remaining tests enforce the repository integrity rule on this surface:
+ * an answer never contains a value the data port did not return, and
+ * "the store could not be consulted" never reads as "the process is quiet".
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type {
+  ActiveAlarmPage,
+  HistorySlice,
+  NLQueryDataPort,
+  PortResult,
+  TagCatalogue,
+  TagReading,
+} from '@shared/types/nl-query';
+import { NLQueryEngine } from '../engine';
+import { parseDurationMs, parseIntent } from '../parser';
+import { TagResolver, tokenize } from '../resolver';
+
+const NOW = 1_800_000_000_000;
+
+// ── Test doubles ───────────────────────────────────────────────────────────
+
+interface StubOptions {
+  tags?: string[];
+  latest?: Record<string, TagReading>;
+  history?: Record<string, TagReading[]>;
+  alarms?: ActiveAlarmPage['alarms'];
+  /** Force a store to report itself unavailable, with this reason. */
+  unavailable?: Partial<Record<'tags' | 'latest' | 'history' | 'alarms', string>>;
+}
+
+function stubPort(options: StubOptions = {}): NLQueryDataPort {
+  const unavailable = options.unavailable ?? {};
+  return {
+    async listTags(limit): Promise<PortResult<TagCatalogue>> {
+      if (unavailable.tags) return { available: false, reason: unavailable.tags };
+      const tags = options.tags ?? [];
+      return {
+        available: true,
+        value: { tagIds: tags.slice(0, limit), truncated: tags.length > limit },
+      };
+    },
+    async readLatest(tagId): Promise<PortResult<TagReading | null>> {
+      if (unavailable.latest) return { available: false, reason: unavailable.latest };
+      return { available: true, value: options.latest?.[tagId] ?? null };
+    },
+    async readHistory(tagId, startMs, endMs, maxSamples): Promise<PortResult<HistorySlice>> {
+      if (unavailable.history) return { available: false, reason: unavailable.history };
+      const all = options.history?.[tagId] ?? [];
+      const inWindow = all.filter((p) => p.timestamp >= startMs && p.timestamp <= endMs);
+      return {
+        available: true,
+        value: {
+          samples: inWindow.slice(0, maxSamples),
+          truncated: inWindow.length > maxSamples,
+        },
+      };
+    },
+    async listActiveAlarms(limit): Promise<PortResult<ActiveAlarmPage>> {
+      if (unavailable.alarms) return { available: false, reason: unavailable.alarms };
+      const alarms = options.alarms ?? [];
+      return {
+        available: true,
+        value: { alarms: alarms.slice(0, limit), truncated: alarms.length > limit },
+      };
+    },
+  };
+}
+
+function reading(
+  tagId: string,
+  value: number | string,
+  timestamp = NOW,
+  source: TagReading['source'] = 'historian',
+): TagReading {
+  return { tagId, value, timestamp, source };
+}
+
+function engineWith(options: StubOptions = {}): NLQueryEngine {
+  return new NLQueryEngine({ dataPort: stubPort(options) });
+}
+
+// ── Parser: ordered grammar ────────────────────────────────────────────────
+
+describe('intent grammar ordering', () => {
+  it('recognises a status question as status, not as the read_tag catch-all', () => {
+    // The ordering regression the reviewed implementation was built to fix:
+    // with read_tag first, this matches the catch-all and status is dead code.
+    expect(parseIntent('what is the status of pump 1', NOW).type).toBe('status');
+  });
+
+  it('recognises a tag listing before the read_tag catch-all', () => {
+    expect(parseIntent('what tags are available?', NOW).type).toBe('list_tags');
+    expect(parseIntent('list tags', NOW).type).toBe('list_tags');
+  });
+
+  it('recognises alarms, including scoped alarms', () => {
+    expect(parseIntent('any active alarms?', NOW).type).toBe('alarms');
+    const scoped = parseIntent('alarms on tank 3', NOW);
+    expect(scoped.type).toBe('alarms');
+    expect(scoped.subjects).toEqual(['tank 3']);
+  });
+
+  it('recognises a trend with a duration', () => {
+    const intent = parseIntent('trend of transformer temperature over the last 2 hours', NOW);
+    expect(intent.type).toBe('trend');
+    expect(intent.subjects).toEqual(['transformer temperature']);
+    expect(NOW - (intent.timeRange?.start ?? 0)).toBe(2 * 3_600_000);
+  });
+
+  it('recognises a comparison and keeps both subjects', () => {
+    const intent = parseIntent('compare FEEDER-01.CURRENT and FEEDER-02.CURRENT', NOW);
+    expect(intent.type).toBe('compare');
+    expect(intent.subjects).toEqual(['FEEDER-01.CURRENT', 'FEEDER-02.CURRENT']);
+  });
+
+  it('keeps measurement and location together for a read', () => {
+    const intent = parseIntent('What is the pressure in tank 3?', NOW);
+    expect(intent.type).toBe('read_tag');
+    expect(intent.subjects).toEqual(['pressure tank 3']);
+  });
+
+  it('returns unknown for an unparseable question rather than guessing', () => {
+    expect(parseIntent('hello there', NOW).type).toBe('unknown');
+  });
+});
+
+describe('duration parsing', () => {
+  it('parses supported units', () => {
+    expect(parseDurationMs(2, 'hours')).toBe(7_200_000);
+    expect(parseDurationMs(30, 'min')).toBe(1_800_000);
+    expect(parseDurationMs(1, 'd')).toBe(86_400_000);
+  });
+
+  it('rejects unknown units and non-positive amounts', () => {
+    expect(parseDurationMs(2, 'fortnights')).toBeNull();
+    expect(parseDurationMs(0, 'hours')).toBeNull();
+    expect(parseDurationMs(-1, 'hours')).toBeNull();
+  });
+});
+
+// ── Resolver: precision and refusal to guess ───────────────────────────────
+
+describe('tag resolution', () => {
+  const tags = [
+    'TANK-3.PRESSURE',
+    'TANK-12.PRESSURE',
+    'FEEDER-01.CURRENT',
+    'TRANSFORMER.TEMPERATURE',
+  ];
+
+  it('tokenizes tag ids and phrases the same way', () => {
+    expect(tokenize('TANK-3.PRESSURE')).toEqual(['tank', '3', 'pressure']);
+    expect(tokenize('the pressure in tank 03')).toEqual(['pressure', 'tank', '3']);
+  });
+
+  it('resolves a measurement + location phrase to the right tag', () => {
+    const r = new TagResolver().resolve('pressure tank 3', tags);
+    expect(r.tagId).toBe('TANK-3.PRESSURE');
+  });
+
+  it('treats numeric tokens as equipment identity — tank 12 is never tank 3', () => {
+    const r = new TagResolver().resolve('pressure tank 12', tags);
+    expect(r.tagId).toBe('TANK-12.PRESSURE');
+  });
+
+  it('matches a prefix like "temp" against "TEMPERATURE"', () => {
+    const r = new TagResolver().resolve('transformer temp', tags);
+    expect(r.tagId).toBe('TRANSFORMER.TEMPERATURE');
+  });
+
+  it('refuses to guess between equally-scored candidates', () => {
+    // "pressure" alone scores identically against both pressure tags.
+    const r = new TagResolver().resolve('pressure', tags);
+    expect(r.tagId).toBeNull();
+    expect(r.candidates).toEqual(
+      expect.arrayContaining(['TANK-3.PRESSURE', 'TANK-12.PRESSURE']),
+    );
+  });
+
+  it('returns null with no candidates for an unmatched phrase', () => {
+    const r = new TagResolver().resolve('reactor coolant flow', tags);
+    expect(r.tagId).toBeNull();
+    expect(r.candidates).toEqual([]);
+  });
+
+  it('never invents a tag id that is absent from the catalogue', () => {
+    const r = new TagResolver().resolve('pressure in tank 99', tags);
+    expect(r.tagId).toBeNull();
+    for (const candidate of r.candidates) expect(tags).toContain(candidate);
+  });
+
+  it('prefers an exact tag id, case-insensitively', () => {
+    const r = new TagResolver().resolve('tank-3.pressure', tags);
+    expect(r.tagId).toBe('TANK-3.PRESSURE');
+  });
+
+  it('honours an explicit alias over scoring', () => {
+    const resolver = new TagResolver();
+    resolver.registerAlias('main feed pressure', 'TANK-3.PRESSURE');
+    expect(resolver.resolve('main feed pressure', tags).tagId).toBe('TANK-3.PRESSURE');
+    expect(resolver.listAliases()).toEqual([
+      { alias: 'main feed pressure', tagId: 'TANK-3.PRESSURE' },
+    ]);
+  });
+});
+
+// ── Engine: real answers ───────────────────────────────────────────────────
+
+describe('answering from data', () => {
+  it('reads the current value of a resolved tag and cites its provenance', async () => {
+    const engine = engineWith({
+      tags: ['TANK-3.PRESSURE'],
+      latest: { 'TANK-3.PRESSURE': reading('TANK-3.PRESSURE', 42.5, NOW, 'live-stream') },
+    });
+
+    const result = await engine.execute('What is the pressure in tank 3?', NOW);
+
+    expect(result.success).toBe(true);
+    expect(result.answer).toContain('TANK-3.PRESSURE is 42.5');
+    expect(result.answer).toContain('live tag stream');
+    expect(result.parsedBy).toBe('regex');
+  });
+
+  it('compares two tags and reports the difference', async () => {
+    const engine = engineWith({
+      tags: ['FEEDER-01.CURRENT', 'FEEDER-02.CURRENT'],
+      latest: {
+        'FEEDER-01.CURRENT': reading('FEEDER-01.CURRENT', 10),
+        'FEEDER-02.CURRENT': reading('FEEDER-02.CURRENT', 4),
+      },
+    });
+
+    const result = await engine.execute(
+      'compare FEEDER-01.CURRENT and FEEDER-02.CURRENT',
+      NOW,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data.difference).toBe(6);
+  });
+
+  it('summarises a trend over real samples', async () => {
+    const engine = engineWith({
+      tags: ['TANK-3.PRESSURE'],
+      history: {
+        'TANK-3.PRESSURE': [
+          reading('TANK-3.PRESSURE', 10, NOW - 3_000),
+          reading('TANK-3.PRESSURE', 20, NOW - 2_000),
+          reading('TANK-3.PRESSURE', 30, NOW - 1_000),
+        ],
+      },
+    });
+
+    const result = await engine.execute('trend of TANK-3.PRESSURE', NOW);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      samples: 3,
+      min: 10,
+      max: 30,
+      avg: 20,
+      delta: 20,
+      direction: 'rising',
+    });
+  });
+
+  it('reports status as the last recorded value, not an invented run state', async () => {
+    const engine = engineWith({
+      tags: ['BK-FEEDER-01.STATE'],
+      latest: { 'BK-FEEDER-01.STATE': reading('BK-FEEDER-01.STATE', 1, NOW - 5_000) },
+    });
+
+    const result = await engine.execute('What is the status of BK-FEEDER-01.STATE?', NOW);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({ ageSeconds: 5 });
+    // No equipment state model exists, so no running/stopped verdict is claimed.
+    expect(result.answer).toMatch(/not a running\/stopped verdict/i);
+  });
+
+  it('lists real tags', async () => {
+    const engine = engineWith({ tags: ['A.B', 'C.D'] });
+    const result = await engine.execute('what tags are available?', NOW);
+    expect(result.success).toBe(true);
+    expect(result.data.tags).toEqual(['A.B', 'C.D']);
+  });
+
+  it('reports active alarms and scopes them to a resolved tag', async () => {
+    const alarms = [
+      {
+        id: 'A1',
+        name: 'HIGH PRESSURE',
+        tagId: 'TANK-3.PRESSURE',
+        severity: 'critical',
+        state: 'active',
+        message: 'over limit',
+        timestamp: NOW,
+      },
+      {
+        id: 'A2',
+        name: 'LOW CURRENT',
+        tagId: 'FEEDER-01.CURRENT',
+        severity: 'warning',
+        state: 'active',
+        message: 'under limit',
+        timestamp: NOW,
+      },
+    ];
+    const engine = engineWith({ tags: ['TANK-3.PRESSURE'], alarms });
+
+    const all = await engine.execute('any active alarms?', NOW);
+    expect(all.data.total).toBe(2);
+
+    const scoped = await engine.execute('alarms on tank 3', NOW);
+    expect(scoped.success).toBe(true);
+    expect(scoped.data.total).toBe(1);
+    expect(scoped.answer).toContain('HIGH PRESSURE');
+  });
+});
+
+// ── Engine: integrity — never invent, never mislead ────────────────────────
+
+describe('answer integrity', () => {
+  it('refuses to answer an ambiguous phrase and offers candidates', async () => {
+    const engine = engineWith({ tags: ['TANK-3.PRESSURE', 'TANK-12.PRESSURE'] });
+
+    const result = await engine.execute('what is the pressure', NOW);
+
+    expect(result.success).toBe(false);
+    expect(result.answer).toMatch(/couldn't uniquely identify/i);
+    expect(result.suggestions.length).toBeGreaterThan(0);
+  });
+
+  it('says no tag matched rather than querying an invented id', async () => {
+    const engine = engineWith({ tags: ['TANK-3.PRESSURE'] });
+    const result = await engine.execute('what is the coolant flow in reactor 9', NOW);
+    expect(result.success).toBe(false);
+    expect(result.answer).toMatch(/couldn't find any tag/i);
+  });
+
+  it('distinguishes "no data recorded" from "store unavailable"', async () => {
+    const noRows = engineWith({ tags: ['TANK-3.PRESSURE'] });
+    const noRowsResult = await noRows.execute('what is TANK-3.PRESSURE', NOW);
+    expect(noRowsResult.success).toBe(false);
+    expect(noRowsResult.answer).toMatch(/no data is recorded/i);
+
+    const down = engineWith({
+      tags: ['TANK-3.PRESSURE'],
+      unavailable: { latest: 'historian unreachable' },
+    });
+    const downResult = await down.execute('what is TANK-3.PRESSURE', NOW);
+    expect(downResult.success).toBe(false);
+    expect(downResult.answer).toMatch(/could not read/i);
+    expect(downResult.answer).toContain('historian unreachable');
+    // Crucially it must NOT claim there is no data.
+    expect(downResult.answer).not.toMatch(/no data is recorded/i);
+  });
+
+  it('never reports an all-clear when the alarm store is unreachable', async () => {
+    const engine = engineWith({ unavailable: { alarms: 'correlation engine down' } });
+
+    const result = await engine.execute('any active alarms?', NOW);
+
+    expect(result.success).toBe(false);
+    expect(result.answer).not.toMatch(/no active alarms/i);
+    expect(result.answer).toContain('correlation engine down');
+  });
+
+  it('does not treat an unresolved alarm scope as an all-clear', async () => {
+    const alarms = [
+      {
+        id: 'A1',
+        name: 'HIGH PRESSURE',
+        tagId: 'TANK-3.PRESSURE',
+        severity: 'critical',
+        state: 'active',
+        message: 'over limit',
+        timestamp: NOW,
+      },
+    ];
+    const engine = engineWith({ tags: ['TANK-3.PRESSURE'], alarms });
+
+    const result = await engine.execute('alarms on reactor 9', NOW);
+
+    expect(result.success).toBe(false);
+    expect(result.answer).not.toMatch(/no active alarms/i);
+    // The operator is still told alarms exist, just not scoped to their phrase.
+    expect(result.answer).toMatch(/1 active alarm/);
+  });
+
+  it('reports missing data in a comparison instead of coercing it to zero', async () => {
+    const engine = engineWith({
+      tags: ['FEEDER-01.CURRENT', 'FEEDER-02.CURRENT'],
+      latest: { 'FEEDER-01.CURRENT': reading('FEEDER-01.CURRENT', 10) },
+    });
+
+    const result = await engine.execute(
+      'compare FEEDER-01.CURRENT and FEEDER-02.CURRENT',
+      NOW,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.answer).toMatch(/No data is recorded for FEEDER-02\.CURRENT/);
+    expect(result.data.difference).toBeUndefined();
+    // 10 - 0 = 10 must never appear as a difference.
+    expect(result.answer).not.toContain('difference');
+  });
+
+  it('refuses to subtract non-numeric values', async () => {
+    const engine = engineWith({
+      tags: ['A.MODE', 'B.MODE'],
+      latest: {
+        'A.MODE': reading('A.MODE', 'AUTO'),
+        'B.MODE': reading('B.MODE', 'MANUAL'),
+      },
+    });
+
+    const result = await engine.execute('compare A.MODE and B.MODE', NOW);
+
+    expect(result.success).toBe(false);
+    expect(result.answer).toMatch(/not both\s+numeric/i);
+  });
+
+  // A `historian_data` row carries either a numeric `value` or a text
+  // `string_value`, so a stored reading legitimately reaches the comparison as
+  // a string. `Number()` turns several of those into plausible readings — the
+  // empty string and whitespace become 0, "0x10" becomes 16 — which would make
+  // the engine state a value no sensor produced, with `success: true`. Each
+  // case must land in the non-numeric refusal instead.
+  it.each([
+    ['an empty stored string', ''],
+    ['a whitespace-only stored string', '   '],
+    ['a hexadecimal stored string', '0x10'],
+    ['a binary-literal stored string', '0b101'],
+    ['an Infinity stored string', 'Infinity'],
+  ])('never coerces %s into a number in a comparison', async (_label, stored) => {
+    const engine = engineWith({
+      tags: ['A.X', 'B.X'],
+      latest: {
+        'A.X': reading('A.X', stored),
+        'B.X': reading('B.X', 5),
+      },
+    });
+
+    const result = await engine.execute('compare A.X and B.X', NOW);
+
+    expect(result.success).toBe(false);
+    expect(result.answer).toMatch(/not both\s+numeric/i);
+    // The refusal legitimately says "I cannot compute a difference"; what must
+    // never appear is a computed one.
+    expect(result.answer).not.toMatch(/a difference of/i);
+    expect(result.data.difference).toBeUndefined();
+    // The specific fabrications this guards against.
+    expect(result.answer).not.toMatch(/A\.X is 0\b/);
+    expect(result.answer).not.toMatch(/A\.X is 16\b/);
+  });
+
+  it('still compares a numeric value stored as a decimal string', async () => {
+    const engine = engineWith({
+      tags: ['A.X', 'B.X'],
+      latest: {
+        'A.X': reading('A.X', '12.5'),
+        'B.X': reading('B.X', 5),
+      },
+    });
+
+    const result = await engine.execute('compare A.X and B.X', NOW);
+
+    expect(result.success).toBe(true);
+    expect(result.data.difference).toBe(7.5);
+  });
+
+  it('reports an empty trend window honestly', async () => {
+    const engine = engineWith({ tags: ['TANK-3.PRESSURE'], history: {} });
+    const result = await engine.execute('trend of TANK-3.PRESSURE', NOW);
+    expect(result.success).toBe(false);
+    expect(result.answer).toMatch(/no numeric samples are recorded/i);
+  });
+
+  it('cannot resolve any tag when the catalogue itself is unreachable', async () => {
+    const engine = engineWith({ unavailable: { tags: 'database not initialized' } });
+
+    const result = await engine.execute('What is the pressure in tank 3?', NOW);
+
+    expect(result.success).toBe(false);
+    expect(result.answer).toContain('database not initialized');
+    expect(result.resolved).toEqual([]);
+  });
+
+  it('answers an unparseable question with examples, never with data', async () => {
+    const engine = engineWith({
+      tags: ['TANK-3.PRESSURE'],
+      latest: { 'TANK-3.PRESSURE': reading('TANK-3.PRESSURE', 42.5) },
+    });
+
+    const result = await engine.execute('hello there', NOW);
+
+    expect(result.success).toBe(false);
+    expect(result.suggestions.length).toBeGreaterThan(0);
+    expect(result.answer).not.toContain('42.5');
+  });
+});
+
+// ── History: bounded and process-local ─────────────────────────────────────
+
+describe('query history', () => {
+  it('records executed queries newest-first', async () => {
+    const engine = engineWith({ tags: ['A.B'] });
+    await engine.execute('what tags are available?', NOW);
+    await engine.execute('list tags', NOW);
+
+    const history = engine.getHistory(10);
+    expect(history).toHaveLength(2);
+    expect(history[0].query).toBe('list tags');
+    expect(history[0].id).not.toBe(history[1].id);
+  });
+
+  it('records unsuccessful queries too, so a refusal is auditable in-process', async () => {
+    const engine = engineWith({ tags: [] });
+    await engine.execute('what is the pressure in tank 3', NOW);
+    const history = engine.getHistory(10);
+    expect(history).toHaveLength(1);
+    expect(history[0].success).toBe(false);
+  });
+
+  it('treats a non-positive limit as empty rather than returning everything', async () => {
+    const engine = engineWith({ tags: ['A.B'] });
+    await engine.execute('list tags', NOW);
+    expect(engine.getHistory(0)).toEqual([]);
+    expect(engine.getHistory(-5)).toEqual([]);
+  });
+});

--- a/server/services/nlquery/data-port.ts
+++ b/server/services/nlquery/data-port.ts
@@ -1,0 +1,327 @@
+/**
+ * Production data port for the NL query engine.
+ * Issue #216; contract in docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md.
+ *
+ * This is what "query REAL data" means for this feature. There are exactly
+ * three backing stores on current `main`, and this adapter reads all three:
+ *
+ *   - **Tag catalogue and history** — the `historian_data` table. There is no
+ *     dedicated tag table in `shared/schema.ts`; the tag id space is defined by
+ *     what the historian has recorded, which is the same projection
+ *     `server/protocols/opcua-server/runtime.ts` uses for its address space.
+ *   - **Latest values** — `tagStreamServer.getLatestValues()`, the live stream
+ *     the gateway scan loop and the field simulator already publish to. A live
+ *     sample is preferred over the newest historian row when one exists,
+ *     because it is fresher; the reading records which it came from so the
+ *     answer can cite its provenance.
+ *   - **Active alarms** — `alarmCorrelationService.engine`, over alarms that
+ *     were actually ingested through `/api/alarm-correlation`.
+ *
+ * What this adapter will NOT do:
+ *
+ *   - It never constructs SQL from operator text. Every query is a Drizzle
+ *     query-builder expression with bound parameters; the operator's string
+ *     only ever reaches a parameter slot, never the statement.
+ *   - It never fabricates a value. When there is no database, when the SQLite
+ *     development fallback is active (it has no `historian_data` table), or
+ *     when a query throws, the method returns `available: false` with a reason
+ *     and the engine says so in its answer.
+ *
+ * Bounding: every method takes an explicit cap and pushes it down to the store
+ * as a SQL `LIMIT` (fetching cap+1 to detect truncation), so an oversized row
+ * set is never materialised in the API process.
+ */
+
+import { and, desc, eq, gte, lte } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import * as schema from '@shared/schema';
+import type {
+  ActiveAlarmPage,
+  ActiveAlarmSummary,
+  HistorySlice,
+  NLQueryDataPort,
+  PortResult,
+  TagCatalogue,
+  TagReading,
+} from '@shared/types/nl-query';
+import { getDatabase, getDatabaseType } from '../../storage';
+import { tagStreamServer, type TagUpdate } from '../../websocket/tag-stream';
+import { alarmCorrelationService } from '../alarm-correlation';
+
+/** Alarm lifecycle states that mean "still demanding operator attention". */
+const ACTIVE_ALARM_STATES = new Set(['active', 'acknowledged', 'unacknowledged']);
+
+/**
+ * The historian is Postgres-only. `server/storage.ts` multiplexes a Drizzle
+ * Postgres client and a reduced SQLite development stub, and the stub does not
+ * carry `historian_data` — the same limitation `opcua-server/runtime.ts`
+ * documents. Reporting that plainly is the honest behaviour; inventing a
+ * reading to fill the gap is not.
+ */
+function historianDatabase(): PortResult<NodePgDatabase<typeof schema>> {
+  if (getDatabaseType() !== 'postgres') {
+    return {
+      available: false,
+      reason:
+        `the historian is not available on the ${getDatabaseType()} development `
+        + 'database (no historian_data table)',
+    };
+  }
+  // `getDatabase()` THROWS when the pool was never initialized, and `dbType`
+  // defaults to 'postgres' before `initializeDatabase()` runs — so the
+  // uninitialized process reaches exactly this line. Catch it here and turn it
+  // into a reason string; letting it escape would replace a precise
+  // "no database connection" message with the engine's generic failure text.
+  try {
+    const db = getDatabase();
+    if (!db) {
+      return { available: false, reason: 'no database connection is configured' };
+    }
+    return { available: true, value: db as NodePgDatabase<typeof schema> };
+  } catch (error) {
+    return { available: false, reason: failureReason(error) };
+  }
+}
+
+function failureReason(error: unknown): string {
+  return reasonFragment(error instanceof Error ? error.message : String(error));
+}
+
+/**
+ * Normalise a reason so it composes into a sentence. Store errors arrive as
+ * full sentences ("Database not initialized. Call initializeDatabase() first.");
+ * trailing punctuation would produce "... first., and no tags ..." once joined.
+ */
+function reasonFragment(reason: string): string {
+  return reason.trim().replace(/[.\s]+$/, '');
+}
+
+/** Map a live tag-stream update onto a reading, or null if not representable. */
+function readingFromStream(update: TagUpdate): TagReading | null {
+  if (typeof update.value === 'boolean') return null;
+  const timestamp = new Date(update.timestamp).getTime();
+  if (!Number.isFinite(timestamp)) return null;
+  return {
+    tagId: update.tagName,
+    value: update.value,
+    quality: update.quality,
+    timestamp,
+    source: 'live-stream',
+  };
+}
+
+/**
+ * Historian rows carry either a numeric `value` or a `stringValue`. A row with
+ * neither is dropped rather than defaulted to 0.
+ */
+function readingFromHistorian(
+  tagId: string,
+  row: { value: number | null; stringValue: string | null; quality: number | null; timestamp: Date },
+): TagReading | null {
+  const value: number | string | null =
+    row.value !== null ? row.value : row.stringValue;
+  if (value === null) return null;
+  return {
+    tagId,
+    value,
+    quality: row.quality === null ? undefined : String(row.quality),
+    timestamp: row.timestamp.getTime(),
+    source: 'historian',
+  };
+}
+
+export class ProcessDataPort implements NLQueryDataPort {
+  /**
+   * Union of the historian's recorded tag ids and the tags currently on the
+   * live stream, capped at `limit`.
+   *
+   * The live stream alone is a valid catalogue when the historian is
+   * unavailable — a dev box running the simulator has real tags with no
+   * database — so the catalogue is only reported unavailable when BOTH sources
+   * are empty and the historian could not be consulted.
+   */
+  async listTags(limit: number): Promise<PortResult<TagCatalogue>> {
+    const cap = Math.max(0, limit);
+    const liveTags = [...tagStreamServer.getLatestValues().keys()];
+
+    const db = historianDatabase();
+    if (!db.available) {
+      if (liveTags.length === 0) {
+        return {
+          available: false,
+          reason: `${db.reason}; no tags are on the live stream either`,
+        };
+      }
+      const tagIds = liveTags.slice(0, cap).sort();
+      return {
+        available: true,
+        value: { tagIds, truncated: liveTags.length > cap },
+      };
+    }
+
+    try {
+      // Fetch cap+1 so truncation is detected without a second COUNT query.
+      const rows = await db.value
+        .selectDistinct({ tagId: schema.historianData.tagId })
+        .from(schema.historianData)
+        .orderBy(schema.historianData.tagId)
+        .limit(cap + 1);
+
+      const merged = new Set<string>(rows.map((r) => r.tagId));
+      const historianTruncated = rows.length > cap;
+      // Merge at most cap+1 live tag ids. The historian side is already
+      // bounded by its SQL LIMIT, but `liveTags` is the whole live-stream map,
+      // which on a large site is far larger than `cap` — merging and sorting
+      // all of it would do unbounded per-request work for a result that is
+      // sliced back to `cap` anyway. One extra element is enough to detect
+      // that the union overflowed.
+      const liveTruncated = liveTags.length > cap;
+      for (const tagId of liveTags.slice(0, cap + 1)) merged.add(tagId);
+
+      const all = [...merged].sort();
+      return {
+        available: true,
+        value: {
+          tagIds: all.slice(0, cap),
+          truncated: historianTruncated || liveTruncated || all.length > cap,
+        },
+      };
+    } catch (error) {
+      if (liveTags.length > 0) {
+        const tagIds = liveTags.slice(0, cap).sort();
+        return {
+          available: true,
+          value: { tagIds, truncated: liveTags.length > cap },
+        };
+      }
+      return {
+        available: false,
+        reason: `historian tag catalogue query failed: ${failureReason(error)}`,
+      };
+    }
+  }
+
+  /**
+   * Prefer the live stream (freshest), fall back to the newest historian row.
+   * `available: true` with `value: null` means "consulted, nothing recorded" —
+   * distinct from `available: false`, "could not consult".
+   */
+  async readLatest(tagId: string): Promise<PortResult<TagReading | null>> {
+    const live = tagStreamServer.getLatestValues().get(tagId);
+    if (live) {
+      const reading = readingFromStream(live);
+      if (reading) return { available: true, value: reading };
+    }
+
+    const db = historianDatabase();
+    if (!db.available) return db;
+
+    try {
+      const rows = await db.value
+        .select({
+          value: schema.historianData.value,
+          stringValue: schema.historianData.stringValue,
+          quality: schema.historianData.quality,
+          timestamp: schema.historianData.timestamp,
+        })
+        .from(schema.historianData)
+        .where(eq(schema.historianData.tagId, tagId))
+        .orderBy(desc(schema.historianData.timestamp))
+        .limit(1);
+
+      const row = rows[0];
+      if (!row) return { available: true, value: null };
+      return { available: true, value: readingFromHistorian(tagId, row) };
+    } catch (error) {
+      return {
+        available: false,
+        reason: `historian read failed: ${failureReason(error)}`,
+      };
+    }
+  }
+
+  async readHistory(
+    tagId: string,
+    startMs: number,
+    endMs: number,
+    maxSamples: number,
+  ): Promise<PortResult<HistorySlice>> {
+    const db = historianDatabase();
+    if (!db.available) return db;
+
+    const cap = Math.max(0, maxSamples);
+    try {
+      const rows = await db.value
+        .select({
+          value: schema.historianData.value,
+          stringValue: schema.historianData.stringValue,
+          quality: schema.historianData.quality,
+          timestamp: schema.historianData.timestamp,
+        })
+        .from(schema.historianData)
+        .where(
+          and(
+            eq(schema.historianData.tagId, tagId),
+            gte(schema.historianData.timestamp, new Date(startMs)),
+            lte(schema.historianData.timestamp, new Date(endMs)),
+          ),
+        )
+        .orderBy(schema.historianData.timestamp)
+        // cap+1 detects truncation; the extra row is dropped below.
+        .limit(cap + 1);
+
+      const truncated = rows.length > cap;
+      const samples: TagReading[] = [];
+      for (const row of rows.slice(0, cap)) {
+        const reading = readingFromHistorian(tagId, row);
+        if (reading) samples.push(reading);
+      }
+      return { available: true, value: { samples, truncated } };
+    } catch (error) {
+      return {
+        available: false,
+        reason: `historian history query failed: ${failureReason(error)}`,
+      };
+    }
+  }
+
+  /**
+   * Active alarms from the correlation engine — real alarms that were ingested
+   * through `/api/alarm-correlation`, not a synthesised list.
+   */
+  async listActiveAlarms(limit: number): Promise<PortResult<ActiveAlarmPage>> {
+    const cap = Math.max(0, limit);
+    try {
+      const groups = alarmCorrelationService.engine.getGroups({ state: 'open' });
+      const alarms: ActiveAlarmSummary[] = [];
+      let truncated = false;
+
+      for (const group of groups) {
+        for (const alarm of group.alarms) {
+          if (!ACTIVE_ALARM_STATES.has(alarm.state)) continue;
+          if (alarms.length >= cap) {
+            truncated = true;
+            break;
+          }
+          alarms.push({
+            id: alarm.id,
+            name: alarm.name,
+            tagId: alarm.tagId,
+            severity: alarm.severity,
+            state: alarm.state,
+            message: alarm.message,
+            timestamp: alarm.timestamp,
+          });
+        }
+        if (truncated) break;
+      }
+
+      return { available: true, value: { alarms, truncated } };
+    } catch (error) {
+      return {
+        available: false,
+        reason: `alarm correlation read failed: ${failureReason(error)}`,
+      };
+    }
+  }
+}

--- a/server/services/nlquery/engine.ts
+++ b/server/services/nlquery/engine.ts
@@ -1,0 +1,715 @@
+/**
+ * NL Query Engine
+ * Issue #216; contract in docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md.
+ *
+ * Parse intent (regex grammar), resolve tag names, read real process data
+ * through an injected {@link NLQueryDataPort}, answer in natural language.
+ *
+ * The integrity rule drives the whole design. Every answer this engine emits
+ * is assembled from values the port actually returned. There are exactly three
+ * outcomes for any question:
+ *
+ *   - answered from real data (`success: true`);
+ *   - "I could not identify that tag" / "no data is recorded for it"
+ *     (`success: false`, with candidates or a plain statement);
+ *   - "I could not consult the store" (`success: false`, carrying the port's
+ *     reason).
+ *
+ * There is no fourth branch that produces a number. `PortResult.available`
+ * keeps "the historian is unreachable" distinct from "the historian returned
+ * no rows", because collapsing those two would let an outage read to an
+ * operator as a quiet process.
+ *
+ * No language model is imported, constructed, or called here — see ADR-0027.
+ */
+
+import type {
+  ActiveAlarmSummary,
+  NLQueryDataPort,
+  QueryIntent,
+  QueryResult,
+  QueryTruncation,
+  ResolvedSubject,
+  TagReading,
+} from '@shared/types/nl-query';
+import { parseIntent } from './parser';
+import { TagResolver } from './resolver';
+import {
+  DEFAULT_TREND_WINDOW_MS,
+  MAX_ALARM_SCAN,
+  MAX_HISTORY_ENTRIES,
+  MAX_HISTORY_SAMPLES,
+  MAX_RESOLVER_CANDIDATE_TAGS,
+  MAX_RESULT_ITEMS,
+  QUERY_TIMEOUT_MS,
+} from './limits';
+
+const EXAMPLE_QUERIES: readonly string[] = [
+  'What is the pressure in tank 3?',
+  'Compare FEEDER-01.CURRENT and FEEDER-02.CURRENT',
+  'Trend of transformer temperature over the last 2 hours',
+  'What is the status of BK-FEEDER-01?',
+  'Any active alarms?',
+  'What tags are available?',
+];
+
+/** One intent's execution outcome, before it is wrapped into a QueryResult. */
+interface Outcome {
+  success: boolean;
+  answer: string;
+  data: Record<string, unknown>;
+  suggestions: string[];
+}
+
+class QueryTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`NL query exceeded ${timeoutMs}ms`);
+    this.name = 'QueryTimeoutError';
+  }
+}
+
+/**
+ * Bound the wall-clock time the caller waits.
+ *
+ * Note honestly what this does and does not do: it bounds the *response*, not
+ * the underlying work. A promise cannot be cancelled in JavaScript, so an
+ * in-flight database query keeps running to completion. That residual work is
+ * bounded separately and independently — every port read carries an explicit
+ * row cap pushed down as a SQL LIMIT (MAX_HISTORY_SAMPLES,
+ * MAX_RESOLVER_CANDIDATE_TAGS, MAX_ALARM_SCAN) — so a timed-out query cannot
+ * leave unbounded work behind it.
+ */
+async function withTimeout<T>(work: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new QueryTimeoutError(timeoutMs)), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export interface NLQueryEngineOptions {
+  dataPort: NLQueryDataPort;
+  resolver?: TagResolver;
+  /** Override for tests; defaults to QUERY_TIMEOUT_MS. */
+  timeoutMs?: number;
+  /** Override for tests; defaults to MAX_HISTORY_ENTRIES. */
+  maxHistory?: number;
+}
+
+export class NLQueryEngine {
+  readonly resolver: TagResolver;
+
+  private readonly dataPort: NLQueryDataPort;
+  private readonly timeoutMs: number;
+  private readonly maxHistory: number;
+  /** Bounded ring buffer. Process-local by design (ADR-0027). */
+  private readonly history: QueryResult[] = [];
+  private queryCounter = 0;
+  private readonly bootId = Date.now().toString(36);
+
+  constructor(options: NLQueryEngineOptions) {
+    this.dataPort = options.dataPort;
+    this.resolver = options.resolver ?? new TagResolver();
+    this.timeoutMs = options.timeoutMs ?? QUERY_TIMEOUT_MS;
+    this.maxHistory = options.maxHistory ?? MAX_HISTORY_ENTRIES;
+  }
+
+  /** Newest first, capped by the caller. History is lost on restart. */
+  getHistory(limit: number): QueryResult[] {
+    // A non-finite limit must not become an unbounded read: `Math.min(NaN, n)`
+    // is NaN, and `slice(-NaN)` is `slice(0)` — the whole buffer again.
+    const requested = Number.isFinite(limit) ? limit : 0;
+    const safeLimit = Math.max(0, Math.min(requested, this.maxHistory));
+    // `slice(-0)` is `slice(0)`, which would return the entire buffer — the
+    // exact opposite of the requested bound. Handle zero explicitly.
+    if (safeLimit === 0) return [];
+    return this.history.slice(-safeLimit).reverse();
+  }
+
+  async execute(query: string, nowMs = Date.now()): Promise<QueryResult> {
+    const startedAt = Date.now();
+    const truncation: QueryTruncation = {
+      tagCatalogue: false,
+      historySamples: false,
+      resultItems: false,
+      timeRange: false,
+    };
+
+    // Parsing is pure, synchronous and linear on an already length-capped
+    // string, so it runs outside the timed section — which also means the
+    // intent is known even if the data reads time out.
+    const intent = parseIntent(query, nowMs);
+    if (intent.timeRangeClamped) truncation.timeRange = true;
+
+    let resolved: ResolvedSubject[] = [];
+    let outcome: Outcome;
+    try {
+      const run = await withTimeout(
+        this.resolveAndExecute(intent, nowMs, truncation),
+        this.timeoutMs,
+      );
+      resolved = run.resolved;
+      outcome = run.outcome;
+    } catch (error) {
+      outcome =
+        error instanceof QueryTimeoutError
+          ? {
+              success: false,
+              answer:
+                `I could not answer within the ${this.timeoutMs}ms query time limit, `
+                + 'so I have no result to report. Narrow the question (a shorter '
+                + 'trend window, or a specific tag id) and try again.',
+              data: { timedOut: true, timeoutMs: this.timeoutMs },
+              suggestions: [],
+            }
+          : {
+              success: false,
+              answer:
+                'I could not complete that query because the process data store '
+                + 'returned an error. No value is available to report.',
+              data: { failed: true },
+              suggestions: [],
+            };
+    }
+
+    const result: QueryResult = {
+      id: `NLQ-${this.bootId}-${++this.queryCounter}`,
+      query,
+      intent,
+      resolved,
+      success: outcome.success,
+      answer: outcome.answer,
+      interpretation: describe(intent, resolved),
+      data: outcome.data,
+      suggestions: outcome.suggestions,
+      timestamp: nowMs,
+      durationMs: Date.now() - startedAt,
+      truncation,
+      parsedBy: 'regex',
+    };
+
+    this.history.push(result);
+    if (this.history.length > this.maxHistory) {
+      this.history.splice(0, this.history.length - this.maxHistory);
+    }
+    return result;
+  }
+
+  // ── Resolution + dispatch ──────────────────────────────────────────────
+
+  private async resolveAndExecute(
+    intent: QueryIntent,
+    nowMs: number,
+    truncation: QueryTruncation,
+  ): Promise<{ resolved: ResolvedSubject[]; outcome: Outcome }> {
+    // `list_tags` needs the catalogue but has no subjects; `alarms` resolves
+    // against the active alarm set instead of the tag catalogue. Both skip the
+    // catalogue read they do not need.
+    if (intent.type === 'alarms') {
+      return this.executeAlarms(intent, truncation);
+    }
+
+    const catalogue = await this.dataPort.listTags(MAX_RESOLVER_CANDIDATE_TAGS);
+    if (!catalogue.available) {
+      return {
+        resolved: [],
+        outcome: {
+          success: false,
+          answer:
+            'I could not read the tag catalogue, so I cannot resolve any tag '
+            + `name or report a value. Reason: ${catalogue.reason}`,
+          data: { tagCatalogueUnavailable: catalogue.reason },
+          suggestions: [],
+        },
+      };
+    }
+    if (catalogue.value.truncated) truncation.tagCatalogue = true;
+
+    // Defence in depth: MAX_RESOLVER_CANDIDATE_TAGS is the only CPU bound on
+    // the O(tags x tokens) scoring path, so the engine re-applies it rather
+    // than trusting every port to have honoured the cap it was passed. A port
+    // that over-returns is then reported as truncated instead of scored.
+    let tags = catalogue.value.tagIds;
+    if (tags.length > MAX_RESOLVER_CANDIDATE_TAGS) {
+      tags = tags.slice(0, MAX_RESOLVER_CANDIDATE_TAGS);
+      truncation.tagCatalogue = true;
+    }
+    const resolved = intent.subjects.map((subject) =>
+      this.resolver.resolve(subject, tags, truncation.tagCatalogue),
+    );
+
+    const outcome = await this.dispatch(intent, resolved, tags, nowMs, truncation);
+    return { resolved, outcome };
+  }
+
+  private dispatch(
+    intent: QueryIntent,
+    resolved: ResolvedSubject[],
+    tags: readonly string[],
+    nowMs: number,
+    truncation: QueryTruncation,
+  ): Promise<Outcome> {
+    switch (intent.type) {
+      case 'read_tag':
+        return this.executeRead(resolved);
+      case 'compare':
+        return this.executeCompare(resolved);
+      case 'trend':
+        return this.executeTrend(resolved, intent, nowMs, truncation);
+      case 'status':
+        return this.executeStatus(resolved, nowMs);
+      case 'list_tags':
+        return Promise.resolve(this.executeListTags(tags, truncation));
+      // 'alarms' never reaches here — resolveAndExecute handles it before the
+      // catalogue read, because it resolves against the active alarm set.
+      case 'unknown':
+      default:
+        return Promise.resolve({
+          success: false,
+          answer:
+            "I couldn't understand that question, so I have not run any query.",
+          data: {},
+          suggestions: [...EXAMPLE_QUERIES],
+        });
+    }
+  }
+
+  // ── Intent execution ───────────────────────────────────────────────────
+
+  private async executeRead(resolved: ResolvedSubject[]): Promise<Outcome> {
+    const subject = resolved[0];
+    if (!subject) return missingSubject('What would you like to read?');
+    if (!subject.tagId) return unresolved(subject);
+
+    const read = await this.dataPort.readLatest(subject.tagId);
+    if (!read.available) return storeUnavailable(subject.tagId, read.reason);
+    if (read.value === null) return noData(subject.tagId);
+
+    const reading = read.value;
+    return {
+      success: true,
+      answer:
+        `${reading.tagId} is ${reading.value}`
+        + qualitySuffix(reading)
+        + ` as of ${new Date(reading.timestamp).toISOString()} (${sourceLabel(reading)}).`,
+      data: { reading },
+      suggestions: [],
+    };
+  }
+
+  private async executeCompare(resolved: ResolvedSubject[]): Promise<Outcome> {
+    if (resolved.length < 2) {
+      return missingSubject('A comparison needs two tags.');
+    }
+    for (const subject of resolved) {
+      if (!subject.tagId) return unresolved(subject);
+    }
+
+    const readings: TagReading[] = [];
+    for (const subject of resolved) {
+      // Non-null asserted by the loop above; keep the check explicit for the
+      // type checker rather than using a non-null assertion.
+      const tagId = subject.tagId;
+      if (tagId === null) return unresolved(subject);
+
+      const read = await this.dataPort.readLatest(tagId);
+      if (!read.available) return storeUnavailable(tagId, read.reason);
+      if (read.value === null) {
+        // Missing data is reported explicitly — never coerced to 0.
+        return {
+          success: false,
+          answer: `No data is recorded for ${tagId}, so I cannot compare the two tags.`,
+          data: { missing: tagId },
+          suggestions: [],
+        };
+      }
+      readings.push(read.value);
+    }
+
+    const [a, b] = readings;
+    const numericA = numericValue(a.value);
+    const numericB = numericValue(b.value);
+    if (numericA === null || numericB === null) {
+      return {
+        success: false,
+        answer:
+          `${a.tagId} (${a.value}) and ${b.tagId} (${b.value}) are not both `
+          + 'numeric, so I cannot compute a difference.',
+        data: { a, b },
+        suggestions: [],
+      };
+    }
+
+    const difference = numericA - numericB;
+    return {
+      success: true,
+      answer:
+        `${a.tagId} is ${numericA} and ${b.tagId} is ${numericB} — `
+        + `a difference of ${Number(difference.toFixed(6))}.`,
+      data: { a, b, difference },
+      suggestions: [],
+    };
+  }
+
+  private async executeTrend(
+    resolved: ResolvedSubject[],
+    intent: QueryIntent,
+    nowMs: number,
+    truncation: QueryTruncation,
+  ): Promise<Outcome> {
+    const subject = resolved[0];
+    if (!subject) return missingSubject('Which tag should I trend?');
+    if (!subject.tagId) return unresolved(subject);
+
+    const range = intent.timeRange ?? {
+      start: nowMs - DEFAULT_TREND_WINDOW_MS,
+      end: nowMs,
+    };
+    const read = await this.dataPort.readHistory(
+      subject.tagId,
+      range.start,
+      range.end,
+      MAX_HISTORY_SAMPLES,
+    );
+    if (!read.available) return storeUnavailable(subject.tagId, read.reason);
+    if (read.value.truncated) truncation.historySamples = true;
+
+    const points = read.value.samples.filter(
+      (p): p is TagReading & { value: number } => typeof p.value === 'number',
+    );
+    if (points.length === 0) {
+      return {
+        success: false,
+        answer:
+          `No numeric samples are recorded for ${subject.tagId} between `
+          + `${new Date(range.start).toISOString()} and `
+          + `${new Date(range.end).toISOString()}, so there is no trend to report.`,
+        data: { tagId: subject.tagId, range, samples: 0 },
+        suggestions: [],
+      };
+    }
+
+    const values = points.map((p) => p.value);
+    let min = values[0];
+    let max = values[0];
+    let sum = 0;
+    for (const value of values) {
+      if (value < min) min = value;
+      if (value > max) max = value;
+      sum += value;
+    }
+    const avg = sum / values.length;
+    const delta = values[values.length - 1] - values[0];
+    const direction = delta > 0 ? 'rising' : delta < 0 ? 'falling' : 'flat';
+    const minutes = Math.round((range.end - range.start) / 60_000);
+
+    const caveats: string[] = [];
+    if (truncation.historySamples) {
+      caveats.push(
+        ` Only the first ${MAX_HISTORY_SAMPLES} samples in the window were read `
+        + '(sample cap), so these figures describe that subset, not the whole window.',
+      );
+    }
+    if (intent.timeRangeClamped) {
+      caveats.push(' The requested window was longer than the maximum and was clamped.');
+    }
+
+    return {
+      success: true,
+      answer:
+        `${subject.tagId} over the last ${minutes} minutes: ${points.length} samples, `
+        + `min ${min}, max ${max}, average ${Number(avg.toFixed(3))} — ${direction} `
+        + `(${delta >= 0 ? '+' : ''}${Number(delta.toFixed(3))}).`
+        + caveats.join(''),
+      data: {
+        tagId: subject.tagId,
+        range,
+        samples: points.length,
+        min,
+        max,
+        avg,
+        delta,
+        direction,
+        sampleCapReached: truncation.historySamples,
+        windowClamped: intent.timeRangeClamped === true,
+      },
+      suggestions: [],
+    };
+  }
+
+  private async executeStatus(
+    resolved: ResolvedSubject[],
+    nowMs: number,
+  ): Promise<Outcome> {
+    const subject = resolved[0];
+    if (!subject) return missingSubject('Which tag or equipment?');
+    if (!subject.tagId) return unresolved(subject);
+
+    const read = await this.dataPort.readLatest(subject.tagId);
+    if (!read.available) return storeUnavailable(subject.tagId, read.reason);
+    if (read.value === null) return noData(subject.tagId);
+
+    const reading = read.value;
+    const ageSeconds = Math.max(0, Math.round((nowMs - reading.timestamp) / 1000));
+    return {
+      success: true,
+      // Deliberately reports the last recorded value and its age rather than a
+      // running/stopped verdict: this repository has no equipment state model,
+      // so inferring one would be an invention.
+      answer:
+        `${reading.tagId}: last recorded value ${reading.value}`
+        + qualitySuffix(reading)
+        + `, ${ageSeconds}s old (${sourceLabel(reading)}). `
+        + 'No equipment state model is configured, so this is the tag value, '
+        + 'not a running/stopped verdict.',
+      data: { reading, ageSeconds },
+      suggestions: [],
+    };
+  }
+
+  private async executeAlarms(
+    intent: QueryIntent,
+    truncation: QueryTruncation,
+  ): Promise<{ resolved: ResolvedSubject[]; outcome: Outcome }> {
+    const read = await this.dataPort.listActiveAlarms(MAX_ALARM_SCAN);
+    if (!read.available) {
+      return {
+        resolved: [],
+        outcome: {
+          success: false,
+          answer:
+            'I could not read the active alarm list, so I cannot tell you '
+            + `whether any alarms are active. Reason: ${read.reason}`,
+          data: { alarmsUnavailable: read.reason },
+          suggestions: [],
+        },
+      };
+    }
+
+    const all = read.value.alarms;
+    const scanTruncated = read.value.truncated;
+    const phrase = intent.subjects[0];
+
+    if (phrase === undefined) {
+      return {
+        resolved: [],
+        outcome: this.summariseAlarms(all, scanTruncated, truncation, null),
+      };
+    }
+
+    // Scope the question to equipment by resolving against the tag ids present
+    // in the ACTIVE alarm set — the only universe in which the answer is
+    // meaningful, and already bounded by MAX_ALARM_SCAN.
+    const alarmTagIds = [...new Set(all.map((a) => a.tagId))];
+    const subject = this.resolver.resolve(phrase, alarmTagIds, scanTruncated);
+    if (!subject.tagId) {
+      return {
+        resolved: [subject],
+        outcome: {
+          success: false,
+          // Critically NOT "no alarms" — an unresolved scope must not read as
+          // an all-clear.
+          answer:
+            `I couldn't identify "${phrase}" among the tags with active alarms, `
+            + `so I cannot scope the answer to it. There ${all.length === 1 ? 'is' : 'are'} `
+            + `${all.length} active alarm${all.length === 1 ? '' : 's'} in total`
+            + (subject.candidates.length > 0
+              ? `. Did you mean: ${subject.candidates.join(', ')}?`
+              : '.'),
+          data: {
+            unresolved: phrase,
+            candidates: subject.candidates,
+            totalActive: all.length,
+          },
+          suggestions: subject.candidates,
+        },
+      };
+    }
+
+    const scoped = all.filter((a) => a.tagId === subject.tagId);
+    return {
+      resolved: [subject],
+      outcome: this.summariseAlarms(scoped, scanTruncated, truncation, subject.tagId),
+    };
+  }
+
+  private summariseAlarms(
+    alarms: readonly ActiveAlarmSummary[],
+    scanTruncated: boolean,
+    truncation: QueryTruncation,
+    scopeTagId: string | null,
+  ): Outcome {
+    const scope = scopeTagId ? ` for ${scopeTagId}` : '';
+    if (alarms.length === 0) {
+      return {
+        success: true,
+        answer: scanTruncated
+          ? `No active alarms${scope} among the first ${MAX_ALARM_SCAN} scanned; `
+            + 'more active alarms exist beyond that cap.'
+          : `No active alarms${scope}.`,
+        data: { alarms: [], total: 0, scanTruncated },
+        suggestions: [],
+      };
+    }
+
+    const shown = alarms.slice(0, MAX_RESULT_ITEMS);
+    if (shown.length < alarms.length) truncation.resultItems = true;
+    const summary = shown.map((a) => `${a.name} (${a.severity})`).join('; ');
+    return {
+      success: true,
+      answer:
+        `${alarms.length} active alarm${alarms.length === 1 ? '' : 's'}${scope}`
+        + (shown.length < alarms.length ? ` (showing ${shown.length})` : '')
+        + `: ${summary}.`
+        + (scanTruncated
+          ? ` More active alarms exist beyond the ${MAX_ALARM_SCAN}-alarm scan cap.`
+          : ''),
+      data: { alarms: shown, total: alarms.length, scanTruncated },
+      suggestions: [],
+    };
+  }
+
+  private executeListTags(
+    tags: readonly string[],
+    truncation: QueryTruncation,
+  ): Outcome {
+    if (tags.length === 0) {
+      return {
+        success: true,
+        answer: 'No tags are recorded in the process data store.',
+        data: { count: 0, tags: [] },
+        suggestions: [],
+      };
+    }
+    const shown = tags.slice(0, MAX_RESULT_ITEMS);
+    if (shown.length < tags.length) truncation.resultItems = true;
+    return {
+      success: true,
+      answer:
+        `${tags.length}${truncation.tagCatalogue ? '+' : ''} tags available`
+        + (shown.length < tags.length ? ` (showing ${shown.length})` : '')
+        + `: ${shown.join(', ')}.`
+        + (truncation.tagCatalogue
+          ? ` The catalogue was capped at ${MAX_RESOLVER_CANDIDATE_TAGS} tags, `
+            + 'so more tags exist than this count reports.'
+          : ''),
+      data: {
+        count: tags.length,
+        countIsCapped: truncation.tagCatalogue,
+        tags: shown,
+      },
+      suggestions: [],
+    };
+  }
+}
+
+// ── Shared outcome builders ──────────────────────────────────────────────
+
+function missingSubject(prompt: string): Outcome {
+  return {
+    success: false,
+    answer: prompt,
+    data: {},
+    suggestions: [...EXAMPLE_QUERIES],
+  };
+}
+
+function unresolved(subject: ResolvedSubject): Outcome {
+  const scopeNote = subject.searchTruncated
+    ? ` I only searched the first ${MAX_RESOLVER_CANDIDATE_TAGS} tags, so this `
+      + 'does not mean the tag does not exist.'
+    : '';
+  return {
+    success: false,
+    answer:
+      subject.candidates.length > 0
+        ? `I couldn't uniquely identify a tag for "${subject.phrase}". `
+          + `Did you mean: ${subject.candidates.join(', ')}?${scopeNote}`
+        : `I couldn't find any tag matching "${subject.phrase}".${scopeNote}`,
+    data: {
+      unresolved: subject.phrase,
+      candidates: subject.candidates,
+      searchTruncated: subject.searchTruncated === true,
+    },
+    suggestions: subject.candidates,
+  };
+}
+
+function noData(tagId: string): Outcome {
+  return {
+    success: false,
+    answer: `No data is recorded for ${tagId}.`,
+    data: { tagId },
+    suggestions: [],
+  };
+}
+
+function storeUnavailable(tagId: string, reason: string): Outcome {
+  return {
+    success: false,
+    answer:
+      `I could not read ${tagId} from the process data store, so I have no `
+      + `value to report. Reason: ${reason}`,
+    data: { tagId, unavailable: reason },
+    suggestions: [],
+  };
+}
+
+/**
+ * Strictly numeric interpretation of a stored reading, or null.
+ *
+ * `Number()` must NOT be used here. A `historian_data` row carries either a
+ * numeric `value` or a text `string_value`, and JavaScript's coercion turns
+ * several non-numeric strings into plausible readings: `Number("")` and
+ * `Number("   ")` are `0`, and `Number("0x10")` is `16`. Feeding those into a
+ * comparison made the engine state a value no sensor produced — `success:
+ * true`, "A.X is 0 and B.X is 5 — a difference of -5" for a tag whose recorded
+ * value was the empty string — which is exactly the fabrication this surface
+ * exists to avoid, and which the "never coerced to 0" comment above already
+ * promised did not happen.
+ *
+ * Only a plain decimal literal (optionally signed, optionally exponent) is
+ * accepted. Anything else returns null and the caller reports that the two
+ * readings are not both numeric, quoting the values as they were stored.
+ */
+const DECIMAL_LITERAL = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+function numericValue(value: number | string): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  const trimmed = value.trim();
+  if (!DECIMAL_LITERAL.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function qualitySuffix(reading: TagReading): string {
+  return reading.quality && reading.quality !== 'good'
+    ? ` (quality: ${reading.quality})`
+    : '';
+}
+
+function sourceLabel(reading: TagReading): string {
+  return reading.source === 'live-stream' ? 'live tag stream' : 'historian';
+}
+
+function describe(intent: QueryIntent, resolved: readonly ResolvedSubject[]): string {
+  const subjects = resolved
+    .map((r) => (r.tagId ? `"${r.phrase}" -> ${r.tagId}` : `"${r.phrase}" (unresolved)`))
+    .join(', ');
+  return `intent: ${intent.type}${subjects ? `; subjects: ${subjects}` : ''}`;
+}
+
+export type { Outcome as NLQueryOutcome };
+export { QueryTimeoutError };
+
+/** Exposed so the route and tests share one list of worked examples. */
+export function exampleQueries(): string[] {
+  return [...EXAMPLE_QUERIES];
+}

--- a/server/services/nlquery/index.ts
+++ b/server/services/nlquery/index.ts
@@ -1,0 +1,74 @@
+/**
+ * NL Query Service
+ * ADR-0013 [13.5] (docs/decisions/ADR-0013-autonomous-agent-architecture.md);
+ * route contract in docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md.
+ * Issue #216.
+ *
+ * Read-only over process data: this service answers questions from the
+ * historian, the live tag stream, and the alarm-correlation engine. It holds
+ * no process state of its own and writes nothing anywhere.
+ *
+ * The only state it keeps is a bounded, process-local ring buffer of recent
+ * query results (MAX_HISTORY_ENTRIES). That history is deliberately NOT
+ * persisted — see ADR-0027 §"History is process-local". The API response and
+ * the docs both say so explicitly, so an operator is never left assuming a
+ * durable audit trail exists here. Control-plane audit lives in `audit_logs`
+ * and is unaffected: this surface performs no mutation to audit.
+ */
+
+export * from './limits';
+export * from './parser';
+export * from './resolver';
+export * from './engine';
+export * from './data-port';
+
+import type { NLQueryDataPort } from '@shared/types/nl-query';
+import { NLQueryEngine } from './engine';
+import { ProcessDataPort } from './data-port';
+
+export interface NLQueryServiceOptions {
+  /** Injectable for tests; production uses the real {@link ProcessDataPort}. */
+  dataPort?: NLQueryDataPort;
+}
+
+export class NLQueryService {
+  readonly engine: NLQueryEngine;
+
+  private initialized = false;
+
+  constructor(options: NLQueryServiceOptions = {}) {
+    this.engine = new NLQueryEngine({
+      dataPort: options.dataPort ?? new ProcessDataPort(),
+    });
+  }
+
+  /**
+   * No timers, sockets, or subscriptions to start: the port pulls from the
+   * historian and the tag stream at query time rather than maintaining a
+   * shadow copy of process data.
+   */
+  async initialize(): Promise<void> {
+    this.initialized = true;
+  }
+
+  async shutdown(): Promise<void> {
+    this.initialized = false;
+  }
+
+  async healthCheck(): Promise<{
+    healthy: boolean;
+    message: string;
+    historyPersistence: 'process-local';
+  }> {
+    return {
+      healthy: this.initialized,
+      message: this.initialized
+        ? 'NL query running: regex intent grammar, read-only over historian, '
+          + 'live tag stream, and alarm correlation'
+        : 'NL query service not initialized',
+      historyPersistence: 'process-local',
+    };
+  }
+}
+
+export const nlQueryService = new NLQueryService();

--- a/server/services/nlquery/limits.ts
+++ b/server/services/nlquery/limits.ts
@@ -1,0 +1,93 @@
+/**
+ * Bounded execution limits for the NL process query surface.
+ * Issue #216; contract in docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md.
+ *
+ * Every bound the query path enforces is named here and nowhere else, so the
+ * set of things an operator-supplied string can grow is auditable by reading
+ * one file. Each constant is covered by a test that proves the bound holds
+ * (server/services/nlquery/__tests__/nl-query-bounds.test.ts).
+ *
+ * The threat model is not a malicious operator so much as an ordinary one on a
+ * large site: a plant with 200k historian tags, a question phrased as "trend of
+ * everything over the last year", or a paste of a log file into the question
+ * box. None of those may be allowed to occupy the API process.
+ */
+
+/**
+ * Longest accepted question, in UTF-16 code units.
+ *
+ * Rejected with 400 rather than truncated: silently answering a question the
+ * operator did not finish asking is exactly the failure mode this feature must
+ * not have. 512 comfortably exceeds any real question — the longest example in
+ * the grammar is 62 characters.
+ */
+export const MAX_QUERY_LENGTH = 512;
+
+/**
+ * Wall-clock ceiling on one `execute()` call, covering parse, resolve, and
+ * every port read. On expiry the engine returns an explicit timeout answer
+ * with `success: false`; it never returns a partial reading as if it were
+ * complete.
+ *
+ * 2s is ~10x the p99 of the two indexed historian queries this path issues
+ * (`idx_historian_tag_timestamp` covers both) while staying well inside a
+ * default 30s HTTP client timeout.
+ */
+export const QUERY_TIMEOUT_MS = 2_000;
+
+/**
+ * Most tags the resolver will score in one query.
+ *
+ * Token-overlap scoring is O(tags x tokens), so this is the only real CPU
+ * bound on the path. A site with more tags than this is not an error: the
+ * catalogue read is capped at this value, `searchTruncated` is set, and an
+ * unresolved phrase is reported as "no match among the N tags I examined"
+ * rather than "no such tag" — a claim the engine cannot support once it has
+ * only seen part of the catalogue. Exact-id and alias lookups are unaffected,
+ * because both are hash lookups the truncation does not reach.
+ */
+export const MAX_RESOLVER_CANDIDATE_TAGS = 2_000;
+
+/**
+ * Most historian samples pulled into memory for one trend query. The port
+ * pushes this down as a SQL LIMIT (plus one, to detect truncation) — the
+ * oversized row set is never materialised.
+ */
+export const MAX_HISTORY_SAMPLES = 5_000;
+
+/**
+ * Longest trend window accepted. A larger request is clamped to this and the
+ * response sets `truncation.timeRange`, so a clamped window is never mistaken
+ * for the one that was asked for.
+ */
+export const MAX_TREND_WINDOW_MS = 7 * 24 * 60 * 60 * 1_000;
+
+/** Default trend window when the question names no duration. */
+export const DEFAULT_TREND_WINDOW_MS = 60 * 60 * 1_000;
+
+/**
+ * Most list items (tag ids, alarm summaries) embedded in one response body.
+ * Aggregates computed over a larger sample set still report the true sample
+ * count; this caps what is serialised, and sets `truncation.resultItems`.
+ */
+export const MAX_RESULT_ITEMS = 50;
+
+/**
+ * Most alarms fetched from the correlation engine for one query.
+ * Larger than MAX_RESULT_ITEMS so the reported total is accurate up to this
+ * point rather than being pinned to the display cap.
+ */
+export const MAX_ALARM_SCAN = 500;
+
+/**
+ * Entries retained by the process-local query history ring buffer.
+ *
+ * History is deliberately NOT persisted (ADR-0027): it is bounded, in-memory,
+ * and lost on restart, and both the API response and the docs say so. The ring
+ * is what keeps that choice safe — a long-running process cannot grow this
+ * buffer without bound.
+ */
+export const MAX_HISTORY_ENTRIES = 100;
+
+/** Most history rows returned by `GET /nlquery/history` in one response. */
+export const MAX_HISTORY_PAGE = 50;

--- a/server/services/nlquery/parser.ts
+++ b/server/services/nlquery/parser.ts
@@ -1,0 +1,152 @@
+/**
+ * Intent Parser (regex grammar)
+ * Issue #216; contract in docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md.
+ *
+ * Ported unchanged in substance from the reviewed implementation: an ORDERED
+ * grammar with the specific intents first and the generic `read_tag` catch-all
+ * last. Ordering is the whole trick — with `read_tag` first, "what is the
+ * status of X" matches the catch-all and can never be recognised as a status
+ * query. The ordering regressions are pinned by tests.
+ *
+ * This module is pure: `(query, nowMs) => QueryIntent`, no I/O, no clock, no
+ * `eval`, no dynamic `RegExp` construction from operator input. It is also the
+ * single seam any future parsing strategy would replace (ADR-0027).
+ *
+ * Regex safety: every pattern below is linear-time on the input. The only
+ * repetition operators applied to operator-controlled text are `.+?`/`.*`,
+ * which are not nested inside another quantifier, so there is no
+ * catastrophic-backtracking path. Input is additionally capped at
+ * MAX_QUERY_LENGTH before it reaches this module.
+ */
+
+import type { QueryIntent } from '@shared/types/nl-query';
+import { DEFAULT_TREND_WINDOW_MS, MAX_TREND_WINDOW_MS } from './limits';
+
+const DURATION_UNITS: Record<string, number> = {
+  m: 60_000,
+  min: 60_000,
+  mins: 60_000,
+  minute: 60_000,
+  minutes: 60_000,
+  h: 3_600_000,
+  hr: 3_600_000,
+  hrs: 3_600_000,
+  hour: 3_600_000,
+  hours: 3_600_000,
+  d: 86_400_000,
+  day: 86_400_000,
+  days: 86_400_000,
+};
+
+/** Unknown units return null so the caller falls back to the default window. */
+export function parseDurationMs(amount: number, unit: string): number | null {
+  const ms = DURATION_UNITS[unit.toLowerCase()];
+  if (ms === undefined) return null;
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  return amount * ms;
+}
+
+function clean(phrase: string): string {
+  return phrase.replace(/[?.!]+$/, '').replace(/^the\s+/i, '').trim();
+}
+
+/**
+ * Build a trend window, clamped to MAX_TREND_WINDOW_MS. The clamp is reported
+ * rather than applied silently: `timeRangeClamped` reaches the response so the
+ * operator sees that a narrower window than requested was searched.
+ */
+function windowFor(
+  requestedMs: number | null,
+  nowMs: number,
+): { start: number; end: number; clamped: boolean } {
+  const desired = requestedMs ?? DEFAULT_TREND_WINDOW_MS;
+  const clamped = desired > MAX_TREND_WINDOW_MS;
+  const width = clamped ? MAX_TREND_WINDOW_MS : desired;
+  return { start: nowMs - width, end: nowMs, clamped };
+}
+
+interface Pattern {
+  regex: RegExp;
+  build: (match: RegExpMatchArray, raw: string, nowMs: number) => QueryIntent;
+}
+
+const PATTERNS: readonly Pattern[] = [
+  // list_tags — "what tags are available", "list tags", "show all tags"
+  {
+    regex: /\b(?:list|show|what|which)\b.*\btags?\b(?:\s+(?:are|do)\b.*)?$/i,
+    build: (_m, raw) => ({ type: 'list_tags', subjects: [], raw }),
+  },
+  // alarms — "any active alarms?", "alarms on tank 3"
+  {
+    regex: /\balarms?\b(?:\s+(?:on|for|in)\s+(.+?))?[?.!]*$/i,
+    build: (m, raw) => ({
+      type: 'alarms',
+      subjects: m[1] ? [clean(m[1])] : [],
+      raw,
+    }),
+  },
+  // trend — "trend of pressure in tank 3 over the last 2 hours"
+  {
+    regex:
+      /\b(?:trend|history|graph|chart)\b(?:\s+(?:of|for))?\s+(.+?)(?:\s+(?:over\s+the\s+|for\s+the\s+)?(?:last|past)\s+(\d+)\s*([a-z]+))?[?.!]*$/i,
+    build: (m, raw, nowMs) => {
+      const requested =
+        m[2] && m[3] ? parseDurationMs(Number.parseInt(m[2], 10), m[3]) : null;
+      const { start, end, clamped } = windowFor(requested, nowMs);
+      return {
+        type: 'trend',
+        subjects: [clean(m[1])],
+        timeRange: { start, end },
+        timeRangeClamped: clamped,
+        raw,
+      };
+    },
+  },
+  // status — "what is the status of pump 1", "health of feeder 2"
+  {
+    regex: /\b(?:status|state|health)\b\s+(?:of|for)?\s*(.+?)[?.!]*$/i,
+    build: (m, raw) => ({ type: 'status', subjects: [clean(m[1])], raw }),
+  },
+  // compare — "compare X and Y", "difference between X and Y"
+  {
+    regex:
+      /\b(?:compare|difference(?:\s+between)?|diff)\s+(.+?)\s+(?:and|vs\.?|versus|with)\s+(.+?)[?.!]*$/i,
+    build: (m, raw) => ({
+      type: 'compare',
+      subjects: [clean(m[1]), clean(m[2])],
+      raw,
+    }),
+  },
+  // read_tag with measurement + location — "what is the pressure in tank 3"
+  {
+    regex:
+      /\b(?:what(?:'s|\s+is)?|show(?:\s+me)?|get|read|give\s+me)\s+(?:the\s+)?(?:current\s+)?(.+?)\s+(?:in|on|at|of|for)\s+(.+?)[?.!]*$/i,
+    build: (m, raw) => ({
+      type: 'read_tag',
+      // Keep the full phrase — resolution scores measurement AND location
+      subjects: [`${clean(m[1])} ${clean(m[2])}`],
+      raw,
+    }),
+  },
+  // read_tag generic catch-all — "show FEEDER-01.CURRENT"
+  {
+    regex:
+      /\b(?:what(?:'s|\s+is)?|show(?:\s+me)?|get|read|value\s+of)\s+(?:the\s+)?(?:current\s+)?(?:value\s+(?:of|for)\s+)?(.+?)[?.!]*$/i,
+    build: (m, raw) => ({ type: 'read_tag', subjects: [clean(m[1])], raw }),
+  },
+];
+
+/**
+ * Match the ordered grammar. An unmatched question yields `unknown`, which the
+ * engine answers with example queries — never with a guess.
+ */
+export function parseIntent(query: string, nowMs: number): QueryIntent {
+  const trimmed = query.trim();
+  for (const pattern of PATTERNS) {
+    const match = trimmed.match(pattern.regex);
+    if (match) {
+      return pattern.build(match, trimmed, nowMs);
+    }
+  }
+  return { type: 'unknown', subjects: [], raw: trimmed };
+}

--- a/server/services/nlquery/resolver.ts
+++ b/server/services/nlquery/resolver.ts
@@ -1,0 +1,142 @@
+/**
+ * Tag Resolver
+ * Issue #216; contract in docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md.
+ *
+ * Resolves a natural-language phrase ("pressure in tank 3") against the actual
+ * tag universe by token-overlap scoring, with exact ids and explicit aliases
+ * taking precedence.
+ *
+ * Two behaviours are safety properties, not heuristics, and are pinned by
+ * tests:
+ *
+ *   1. **It never invents a tag id.** There is no path from a phrase to a tag
+ *      id other than matching a string the caller supplied in `availableTags`.
+ *      An unmatched phrase resolves to null.
+ *   2. **It never guesses between ambiguous candidates.** Equal top scores
+ *      resolve to null plus the tied candidates, so the operator disambiguates.
+ *      Silently picking one of two equally-good tags would put a reading from
+ *      the wrong vessel in front of an operator.
+ *
+ * Numeric tokens are treated as equipment identity and must match exactly:
+ * "tank 12" must never resolve to TANK-3.PRESSURE.
+ *
+ * Bounding: scoring is O(tags x tokens), so the caller passes an already-capped
+ * `availableTags` (MAX_RESOLVER_CANDIDATE_TAGS) and sets `searchTruncated` when
+ * the real catalogue was larger. Under truncation a miss is reported as "not
+ * found among the tags examined" — the engine must not claim a tag does not
+ * exist when it only looked at part of the catalogue.
+ */
+
+import type { ResolvedSubject } from '@shared/types/nl-query';
+
+const STOP_WORDS = new Set([
+  'the', 'a', 'an', 'in', 'on', 'at', 'of', 'for', 'is', 'me', 'current',
+  'value', 'level', 'and', 'to', 'from', 'what', 'show',
+]);
+
+/** Most candidates echoed back to the caller for disambiguation. */
+const MAX_CANDIDATES = 5;
+
+/** Minimum token-overlap fraction for a tag to be considered a candidate. */
+const MIN_SCORE = 0.5;
+
+/** Split a phrase or tag id into normalized comparable tokens. */
+export function tokenize(text: string): string[] {
+  return text
+    .split(/[\s._\-/:]+/)
+    .map((t) => t.toLowerCase().replace(/^0+(?=\d)/, ''))
+    .filter((t) => t.length > 0 && !STOP_WORDS.has(t));
+}
+
+export class TagResolver {
+  private readonly aliases = new Map<string, string>();
+
+  registerAlias(alias: string, tagId: string): void {
+    this.aliases.set(alias.trim().toLowerCase(), tagId);
+  }
+
+  listAliases(): Array<{ alias: string; tagId: string }> {
+    return [...this.aliases.entries()].map(([alias, tagId]) => ({ alias, tagId }));
+  }
+
+  /**
+   * Resolve a phrase against the available tags.
+   *
+   * @param availableTags Already capped by the caller to
+   *   MAX_RESOLVER_CANDIDATE_TAGS.
+   * @param searchTruncated True when the real catalogue was larger than
+   *   `availableTags`, so a null result means "no match here", not "no such tag".
+   */
+  resolve(
+    phrase: string,
+    availableTags: readonly string[],
+    searchTruncated = false,
+  ): ResolvedSubject {
+    const trimmed = phrase.trim();
+    const base = { phrase, searchTruncated };
+
+    // Exact tag id (case-insensitive) always wins, and is unaffected by
+    // catalogue truncation when the caller also consulted an index.
+    const exact = availableTags.find((t) => t.toLowerCase() === trimmed.toLowerCase());
+    if (exact) return { ...base, tagId: exact, candidates: [exact] };
+
+    // Explicit alias — an operator-configured mapping outranks scoring.
+    const alias = this.aliases.get(trimmed.toLowerCase());
+    if (alias) return { ...base, tagId: alias, candidates: [alias] };
+
+    const phraseTokens = tokenize(trimmed);
+    if (phraseTokens.length === 0) return { ...base, tagId: null, candidates: [] };
+
+    const scored: Array<{ tagId: string; score: number }> = [];
+    for (const tagId of availableTags) {
+      const score = this.scoreTag(tagId, phraseTokens);
+      if (score >= MIN_SCORE) scored.push({ tagId, score });
+    }
+    scored.sort((a, b) => b.score - a.score);
+
+    if (scored.length === 0) return { ...base, tagId: null, candidates: [] };
+
+    const best = scored[0];
+    const ties = scored.filter((s) => s.score === best.score);
+    if (ties.length > 1) {
+      // Ambiguous — never guess between equally good matches.
+      return {
+        ...base,
+        tagId: null,
+        candidates: ties.slice(0, MAX_CANDIDATES).map((s) => s.tagId),
+      };
+    }
+    return {
+      ...base,
+      tagId: best.tagId,
+      candidates: scored.slice(0, MAX_CANDIDATES).map((s) => s.tagId),
+    };
+  }
+
+  /** Fraction of phrase tokens found among the tag's tokens, 0 on identity mismatch. */
+  private scoreTag(tagId: string, phraseTokens: readonly string[]): number {
+    const tagTokens = new Set(tokenize(tagId));
+    let matched = 0;
+    for (const token of phraseTokens) {
+      // Numeric tokens are equipment identity — they must match exactly.
+      // "tank 12" must never resolve to TANK-3.PRESSURE.
+      if (/^\d+$/.test(token)) {
+        if (!tagTokens.has(token)) return 0;
+        matched++;
+        continue;
+      }
+      if (tagTokens.has(token)) {
+        matched++;
+        continue;
+      }
+      // Loose singular/plural and prefix matching ("temp" ~ "temperature")
+      const prefixHit = [...tagTokens].some(
+        (t) =>
+          (token.length >= 3 && t.startsWith(token)) ||
+          (t.length >= 3 && token.startsWith(t)),
+      );
+      if (prefixHit) matched += 0.75;
+    }
+    return matched / phraseTokens.length;
+  }
+}

--- a/shared/types/nl-query.ts
+++ b/shared/types/nl-query.ts
@@ -1,0 +1,181 @@
+/**
+ * Natural Language Process Query — shared contract
+ * ADR-0013 [13.5] (docs/decisions/ADR-0013-autonomous-agent-architecture.md),
+ * refined for this route by docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md.
+ * Issue #216.
+ *
+ * The engine is READ-ONLY over process data. It answers questions; it never
+ * writes a tag, a setpoint, or a controller parameter. `POST /nlquery` is a
+ * POST only because the question travels in the request body — see ADR-0027.
+ *
+ * Two invariants are load-bearing for operator safety and are encoded in these
+ * types rather than left to convention:
+ *
+ *   1. A phrase that does not resolve to exactly one tag yields `tagId: null`
+ *      plus candidates. There is no code path that turns a phrase into a tag
+ *      id by string munging.
+ *   2. Every data read returns a {@link PortResult}, so "the historian is not
+ *      reachable" is a distinct outcome from "the historian returned no rows".
+ *      The engine reports both honestly and never substitutes a value.
+ *
+ * No language-model backend is defined here, imported here, or called
+ * anywhere in this feature. See ADR-0027 §"No LLM backend ships".
+ */
+
+export type QueryIntentType =
+  | 'read_tag'
+  | 'compare'
+  | 'trend'
+  | 'status'
+  | 'alarms'
+  | 'list_tags'
+  | 'unknown';
+
+export interface QueryTimeRange {
+  /** Epoch ms */
+  start: number;
+  end: number;
+}
+
+export interface QueryIntent {
+  type: QueryIntentType;
+  /** Natural-language phrases naming tags/equipment ("pressure in tank 3") */
+  subjects: string[];
+  timeRange?: QueryTimeRange;
+  /**
+   * True when the requested trend window exceeded MAX_TREND_WINDOW_MS and was
+   * clamped. Surfaced to the caller so a clamped window is never mistaken for
+   * the window that was asked for.
+   */
+  timeRangeClamped?: boolean;
+  raw: string;
+}
+
+/**
+ * Resolution of one subject phrase against the known tag universe.
+ * An unresolvable or ambiguous phrase yields `tagId: null` plus candidates —
+ * it is never silently passed through as if it were a tag id.
+ */
+export interface ResolvedSubject {
+  phrase: string;
+  tagId: string | null;
+  candidates: string[];
+  /**
+   * True when the tag universe was larger than the resolver's candidate cap,
+   * so scoring considered only part of it. The engine says so in its answer:
+   * a miss under truncation means "not found in the tags I examined", which is
+   * not the same claim as "no such tag exists".
+   */
+  searchTruncated?: boolean;
+}
+
+export interface TagReading {
+  tagId: string;
+  value: number | string;
+  /** Historian quality code, or the tag-stream quality word, when known. */
+  quality?: string;
+  /** Epoch ms */
+  timestamp: number;
+  /** Where the value came from, so an answer can cite its provenance. */
+  source: 'live-stream' | 'historian';
+}
+
+export interface ActiveAlarmSummary {
+  id: string;
+  name: string;
+  tagId: string;
+  severity: string;
+  state: string;
+  message: string;
+  /** Epoch ms */
+  timestamp: number;
+}
+
+/**
+ * Result of one read against a backing store.
+ *
+ * `available: false` means the store could not be consulted (no database
+ * configured, the SQLite development fallback has no historian tables, the
+ * query failed). It is deliberately NOT collapsed into an empty array: an
+ * operator must never be told "no data" when the truth is "not asked".
+ */
+export type PortResult<T> =
+  | { available: true; value: T }
+  | { available: false; reason: string };
+
+export interface TagCatalogue {
+  tagIds: string[];
+  /** True when more tags exist than the requested cap allowed us to return. */
+  truncated: boolean;
+}
+
+export interface HistorySlice {
+  samples: TagReading[];
+  /** True when the window held more samples than `maxSamples` allowed. */
+  truncated: boolean;
+}
+
+export interface ActiveAlarmPage {
+  alarms: ActiveAlarmSummary[];
+  truncated: boolean;
+}
+
+/**
+ * The narrow, injectable port the engine answers from.
+ *
+ * Every method takes an explicit cap: the port implementation is responsible
+ * for pushing that cap down to the store (SQL LIMIT, map slice) so an
+ * unbounded row set is never materialised in this process. Tests inject a
+ * fake; production injects {@link ProcessDataPort} over the historian, the
+ * live tag stream, and the alarm-correlation engine.
+ */
+export interface NLQueryDataPort {
+  listTags(limit: number): Promise<PortResult<TagCatalogue>>;
+  readLatest(tagId: string): Promise<PortResult<TagReading | null>>;
+  readHistory(
+    tagId: string,
+    startMs: number,
+    endMs: number,
+    maxSamples: number,
+  ): Promise<PortResult<HistorySlice>>;
+  listActiveAlarms(limit: number): Promise<PortResult<ActiveAlarmPage>>;
+}
+
+/** What the bounds did to this particular answer, reported rather than hidden. */
+export interface QueryTruncation {
+  /** The tag catalogue hit MAX_RESOLVER_CANDIDATE_TAGS. */
+  tagCatalogue: boolean;
+  /** A history window hit MAX_HISTORY_SAMPLES. */
+  historySamples: boolean;
+  /** An alarm or tag list was cut to MAX_RESULT_ITEMS for the response body. */
+  resultItems: boolean;
+  /** The requested trend window exceeded MAX_TREND_WINDOW_MS and was clamped. */
+  timeRange: boolean;
+}
+
+export interface QueryResult {
+  id: string;
+  query: string;
+  intent: QueryIntent;
+  resolved: ResolvedSubject[];
+  /** False whenever the engine could not answer from real data. */
+  success: boolean;
+  /** Natural-language answer. Never contains a value the port did not return. */
+  answer: string;
+  /** Human-readable description of how the query was interpreted */
+  interpretation: string;
+  /** Structured data backing the answer */
+  data: Record<string, unknown>;
+  suggestions: string[];
+  /** Epoch ms */
+  timestamp: number;
+  /** Wall-clock execution time, for operators comparing against the timeout. */
+  durationMs: number;
+  /** Which bounds bit this answer. */
+  truncation: QueryTruncation;
+  /**
+   * How the intent was derived. Always `'regex'`: this feature ships no
+   * language-model backend and calls none (ADR-0027).
+   */
+  parsedBy: 'regex';
+}


### PR DESCRIPTION
## What

Replaces the two `501` stubs on `/api/intelligence` with a real, guarded, bounded read surface, rebuilt on current `main` per the #576 pattern.

The three properties the previous review praised are carried forward rather than rewritten: the **ordered 6-intent regex grammar** (specific intents before the `read_tag` catch-all — with `read_tag` first, "what is the status of X" is unreachable as a status query), the **token-overlap scoring**, and the **resolver that refuses to guess** between ambiguous tags. Still no SQL construction, no `eval`, no external LLM call, no hardcoded key.

## Scoped read auth (#576 pattern)

Both routes carry a route-local `requireControlPlaneAccess({ scopes: ["nlquery.read"] })`, replacing the no-op `requireAuth` the review found.

**`POST /nlquery` is a POST but semantically a READ**, and must not require or imply write privilege. It is a POST for transport reasons only: the question is operator free text, and a free-text query string lands in access logs, proxy logs, and browser history. The handler mutates nothing — the only state a POST changes is a process-local history ring.

That needed help from the gateway. `mutationAuthorizationMiddleware` applies `DEFAULT_MUTATION_POLICY` (scope `write`) to every mutating `/api` request, and a POST is mutating *by method* — so left alone the floor would have demanded `write` for a read-only route, locking read-only operators out and implying a control privilege the route never exercises. `control-route-policy.ts` gains an explicit `nl-query-read` entry so the floor and the route-local guard agree.

Auth matrix tested **per route** (17 tests): anonymous → 401, unknown credential → 401, wrong scope → 403, correct scope → 200, admin → 200, credential-in-query-string → 401, and guard-before-validation. Both directions of the scope decision are pinned: a key with **only** `nlquery.read` succeeds, and a key with `write` but not `nlquery.read` gets **403**.

## Bounded execution

Every limit is a named constant in `limits.ts`, documented, and proved by a test — both that the mechanism holds *and* that the magnitude has not drifted.

| Constant | Value | On breach |
| --- | --- | --- |
| `MAX_QUERY_LENGTH` | 512 | **400, never truncated** |
| `QUERY_TIMEOUT_MS` | 2000 ms | Explicit timeout answer, `success: false` |
| `MAX_RESOLVER_CANDIDATE_TAGS` | 2000 | `searchTruncated`; a miss reads "not found among the tags I examined" |
| `MAX_HISTORY_SAMPLES` | 5000 | Reported; answer says the aggregate covers the subset |
| `MAX_TREND_WINDOW_MS` | 7 days | Clamped **and stated** |
| `MAX_ALARM_SCAN` | 500 | Never a bare all-clear |
| `MAX_RESULT_ITEMS` | 50 | True total still reported |
| `MAX_HISTORY_ENTRIES` / `MAX_HISTORY_PAGE` | 100 / 50 | Oldest evicted / 400 |

Truncation is **reported, never silent** — a `truncation` object plus the caveat in words. A capped tag count renders as `2000+`, not as the site's total. The candidate cap is applied by the engine to whatever the port returns, so a port that ignores its limit cannot widen the `O(tags x tokens)` scoring path.

On the timeout: `Promise.race` bounds the *response*, not the work — a promise cannot be cancelled, so the code says that plainly instead of claiming cancellation. The residual work is bounded independently: every port read pushes its cap down as a SQL `LIMIT`.

## Real data

`NLQueryDataPort` (narrow, injectable, every method takes a cap) over the three stores that exist on `main`: **`historian_data`** via Drizzle (there is no dedicated tag table — the tag id space is what the historian recorded, the same projection `opcua-server/runtime.ts` uses), the **live tag stream** for latest values, and the **alarm-correlation engine** for active alarms. Readings record their source so answers cite provenance.

Reads return `PortResult`, keeping *"could not consult the store"* distinct from *"consulted, nothing recorded"* — collapsing those would let an outage read to an operator as a quiet process. Honest-refusal cases, all tested: the Postgres-only historian on a SQLite dev database; a missing reading in a comparison (never coerced to `0`); a **non-numeric stored value** in a comparison (see below); an unresolved alarm scope (reports the active total, explicitly not an all-clear); and `status`, which reports the last value and its age and says no equipment state model is configured rather than inventing a running/stopped verdict.

## The dead LLM path — deleted

Decisive reason: `formatAnswer` let a model rewrite an operator-facing process answer wholesale. A model doing that can emit a number no sensor produced, and no output validation catches a plausible-looking wrong reading. On a SCADA surface that is the worst available failure.

`parseQuery` was safer in principle but was still dead code by the review's own finding, and bought no extensibility the module boundary doesn't already give — `parseIntent` is a pure `(query, nowMs) => QueryIntent` seam. Issue #216 asks for a "pluggable LLM backend interface"; that framing predates the operator-safety review, and where they conflict the safety constraint wins. **No model is imported, constructed, or called; no key; no network dependency.**

## History — process-local, bounded, and says so

Not persisted, deliberately. This surface performs no mutation, so there is nothing to audit durably (ADR-0026's durability row covers pending approvals and audit records; `audit_logs` is untouched). Persisting would be worse than losing it: a `QueryResult` embeds the readings that answered it, so a history table would put a durable, retention-policy-free copy of process values outside the historian, reachable by two paths that can disagree.

Disclosure is the obligation that comes with that choice: `GET /nlquery/history` returns `persistence: "process-local"` plus a note that it is **lost on restart and not shared across replicas**; every query response carries `historyPersistence`. **No migration added** — `migrations/`, `shared/schema.ts` and `shared/schema-sqlite.ts` have an empty diff.

## ADR-0013

The earlier review reported it missing from `docs/adr/`. **It exists** — `docs/decisions/ADR-0013-autonomous-agent-architecture.md` (Accepted, 2026-02-15), cited 92 times on `main` at `0aec4ec99` by the whole `13.x` series. The repo keeps ADRs in two directories and the reviewer checked the other one. So the citation is **corrected, not dropped**.

Added `docs/adr/ADR-0027-nl-query-read-scope-and-bounds.md` as the real ADR for this contract (0027 verified free in both directories — 0026 is already used twice across them). It closes the Authentication and Authorization rows ADR-0026 left open for NL query.

## Bugs found and fixed along the way

- `getHistory` used `slice(-0)`, which returns the **entire** buffer instead of none. The `slice(-NaN)` variant of the same trap was fixed too — `Math.min(NaN, n)` is `NaN`, and `slice(-NaN)` is `slice(0)`.
- **`executeCompare` coerced stored readings with `Number()`.** A `historian_data` row carries either a numeric `value` or a text `string_value`, so a stored string legitimately reaches that path — and JS coercion turned a recorded empty string into `"A.X is 0 … a difference of -5"` with `success: true`, whitespace into `0`, and `"0x10"` into `16`. Stored strings are now accepted only as plain decimal literals; anything else lands in the existing not-both-numeric refusal, quoting the values as stored.
- `ProcessDataPort.listTags` merged and sorted the **entire** live-stream tag map before slicing it back to the cap, so per-request work scaled with total site tag count rather than with `MAX_RESOLVER_CANDIDATE_TAGS`.
- The data port called `getDatabase()` outside a `try`. It *throws* when the pool is uninitialized, and `dbType` defaults to `postgres`, so the uninitialized process hit exactly that line and the throw escaped as a generic error, hiding the precise reason.
- The client intelligence page and the #599 contract test both asserted these endpoints return `501`. Both updated; the contract test now pins that with no store reachable the routes **refuse rather than fabricate**, including that the precise reason surfaces.

## Verification

`npx tsc --noEmit` exits 0. Baseline measured on the clean tree at `0aec4ec99`: **3215 passed / 5 skipped across 158 files**. After: **3311 passed / 5 skipped across 161 files** — zero failures, zero regressions, +96 tests.

Test non-vacuity was checked by deliberate sabotage, each reverted: neutering the auth guard fails 10 of 17 auth tests with literal `expected 200 to be 401` / `expected 200 to be 403`; removing the `Promise.race` fails the timeout test; and loosening a bound constant now fails its literal pin (it did not before — every bounds test bar two asserted in terms of the constant under test, so the pins were added).

### Known limitations

- No integration test exercises the historian SQL against a real Postgres instance with rows; `test/integration/**` is excluded from the default unit run. A DB-backed integration test is the natural follow-up.
- `tagStreamServer.getLatestValues()` returns a full copy of the live tag map on every call, so `readLatest` copies the whole map to fetch one key. Left alone here because `tag-stream.ts` is shared with three other callers; a single-key accessor would benefit all of them.
- `nlquery.read` is a new scope. Any deployment wanting this surface must add it to an API key; a key holding only `write` is intentionally rejected.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)