### PR TITLE
ci(blueprint): gate deterministic runtime on constrained ARM (#457)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,63 @@ jobs:
       - name: Enforce npm audit (high and critical)
         run: npm audit --audit-level=high
 
+  blueprint-runtime-arm:
+    name: Blueprint Runtime ARM p99 + allocation (constrained proxy)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+      - run: npm ci
+      - name: Assert the constrained ARM shape and gate the runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --cpuset-cpus 0 \
+            --memory 6g \
+            --memory-swap 6g \
+            --network none \
+            --pids-limit 128 \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --mount "type=bind,source=${GITHUB_WORKSPACE},target=/workspace,readonly" \
+            --workdir /workspace \
+            node:20-bookworm-slim \
+            sh -euc '
+              arch="$(node -p "process.arch")"
+              node_major="$(node -p "process.versions.node.split(\".\")[0]")"
+              cpus="$(node -p "require(\"node:os\").availableParallelism()")"
+              memory_limit="$(cat /sys/fs/cgroup/memory.max)"
+              printf "constrained ARM proxy: arch=%s node=%s cpus=%s memory.max=%s\n" \
+                "$arch" "$node_major" "$cpus" "$memory_limit"
+              test "$arch" = "arm64"
+              test "$node_major" = "20"
+              test "$cpus" = "1"
+              test "$memory_limit" = "6442450944"
+              gc_type="$(node --expose-gc -p "typeof globalThis.gc")"
+              test "$gc_type" = "function"
+              node --expose-gc \
+                node_modules/vitest/vitest.mjs run \
+                server/blueprint/__tests__/runtime.test.ts
+              node --expose-gc --max-semi-space-size=1 --import tsx \
+                bench/blueprint-runtime/allocation.bench.ts
+              node --expose-gc --import tsx \
+                bench/blueprint-runtime/locked.bench.ts
+            ' 2>&1 | tee blueprint-runtime-arm-gate.txt
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: blueprint-runtime-arm-gate-${{ github.sha }}
+          path: blueprint-runtime-arm-gate.txt
+          if-no-files-found: error
+          retention-days: 30
+
   helm-gateway:
     name: Helm Chart Validation
     runs-on: ubuntu-latest
@@ -267,7 +324,7 @@ jobs:
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, security, helm-gateway, test, build, integration-test]
+    needs: [lint, typecheck, security, blueprint-runtime-arm, helm-gateway, test, build, integration-test]
     if: always()
     steps:
       - name: Check results
@@ -275,6 +332,7 @@ jobs:
           if [ "${{ needs.lint.result }}" != "success" ] || \
              [ "${{ needs.typecheck.result }}" != "success" ] || \
              [ "${{ needs.security.result }}" != "success" ] || \
+             [ "${{ needs.blueprint-runtime-arm.result }}" != "success" ] || \
              [ "${{ needs.helm-gateway.result }}" != "success" ] || \
              [ "${{ needs.test.result }}" != "success" ] || \
              [ "${{ needs.build.result }}" != "success" ] || \

--- a/bench/blueprint-runtime/README.md
+++ b/bench/blueprint-runtime/README.md
@@ -11,7 +11,8 @@ latency (p50/p90/p99/p99.9/max + jitter), not throughput.
 | ------------------- | --------------------------------------------------------------------------- |
 | `harness.ts`        | Dependency-free latency harness (percentiles, jitter, GC-pause instrumentation). Allocation-free inside the measured loop. |
 | `baseline.bench.ts` | The "before": a naive `Map`-lookup, per-tick-allocating interpreter. Establishes the contrast numbers. |
-| `locked.bench.ts`   | The "after": the production `BlueprintRuntime`. **Exits non-zero if measured p99 ≥ 1 ms** so CI can gate on it. |
+| `locked.bench.ts`   | The "after": the production `BlueprintRuntime`. **Exits non-zero if measured p99 ≥ 1 ms** so CI can gate latency. |
+| `allocation.bench.ts` | Isolates `tickFast()` under `v8.GCProfiler`, with no-op and allocating controls. **Exits non-zero on probe contamination, a vacuous canary, or runtime GC.** |
 
 ## Running (deps must be installed in the repo)
 
@@ -19,18 +20,36 @@ latency (p50/p90/p99/p99.9/max + jitter), not throughput.
 npx tsx bench/blueprint-runtime/baseline.bench.ts
 npx tsx bench/blueprint-runtime/locked.bench.ts      # CI gate: nonzero exit on SLO miss
 
-# With GC visibility (recommended for tail analysis):
-NODE_OPTIONS="--expose-gc" npx tsx bench/blueprint-runtime/locked.bench.ts
+# Bounded-allocation gate with a deliberately small V8 nursery:
+node --expose-gc --max-semi-space-size=1 --import tsx \
+  bench/blueprint-runtime/allocation.bench.ts
 ```
 
-Both files also export a programmatic API (`runLockedBench()` / `runBaselineBench()`
-returning `LatencyStats`) for wiring into a CI assertion harness.
+Both latency files export a programmatic API (`runLockedBench()` / `runBaselineBench()`
+returning `Promise<LatencyStats>`) for wiring into a CI assertion harness.
 
 ## Honesty note
 
 `locked.bench.ts` prints the verdict for **whatever machine it runs on**. A local
-x86 pass is *not* the reference ARM verdict. The binding gate is the CI run on the
-reference image. See
+x86 pass is *not* the reference ARM verdict. The
+`Blueprint Runtime ARM p99 + allocation (constrained proxy)` CI job runs on GitHub's native
+`ubuntu-24.04-arm` runner, then executes the benchmark inside an ARM64 Node 20
+container constrained to one CPU and 6 GiB of memory. Node 20 matches the
+current server image. The job verifies the architecture, Node major, effective
+CPU count, and cgroup memory ceiling before measuring, and preserves the report
+as a build artifact. It also requires exposed GC, runs the runtime's forced-GC
+heap-retention invariant, and runs the isolated allocation probe with a 1 MiB V8
+semi-space. That probe profiles a loop containing only `tickFast()`: a no-op
+control must observe zero collections, an escaping-object canary must observe at
+least one, and the runtime must observe zero. These are empirical regression
+signals rather than a formal proof that V8 performs no allocation.
+
+That required CI environment is a native-ARM regression **proxy** for the issue's
+reference shape. It does not claim that GitHub's physical CPU model, frequency,
+virtualization, or host contention is identical to the intended appliance. The
+strict reference-hardware verdict still requires the same command on the
+1-OCPU / 6-GB target, or explicit maintainer designation of this constrained
+profile as the reference image. See
 [`docs/decisions/ADR-0026-deterministic-blueprint-runtime.md`](../../docs/decisions/ADR-0026-deterministic-blueprint-runtime.md)
 for measured results and the Rust/N-API contingency if the reference target is
 missed.

--- a/bench/blueprint-runtime/allocation.bench.ts
+++ b/bench/blueprint-runtime/allocation.bench.ts
@@ -1,0 +1,187 @@
+/**
+ * Bounded-allocation gate for issue #457.
+ *
+ * The latency harness necessarily times calls and performs IO marshalling, so
+ * its GC count cannot attribute a pause specifically to BlueprintRuntime.
+ * This probe profiles a loop containing only tickFast() and surrounds it with
+ * negative and positive controls. CI runs it with a small V8 semi-space to make
+ * transient allocation regressions reliably produce a collection.
+ */
+
+import { GCProfiler } from "node:v8";
+import { compileBlueprint } from "../../server/blueprint/compiler.js";
+import {
+  makeControlFarmBlueprint,
+  makeInputVector,
+} from "../../server/blueprint/fixtures.js";
+import { BlueprintRuntime } from "../../server/blueprint/runtime.js";
+import { isMain } from "./harness.js";
+
+const TAG_COUNT = 1000;
+const INSTRUCTION_COUNT = 800;
+const WARMUP_TICKS = 20_000;
+const PROBE_TICKS = 250_000;
+const CANARY_ALLOCATIONS = 250_000;
+const CANARY_SLOTS = 1024;
+
+export interface AllocationProbeStats {
+  noopGcCount: number;
+  canaryGcCount: number;
+  runtimeGcCount: number;
+  runtimeTicks: number;
+}
+
+function exposedGc(): () => void {
+  const gc = (globalThis as { gc?: () => void }).gc;
+  if (typeof gc !== "function") {
+    throw new Error(
+      "allocation probe requires Node to run with --expose-gc",
+    );
+  }
+  return gc;
+}
+
+function profileGc<T>(gc: () => void, run: () => T): {
+  gcCount: number;
+  result: T;
+} {
+  gc();
+  const profiler = new GCProfiler();
+  profiler.start();
+  const result = run();
+  const profile = profiler.stop();
+  return { gcCount: profile.statistics.length, result };
+}
+
+function runNoopControl(): number {
+  let checksum = 0;
+  for (let i = 0; i < PROBE_TICKS; i++) {
+    checksum = (checksum + i) | 0;
+  }
+  return checksum;
+}
+
+function runRuntimeTicks(runtime: BlueprintRuntime, ticks: number): number {
+  for (let i = 0; i < ticks; i++) runtime.tickFast();
+  return runtime.ticks;
+}
+
+export function runAllocationProbe(): AllocationProbeStats {
+  const gc = exposedGc();
+
+  // Negative control: the profiler and a tight arithmetic loop must not create
+  // a collection by themselves. Warm this exact function first so JIT work is
+  // outside the profiled window.
+  runNoopControl();
+  runNoopControl();
+  const noop = profileGc(gc, runNoopControl);
+
+  const program = compileBlueprint(makeControlFarmBlueprint(TAG_COUNT));
+  if (
+    program.tagCount !== TAG_COUNT ||
+    program.instructionCount !== INSTRUCTION_COUNT
+  ) {
+    throw new Error(
+      `allocation fixture must contain exactly ${TAG_COUNT} tags / ` +
+        `${INSTRUCTION_COUNT} instructions, got ${program.tagCount} / ` +
+        `${program.instructionCount}`,
+    );
+  }
+  const runtime = new BlueprintRuntime(program);
+  runtime.writeInputs(makeInputVector(runtime.inputCount, 7));
+  runRuntimeTicks(runtime, WARMUP_TICKS);
+
+  // Nothing except tickFast() executes while this profiler is active.
+  const runtimeProfile = profileGc(gc, () =>
+    runRuntimeTicks(runtime, PROBE_TICKS),
+  );
+  const expectedTicks = WARMUP_TICKS + PROBE_TICKS;
+  if (runtimeProfile.result !== expectedTicks) {
+    throw new Error(
+      `allocation probe expected ${expectedTicks} ticks, observed ` +
+        `${runtimeProfile.result}`,
+    );
+  }
+
+  // Positive control runs last so its deliberate garbage cannot contaminate
+  // the runtime result. Keep a rotating set of objects observable while
+  // replacing them. Under CI's 1 MiB semi-space this must collect, proving the
+  // profiler cannot silently report a vacuous zero.
+  const canarySlots: Array<{ value: number } | undefined> = new Array(
+    CANARY_SLOTS,
+  );
+  const canary = profileGc(gc, () => {
+    let checksum = 0;
+    for (let i = 0; i < CANARY_ALLOCATIONS; i++) {
+      const slot = i & (CANARY_SLOTS - 1);
+      const previous = canarySlots[slot];
+      if (previous) checksum = (checksum + previous.value) | 0;
+      canarySlots[slot] = { value: i };
+    }
+    return checksum;
+  });
+  if (!Number.isInteger(noop.result) || !Number.isInteger(canary.result)) {
+    throw new Error("allocation probe controls did not complete");
+  }
+
+  return {
+    noopGcCount: noop.gcCount,
+    canaryGcCount: canary.gcCount,
+    runtimeGcCount: runtimeProfile.gcCount,
+    runtimeTicks: PROBE_TICKS,
+  };
+}
+
+export function allocationGateFailures(stats: AllocationProbeStats): string[] {
+  const failures: string[] = [];
+  if (stats.noopGcCount !== 0) {
+    failures.push(
+      `allocation probe contaminated: no-op control observed ` +
+        `${stats.noopGcCount} GC pause(s)`,
+    );
+  }
+  if (stats.canaryGcCount === 0) {
+    failures.push(
+      "allocation probe vacuous: allocating canary did not trigger GC; " +
+        "run with --max-semi-space-size=1",
+    );
+  }
+  if (stats.runtimeGcCount !== 0) {
+    failures.push(
+      `bounded-allocation gate failed: tickFast() observed ` +
+        `${stats.runtimeGcCount} GC pause(s) across ` +
+        `${stats.runtimeTicks.toLocaleString()} ticks`,
+    );
+  }
+  return failures;
+}
+
+function formatAllocationReport(stats: AllocationProbeStats): string {
+  return [
+    "── LOCKED BlueprintRuntime allocation probe ──",
+    `  no-op control       : ${stats.noopGcCount} GC pause(s)`,
+    `  allocating canary   : ${stats.canaryGcCount} GC pause(s)`,
+    `  tickFast()          : ${stats.runtimeGcCount} GC pause(s)`,
+    `  measured ticks      : ${stats.runtimeTicks.toLocaleString()}`,
+  ].join("\n");
+}
+
+function main(): void {
+  const stats = runAllocationProbe();
+  console.log(formatAllocationReport(stats));
+
+  const failures = allocationGateFailures(stats);
+  for (const failure of failures) {
+    console.error(`\n${failure}`);
+  }
+  if (failures.length > 0) process.exitCode = 1;
+}
+
+if (isMain(import.meta.url)) {
+  try {
+    main();
+  } catch (err: unknown) {
+    console.error(err);
+    process.exitCode = 1;
+  }
+}

--- a/bench/blueprint-runtime/baseline.bench.ts
+++ b/bench/blueprint-runtime/baseline.bench.ts
@@ -164,9 +164,21 @@ class NaiveBlueprintInterpreter {
 }
 
 const TAG_COUNT = 1000;
+const INSTRUCTION_COUNT = 800;
 
-export function runBaselineBench(): LatencyStats {
+export async function runBaselineBench(): Promise<LatencyStats> {
   const def = makeControlFarmBlueprint(TAG_COUNT);
+  if (def.tags.length !== TAG_COUNT) {
+    throw new Error(
+      `benchmark fixture must contain exactly ${TAG_COUNT} tags, got ${def.tags.length}`,
+    );
+  }
+  if (def.nodes.length !== INSTRUCTION_COUNT) {
+    throw new Error(
+      `benchmark fixture must contain exactly ${INSTRUCTION_COUNT} instructions, ` +
+        `got ${def.nodes.length}`,
+    );
+  }
   const interp = new NaiveBlueprintInterpreter(def);
 
   // Pre-build a few input vectors so beforeTick rotates inputs without Math.random.
@@ -192,11 +204,14 @@ export function runBaselineBench(): LatencyStats {
   });
 }
 
-function main(): void {
-  const stats = runBaselineBench();
+async function main(): Promise<void> {
+  const stats = await runBaselineBench();
   console.log(formatReport(stats));
 }
 
 if (isMain(import.meta.url)) {
-  main();
+  void main().catch((err: unknown) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
 }

--- a/bench/blueprint-runtime/harness.ts
+++ b/bench/blueprint-runtime/harness.ts
@@ -64,42 +64,74 @@ function percentile(sorted: Float64Array, p: number): number {
  * Run a tail-latency benchmark. Returns the percentile distribution of a single
  * `tick()`. Allocation-free inside the measured loop.
  */
-export function runLatencyBench(opts: LatencyBenchOptions): LatencyStats {
+export async function runLatencyBench(
+  opts: LatencyBenchOptions,
+): Promise<LatencyStats> {
   const warmup = opts.warmup ?? 10_000;
   const iterations = opts.iterations ?? 100_000;
+
+  // Warm up before GC observation starts so compilation/JIT activity is not
+  // reported as part of the measured steady-state window.
+  for (let i = 0; i < warmup; i++) {
+    opts.beforeTick?.(i);
+    opts.tick();
+  }
+
+  // Start the measured window from a clean heap when the caller exposes GC.
+  // Its entry is outside the timestamp window below and is therefore ignored.
+  const gc = (globalThis as { gc?: () => void }).gc;
+  if (typeof gc === "function") gc();
 
   // Optional GC instrumentation via PerformanceObserver. Best-effort; if the
   // 'gc' entry type is unavailable on this host we simply omit GC stats.
   let gcCount = 0;
   let gcTotalMs = 0;
   let observer: PerformanceObserver | undefined;
+  let measurementStartedAt = Number.NEGATIVE_INFINITY;
+  let measurementEndedAt = Number.POSITIVE_INFINITY;
+  const recordGcEntries = (
+    entries: ReadonlyArray<{ duration: number; startTime: number }>,
+  ): void => {
+    for (const entry of entries) {
+      if (
+        entry.startTime < measurementStartedAt ||
+        entry.startTime > measurementEndedAt
+      ) {
+        continue;
+      }
+      gcCount++;
+      gcTotalMs += entry.duration;
+    }
+  };
   try {
     observer = new PerformanceObserver((list) => {
-      for (const entry of list.getEntries()) {
-        gcCount++;
-        gcTotalMs += entry.duration;
-      }
+      recordGcEntries(list.getEntries());
     });
     observer.observe({ entryTypes: ["gc"], buffered: false });
   } catch {
     observer = undefined;
   }
 
-  // Warm up (not measured).
-  for (let i = 0; i < warmup; i++) {
-    opts.beforeTick?.(i);
-    opts.tick();
-  }
-
   const samples = new Float64Array(iterations);
+  measurementStartedAt = performance.now();
   for (let i = 0; i < iterations; i++) {
     opts.beforeTick?.(i);
     const start = performance.now();
     opts.tick();
     samples[i] = performance.now() - start;
   }
+  measurementEndedAt = performance.now();
 
-  observer?.disconnect();
+  if (observer) {
+    // The benchmark loop is deliberately synchronous, so the observer callback
+    // cannot run until after this function yields back to the event loop.
+    // Yield once, then drain anything not delivered to the callback before
+    // disconnecting. Without the yield, even forced GC misleadingly reports
+    // zero pauses because the observer is disconnected too early.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    recordGcEntries(observer.takeRecords());
+    observer.disconnect();
+  }
 
   // Sort a copy for percentiles. This allocation happens AFTER the measured loop.
   const sorted = samples.slice().sort();

--- a/bench/blueprint-runtime/locked.bench.ts
+++ b/bench/blueprint-runtime/locked.bench.ts
@@ -8,8 +8,9 @@
  *
  * This file is the SLO gate referenced in the issue's Verification section:
  *   "assertion: p99 under 1ms for the 1000-tag fixture."
- * When run as a script it exits non-zero if the measured p99 misses the SLO, so
- * CI can fail the build (or the workflow can route to the gate-decision path).
+ * When run as a script it exits non-zero if the measured p99 misses the SLO.
+ * Per-tick allocation is gated separately by allocation.bench.ts so timing
+ * instrumentation and IO marshalling cannot be mistaken for runtime allocation.
  *
  * IMPORTANT (honesty): the < 1 ms p99 target is specified for REFERENCE ARM
  * hardware (1 ARM OCPU / 6 GB RAM). The number printed here is whatever THIS
@@ -30,10 +31,48 @@ import {
 } from "./harness.js";
 
 const TAG_COUNT = 1000;
+const INSTRUCTION_COUNT = 800;
+const WARMUP_TICKS = 20_000;
+const MEASURED_TICKS = 100_000;
 
-export function runLockedBench(): LatencyStats {
+function assertRuntimeSemantics(rt: BlueprintRuntime): void {
+  rt.reset();
+  const inputs = new Float64Array(rt.inputCount);
+  for (let i = 0; i < inputs.length; i += 2) {
+    inputs[i] = 80;
+    inputs[i + 1] = 10;
+  }
+  rt.writeInputs(inputs);
+  for (let i = 0; i < 6; i++) rt.tickFast();
+
+  if (rt.ticks !== 6) {
+    throw new Error(`semantic sentinel expected 6 ticks, observed ${rt.ticks}`);
+  }
+  const outputs = new Float64Array(rt.outputCount);
+  rt.readOutputs(outputs);
+  for (let i = 0; i < outputs.length; i++) {
+    if (outputs[i] !== 90) {
+      throw new Error(
+        `semantic sentinel output ${i} expected 90, observed ${outputs[i]}`,
+      );
+    }
+  }
+}
+
+export async function runLockedBench(): Promise<LatencyStats> {
   const def = makeControlFarmBlueprint(TAG_COUNT);
   const program = compileBlueprint(def);
+  if (program.tagCount !== TAG_COUNT) {
+    throw new Error(
+      `benchmark fixture must contain exactly ${TAG_COUNT} tags, got ${program.tagCount}`,
+    );
+  }
+  if (program.instructionCount !== INSTRUCTION_COUNT) {
+    throw new Error(
+      `benchmark fixture must contain exactly ${INSTRUCTION_COUNT} instructions, ` +
+        `got ${program.instructionCount}`,
+    );
+  }
   const rt = new BlueprintRuntime(program);
 
   // Pre-allocate input vectors ONCE (outside the timed loop). Rotating between a
@@ -43,10 +82,10 @@ export function runLockedBench(): LatencyStats {
   const v3 = makeInputVector(rt.inputCount, 3);
   const vectors = [v1, v2, v3];
 
-  return runLatencyBench({
+  const stats = await runLatencyBench({
     label: `LOCKED BlueprintRuntime — ${program.tagCount}-tag / ${program.instructionCount}-instruction blueprint`,
-    warmup: 20_000,
-    iterations: 100_000,
+    warmup: WARMUP_TICKS,
+    iterations: MEASURED_TICKS,
     beforeTick: (i) => {
       // writeInputs is allocation-free; this is the realistic IO marshalling
       // that precedes every real scan.
@@ -57,10 +96,32 @@ export function runLockedBench(): LatencyStats {
       rt.tickFast();
     },
   });
+  if (rt.ticks !== WARMUP_TICKS + MEASURED_TICKS) {
+    throw new Error(
+      `benchmark expected ${WARMUP_TICKS + MEASURED_TICKS} ticks, observed ${rt.ticks}`,
+    );
+  }
+  assertRuntimeSemantics(rt);
+  return stats;
 }
 
-function main(): void {
-  const stats = runLockedBench();
+/** Return every failed latency invariant for a single CI report. */
+export function lockedGateFailures(stats: LatencyStats): string[] {
+  const failures: string[] = [];
+
+  if (!meetsSlo(stats)) {
+    failures.push(
+      `p99 SLO NOT MET on this host (p99=${stats.p99.toFixed(4)} ms >= 1.0 ms). ` +
+        `If this reproduces on accepted reference ARM hardware with p99 > 1.5 ms, ` +
+        `follow the gate decision in ADR-0026 (Rust control-loop crate via N-API).`,
+    );
+  }
+
+  return failures;
+}
+
+async function main(): Promise<void> {
+  const stats = await runLockedBench();
   console.log(formatReport(stats));
   console.log("");
   console.log(
@@ -68,17 +129,18 @@ function main(): void {
       "The verdict above reflects THIS machine only.",
   );
 
-  if (!meetsSlo(stats)) {
-    console.error(
-      `\np99 SLO NOT MET on this host (p99=${stats.p99.toFixed(4)} ms >= 1.0 ms). ` +
-        `If this reproduces on reference ARM hardware with p99 > 1.5 ms, follow the ` +
-        `gate decision in ADR-0026 (Rust control-loop crate via N-API).`,
-    );
-    // Non-zero exit so CI's "p99 < 1ms" assertion fails loudly.
+  const failures = lockedGateFailures(stats);
+  for (const failure of failures) {
+    console.error(`\n${failure}`);
+  }
+  if (failures.length > 0) {
     process.exitCode = 1;
   }
 }
 
 if (isMain(import.meta.url)) {
-  main();
+  void main().catch((err: unknown) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
 }

--- a/docs/decisions/ADR-0026-deterministic-blueprint-runtime.md
+++ b/docs/decisions/ADR-0026-deterministic-blueprint-runtime.md
@@ -1,6 +1,6 @@
 # ADR-0026: Deterministic Blueprint Runtime
 
-**Status:** Accepted (with a measured gate condition — see "Gate decision")
+**Status:** Provisionally accepted (strict reference-hardware gate pending)
 **Date:** 2026-06-22
 **Deciders:** 0xSCADA Core Team
 **References:** [ADR-0021 (Dual-Time Control Plane)](ADR-0021-dual-time-control-plane.md), [Wave-2 Build Set Design](../plans/2026-06-01-wave-2-build-set-design.md), [Issue #457](https://github.com/NickFlach/0xSCADA/issues/457)
@@ -70,28 +70,34 @@ allocation-free hot loop.
 > (1 ARM OCPU / 6 GB). The numbers below were measured on the **development
 > x86_64 host** (Node v24, Windows). They demonstrate the design works and that
 > the bounded-allocation goal is met, but a local pass is **not** the reference
-> ARM verdict. The reference run must be executed in CI on the target image.
+> ARM verdict. Required CI supplies a native-ARM constrained proxy; the strict
+> verdict still requires the accepted target image described below.
 
-Fixture: control-farm blueprint, **1250 tags / 1000 instructions** (the
-`makeControlFarmBlueprint(1000)` fixture rounds to 125 units × 10 tags / 8 nodes,
-i.e. slightly *more* than 1000 tags — a conservative test).
+Fixture: control-farm blueprint, **1000 tags / 800 instructions** (100 units ×
+10 tags / 8 nodes). The benchmark asserts the exact tag count before measuring
+so a fixture-size regression fails rather than silently changing the workload.
 
 | Metric        | Baseline (naive Map + alloc) | Locked (compiled SoA) | Improvement |
 | ------------- | ---------------------------- | --------------------- | ----------- |
-| p50           | 0.2303 ms                    | 0.0065 ms             | ~35×        |
-| p90           | 0.3971 ms                    | 0.0101 ms             | ~39×        |
-| p99           | 0.7867 ms                    | **0.0319 ms**         | ~25×        |
-| p99.9         | 1.1275 ms (over SLO)         | 0.0538 ms             | ~21×        |
-| max           | 6.6983 ms                    | 0.2292 ms             | ~29×        |
-| stddev/jitter | 0.1382 ms                    | 0.0044 ms             | ~31×        |
+| p50           | 0.2723 ms                    | 0.0087 ms             | ~31×        |
+| p90           | 0.3923 ms                    | 0.0110 ms             | ~36×        |
+| p99           | 0.7897 ms                    | **0.0383 ms**         | ~21×        |
+| p99.9         | 1.6207 ms (over SLO)         | 0.0907 ms             | ~18×        |
+| max           | 17.9633 ms                   | 1.8549 ms             | ~10×        |
+| stddev/jitter | 0.1726 ms                    | 0.0118 ms             | ~15×        |
 
-Allocation probe (`tickFast` × 200,000 with `--expose-gc`): heap growth across
-the measured window was **−0.96 B/tick** (negative — i.e. effectively zero;
-within GC noise), and the bench observed **0 GC pauses** in the measured loop.
-This empirically confirms the no-allocation-in-tick invariant.
+On this run the repaired GC observer recorded **0 pauses** for the locked loop
+and **738 pauses / 249.0687 ms** for the deliberately allocating baseline. The
+observer starts after warm-up, the benchmark yields once after measurement so
+Node can deliver queued entries, and a forced-GC regression test proves the
+accounting is non-vacuous. The isolated allocation gate independently observed
+**0 pauses** for its no-op control, **8 pauses** for its allocating canary, and
+**0 pauses** across 250,000 `tickFast()` calls. This is empirical evidence, not
+a proof that V8 can never allocate.
 
-On this x86_64 host the locked runtime's measured p99 (0.0319 ms) is ~31× under
-the 1 ms SLO, and even its worst observed single tick (0.2292 ms) is under 1 ms.
+On this x86_64 host the locked runtime's measured p99 (0.0383 ms) is ~26× under
+the 1 ms SLO. A single 1.8549 ms outlier reinforces why the issue gates p99
+rather than claiming a hard per-tick maximum.
 
 ## Gate decision
 
@@ -100,12 +106,12 @@ The issue defines the gate: *"If Node's event loop refuses to be tamed enough
 proposing swap for a Rust control-loop crate via N-API. Mark this issue as
 deferred, not abandoned."*
 
-**Local verdict:** p99 = 0.0319 ms ≪ 1 ms, with zero GC pauses and confirmed
-bounded allocation. The gate condition (p99 > 1.5 ms) is **not** triggered on the
-development host. Therefore #457 is **Accepted**, not deferred, pending the
-reference-ARM CI confirmation below.
+**Local verdict:** p99 = 0.0383 ms ≪ 1 ms, with zero observed runtime GC and
+non-vacuous controls. The gate condition (p99 > 1.5 ms) is **not** triggered on
+the development host. Therefore #457 is not deferred, pending an accepted
+reference-ARM confirmation.
 
-**If the reference ARM CI run measures p99 > 1.5 ms** (e.g. due to GC behaviour
+**If an accepted reference ARM run measures p99 > 1.5 ms** (e.g. due to GC behaviour
 or scheduler jitter under a single OCPU), the contingency is:
 
 1. Mark #457 **deferred, not abandoned** (the TS runtime stays as the reference
@@ -133,8 +139,9 @@ or scheduler jitter under a single OCPU), the contingency is:
 
 **Negative / risks**
 
-- The local x86 numbers do not bind the reference ARM target; the CI assertion on
-  the reference image is the source of truth and must be wired up.
+- Neither local x86 numbers nor the required constrained GitHub-hosted ARM proxy
+  bind the appliance's physical CPU. The accepted reference-image run remains
+  the source of truth.
 - The float64-only tag model (booleans as 0.0/1.0) trades a richer type system
   for a single homogeneous cache-friendly buffer. Acceptable for control logic;
   documented in `server/blueprint/types.ts`.
@@ -241,16 +248,40 @@ synchronous — is exercised by the test suite and available to callers, but is
 not yet wired to a process shutdown hook. That wiring belongs with a
 server-wide graceful-shutdown change, not with this one.
 
-## Verification procedure (reference hardware)
+## Verification procedure (proxy CI and reference hardware)
 
 ```bash
 # On the reference ARM image, from the repo root, with deps installed:
 npx tsx bench/blueprint-runtime/baseline.bench.ts   # contrast numbers
-npx tsx bench/blueprint-runtime/locked.bench.ts     # exits non-zero if p99 >= 1ms
+node --expose-gc --import tsx bench/blueprint-runtime/locked.bench.ts
+node --expose-gc --max-semi-space-size=1 --import tsx \
+  bench/blueprint-runtime/allocation.bench.ts
 
-# Allocation invariant (any host):
-NODE_OPTIONS="--expose-gc" npx vitest run server/blueprint/__tests__/runtime.test.ts
+# Heap-retention invariant (any host):
+node --expose-gc node_modules/vitest/vitest.mjs run \
+  server/blueprint/__tests__/runtime.test.ts
 ```
 
-CI must assert `p99 < 1 ms` for the 1000-tag fixture on the reference image; that
-assertion — not the local development numbers above — is the binding gate.
+The `Blueprint Runtime ARM p99 + allocation (constrained proxy)` job in
+`.github/workflows/ci.yml` is a required repository regression gate. It runs on
+a native `ubuntu-24.04-arm` GitHub-hosted runner and executes `locked.bench.ts`
+inside an ARM64 Node 20 container constrained with a one-CPU cpuset and a 6 GiB
+cgroup memory ceiling. Node 20 matches the current server container. Before
+measuring, the job fails unless `process.arch` is `arm64`, the Node major is 20,
+`os.availableParallelism()` is `1`, and `memory.max` is `6442450944`. The
+benchmark itself exits non-zero unless the exact 1000-tag fixture has
+`p99 < 1 ms`. A separate `v8.GCProfiler` gate runs with a 1 MiB V8 semi-space
+and profiles a loop containing only `tickFast()`, excluding timing and IO
+marshalling. Its no-op control must observe zero collections, its
+escaping-object canary must observe at least one, and the runtime must observe
+zero. The job also runs the forced-GC heap-retention invariant under
+`--expose-gc`. These are complementary empirical signals, not a formal
+no-allocation proof. `CI Complete` requires the job, and the complete report is
+retained as an artifact.
+
+This is an honest native-ARM proxy, not an assertion that a constrained
+GitHub-hosted VM has the same CPU model, frequency, virtualization, or host
+contention as the 1-OCPU / 6-GB appliance. The strict reference verdict requires
+the same benchmark on that target (or explicit maintainer designation of this
+profile as the reference image). Only that accepted reference result can trigger
+the Rust/N-API gate decision above.

--- a/server/blueprint/__tests__/runtime.test.ts
+++ b/server/blueprint/__tests__/runtime.test.ts
@@ -213,6 +213,10 @@ describe("BlueprintRuntime — control-farm fixture end-to-end", () => {
   it("runs a 1000-tag blueprint deterministically (same inputs -> same outputs)", () => {
     const bp = makeControlFarmBlueprint(1000);
     const program = compileBlueprint(bp);
+    expect(bp.tags).toHaveLength(1000);
+    expect(program.tagCount).toBe(1000);
+    expect(bp.nodes).toHaveLength(800);
+    expect(program.instructionCount).toBe(800);
     const rt = new BlueprintRuntime(program);
 
     const inputs = makeInputVector(rt.inputCount, 12345);
@@ -246,12 +250,11 @@ describe("BlueprintRuntime — control-farm fixture end-to-end", () => {
 });
 
 describe("BlueprintRuntime — bounded-allocation invariant", () => {
-  // The defining requirement of #457: a steady-state tick allocates nothing.
-  // We can't observe V8's nursery directly without --expose-gc, so this test is
-  // conditional: it only asserts when GC is exposed (run via the bench harness
-  // or `node --expose-gc`). Under a plain `vitest` run it self-skips with a note
-  // rather than producing a flaky/false signal.
-  it("does not grow the heap across many ticks (requires --expose-gc)", () => {
+  // This complements allocation.bench.ts's isolated GC gate by catching
+  // retained heap growth. It is conditional because a stable before/after
+  // comparison requires forced GC; required ARM CI proves GC is exposed before
+  // invoking this file.
+  it("does not retain heap growth across many ticks (requires --expose-gc)", () => {
     const gc = (globalThis as { gc?: () => void }).gc;
     if (typeof gc !== "function") {
       // Documented skip — see header. Not a silent pass: we record why.
@@ -272,8 +275,8 @@ describe("BlueprintRuntime — bounded-allocation invariant", () => {
     gc();
     const after = process.memoryUsage().heapUsed;
 
-    // Allow a small slack for measurement noise; a per-tick allocation would
-    // grow heapUsed by megabytes over 50k iterations.
+    // Allow a small slack for measurement noise. Transient allocations may be
+    // reclaimed here; those are detected separately by the benchmark GC gate.
     const growth = after - before;
     expect(growth).toBeLessThan(512 * 1024);
   });

--- a/server/blueprint/fixtures.ts
+++ b/server/blueprint/fixtures.ts
@@ -11,12 +11,14 @@
 import type { BlueprintDefinition, BlueprintNode, TagDescriptor } from "./types.js";
 
 /**
- * Build a blueprint with roughly `tagCount` tags that exercises every opcode
- * class. The shape mimics a control-module farm: each "unit" reads two analog
- * inputs, runs a comparator + interlock chain, drives a latch and an on-delay
- * timer, and writes a command output.
+ * Build a blueprint targeting `tagCount` tags that exercises every opcode
+ * class. Each unit contains ten tags, so positive multiples of ten are exact;
+ * remainder requests round down and requests below ten produce one unit. The
+ * shape mimics a control-module farm: each unit reads two analog inputs, runs a
+ * comparator + interlock chain, drives a latch and an on-delay timer, and writes
+ * a command output.
  *
- * Layout per unit (8 tags):
+ * Layout per unit (10 tags):
  *   in_a, in_b           : inputs (analog)
  *   hi_alarm             : in_a > limit             (GT)
  *   permissive           : in_b < limit2            (LT)
@@ -26,7 +28,7 @@ import type { BlueprintDefinition, BlueprintNode, TagDescriptor } from "./types.
  *   out_cmd              : SELECT(delayed, in_a + in_b, 0)        (SELECT + ADD)
  */
 export function makeControlFarmBlueprint(tagCount: number): BlueprintDefinition {
-  const TAGS_PER_UNIT = 8;
+  const TAGS_PER_UNIT = 10;
   const units = Math.max(1, Math.floor(tagCount / TAGS_PER_UNIT));
 
   const tags: TagDescriptor[] = [];

--- a/test/ci/blueprint-benchmark-gate.test.ts
+++ b/test/ci/blueprint-benchmark-gate.test.ts
@@ -1,0 +1,104 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  allocationGateFailures,
+  type AllocationProbeStats,
+} from "../../bench/blueprint-runtime/allocation.bench";
+import { lockedGateFailures } from "../../bench/blueprint-runtime/locked.bench";
+import type { LatencyStats } from "../../bench/blueprint-runtime/harness";
+
+function stats(overrides: Partial<LatencyStats> = {}): LatencyStats {
+  return {
+    label: "locked gate test",
+    samples: 100_000,
+    min: 0.01,
+    p50: 0.02,
+    p90: 0.03,
+    p99: 0.04,
+    p999: 0.05,
+    max: 0.06,
+    mean: 0.02,
+    stddev: 0.01,
+    gcCount: 0,
+    gcTotalMs: 0,
+    ...overrides,
+  };
+}
+
+function allocationStats(
+  overrides: Partial<AllocationProbeStats> = {},
+): AllocationProbeStats {
+  return {
+    noopGcCount: 0,
+    canaryGcCount: 7,
+    runtimeGcCount: 0,
+    runtimeTicks: 250_000,
+    ...overrides,
+  };
+}
+
+describe("locked blueprint latency gate", () => {
+  test("accepts a sub-millisecond run", () => {
+    expect(lockedGateFailures(stats())).toEqual([]);
+  });
+
+  test("rejects a p99 SLO miss", () => {
+    expect(lockedGateFailures(stats({ p99: 1 }))).toEqual([
+      expect.stringContaining("p99 SLO NOT MET"),
+    ]);
+  });
+});
+
+describe("locked blueprint allocation gate", () => {
+  test("accepts a clean runtime with working controls", () => {
+    expect(allocationGateFailures(allocationStats())).toEqual([]);
+  });
+
+  test("rejects profiler contamination", () => {
+    expect(
+      allocationGateFailures(allocationStats({ noopGcCount: 1 })),
+    ).toEqual([expect.stringContaining("probe contaminated")]);
+  });
+
+  test("rejects a vacuous allocation canary", () => {
+    expect(
+      allocationGateFailures(allocationStats({ canaryGcCount: 0 })),
+    ).toEqual([expect.stringContaining("probe vacuous")]);
+  });
+
+  test("rejects runtime GC", () => {
+    expect(
+      allocationGateFailures(allocationStats({ runtimeGcCount: 4 })),
+    ).toEqual([
+      expect.stringContaining("tickFast() observed 4 GC pause(s)"),
+    ]);
+  });
+
+  test(
+    "passes end to end with exposed GC and a 1 MiB semi-space",
+    () => {
+      const script = resolve(
+        process.cwd(),
+        "bench/blueprint-runtime/allocation.bench.ts",
+      );
+      const output = execFileSync(
+        process.execPath,
+        [
+          "--expose-gc",
+          "--max-semi-space-size=1",
+          "--import",
+          "tsx",
+          script,
+        ],
+        { cwd: process.cwd(), encoding: "utf8" },
+      );
+
+      expect(output).toContain("no-op control       : 0 GC pause(s)");
+      expect(output).toMatch(/allocating canary {3}: [1-9]\d* GC pause\(s\)/);
+      expect(output).toContain("tickFast()          : 0 GC pause(s)");
+    },
+    // Keep all 250k ticks: that sample is load-bearing evidence for the gate.
+    60_000,
+  );
+});

--- a/test/ci/blueprint-benchmark-harness.test.ts
+++ b/test/ci/blueprint-benchmark-harness.test.ts
@@ -1,0 +1,45 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, test } from "vitest";
+
+describe("blueprint latency harness GC accounting", () => {
+  test("flushes GC performance entries before disconnecting", () => {
+    const harnessUrl = pathToFileURL(
+      resolve(process.cwd(), "bench/blueprint-runtime/harness.ts"),
+    ).href;
+    const probe = `
+      import { runLatencyBench } from ${JSON.stringify(harnessUrl)};
+      const stats = await runLatencyBench({
+        label: "forced-gc",
+        warmup: 0,
+        iterations: 4,
+        tick: () => {
+          const retainedForTick = new Array(10_000).fill({});
+          globalThis.gc();
+          if (retainedForTick.length !== 10_000) throw new Error("unreachable");
+        },
+      });
+      process.stdout.write(JSON.stringify({
+        gcCount: stats.gcCount,
+        gcTotalMs: stats.gcTotalMs,
+      }));
+    `;
+
+    const output = execFileSync(
+      process.execPath,
+      ["--expose-gc", "--import", "tsx", "--input-type=module", "--eval", probe],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      },
+    );
+    const observed = JSON.parse(output) as {
+      gcCount?: number;
+      gcTotalMs?: number;
+    };
+
+    expect(observed.gcCount).toBeGreaterThanOrEqual(4);
+    expect(observed.gcTotalMs).toBeGreaterThan(0);
+  });
+});

--- a/test/ci/blueprint-runtime-arm-workflow.test.ts
+++ b/test/ci/blueprint-runtime-arm-workflow.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression guard for issue #457's required ARM performance proxy.
+ *
+ * The latency benchmark exits non-zero on p99 >= 1 ms, while the isolated
+ * allocation probe gates tickFast() with non-vacuous GC-profiler controls.
+ * These assertions make sure CI continues to run both gates and the
+ * heap-retention invariant on native ARM64, inside the declared one-CPU / 6 GiB
+ * constrained shape, and that branch protection cannot report success while
+ * the benchmark job failed or was omitted.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSON_SCHEMA, load } from "js-yaml";
+import { describe, expect, test } from "vitest";
+
+type WorkflowStep = {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+};
+
+type WorkflowJob = {
+  name?: string;
+  "runs-on"?: string;
+  "timeout-minutes"?: number;
+  permissions?: Record<string, string>;
+  needs?: string | string[];
+  steps?: WorkflowStep[];
+};
+
+type Workflow = {
+  jobs?: Record<string, WorkflowJob>;
+};
+
+const workflowPath = resolve(process.cwd(), ".github/workflows/ci.yml");
+const workflow = load(readFileSync(workflowPath, "utf8"), {
+  schema: JSON_SCHEMA,
+}) as Workflow;
+
+const benchmarkJob = workflow.jobs?.["blueprint-runtime-arm"];
+const summaryJob = workflow.jobs?.["ci-complete"];
+
+describe("Blueprint runtime ARM p99 workflow", () => {
+  test("runs on native ARM64 with the repository Node major", () => {
+    expect(benchmarkJob).toBeDefined();
+    expect(benchmarkJob?.name).toBe(
+      "Blueprint Runtime ARM p99 + allocation (constrained proxy)",
+    );
+    expect(benchmarkJob?.["runs-on"]).toBe("ubuntu-24.04-arm");
+    expect(benchmarkJob?.["timeout-minutes"]).toBe(15);
+    expect(benchmarkJob?.permissions).toEqual({ contents: "read" });
+
+    const setupNode = benchmarkJob?.steps?.find((step) =>
+      step.uses?.startsWith("actions/setup-node@"),
+    );
+    expect(setupNode?.with?.["node-version"]).toBe("${{ env.NODE_VERSION }}");
+  });
+
+  test("asserts the one-CPU / 6 GiB shape before running both gates", () => {
+    const gate = benchmarkJob?.steps?.find((step) =>
+      step.name?.includes("gate the runtime"),
+    );
+    expect(gate?.run).toBeDefined();
+
+    const command = gate?.run ?? "";
+    expect(command).toContain("--cpuset-cpus 0");
+    expect(command).toContain("--memory 6g");
+    expect(command).toContain("--memory-swap 6g");
+    expect(command).toContain("node:20-bookworm-slim");
+    expect(command).toContain('test "$arch" = "arm64"');
+    expect(command).toContain('test "$node_major" = "20"');
+    expect(command).toContain('test "$cpus" = "1"');
+    expect(command).toContain('test "$memory_limit" = "6442450944"');
+    expect(command).toContain('test "$gc_type" = "function"');
+    expect(command).toContain(
+      "node_modules/vitest/vitest.mjs run",
+    );
+    expect(command).toContain(
+      "server/blueprint/__tests__/runtime.test.ts",
+    );
+    const flattenedCommand = command
+      .replace(/\\\s+/g, " ")
+      .replace(/\s+/g, " ");
+    expect(flattenedCommand).toContain(
+      "node --expose-gc --max-semi-space-size=1 --import tsx " +
+        "bench/blueprint-runtime/allocation.bench.ts",
+    );
+    expect(flattenedCommand).toContain(
+      "node --expose-gc --import tsx " +
+        "bench/blueprint-runtime/locked.bench.ts",
+    );
+    expect(command).toContain("2>&1 | tee blueprint-runtime-arm-gate.txt");
+  });
+
+  test("makes the benchmark a required input to CI Complete", () => {
+    const needs = Array.isArray(summaryJob?.needs)
+      ? summaryJob.needs
+      : [summaryJob?.needs].filter((value): value is string => Boolean(value));
+    expect(needs).toContain("blueprint-runtime-arm");
+
+    const resultCheck = summaryJob?.steps
+      ?.map((step) => step.run ?? "")
+      .join("\n");
+    expect(resultCheck).toContain("needs.blueprint-runtime-arm.result");
+  });
+});


### PR DESCRIPTION
## What changed

- adds a required native-ARM CI job that runs Node 20 in a one-CPU / 6 GiB constrained container and makes `CI Complete` depend on it
- corrects the control-farm fixture so the benchmark is exactly 1,000 tags / 800 instructions, then asserts the workload, tick count, and output semantics before accepting a result
- repairs measured-window GC delivery in the latency harness
- adds an isolated `v8.GCProfiler` allocation gate around only `tickFast()`, with a zero-GC no-op control and a positive allocating canary so the assertion cannot pass vacuously
- retains the forced-GC heap-growth invariant as a complementary retention check and documents the proxy/reference-hardware boundary in ADR-0026

## Why

The runtime/compiler work from #530 and the production host from #602 are already merged. The remaining #457 acceptance gap was enforceable ARM-shaped CI evidence. The hosted job is intentionally described as a constrained native-ARM **proxy**: it does not claim GitHub's physical CPU is the appliance reference target.

The allocation probe is separate from the latency loop because the latter also contains timing and input-marshalling work. Profiling only `tickFast()` avoids attributing harness allocations to the runtime.

## Verification

- `npx vitest run ...` — 6 files / 68 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm audit --audit-level=high` — 0 vulnerabilities
- allocation probe — no-op: 0 GC; allocating canary: 8 GC; `tickFast()`: 0 GC across 250,000 ticks
- exact 1,000-tag locked benchmark — p99 0.0247 ms locally; 0 measured GC
- independent patch review — no functional blockers; allocation probe passed 10/10 repeated runs

## Scope

Refs #457.

This remains a draft until the exact-head constrained ARM job produces its artifact. It deliberately does not close #457: the strict reference verdict still requires the target appliance run, or explicit maintainer designation of this constrained profile as the reference image.