### PR TITLE
feat(intelligence): add intelligent reporting engine

### DIFF
--- a/docs/intelligence/intelligent-reporting.md
+++ b/docs/intelligence/intelligent-reporting.md
@@ -1,0 +1,110 @@
+# Intelligent reporting engine
+
+Issue [#219](https://github.com/NickFlach/0xSCADA/issues/219) implements the
+ADR-0013 historical reporting engine. It ships three templates:
+
+| Template           | Content                                                              |
+| ------------------ | -------------------------------------------------------------------- |
+| `shift-summary`    | period coverage, alarms, OEE/throughput/quality KPIs, operator notes |
+| `compliance-audit` | pass/warning/fail control evidence, alarms, process-data coverage    |
+| `trend-analysis`   | per-tag statistics, timestamped trend points, alarms                 |
+
+Custom templates use the same section types and safe renderers as the built-ins.
+Templates contain data declarations, not executable HTML.
+
+## Historian input
+
+Inject a `HistoricalDataProvider`:
+
+```ts
+import { ReportingEngine } from "../../server/services/reporting";
+
+const reports = new ReportingEngine({
+  dataProvider: {
+    querySeries: (pattern, period) => historian.series(pattern, period),
+    queryAlarms: (period) => historian.alarms(period),
+    queryKPIs: (names, period) => historian.kpis(names, period),
+    queryCompliance: (period) => auditStore.controls(period),
+    queryNotes: (kind, period) => shiftLog.notes(kind, period),
+  },
+});
+
+const report = await reports.generate("shift-summary", shiftStartMs, shiftEndMs);
+```
+
+The engine validates the period, filters provider over-fetch, orders historical
+records deterministically, and fails explicitly if no provider is configured.
+Historical windows use `(start, end]` semantics so adjacent scheduled reports
+cover a boundary sample exactly once.
+It does not silently emit a successful report containing data-source errors.
+The original `queryTags`/`queryAlarms`/`queryKPIs` provider shape is supported
+through a compatibility adapter.
+
+## Safe rendering
+
+`renderHTML`, `renderText`, and `renderJSON` render the same generated report.
+HTML escapes the report title, section titles, table headers, table cells,
+plain text, and serialized objects. Raw HTML sections are not supported. The
+document includes a restrictive Content Security Policy and has no scripts or
+external assets.
+
+## Delivery
+
+Webhook and email are delivery-channel abstractions. No live network or SMTP
+client is created by default:
+
+```ts
+import {
+  EmailDeliveryChannel,
+  ReportingEngine,
+  WebhookDeliveryChannel,
+} from "../../server/services/reporting";
+
+const reports = new ReportingEngine({
+  dataProvider,
+  deliveryChannels: [
+    new WebhookDeliveryChannel({
+      post: (request) => approvedHttpClient.post(request),
+    }),
+    new EmailDeliveryChannel({
+      send: (message) => approvedMailProvider.send(message),
+    }),
+  ],
+});
+```
+
+Every delivery returns and retains a `DeliveryStatus` with each attempt,
+timestamps, HTTP status (when applicable), retryability, provider ID, and final
+error. A stable `x-0xscada-delivery-id` is supplied to webhook and email
+transports on every retry so providers can make ambiguous retries idempotent.
+Retries use bounded exponential backoff. HTTP 408/425/429 and 5xx
+responses are retryable; permanent 4xx responses are not. `Sleeper` and retry
+policy are injectable for deterministic tests.
+
+Webhook target authorization and network egress policy remain the
+deployment-owned transport's responsibility. The built-in adapter validates
+HTTP(S) syntax and rejects credentials embedded in a URL.
+
+## Scheduling
+
+The default scheduler uses an unreferenced Node interval. A scheduler and clock
+can be injected for a job system or deterministic test:
+
+```ts
+reports.schedule({
+  id: "plant-a-shift",
+  templateId: "shift-summary",
+  intervalMs: 8 * 60 * 60 * 1000,
+  lookbackMs: 8 * 60 * 60 * 1000,
+  deliveries: [{ method: "email", target: "shift-lead@example.com" }],
+});
+```
+
+`runSchedule()` is public for job runners. A schedule never overlaps itself;
+an attempted overlap increments `skippedOverlaps`. Status records run count,
+consecutive failures, last report, delivery IDs, timestamps, and the last
+error. `unscheduleReport()` and `destroyAll()` cancel timers cleanly.
+
+Primary imports use `server/services/reporting`. The historical
+`server/intelligence/reporting-engine.ts` path remains as a compatibility
+export.

--- a/server/intelligence/reporting-engine.ts
+++ b/server/intelligence/reporting-engine.ts
@@ -1,0 +1,5 @@
+/**
+ * Compatibility entry point for the original ADR-0013 issue path.
+ * New code should import from `server/services/reporting`.
+ */
+export * from "../services/reporting";

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -99,6 +99,11 @@ export { alarmCorrelationService } from './alarm-correlation';
 export * from './tuning';
 export { tuningService } from './tuning';
 
+// ── Intelligent Reporting (ADR-0013 [13.8], #219) ───────────────────────────
+// The engine has no process-global singleton: historian, scheduler and delivery
+// transports are injected by the deployment.
+export * from './reporting';
+
 // ── Agent Marketplace Service (ADR-0013 [13.6], #217) ────────────────────────
 export * from './marketplace';
 export { marketplaceService } from './marketplace';
@@ -113,10 +118,6 @@ export { NLQueryService, nlQueryService } from './nlquery';
 // No singleton is exported: capability verification and the physical action
 // executor are deployment-owned dependencies and must fail closed if absent.
 export * from './ghostos';
-// ── Intelligent Reporting (ADR-0013 [13.8], #219) ───────────────────────────
-// The engine has no process-global singleton: historian, scheduler and delivery
-// transports are injected by the deployment.
-export * from './reporting';
 
 /**
  * Initialize all services

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -113,6 +113,10 @@ export { NLQueryService, nlQueryService } from './nlquery';
 // No singleton is exported: capability verification and the physical action
 // executor are deployment-owned dependencies and must fail closed if absent.
 export * from './ghostos';
+// ── Intelligent Reporting (ADR-0013 [13.8], #219) ───────────────────────────
+// The engine has no process-global singleton: historian, scheduler and delivery
+// transports are injected by the deployment.
+export * from './reporting';
 
 /**
  * Initialize all services

--- a/server/services/reporting/__tests__/reporting.test.ts
+++ b/server/services/reporting/__tests__/reporting.test.ts
@@ -1,0 +1,531 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DeliveryChannelError,
+  EmailDeliveryChannel,
+  ReportingEngine,
+  WebhookDeliveryChannel,
+  type HistoricalDataProvider,
+  type ReportClock,
+  type ReportScheduler,
+  type ScheduledHandle,
+  type Sleeper,
+} from "..";
+
+class MutableClock implements ReportClock {
+  constructor(public value: number) {}
+  now(): number {
+    return this.value;
+  }
+}
+
+class ManualScheduler implements ReportScheduler {
+  readonly tasks = new Map<string, () => void | Promise<void>>();
+  readonly cancelled: string[] = [];
+
+  every(id: string, _intervalMs: number, task: () => void | Promise<void>): ScheduledHandle {
+    this.tasks.set(id, task);
+    return {
+      cancel: () => {
+        this.cancelled.push(id);
+        this.tasks.delete(id);
+      },
+    };
+  }
+
+  async trigger(id: string): Promise<void> {
+    const task = this.tasks.get(id);
+    if (!task) throw new Error(`No task ${id}`);
+    await task();
+  }
+}
+
+function provider(overrides: Partial<HistoricalDataProvider> = {}): HistoricalDataProvider {
+  return {
+    querySeries: async () => ({
+      pressure: [
+        { timestamp: 1_000, value: 10, quality: "good" },
+        { timestamp: 2_000, value: 20, quality: "good" },
+        { timestamp: 3_000, value: 30, quality: "uncertain" },
+        // The engine must discard provider over-fetch.
+        { timestamp: 99_000, value: 999, quality: "bad" },
+      ],
+    }),
+    queryAlarms: async () => [
+      {
+        id: "alarm-1",
+        tag: "pressure",
+        severity: "high",
+        message: "Pressure exceeded",
+        timestamp: 2_500,
+      },
+    ],
+    queryKPIs: async (names) => Object.fromEntries(names.map((name) => [name, 95])),
+    queryCompliance: async () => [
+      {
+        control: "IEC-62443-SR-3.1",
+        status: "pass",
+        detail: "Integrity check succeeded",
+        timestamp: 2_700,
+        evidenceId: "anchor-7",
+      },
+      {
+        control: "NIST-DE.CM-1",
+        status: "warning",
+        detail: "Review pending",
+        timestamp: 2_800,
+      },
+    ],
+    queryNotes: async () => ["Routine handoff complete"],
+    ...overrides,
+  };
+}
+
+describe("ReportingEngine generation and rendering", () => {
+  it("ships shift, compliance, and trend templates backed by historical inputs", async () => {
+    const clock = new MutableClock(4_000);
+    const engine = new ReportingEngine({ clock, dataProvider: provider() });
+
+    expect(engine.listTemplates().map((template) => template.id)).toEqual([
+      "shift-summary",
+      "compliance-audit",
+      "trend-analysis",
+    ]);
+
+    const shift = await engine.generate("shift-summary", 500, 3_500);
+    const compliance = await engine.generate("compliance-audit", 500, 3_500);
+    const trend = await engine.generate("trend-analysis", 500, 3_500);
+
+    expect(shift).toMatchObject({
+      id: "RPT-000001",
+      generatedAt: 4_000,
+      type: "shift-summary",
+    });
+    expect(shift?.sections[0].content).toMatchObject({
+      tagsMonitored: 1,
+      dataPoints: 3,
+      goodQuality: 2,
+      uncertainQuality: 1,
+      badQuality: 0,
+    });
+    expect(compliance?.sections[0].content).toMatchObject({
+      summary: { total: 2, pass: 1, warning: 1, fail: 0 },
+    });
+    expect(trend?.sections[0].content).toEqual([
+      {
+        tag: "pressure",
+        count: 3,
+        min: 10,
+        max: 30,
+        mean: 20,
+        first: 10,
+        last: 30,
+        delta: 20,
+      },
+    ]);
+  });
+
+  it("escapes template and historical content in every HTML context", async () => {
+    const engine = new ReportingEngine({
+      clock: new MutableClock(4_000),
+      dataProvider: provider({
+        queryAlarms: async () => [
+          {
+            tag: "<img src=x onerror=alert(1)>",
+            severity: "high",
+            message: "</td><script>alert('x')</script>",
+            timestamp: 2_000,
+          },
+        ],
+      }),
+    });
+    engine.registerTemplate({
+      id: "hostile-template",
+      name: "<script>title()</script>",
+      type: "custom",
+      sections: [
+        {
+          id: "hostile",
+          title: "<img src=x onerror=alert(2)>",
+          type: "alarm-list",
+        },
+      ],
+    });
+    const report = await engine.generate("hostile-template", 1_000, 3_000);
+    const html = engine.renderHTML(report!);
+
+    expect(html).toContain("&lt;script&gt;title()&lt;/script&gt;");
+    expect(html).toContain("&lt;img src=x onerror=alert(2)&gt;");
+    expect(html).toContain("&lt;/td&gt;&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;");
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("Content-Security-Policy");
+  });
+
+  it("fails explicitly when no historian is configured", async () => {
+    const engine = new ReportingEngine({ clock: new MutableClock(4_000) });
+    await expect(engine.generate("shift-summary", 1_000, 2_000)).rejects.toThrow(
+      "Historical data provider is not configured",
+    );
+    expect(engine.getReports()).toEqual([]);
+  });
+
+  it("computes statistics for high-cardinality histories without argument spreading", async () => {
+    const points = Array.from({ length: 200_000 }, (_, index) => ({
+      timestamp: index + 1,
+      value: index,
+      quality: "good" as const,
+    }));
+    const engine = new ReportingEngine({
+      clock: new MutableClock(300_000),
+      dataProvider: provider({
+        querySeries: async () => ({ highRateTag: points }),
+      }),
+    });
+    engine.registerTemplate({
+      id: "high-cardinality",
+      name: "High-cardinality statistics",
+      type: "custom",
+      sections: [
+        {
+          id: "statistics",
+          title: "Statistics",
+          type: "statistics",
+          query: "*",
+        },
+      ],
+    });
+
+    const report = await engine.generate("high-cardinality", 0, 200_000);
+
+    expect(report?.sections[0].content).toEqual([
+      {
+        tag: "highRateTag",
+        count: 200_000,
+        min: 0,
+        max: 199_999,
+        mean: 99_999.5,
+        first: 0,
+        last: 199_999,
+        delta: 199_999,
+      },
+    ]);
+  });
+
+  it("uses half-open adjacent windows without double-counting boundary records", async () => {
+    const engine = new ReportingEngine({
+      clock: new MutableClock(3_000),
+      dataProvider: provider({
+        querySeries: async () => ({
+          pressure: [
+            { timestamp: 1_000, value: 10 },
+            { timestamp: 2_000, value: 20 },
+          ],
+        }),
+        queryAlarms: async () => [
+          {
+            id: "alarm-1",
+            tag: "pressure",
+            severity: "high",
+            message: "first",
+            timestamp: 1_000,
+          },
+          {
+            id: "alarm-2",
+            tag: "pressure",
+            severity: "high",
+            message: "second",
+            timestamp: 2_000,
+          },
+        ],
+        queryCompliance: async () => [
+          {
+            control: "first",
+            status: "pass",
+            detail: "first",
+            timestamp: 1_000,
+          },
+          {
+            control: "second",
+            status: "pass",
+            detail: "second",
+            timestamp: 2_000,
+          },
+        ],
+      }),
+    });
+    engine.registerTemplate({
+      id: "boundary-check",
+      name: "Boundary check",
+      type: "custom",
+      sections: [
+        { id: "stats", title: "Stats", type: "statistics", query: "*" },
+        { id: "alarms", title: "Alarms", type: "alarm-list" },
+        { id: "compliance", title: "Compliance", type: "compliance" },
+      ],
+    });
+
+    const first = await engine.generate("boundary-check", 0, 1_000);
+    const second = await engine.generate("boundary-check", 1_000, 2_000);
+
+    expect(first?.sections[0].content).toMatchObject([{ count: 1, first: 10 }]);
+    expect(second?.sections[0].content).toMatchObject([{ count: 1, first: 20 }]);
+    expect(first?.sections[1].content).toMatchObject([{ id: "alarm-1" }]);
+    expect(second?.sections[1].content).toMatchObject([{ id: "alarm-2" }]);
+    expect(first?.sections[2].content).toMatchObject({
+      summary: { total: 1 },
+      events: [{ control: "first" }],
+    });
+    expect(second?.sections[2].content).toMatchObject({
+      summary: { total: 1 },
+      events: [{ control: "second" }],
+    });
+  });
+});
+
+describe("delivery adapters and retry status", () => {
+  it("retries transient webhook failures with deterministic backoff", async () => {
+    const clock = new MutableClock(5_000);
+    const sleeps: number[] = [];
+    const sleeper: Sleeper = {
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+        clock.value += milliseconds;
+      },
+    };
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 500, requestId: "req-1" })
+      .mockResolvedValueOnce({ status: 429, requestId: "req-2" })
+      .mockResolvedValueOnce({ status: 204, requestId: "req-3" });
+    const engine = new ReportingEngine({
+      clock,
+      sleeper,
+      dataProvider: provider(),
+      retryPolicy: { maxAttempts: 3, baseDelayMs: 10, maxDelayMs: 50 },
+      deliveryChannels: [new WebhookDeliveryChannel({ post })],
+    });
+    const report = await engine.generate("shift-summary", 1_000, 3_000);
+    const delivery = await engine.deliver(report!, {
+      method: "webhook",
+      target: "https://reports.example.test/hooks/shift",
+      headers: { authorization: "Bearer injected-by-config" },
+    });
+
+    expect(delivery).toMatchObject({
+      id: "DLV-000001",
+      state: "delivered",
+      providerId: "req-3",
+      deliveredAt: 5_030,
+    });
+    expect(delivery.attempts.map((attempt) => attempt.statusCode)).toEqual([500, 429, 204]);
+    expect(sleeps).toEqual([10, 20]);
+    expect(post).toHaveBeenCalledTimes(3);
+    expect(post.mock.calls[0][0]).toMatchObject({
+      headers: {
+        "content-type": "application/json",
+        "x-0xscada-delivery-id": "DLV-000001",
+        "x-0xscada-report-id": "RPT-000001",
+        authorization: "Bearer injected-by-config",
+      },
+    });
+    expect(post.mock.calls.map((call) => call[0].headers["x-0xscada-delivery-id"])).toEqual([
+      "DLV-000001",
+      "DLV-000001",
+      "DLV-000001",
+    ]);
+  });
+
+  it("does not retry permanent failures and retains their error status", async () => {
+    const send = vi.fn(async () => {
+      throw new DeliveryChannelError("Recipient rejected", false, 400);
+    });
+    const engine = new ReportingEngine({
+      clock: new MutableClock(5_000),
+      dataProvider: provider(),
+      deliveryChannels: [{ method: "email", send }],
+    });
+    const report = await engine.generate("shift-summary", 1_000, 3_000);
+    const delivery = await engine.deliver(report!, {
+      method: "email",
+      target: "operator@example.test",
+    });
+
+    expect(delivery).toMatchObject({
+      state: "failed",
+      error: "Recipient rejected",
+      attempts: [
+        {
+          attempt: 1,
+          state: "failed",
+          retryable: false,
+          statusCode: 400,
+        },
+      ],
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(engine.getDeliveryStatus(delivery.id)).toHaveLength(1);
+  });
+
+  it("uses an injected email transport and supplies safe HTML plus plain text", async () => {
+    const send = vi.fn(async () => ({ messageId: "mail-9" }));
+    const engine = new ReportingEngine({
+      clock: new MutableClock(5_000),
+      dataProvider: provider(),
+      deliveryChannels: [new EmailDeliveryChannel({ send })],
+    });
+    const report = await engine.generate("shift-summary", 1_000, 3_000);
+    const delivery = await engine.deliver(report!, {
+      method: "email",
+      target: "operator@example.test",
+      subject: "Shift handoff",
+    });
+
+    expect(delivery).toMatchObject({
+      state: "delivered",
+      providerId: "mail-9",
+    });
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "operator@example.test",
+        subject: "Shift handoff",
+        html: expect.stringContaining("<!DOCTYPE html>"),
+        text: expect.stringContaining("Shift Summary Report"),
+        headers: {
+          "x-0xscada-delivery-id": "DLV-000001",
+          "x-0xscada-report-id": "RPT-000001",
+        },
+      }),
+    );
+  });
+
+  it("keeps a stable email idempotency key across an ambiguous retry", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("provider response was lost"))
+      .mockResolvedValueOnce({ messageId: "mail-after-retry" });
+    const engine = new ReportingEngine({
+      clock: new MutableClock(5_000),
+      dataProvider: provider(),
+      sleeper: { sleep: async () => undefined },
+      deliveryChannels: [new EmailDeliveryChannel({ send })],
+    });
+    const report = await engine.generate("shift-summary", 1_000, 3_000);
+
+    const delivery = await engine.deliver(report!, {
+      method: "email",
+      target: "operator@example.test",
+    });
+
+    expect(delivery.state).toBe("delivered");
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls.map(([message]) => message.headers["x-0xscada-delivery-id"])).toEqual([
+      "DLV-000001",
+      "DLV-000001",
+    ]);
+  });
+
+  it("rejects case-insensitive attempts to override reserved webhook headers", async () => {
+    const post = vi.fn(async () => ({ status: 204 }));
+    const engine = new ReportingEngine({
+      clock: new MutableClock(5_000),
+      dataProvider: provider(),
+      deliveryChannels: [new WebhookDeliveryChannel({ post })],
+    });
+    const report = await engine.generate("shift-summary", 1_000, 3_000);
+
+    const delivery = await engine.deliver(report!, {
+      method: "webhook",
+      target: "https://reports.example.test/hook",
+      headers: { "Content-Type": "text/plain" },
+    });
+
+    expect(delivery).toMatchObject({
+      state: "failed",
+      error: "Delivery header Content-Type is reserved",
+    });
+    expect(post).not.toHaveBeenCalled();
+  });
+});
+
+describe("injectable scheduling", () => {
+  it("generates the configured historical window and records delivery status", async () => {
+    const clock = new MutableClock(20_000);
+    const scheduler = new ManualScheduler();
+    const periods: Array<{ start: number; end: number }> = [];
+    const data = provider({
+      querySeries: async (_pattern, period) => {
+        periods.push(period);
+        return {};
+      },
+    });
+    const send = vi.fn(async () => ({}));
+    const engine = new ReportingEngine({
+      clock,
+      scheduler,
+      dataProvider: data,
+      deliveryChannels: [{ method: "webhook", send }],
+    });
+
+    expect(
+      engine.schedule({
+        id: "shift-every-hour",
+        templateId: "shift-summary",
+        intervalMs: 3_600_000,
+        lookbackMs: 8_000,
+        deliveries: [{ method: "webhook", target: "https://example.test/report" }],
+      }),
+    ).toBe(true);
+    await scheduler.trigger("shift-every-hour");
+
+    expect(periods[0]).toEqual({ start: 12_000, end: 20_000 });
+    expect(engine.getScheduleStatus("shift-every-hour")[0]).toMatchObject({
+      active: true,
+      running: false,
+      runCount: 1,
+      consecutiveFailures: 0,
+      lastReportId: "RPT-000001",
+      lastDeliveryIds: ["DLV-000001"],
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(engine.unscheduleReport("shift-every-hour")).toBe(true);
+    expect(scheduler.cancelled).toEqual(["shift-every-hour"]);
+  });
+
+  it("skips overlapping runs instead of generating duplicate reports", async () => {
+    const clock = new MutableClock(20_000);
+    const scheduler = new ManualScheduler();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const engine = new ReportingEngine({
+      clock,
+      scheduler,
+      dataProvider: provider({
+        querySeries: async () => {
+          await gate;
+          return {};
+        },
+      }),
+    });
+    engine.schedule({
+      id: "non-overlap",
+      templateId: "shift-summary",
+      intervalMs: 1_000,
+      lookbackMs: 1_000,
+    });
+
+    const first = engine.runSchedule("non-overlap");
+    const second = await engine.runSchedule("non-overlap");
+    expect(second).toMatchObject({ running: true, skippedOverlaps: 1 });
+    release();
+    await first;
+
+    expect(engine.getReports()).toHaveLength(1);
+    expect(engine.getScheduleStatus("non-overlap")[0]).toMatchObject({
+      running: false,
+      runCount: 1,
+      skippedOverlaps: 1,
+    });
+  });
+});

--- a/server/services/reporting/__tests__/webhook-target-validation.test.ts
+++ b/server/services/reporting/__tests__/webhook-target-validation.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Pins `validateWebhookTarget` in `WebhookDeliveryChannel`.
+ *
+ * The guard rejects unparseable URLs, non-HTTP(S) protocols, and credentials
+ * embedded in the URL. Mutation testing on the review of #626 showed the whole
+ * condition could be neutralised with all 12 existing tests still green — the
+ * suite exercises successful webhook delivery, never a rejected target.
+ *
+ * The credential check is the one most worth holding onto: a target of the
+ * form `https://user:pass@host/hook` puts a secret into whatever egress proxy,
+ * access log or error report sees the outbound request. That is the kind of
+ * check a later refactor drops without noticing, because nothing about the
+ * happy path depends on it.
+ *
+ * Each case asserts the rejection is NON-RETRYABLE. A malformed target is a
+ * configuration error, and retrying it just repeats the mistake — including,
+ * for the credential case, repeating the leak.
+ *
+ * SCOPE — this guard is not SSRF protection, and these tests do not pretend
+ * otherwise. It checks protocol and credentials; it does not restrict the
+ * destination address, so `http://127.0.0.1`, `http://169.254.169.254/` and
+ * `http://10.0.0.5:20000` all pass. The final case below documents that
+ * explicitly rather than leaving the omission ambiguous. See the review thread
+ * on #626 for whether the module should own destination policy or delegate it
+ * to the injected transport.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DeliveryChannelError,
+  WebhookDeliveryChannel,
+  type DeliveryPayload,
+  type GeneratedReport,
+} from "..";
+
+/** A transport that fails the test if the guard ever lets a request through. */
+function transport() {
+  return {
+    post: vi.fn(async () => ({ status: 200, body: "" })),
+  };
+}
+
+const REPORT = {
+  id: "report-1",
+  templateId: "shift-summary",
+  title: "Shift Summary",
+  generatedAt: new Date("2026-07-28T12:00:00.000Z"),
+  periodStart: new Date("2026-07-28T00:00:00.000Z"),
+  periodEnd: new Date("2026-07-28T12:00:00.000Z"),
+  sections: [],
+} as unknown as GeneratedReport;
+
+function payload(target: string): DeliveryPayload {
+  return {
+    deliveryId: "delivery-1",
+    report: REPORT,
+    target,
+    subject: "Shift Summary",
+    headers: {},
+    html: "<p>ok</p>",
+    text: "ok",
+    json: "{}",
+  };
+}
+
+async function reject(target: string): Promise<DeliveryChannelError> {
+  const post = transport();
+  const channel = new WebhookDeliveryChannel(post);
+  const error = await channel.send(payload(target)).catch((caught: unknown) => caught);
+
+  expect(error).toBeInstanceOf(DeliveryChannelError);
+  // The guard runs before the transport; nothing should have been dispatched.
+  expect(post.post).not.toHaveBeenCalled();
+  return error as DeliveryChannelError;
+}
+
+describe("webhook target validation", () => {
+  it("accepts an ordinary https target", async () => {
+    const post = transport();
+    const channel = new WebhookDeliveryChannel(post);
+
+    await channel.send(payload("https://hooks.example.com/reports"));
+
+    expect(post.post).toHaveBeenCalledTimes(1);
+    expect(post.post.mock.calls[0][0]).toMatchObject({
+      url: "https://hooks.example.com/reports",
+    });
+  });
+
+  it("rejects a target that is not a URL at all", async () => {
+    const error = await reject("not-a-url");
+    expect(error.message).toMatch(/invalid webhook url/i);
+    expect(error.retryable).toBe(false);
+  });
+
+  it("rejects a non-HTTP(S) protocol", async () => {
+    // file:// would make the "delivery" a local read on the server host.
+    const error = await reject("file:///etc/passwd");
+    expect(error.message).toMatch(/HTTP\(S\)/i);
+    expect(error.retryable).toBe(false);
+  });
+
+  it("rejects credentials embedded in the URL", async () => {
+    // The leak case: these end up in egress proxy and access logs.
+    const error = await reject("https://user:secret@hooks.example.com/reports");
+    expect(error.message).toMatch(/credentials/i);
+    expect(error.retryable).toBe(false);
+  });
+
+  it("rejects a username even without a password", async () => {
+    const error = await reject("https://user@hooks.example.com/reports");
+    expect(error.retryable).toBe(false);
+  });
+
+  it("documents that destination filtering is NOT performed here", async () => {
+    // Deliberately asserting current behaviour, not endorsing it. This guard
+    // is protocol/credential validation only — an internal address passes.
+    // If destination policy moves into this module, this test should flip to
+    // expecting a rejection, and that change should be a conscious one.
+    const post = transport();
+    const channel = new WebhookDeliveryChannel(post);
+
+    await channel.send(payload("http://169.254.169.254/latest/meta-data/"));
+
+    expect(post.post).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/services/reporting/delivery.ts
+++ b/server/services/reporting/delivery.ts
@@ -1,0 +1,139 @@
+import type { DeliveryChannel, DeliveryPayload, DeliveryReceipt } from "./types";
+
+export class DeliveryChannelError extends Error {
+  constructor(
+    message: string,
+    readonly retryable: boolean,
+    readonly statusCode?: number,
+  ) {
+    super(message);
+    this.name = "DeliveryChannelError";
+  }
+}
+
+export interface WebhookTransport {
+  post(request: {
+    url: string;
+    headers: Readonly<Record<string, string>>;
+    body: string;
+  }): Promise<{ status: number; requestId?: string }>;
+}
+
+export interface EmailTransport {
+  send(message: {
+    to: string;
+    subject: string;
+    html: string;
+    text: string;
+    headers: Readonly<Record<string, string>>;
+  }): Promise<{ messageId?: string }>;
+}
+
+/**
+ * Executable webhook adapter with the network operation injected.  Tests and
+ * the default engine never perform live HTTP.
+ */
+export class WebhookDeliveryChannel implements DeliveryChannel {
+  readonly method = "webhook" as const;
+
+  constructor(private readonly transport: WebhookTransport) {}
+
+  async send(payload: DeliveryPayload): Promise<DeliveryReceipt> {
+    const target = validateWebhookTarget(payload.target);
+    validateHeaders(payload.headers, [
+      "content-type",
+      "x-0xscada-delivery-id",
+      "x-0xscada-report-id",
+    ]);
+    const response = await this.transport.post({
+      url: target,
+      headers: {
+        ...payload.headers,
+        "content-type": "application/json",
+        "x-0xscada-delivery-id": payload.deliveryId,
+        "x-0xscada-report-id": payload.report.id,
+      },
+      body: payload.json,
+    });
+    if (response.status < 200 || response.status >= 300) {
+      throw new DeliveryChannelError(
+        `Webhook returned HTTP ${response.status}`,
+        response.status === 408 ||
+          response.status === 425 ||
+          response.status === 429 ||
+          response.status >= 500,
+        response.status,
+      );
+    }
+    return { statusCode: response.status, providerId: response.requestId };
+  }
+}
+
+/** Email provider adapter; SMTP/API details remain deployment-owned. */
+export class EmailDeliveryChannel implements DeliveryChannel {
+  readonly method = "email" as const;
+
+  constructor(private readonly transport: EmailTransport) {}
+
+  async send(payload: DeliveryPayload): Promise<DeliveryReceipt> {
+    if (!isPlausibleEmail(payload.target)) {
+      throw new DeliveryChannelError("Invalid email delivery target", false);
+    }
+    if (/[\r\n]/.test(payload.subject)) {
+      throw new DeliveryChannelError("Email subject contains a newline", false);
+    }
+    validateHeaders(payload.headers, ["x-0xscada-delivery-id", "x-0xscada-report-id"]);
+    try {
+      const response = await this.transport.send({
+        to: payload.target,
+        subject: payload.subject,
+        html: payload.html,
+        text: payload.text,
+        headers: {
+          ...payload.headers,
+          "x-0xscada-delivery-id": payload.deliveryId,
+          "x-0xscada-report-id": payload.report.id,
+        },
+      });
+      return { providerId: response.messageId };
+    } catch (error) {
+      if (error instanceof DeliveryChannelError) throw error;
+      throw new DeliveryChannelError(error instanceof Error ? error.message : String(error), true);
+    }
+  }
+}
+
+function validateWebhookTarget(target: string): string {
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch {
+    throw new DeliveryChannelError("Invalid webhook URL", false);
+  }
+  if (!["https:", "http:"].includes(url.protocol) || url.username || url.password) {
+    throw new DeliveryChannelError(
+      "Webhook URL must use HTTP(S) and must not contain credentials",
+      false,
+    );
+  }
+  return url.toString();
+}
+
+function isPlausibleEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function validateHeaders(
+  headers: Readonly<Record<string, string>>,
+  reserved: readonly string[] = [],
+): void {
+  const reservedNames = new Set(reserved.map((name) => name.toLowerCase()));
+  for (const [name, value] of Object.entries(headers)) {
+    if (!name || /[\r\n:]/.test(name) || /[\r\n]/.test(value)) {
+      throw new DeliveryChannelError("Invalid delivery header", false);
+    }
+    if (reservedNames.has(name.toLowerCase())) {
+      throw new DeliveryChannelError(`Delivery header ${name} is reserved`, false);
+    }
+  }
+}

--- a/server/services/reporting/engine.ts
+++ b/server/services/reporting/engine.ts
@@ -1,0 +1,742 @@
+import { EventEmitter } from "events";
+import { DeliveryChannelError } from "./delivery";
+import { renderReportHtml, renderReportJson, renderReportText } from "./render";
+import { IntervalReportScheduler, timerSleeper } from "./scheduler";
+import { BUILT_IN_TEMPLATES } from "./templates";
+import {
+  systemReportClock,
+  type ComplianceEvent,
+  type DeliveryAttempt,
+  type DeliveryChannel,
+  type DeliveryConfig,
+  type DeliveryStatus,
+  type GeneratedReport,
+  type GeneratedSection,
+  type HistoricalAlarm,
+  type HistoricalDataProvider,
+  type HistoricalPoint,
+  type LegacyDataProvider,
+  type OutputFormat,
+  type ReportClock,
+  type ReportContent,
+  type ReportPeriod,
+  type ReportSchedule,
+  type ReportScheduler,
+  type ReportScheduleStatus,
+  type ReportSection,
+  type ReportTemplate,
+  type ReportType,
+  type RetryPolicy,
+  type ScheduledHandle,
+  type Sleeper,
+} from "./types";
+
+const DEFAULT_RETRY_POLICY: Readonly<RetryPolicy> = Object.freeze({
+  maxAttempts: 3,
+  baseDelayMs: 250,
+  maxDelayMs: 5_000,
+});
+
+export interface ReportingEngineOptions {
+  dataProvider?: HistoricalDataProvider | LegacyDataProvider;
+  clock?: ReportClock;
+  scheduler?: ReportScheduler;
+  sleeper?: Sleeper;
+  deliveryChannels?: readonly DeliveryChannel[];
+  retryPolicy?: RetryPolicy;
+  maxReports?: number;
+  maxDeliveries?: number;
+}
+
+interface InternalSchedule {
+  spec: ReportSchedule;
+  handle: ScheduledHandle;
+  status: ReportScheduleStatus;
+}
+
+export class ReportingConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReportingConfigurationError";
+  }
+}
+
+/**
+ * Template-based, historical reporting engine with injectable scheduling and
+ * delivery boundaries.
+ */
+export class ReportingEngine extends EventEmitter {
+  private readonly clock: ReportClock;
+  private readonly scheduler: ReportScheduler;
+  private readonly sleeper: Sleeper;
+  private readonly retryPolicy: RetryPolicy;
+  private readonly maxReports: number;
+  private readonly maxDeliveries: number;
+  private readonly templates = new Map<string, ReportTemplate>();
+  private readonly channels = new Map<DeliveryConfig["method"], DeliveryChannel>();
+  private readonly reports: GeneratedReport[] = [];
+  private readonly deliveries: DeliveryStatus[] = [];
+  private readonly schedules = new Map<string, InternalSchedule>();
+  private dataProvider?: HistoricalDataProvider;
+  private reportCounter = 0;
+  private deliveryCounter = 0;
+
+  constructor(options: ReportingEngineOptions = {}) {
+    super();
+    this.clock = options.clock ?? systemReportClock;
+    this.scheduler = options.scheduler ?? new IntervalReportScheduler();
+    this.sleeper = options.sleeper ?? timerSleeper;
+    this.retryPolicy = validateRetryPolicy(options.retryPolicy ?? DEFAULT_RETRY_POLICY);
+    this.maxReports = positiveInteger(options.maxReports ?? 500, "maxReports");
+    this.maxDeliveries = positiveInteger(options.maxDeliveries ?? 2_000, "maxDeliveries");
+    for (const template of BUILT_IN_TEMPLATES) this.registerTemplate(template);
+    for (const channel of options.deliveryChannels ?? []) {
+      this.registerDeliveryChannel(channel);
+    }
+    if (options.dataProvider) this.setDataProvider(options.dataProvider);
+  }
+
+  setDataProvider(provider: HistoricalDataProvider | LegacyDataProvider): void {
+    this.dataProvider = isLegacyProvider(provider) ? adaptLegacyProvider(provider) : provider;
+  }
+
+  registerTemplate(template: ReportTemplate): void {
+    validateTemplate(template);
+    this.templates.set(template.id, cloneTemplate(template));
+  }
+
+  getTemplate(templateId: string): ReportTemplate | undefined {
+    const template = this.templates.get(templateId);
+    return template ? cloneTemplate(template) : undefined;
+  }
+
+  listTemplates(): ReportTemplate[] {
+    return [...this.templates.values()].map(cloneTemplate);
+  }
+
+  async generate(
+    templateId: string,
+    periodStart: number,
+    periodEnd: number,
+    format: OutputFormat = "html",
+  ): Promise<GeneratedReport | null> {
+    const template = this.templates.get(templateId);
+    if (!template) return null;
+    const period = validatePeriod({ start: periodStart, end: periodEnd });
+    const provider = this.dataProvider;
+    if (!provider) {
+      throw new ReportingConfigurationError("Historical data provider is not configured");
+    }
+
+    const sections: GeneratedSection[] = [];
+    for (const section of template.sections) {
+      sections.push({
+        id: section.id,
+        title: section.title,
+        type: section.type,
+        content: await generateSection(provider, section, period),
+      });
+    }
+    const report: GeneratedReport = {
+      id: `RPT-${String(++this.reportCounter).padStart(6, "0")}`,
+      templateId: template.id,
+      type: template.type,
+      title: template.name,
+      generatedAt: this.clock.now(),
+      periodStart: period.start,
+      periodEnd: period.end,
+      sections,
+      format,
+    };
+    this.reports.push(report);
+    if (this.reports.length > this.maxReports) {
+      this.reports.splice(0, this.reports.length - this.maxReports);
+    }
+    this.emit("report", cloneReport(report));
+    return cloneReport(report);
+  }
+
+  renderHTML(report: Readonly<GeneratedReport>): string {
+    return renderReportHtml(report);
+  }
+
+  renderText(report: Readonly<GeneratedReport>): string {
+    return renderReportText(report);
+  }
+
+  renderJSON(report: Readonly<GeneratedReport>): string {
+    return renderReportJson(report);
+  }
+
+  registerDeliveryChannel(channel: DeliveryChannel): void {
+    if (this.channels.has(channel.method)) {
+      throw new Error(`Delivery channel ${channel.method} is already registered`);
+    }
+    this.channels.set(channel.method, channel);
+  }
+
+  /**
+   * Compatibility helper for the prototype API.  New integrations should
+   * implement DeliveryChannel so they also receive rendered payloads.
+   */
+  registerDeliveryHandler(
+    method: DeliveryConfig["method"],
+    handler: (report: GeneratedReport, config: DeliveryConfig) => Promise<void>,
+  ): void {
+    this.registerDeliveryChannel({
+      method,
+      send: async (payload) => {
+        await handler(cloneReport(payload.report), {
+          method,
+          target: payload.target,
+          headers: { ...payload.headers },
+          subject: payload.subject,
+        });
+        return {};
+      },
+    });
+  }
+
+  async deliver(
+    report: Readonly<GeneratedReport>,
+    config: DeliveryConfig,
+    retryPolicy: RetryPolicy = this.retryPolicy,
+  ): Promise<DeliveryStatus> {
+    const channel = this.channels.get(config.method);
+    const policy = validateRetryPolicy(retryPolicy);
+    const delivery: DeliveryStatus = {
+      id: `DLV-${String(++this.deliveryCounter).padStart(6, "0")}`,
+      reportId: report.id,
+      method: config.method,
+      target: config.target,
+      state: "failed",
+      attempts: [],
+    };
+    if (!channel) {
+      delivery.error = `Delivery channel ${config.method} is not configured`;
+      this.storeDelivery(delivery);
+      this.emit("delivery", cloneDelivery(delivery));
+      return cloneDelivery(delivery);
+    }
+
+    const payload = {
+      deliveryId: delivery.id,
+      report: cloneReport(report),
+      target: config.target,
+      subject: config.subject ?? report.title,
+      headers: { ...(config.headers ?? {}) },
+      html: this.renderHTML(report),
+      text: this.renderText(report),
+      json: this.renderJSON(report),
+    };
+    const attempts: DeliveryAttempt[] = [];
+    for (let attempt = 1; attempt <= policy.maxAttempts; attempt += 1) {
+      const startedAt = this.clock.now();
+      try {
+        const receipt = await channel.send(payload);
+        const completedAt = this.clock.now();
+        attempts.push({
+          attempt,
+          startedAt,
+          completedAt,
+          state: "delivered",
+          ...(receipt.statusCode !== undefined ? { statusCode: receipt.statusCode } : {}),
+        });
+        delivery.state = "delivered";
+        delivery.attempts = attempts;
+        delivery.deliveredAt = completedAt;
+        delivery.providerId = receipt.providerId;
+        delete delivery.error;
+        this.storeDelivery(delivery);
+        this.emit("delivery", cloneDelivery(delivery));
+        return cloneDelivery(delivery);
+      } catch (error) {
+        const completedAt = this.clock.now();
+        const retryable = error instanceof DeliveryChannelError ? error.retryable : true;
+        const message = error instanceof Error ? error.message : String(error);
+        attempts.push({
+          attempt,
+          startedAt,
+          completedAt,
+          state: "failed",
+          error: message,
+          retryable,
+          ...(error instanceof DeliveryChannelError && error.statusCode !== undefined
+            ? { statusCode: error.statusCode }
+            : {}),
+        });
+        delivery.error = message;
+        if (!retryable || attempt === policy.maxAttempts) break;
+        const delay = Math.min(policy.maxDelayMs, policy.baseDelayMs * 2 ** (attempt - 1));
+        await this.sleeper.sleep(delay);
+      }
+    }
+    delivery.attempts = attempts;
+    this.storeDelivery(delivery);
+    this.emit("delivery", cloneDelivery(delivery));
+    return cloneDelivery(delivery);
+  }
+
+  schedule(schedule: ReportSchedule): boolean {
+    validateSchedule(schedule);
+    if (!this.templates.has(schedule.templateId)) return false;
+    if (this.schedules.has(schedule.id)) {
+      throw new Error(`Report schedule ${schedule.id} already exists`);
+    }
+    const spec = cloneSchedule(schedule);
+    const status: ReportScheduleStatus = {
+      id: spec.id,
+      templateId: spec.templateId,
+      active: true,
+      running: false,
+      runCount: 0,
+      skippedOverlaps: 0,
+      consecutiveFailures: 0,
+      lastDeliveryIds: [],
+    };
+    const scheduled: InternalSchedule = {
+      spec,
+      handle: { cancel: () => undefined },
+      status,
+    };
+    this.schedules.set(spec.id, scheduled);
+    try {
+      scheduled.handle = this.scheduler.every(spec.id, spec.intervalMs, async () => {
+        await this.runSchedule(spec.id);
+      });
+    } catch (error) {
+      this.schedules.delete(spec.id);
+      throw error;
+    }
+    return true;
+  }
+
+  /** Original prototype API: schedule id is the template id. */
+  scheduleReport(templateId: string, intervalMs: number, format: OutputFormat = "html"): boolean {
+    return this.schedule({
+      id: templateId,
+      templateId,
+      intervalMs,
+      lookbackMs: intervalMs,
+      format,
+    });
+  }
+
+  async runSchedule(scheduleId: string): Promise<ReportScheduleStatus> {
+    const scheduled = this.schedules.get(scheduleId);
+    if (!scheduled) throw new Error(`Report schedule ${scheduleId} not found`);
+    if (scheduled.status.running) {
+      scheduled.status.skippedOverlaps += 1;
+      return cloneScheduleStatus(scheduled.status);
+    }
+    scheduled.status.running = true;
+    scheduled.status.lastStartedAt = this.clock.now();
+    scheduled.status.lastError = undefined;
+    try {
+      const periodEnd = this.clock.now();
+      const report = await this.generate(
+        scheduled.spec.templateId,
+        periodEnd - scheduled.spec.lookbackMs,
+        periodEnd,
+        scheduled.spec.format ?? "html",
+      );
+      if (!report) {
+        throw new Error(`Template ${scheduled.spec.templateId} no longer exists`);
+      }
+      const template = this.templates.get(scheduled.spec.templateId)!;
+      const deliveryConfigs = scheduled.spec.deliveries ?? template.delivery ?? [];
+      const deliveryIds: string[] = [];
+      const failures: string[] = [];
+      for (const config of deliveryConfigs) {
+        const delivery = await this.deliver(report, config);
+        deliveryIds.push(delivery.id);
+        if (delivery.state === "failed") {
+          failures.push(`${config.method}: ${delivery.error ?? "delivery failed"}`);
+        }
+      }
+      scheduled.status.runCount += 1;
+      scheduled.status.lastReportId = report.id;
+      scheduled.status.lastDeliveryIds = deliveryIds;
+      if (failures.length > 0) {
+        scheduled.status.consecutiveFailures += 1;
+        scheduled.status.lastError = failures.join("; ");
+      } else {
+        scheduled.status.consecutiveFailures = 0;
+      }
+    } catch (error) {
+      scheduled.status.consecutiveFailures += 1;
+      scheduled.status.lastError = error instanceof Error ? error.message : String(error);
+    } finally {
+      scheduled.status.running = false;
+      scheduled.status.lastCompletedAt = this.clock.now();
+      this.emit("schedule", cloneScheduleStatus(scheduled.status));
+    }
+    return cloneScheduleStatus(scheduled.status);
+  }
+
+  unscheduleReport(scheduleId: string): boolean {
+    const scheduled = this.schedules.get(scheduleId);
+    if (!scheduled) return false;
+    scheduled.handle.cancel();
+    scheduled.status.active = false;
+    this.schedules.delete(scheduleId);
+    return true;
+  }
+
+  getScheduleStatus(scheduleId?: string): ReportScheduleStatus[] {
+    return [...this.schedules.values()]
+      .filter((scheduled) => !scheduleId || scheduled.spec.id === scheduleId)
+      .map((scheduled) => cloneScheduleStatus(scheduled.status));
+  }
+
+  getReports(type?: ReportType): GeneratedReport[] {
+    return this.reports.filter((report) => !type || report.type === type).map(cloneReport);
+  }
+
+  getReport(reportId: string): GeneratedReport | undefined {
+    const report = this.reports.find((candidate) => candidate.id === reportId);
+    return report ? cloneReport(report) : undefined;
+  }
+
+  getDeliveryStatus(deliveryId?: string): DeliveryStatus[] {
+    return this.deliveries
+      .filter((delivery) => !deliveryId || delivery.id === deliveryId)
+      .map(cloneDelivery);
+  }
+
+  destroyAll(): void {
+    for (const scheduleId of [...this.schedules.keys()]) {
+      this.unscheduleReport(scheduleId);
+    }
+    this.reports.splice(0);
+    this.deliveries.splice(0);
+  }
+
+  private storeDelivery(delivery: DeliveryStatus): void {
+    this.deliveries.push(cloneDelivery(delivery));
+    if (this.deliveries.length > this.maxDeliveries) {
+      this.deliveries.splice(0, this.deliveries.length - this.maxDeliveries);
+    }
+  }
+}
+
+async function generateSection(
+  provider: HistoricalDataProvider,
+  section: ReportSection,
+  period: ReportPeriod,
+): Promise<ReportContent> {
+  switch (section.type) {
+    case "summary": {
+      const series = normalizeSeries(
+        await provider.querySeries(section.query ?? section.dataQuery ?? "*", period),
+        period,
+      );
+      const points = Object.values(series).flat();
+      return {
+        periodStart: new Date(period.start).toISOString(),
+        periodEnd: new Date(period.end).toISOString(),
+        tagsMonitored: Object.keys(series).length,
+        dataPoints: points.length,
+        goodQuality: points.filter(
+          (point) => point.quality === undefined || point.quality === "good",
+        ).length,
+        uncertainQuality: points.filter((point) => point.quality === "uncertain").length,
+        badQuality: points.filter((point) => point.quality === "bad").length,
+      };
+    }
+    case "alarm-list":
+      return normalizeAlarms(await provider.queryAlarms(period), period).map((alarm) => ({
+        id: alarm.id ?? "",
+        tag: alarm.tag,
+        severity: alarm.severity,
+        message: alarm.message,
+        timestamp: new Date(alarm.timestamp).toISOString(),
+        acknowledged: alarm.acknowledged ?? false,
+      }));
+    case "kpi":
+      return provider.queryKPIs(section.kpis ?? [], period);
+    case "statistics": {
+      const series = normalizeSeries(
+        await provider.querySeries(section.query ?? section.dataQuery ?? "*", period),
+        period,
+      );
+      return Object.keys(series)
+        .sort()
+        .map((tag) => statisticsFor(tag, series[tag]));
+    }
+    case "trend-data": {
+      const series = normalizeSeries(
+        await provider.querySeries(section.query ?? section.dataQuery ?? "*", period),
+        period,
+      );
+      return Object.keys(series)
+        .sort()
+        .flatMap((tag) =>
+          series[tag].map((point) => ({
+            tag,
+            timestamp: new Date(point.timestamp).toISOString(),
+            value: point.value,
+            quality: point.quality ?? "good",
+          })),
+        );
+    }
+    case "compliance": {
+      const events = normalizeCompliance(await provider.queryCompliance(period), period);
+      return {
+        summary: {
+          total: events.length,
+          pass: events.filter((event) => event.status === "pass").length,
+          warning: events.filter((event) => event.status === "warning").length,
+          fail: events.filter((event) => event.status === "fail").length,
+        },
+        events: events.map((event) => ({
+          ...event,
+          timestamp: new Date(event.timestamp).toISOString(),
+        })),
+      };
+    }
+    case "notes": {
+      if (!provider.queryNotes) return [];
+      return (await provider.queryNotes(section.query ?? section.dataQuery ?? "shift", period)).map(
+        (note, index) => ({ index: index + 1, note }),
+      );
+    }
+    case "text":
+      return section.text ?? section.dataQuery ?? "";
+  }
+}
+
+function statisticsFor(
+  tag: string,
+  points: readonly HistoricalPoint[],
+): Readonly<Record<string, unknown>> {
+  if (points.length === 0) {
+    return {
+      tag,
+      count: 0,
+      min: null,
+      max: null,
+      mean: null,
+      first: null,
+      last: null,
+      delta: null,
+    };
+  }
+  const first = points[0].value;
+  const last = points[points.length - 1].value;
+  let min = first;
+  let max = first;
+  let sum = 0;
+  for (const point of points) {
+    min = Math.min(min, point.value);
+    max = Math.max(max, point.value);
+    sum += point.value;
+  }
+  return {
+    tag,
+    count: points.length,
+    min,
+    max,
+    mean: sum / points.length,
+    first,
+    last,
+    delta: last - first,
+  };
+}
+
+function normalizeSeries(
+  input: Record<string, readonly HistoricalPoint[]>,
+  period: ReportPeriod,
+): Record<string, HistoricalPoint[]> {
+  const result: Record<string, HistoricalPoint[]> = {};
+  for (const tag of Object.keys(input).sort()) {
+    result[tag] = input[tag]
+      .filter(
+        (point) =>
+          Number.isFinite(point.timestamp) &&
+          Number.isFinite(point.value) &&
+          point.timestamp > period.start &&
+          point.timestamp <= period.end,
+      )
+      .map((point) => ({ ...point }))
+      .sort((left, right) => left.timestamp - right.timestamp);
+  }
+  return result;
+}
+
+function normalizeAlarms(
+  alarms: readonly HistoricalAlarm[],
+  period: ReportPeriod,
+): HistoricalAlarm[] {
+  return alarms
+    .filter(
+      (alarm) =>
+        Number.isFinite(alarm.timestamp) &&
+        alarm.timestamp > period.start &&
+        alarm.timestamp <= period.end,
+    )
+    .map((alarm) => ({ ...alarm }))
+    .sort(
+      (left, right) =>
+        left.timestamp - right.timestamp ||
+        left.tag.localeCompare(right.tag) ||
+        left.message.localeCompare(right.message),
+    );
+}
+
+function normalizeCompliance(
+  events: readonly ComplianceEvent[],
+  period: ReportPeriod,
+): ComplianceEvent[] {
+  return events
+    .filter(
+      (event) =>
+        Number.isFinite(event.timestamp) &&
+        event.timestamp > period.start &&
+        event.timestamp <= period.end,
+    )
+    .map((event) => ({ ...event }))
+    .sort(
+      (left, right) =>
+        left.timestamp - right.timestamp || left.control.localeCompare(right.control),
+    );
+}
+
+function adaptLegacyProvider(provider: LegacyDataProvider): HistoricalDataProvider {
+  return {
+    querySeries: async (pattern, period) => {
+      const values = await provider.queryTags(pattern, period.start, period.end);
+      const result: Record<string, HistoricalPoint[]> = {};
+      for (const [tag, samples] of Object.entries(values)) {
+        const spacing = samples.length > 1 ? (period.end - period.start) / (samples.length - 1) : 0;
+        result[tag] = samples.map((value, index) => ({
+          timestamp: period.start + spacing * index,
+          value,
+          quality: "good",
+        }));
+      }
+      return result;
+    },
+    queryAlarms: (period) => provider.queryAlarms(period.start, period.end),
+    queryKPIs: (names) => provider.queryKPIs([...names]),
+    queryCompliance: async () => [],
+    queryNotes: async () => [],
+  };
+}
+
+function isLegacyProvider(
+  provider: HistoricalDataProvider | LegacyDataProvider,
+): provider is LegacyDataProvider {
+  return "queryTags" in provider;
+}
+
+function validatePeriod(period: ReportPeriod): ReportPeriod {
+  if (
+    !Number.isFinite(period.start) ||
+    !Number.isFinite(period.end) ||
+    period.start >= period.end
+  ) {
+    throw new Error("Report period must have finite start < end");
+  }
+  return { ...period };
+}
+
+function validateTemplate(template: ReportTemplate): void {
+  if (!/^[a-z0-9][a-z0-9-]{0,127}$/.test(template.id)) {
+    throw new Error("Template id must be a lowercase slug");
+  }
+  if (!template.name.trim() || template.sections.length === 0) {
+    throw new Error("Template name and at least one section are required");
+  }
+  const sectionIds = new Set<string>();
+  for (const section of template.sections) {
+    if (!section.id || !section.title || sectionIds.has(section.id)) {
+      throw new Error(`Template ${template.id} has an invalid or duplicate section id`);
+    }
+    sectionIds.add(section.id);
+    if (section.type === "text" && section.text === undefined && section.dataQuery === undefined) {
+      throw new Error(`Text section ${section.id} must declare text`);
+    }
+  }
+}
+
+function validateSchedule(schedule: ReportSchedule): void {
+  if (!schedule.id || !schedule.templateId) {
+    throw new Error("Schedule id and template id are required");
+  }
+  positiveInteger(schedule.intervalMs, "intervalMs");
+  positiveInteger(schedule.lookbackMs, "lookbackMs");
+}
+
+function validateRetryPolicy(policy: RetryPolicy): RetryPolicy {
+  positiveInteger(policy.maxAttempts, "retryPolicy.maxAttempts");
+  if (
+    !Number.isFinite(policy.baseDelayMs) ||
+    policy.baseDelayMs < 0 ||
+    !Number.isFinite(policy.maxDelayMs) ||
+    policy.maxDelayMs < policy.baseDelayMs
+  ) {
+    throw new Error("Retry delays must be finite and maxDelayMs >= baseDelayMs");
+  }
+  return { ...policy };
+}
+
+function cloneTemplate(template: ReportTemplate): ReportTemplate {
+  return {
+    ...template,
+    sections: template.sections.map((section) => ({
+      ...section,
+      kpis: section.kpis ? [...section.kpis] : undefined,
+    })),
+    delivery: template.delivery?.map((config) => ({
+      ...config,
+      headers: config.headers ? { ...config.headers } : undefined,
+    })),
+  };
+}
+
+function cloneReport(report: Readonly<GeneratedReport>): GeneratedReport {
+  return {
+    ...report,
+    sections: report.sections.map((section) => ({
+      ...section,
+      content: cloneContent(section.content),
+    })),
+  };
+}
+
+function cloneContent(content: ReportContent): ReportContent {
+  if (Array.isArray(content)) return content.map((row) => ({ ...row }));
+  if (content !== null && typeof content === "object") {
+    return structuredClone(content) as Readonly<Record<string, unknown>>;
+  }
+  return content;
+}
+
+function cloneDelivery(delivery: DeliveryStatus): DeliveryStatus {
+  return {
+    ...delivery,
+    attempts: delivery.attempts.map((attempt) => ({ ...attempt })),
+  };
+}
+
+function cloneSchedule(schedule: ReportSchedule): ReportSchedule {
+  return {
+    ...schedule,
+    deliveries: schedule.deliveries?.map((config) => ({
+      ...config,
+      headers: config.headers ? { ...config.headers } : undefined,
+    })),
+  };
+}
+
+function cloneScheduleStatus(status: ReportScheduleStatus): ReportScheduleStatus {
+  return { ...status, lastDeliveryIds: [...status.lastDeliveryIds] };
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}

--- a/server/services/reporting/index.ts
+++ b/server/services/reporting/index.ts
@@ -1,0 +1,6 @@
+export * from "./types";
+export * from "./templates";
+export * from "./render";
+export * from "./delivery";
+export * from "./scheduler";
+export * from "./engine";

--- a/server/services/reporting/render.ts
+++ b/server/services/reporting/render.ts
@@ -1,0 +1,107 @@
+import type {
+  GeneratedReport,
+  GeneratedSection,
+  ReportContent,
+} from "./types";
+
+export function escapeHtml(value: unknown): string {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function renderReportHtml(report: Readonly<GeneratedReport>): string {
+  const sections = report.sections.map(renderSection).join("\n");
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:">
+<title>${escapeHtml(report.title)}</title>
+<style>
+body{font-family:system-ui,sans-serif;line-height:1.45;margin:2rem;color:#1f2937}
+table{border-collapse:collapse;width:100%;margin:.75rem 0}
+th,td{border:1px solid #d1d5db;padding:.45rem;text-align:left;vertical-align:top}
+th{background:#f3f4f6}h1{margin-bottom:.25rem}h2{border-bottom:1px solid #e5e7eb;padding-bottom:.25rem}
+pre{white-space:pre-wrap;overflow-wrap:anywhere;background:#f9fafb;padding:.75rem}
+.meta{color:#4b5563}
+</style>
+</head>
+<body>
+<h1>${escapeHtml(report.title)}</h1>
+<p class="meta">Generated: ${escapeHtml(toIso(report.generatedAt))}</p>
+<p class="meta">Period: ${escapeHtml(toIso(report.periodStart))} — ${escapeHtml(toIso(report.periodEnd))}</p>
+${sections}
+</body>
+</html>`;
+}
+
+export function renderReportText(report: Readonly<GeneratedReport>): string {
+  const sections = report.sections
+    .map(
+      (section) =>
+        `${section.title}\n${"-".repeat(section.title.length)}\n${contentToText(section.content)}`,
+    )
+    .join("\n\n");
+  return `${report.title}
+Generated: ${toIso(report.generatedAt)}
+Period: ${toIso(report.periodStart)} — ${toIso(report.periodEnd)}
+
+${sections}
+`;
+}
+
+export function renderReportJson(report: Readonly<GeneratedReport>): string {
+  return JSON.stringify(report, null, 2);
+}
+
+function renderSection(section: Readonly<GeneratedSection>): string {
+  return `<section>
+<h2>${escapeHtml(section.title)}</h2>
+${renderContent(section.content)}
+</section>`;
+}
+
+function renderContent(content: ReportContent): string {
+  if (Array.isArray(content)) return renderTable(content);
+  if (content !== null && typeof content === "object") {
+    return `<pre>${escapeHtml(JSON.stringify(content, null, 2))}</pre>`;
+  }
+  return `<pre>${escapeHtml(content ?? "")}</pre>`;
+}
+
+function renderTable(
+  rows: readonly Readonly<Record<string, unknown>>[],
+): string {
+  if (rows.length === 0) return "<p>No data</p>";
+  const headers = [...new Set(rows.flatMap((row) => Object.keys(row)))].sort();
+  return `<table>
+<thead><tr>${headers.map((header) => `<th>${escapeHtml(header)}</th>`).join("")}</tr></thead>
+<tbody>${rows
+    .map(
+      (row) =>
+        `<tr>${headers
+          .map((header) => `<td>${escapeHtml(formatCell(row[header]))}</td>`)
+          .join("")}</tr>`,
+    )
+    .join("")}</tbody>
+</table>`;
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return typeof value === "object" ? JSON.stringify(value) : String(value);
+}
+
+function contentToText(content: ReportContent): string {
+  if (typeof content === "string") return content;
+  return JSON.stringify(content, null, 2);
+}
+
+function toIso(timestamp: number): string {
+  return new Date(timestamp).toISOString();
+}

--- a/server/services/reporting/scheduler.ts
+++ b/server/services/reporting/scheduler.ts
@@ -1,0 +1,29 @@
+import type {
+  ReportScheduler,
+  ScheduledHandle,
+  Sleeper,
+} from "./types";
+
+export class IntervalReportScheduler implements ReportScheduler {
+  every(
+    _id: string,
+    intervalMs: number,
+    task: () => void | Promise<void>,
+  ): ScheduledHandle {
+    const timer = setInterval(() => {
+      void task();
+    }, intervalMs);
+    timer.unref?.();
+    return {
+      cancel: () => clearInterval(timer),
+    };
+  }
+}
+
+export const timerSleeper: Sleeper = Object.freeze({
+  sleep: (milliseconds: number) =>
+    new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, milliseconds);
+      timer.unref?.();
+    }),
+});

--- a/server/services/reporting/templates.ts
+++ b/server/services/reporting/templates.ts
@@ -1,0 +1,85 @@
+import type { ReportTemplate } from "./types";
+
+/**
+ * Built-ins are data/query declarations, not HTML fragments.  All content
+ * therefore passes through the same escaping renderer as custom templates.
+ */
+export const BUILT_IN_TEMPLATES: readonly ReportTemplate[] = Object.freeze([
+  Object.freeze({
+    id: "shift-summary",
+    name: "Shift Summary Report",
+    type: "shift-summary",
+    sections: Object.freeze([
+      Object.freeze({
+        id: "overview",
+        title: "Shift Overview",
+        type: "summary",
+        query: "*",
+      }),
+      Object.freeze({
+        id: "alarms",
+        title: "Alarm Summary",
+        type: "alarm-list",
+      }),
+      Object.freeze({
+        id: "kpis",
+        title: "Key Performance Indicators",
+        type: "kpi",
+        kpis: Object.freeze(["oee", "throughput", "quality"]),
+      }),
+      Object.freeze({
+        id: "notes",
+        title: "Operator Notes",
+        type: "notes",
+        query: "shift",
+      }),
+    ]),
+  }),
+  Object.freeze({
+    id: "compliance-audit",
+    name: "Compliance Summary Report",
+    type: "compliance-audit",
+    sections: Object.freeze([
+      Object.freeze({
+        id: "compliance",
+        title: "Control Compliance",
+        type: "compliance",
+      }),
+      Object.freeze({
+        id: "exceptions",
+        title: "Alarm and Exception Evidence",
+        type: "alarm-list",
+      }),
+      Object.freeze({
+        id: "process-summary",
+        title: "Process Data Coverage",
+        type: "summary",
+        query: "*",
+      }),
+    ]),
+  }),
+  Object.freeze({
+    id: "trend-analysis",
+    name: "Trend Analysis Report",
+    type: "trend-analysis",
+    sections: Object.freeze([
+      Object.freeze({
+        id: "statistics",
+        title: "Statistical Summary",
+        type: "statistics",
+        query: "*",
+      }),
+      Object.freeze({
+        id: "trends",
+        title: "Historical Trend Data",
+        type: "trend-data",
+        query: "*",
+      }),
+      Object.freeze({
+        id: "anomalies",
+        title: "Alarms During Period",
+        type: "alarm-list",
+      }),
+    ]),
+  }),
+] satisfies ReportTemplate[]);

--- a/server/services/reporting/types.ts
+++ b/server/services/reporting/types.ts
@@ -1,0 +1,219 @@
+/**
+ * Public contracts for the ADR-0013 intelligent reporting engine.
+ */
+
+export type ReportType = "shift-summary" | "compliance-audit" | "trend-analysis" | "custom";
+
+export type OutputFormat = "html" | "json" | "text";
+export type DeliveryMethod = "webhook" | "email";
+
+export interface ReportClock {
+  now(): number;
+}
+
+export const systemReportClock: ReportClock = Object.freeze({
+  now: () => Date.now(),
+});
+
+export interface ReportPeriod {
+  start: number;
+  end: number;
+}
+
+export interface HistoricalPoint {
+  timestamp: number;
+  value: number;
+  quality?: "good" | "uncertain" | "bad";
+}
+
+export interface HistoricalAlarm {
+  id?: string;
+  tag: string;
+  severity: string;
+  message: string;
+  timestamp: number;
+  acknowledged?: boolean;
+}
+
+export interface ComplianceEvent {
+  control: string;
+  status: "pass" | "fail" | "warning";
+  detail: string;
+  timestamp: number;
+  evidenceId?: string;
+}
+
+export interface HistoricalDataProvider {
+  querySeries(
+    pattern: string,
+    period: ReportPeriod,
+  ): Promise<Record<string, readonly HistoricalPoint[]>>;
+  queryAlarms(period: ReportPeriod): Promise<readonly HistoricalAlarm[]>;
+  queryKPIs(
+    names: readonly string[],
+    period: ReportPeriod,
+  ): Promise<Record<string, number | string | null>>;
+  queryCompliance(period: ReportPeriod): Promise<readonly ComplianceEvent[]>;
+  queryNotes?(kind: string, period: ReportPeriod): Promise<readonly string[]>;
+}
+
+/** Adapter shape supported for callers of the original issue prototype. */
+export interface LegacyDataProvider {
+  queryTags(pattern: string, start: number, end: number): Promise<Record<string, number[]>>;
+  queryAlarms(
+    start: number,
+    end: number,
+  ): Promise<
+    Array<{
+      tag: string;
+      severity: string;
+      message: string;
+      timestamp: number;
+    }>
+  >;
+  queryKPIs(names: string[]): Promise<Record<string, number>>;
+}
+
+export type ReportSectionKind =
+  "summary" | "alarm-list" | "kpi" | "statistics" | "trend-data" | "compliance" | "notes" | "text";
+
+export interface ReportSection {
+  id: string;
+  title: string;
+  type: ReportSectionKind;
+  query?: string;
+  /** Compatibility alias used by the original issue prototype. */
+  dataQuery?: string;
+  kpis?: readonly string[];
+  text?: string;
+}
+
+export interface DeliveryConfig {
+  method: DeliveryMethod;
+  target: string;
+  headers?: Readonly<Record<string, string>>;
+  subject?: string;
+}
+
+export interface ReportTemplate {
+  id: string;
+  name: string;
+  type: ReportType;
+  sections: readonly ReportSection[];
+  delivery?: readonly DeliveryConfig[];
+}
+
+export type ReportContent =
+  | string
+  | number
+  | boolean
+  | null
+  | Readonly<Record<string, unknown>>
+  | readonly Readonly<Record<string, unknown>>[];
+
+export interface GeneratedSection {
+  id: string;
+  title: string;
+  type: ReportSectionKind;
+  content: ReportContent;
+}
+
+export interface GeneratedReport {
+  id: string;
+  templateId: string;
+  type: ReportType;
+  title: string;
+  generatedAt: number;
+  periodStart: number;
+  periodEnd: number;
+  sections: readonly GeneratedSection[];
+  format: OutputFormat;
+}
+
+export interface DeliveryPayload {
+  /** Stable across every retry of this delivery operation. */
+  deliveryId: string;
+  report: Readonly<GeneratedReport>;
+  target: string;
+  subject: string;
+  headers: Readonly<Record<string, string>>;
+  html: string;
+  text: string;
+  json: string;
+}
+
+export interface DeliveryReceipt {
+  providerId?: string;
+  statusCode?: number;
+}
+
+export interface DeliveryChannel {
+  readonly method: DeliveryMethod;
+  send(payload: DeliveryPayload): Promise<DeliveryReceipt>;
+}
+
+export interface RetryPolicy {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export interface Sleeper {
+  sleep(milliseconds: number): Promise<void>;
+}
+
+export type DeliveryState = "delivered" | "failed";
+
+export interface DeliveryAttempt {
+  attempt: number;
+  startedAt: number;
+  completedAt: number;
+  state: DeliveryState;
+  error?: string;
+  retryable?: boolean;
+  statusCode?: number;
+}
+
+export interface DeliveryStatus {
+  id: string;
+  reportId: string;
+  method: DeliveryMethod;
+  target: string;
+  state: DeliveryState;
+  attempts: readonly DeliveryAttempt[];
+  deliveredAt?: number;
+  providerId?: string;
+  error?: string;
+}
+
+export interface ScheduledHandle {
+  cancel(): void;
+}
+
+export interface ReportScheduler {
+  every(id: string, intervalMs: number, task: () => void | Promise<void>): ScheduledHandle;
+}
+
+export interface ReportSchedule {
+  id: string;
+  templateId: string;
+  intervalMs: number;
+  lookbackMs: number;
+  format?: OutputFormat;
+  deliveries?: readonly DeliveryConfig[];
+}
+
+export interface ReportScheduleStatus {
+  id: string;
+  templateId: string;
+  active: boolean;
+  running: boolean;
+  runCount: number;
+  skippedOverlaps: number;
+  consecutiveFailures: number;
+  lastStartedAt?: number;
+  lastCompletedAt?: number;
+  lastReportId?: string;
+  lastDeliveryIds: readonly string[];
+  lastError?: string;
+}


### PR DESCRIPTION
## Summary

- Adds shift-summary, compliance-audit, trend-analysis, and custom report templates over injected historical data.
- Renders HTML, JSON, and text safely, including contextual HTML escaping.
- Adds injectable scheduling plus webhook and email delivery with retry, idempotency, and delivery status tracking.
- Adds a service export, compatibility entry point, focused tests, and operator documentation.

## Why

The repository lacked an executable reporting subsystem for ADR-0013. This implementation provides a standalone engine while keeping the historian, scheduler, sleeper, and delivery transports deployment-owned and testable.

## Validation

- `npm test -- --run server/services/reporting/__tests__/reporting.test.ts` — 12 tests passed
- `npm run typecheck`
- `npm run build`
- `git diff --check origin/main..HEAD`

Closes #219
