### PR TITLE
Add horizontal scaling architecture

### DIFF
--- a/docs/architecture/horizontal-scaling.md
+++ b/docs/architecture/horizontal-scaling.md
@@ -27,6 +27,21 @@ The implementation depends only on the shared deterministic hashing helpers in
 their database and NATS/Kafka clients; no network or storage implementation is
 silently selected by this module.
 
+`server/scaling/horizontal-runtime.ts` makes those bindings reachable from the
+running server. Enable it with:
+
+```text
+HORIZONTAL_SCALING_ENABLED=true
+HORIZONTAL_SCALING_REQUIRED=true
+HORIZONTAL_SCALING_BINDINGS_MODULE=/absolute/path/to/horizontal-bindings.mjs
+```
+
+The module may export `createHorizontalScaleBindings`,
+`horizontalScaleBindings`, or a default bindings object. Startup validates all
+four services before accepting traffic and fails closed when an enabled binding
+is incomplete. `/health` exposes the binding health and can make it
+readiness-critical with `HORIZONTAL_SCALING_REQUIRED=true`.
+
 Changing ring membership is a control-plane operation. Capture the current
 assignment, change membership, call `rebalance(tags, oldAssignment)`, move the
 listed tags, and only then publish the new ring generation. Two generations
@@ -38,6 +53,7 @@ Run:
 
 ```bash
 npx vitest run server/scaling/__tests__/horizontal.test.ts
+npx vitest run server/scaling/__tests__/horizontal-runtime.test.ts
 npm run typecheck
 npm run build
 ```

--- a/docs/architecture/horizontal-scaling.md
+++ b/docs/architecture/horizontal-scaling.md
@@ -1,0 +1,47 @@
+# Horizontal scaling architecture
+
+This document is the executable companion to
+[ADR-0014](../decisions/ADR-0014-production-scale-architecture.md) for issue
+[#222](https://github.com/NickFlach/0xSCADA/issues/222).
+
+`server/scaling/horizontal.ts` provides four independently bindable runtime
+primitives:
+
+- `ConsistentHashRing` assigns gateways with configurable virtual nodes and
+  produces explicit `rebalance()` plans. Ring construction and ownership are
+  deterministic across processes. Adding a node moves only keys assigned to
+  that node; removing a node moves only keys owned by the removed node.
+- `ServerLoadBalancer` implements round-robin, smooth weighted round-robin,
+  and weight-normalized least-connections. `acquire()` returns an idempotent
+  lease so connection accounting cannot be decremented twice.
+- `PartitionedHistorian` routes writes by stable tag hash, groups tag-filtered
+  reads by partition, federates unfiltered reads, sorts the result, and reports
+  unavailable partitions instead of returning a complete-looking partial
+  result.
+- `PartitionedEventFanout` preserves publication order within each topic
+  partition, fans out to every eligible subscriber, and reports consumer
+  failures individually.
+
+The implementation depends only on the shared deterministic hashing helpers in
+`server/scaling/hash.ts`. Deployments bind the historian and event interfaces to
+their database and NATS/Kafka clients; no network or storage implementation is
+silently selected by this module.
+
+Changing ring membership is a control-plane operation. Capture the current
+assignment, change membership, call `rebalance(tags, oldAssignment)`, move the
+listed tags, and only then publish the new ring generation. Two generations
+must not write the same historian tag concurrently.
+
+## Verification
+
+Run:
+
+```bash
+npx vitest run server/scaling/__tests__/horizontal.test.ts
+npm run typecheck
+npm run build
+```
+
+The focused suite covers deterministic assignment, membership churn, every
+load-balancing mode, historian partial failures, ordered partition fan-out,
+idempotent leases, and duplicate-node rejection.

--- a/server/__tests__/startup-singleton-imports.test.ts
+++ b/server/__tests__/startup-singleton-imports.test.ts
@@ -57,6 +57,7 @@ describe("startup singleton module identity", () => {
         "./services/flux",
         "./services/nats",
         "./bridge/anchor-backend",
+        "./scaling/horizontal-runtime",
       ],
     },
     {
@@ -65,6 +66,7 @@ describe("startup singleton module identity", () => {
         "../simulator",
         "../gateway/store-and-forward",
         "../bridge",
+        "../scaling/horizontal-runtime",
       ],
     },
     {

--- a/server/health/index.ts
+++ b/server/health/index.ts
@@ -28,6 +28,7 @@ import type { Response } from 'express';
 // applied only by an explicit `applyScheduler()` call from a composition root
 // that owns a dedicated control process (see server/blueprint/scheduler.ts).
 import { createSchedulerCheck, exposeBlueprintMetrics } from '../blueprint';
+import { horizontalScaleRuntime } from '../scaling/horizontal-runtime';
 
 // Control-loop latency telemetry (#460): publish the sentinel probe's liveness
 // gauge as part of normal server composition so `scada_control_loop_probe_up`
@@ -138,6 +139,25 @@ healthManager.registerSimple(
   },
   true, // Required for edge deployments
 );
+
+healthManager.register({
+  name: 'horizontal-scaling',
+  required: horizontalScaleRuntime.isRequired(),
+  check: async () => {
+    const health = await horizontalScaleRuntime.health();
+    return {
+      name: 'horizontal-scaling',
+      status: health.healthy
+        ? health.degraded
+          ? 'degraded'
+          : 'healthy'
+        : 'unhealthy',
+      lastCheck: new Date(),
+      message: health.message,
+      details: health.details ? { ...health.details } : undefined,
+    };
+  },
+});
 
 // 8. Bridge modules (event-anchor, state-sync)
 healthManager.registerSimple(

--- a/server/index.ts
+++ b/server/index.ts
@@ -26,6 +26,7 @@ import { blueprintSafetyHost } from "./blueprint/safety-host";
 // Observed-liveness collector (#456). Off unless
 // VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true and ANCHOR_NODE_URLS is set.
 import { startValidatorLivenessCollector } from "./blockchain/liveness-collector";
+import { horizontalScaleRuntime } from "./scaling/horizontal-runtime";
 
 // Re-export log for backward compatibility
 export { log } from "./logger";
@@ -89,6 +90,13 @@ registerSwaggerRoutes(app, gatewayConfig);
   
   await initializeDefaultAgents();
   await startDefaultAgents();
+
+  // Bind real historian, gateway, load-balancer, and event-bus adapters before
+  // accepting traffic. An enabled but incomplete deployment fails startup.
+  await horizontalScaleRuntime.initialize();
+  if (horizontalScaleRuntime.isEnabled()) {
+    log("Horizontal scaling runtime initialized");
+  }
   
   // Initialize edge store-and-forward service
   await storeAndForwardService.initialize();

--- a/server/scaling/__tests__/horizontal-runtime.test.ts
+++ b/server/scaling/__tests__/horizontal-runtime.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  ConsistentHashRing,
+  PartitionedEventFanout,
+  PartitionedHistorian,
+  ServerLoadBalancer,
+} from "../horizontal";
+import {
+  HorizontalScaleRuntime,
+  type HorizontalScaleBindings,
+} from "../horizontal-runtime";
+
+function bindings(): HorizontalScaleBindings {
+  return {
+    gatewayRing: new ConsistentHashRing([{ id: "gateway-a" }]),
+    loadBalancer: new ServerLoadBalancer([{ id: "api-a" }]),
+    historian: new PartitionedHistorian([
+      {
+        id: "history-a",
+        write: async () => undefined,
+        query: async () => [],
+      },
+    ]),
+    eventFanout: new PartitionedEventFanout(2),
+    healthCheck: async () => ({
+      healthy: true,
+      details: { generation: 4 },
+    }),
+  };
+}
+
+describe("horizontal scaling production runtime", () => {
+  it("binds production adapters and exposes their health", async () => {
+    const runtime = new HorizontalScaleRuntime();
+    runtime.configure(bindings());
+    await runtime.initialize();
+
+    expect(runtime.isInitialized()).toBe(true);
+    expect(runtime.bindings().gatewayRing.owner("site/tag")).toBe("gateway-a");
+    await expect(runtime.health()).resolves.toEqual({
+      healthy: true,
+      details: { generation: 4 },
+    });
+  });
+
+  it("fails closed when any required production adapter is missing", () => {
+    const incomplete = bindings() as unknown as Record<string, unknown>;
+    delete incomplete.historian;
+    expect(() =>
+      new HorizontalScaleRuntime().configure(
+        incomplete as unknown as HorizontalScaleBindings,
+      ),
+    ).toThrow(/partitioned historian/);
+  });
+
+  it("turns binding health exceptions into unhealthy status", async () => {
+    const runtime = new HorizontalScaleRuntime();
+    runtime.configure({
+      ...bindings(),
+      healthCheck: () => {
+        throw new Error("message bus unavailable");
+      },
+    });
+    await runtime.initialize();
+    await expect(runtime.health()).resolves.toMatchObject({
+      healthy: false,
+      message: "message bus unavailable",
+    });
+  });
+});

--- a/server/scaling/__tests__/horizontal.test.ts
+++ b/server/scaling/__tests__/horizontal.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ConsistentHashRing,
+  PartitionedEventFanout,
+  PartitionedHistorian,
+  ServerLoadBalancer,
+  type HistorianPartition,
+  type HistorianPoint,
+  type HistorianQuery,
+} from "../horizontal";
+
+describe("horizontal scaling primitives (#222)", () => {
+  it("rebalances a consistent-hash ring with minimal movement on join/leave", () => {
+    const tags = Array.from({ length: 2_000 }, (_, index) => `site:area/tag-${index}`);
+    const ring = new ConsistentHashRing([{ id: "gw-a" }, { id: "gw-b" }], 128);
+    const original = ring.assign(tags);
+
+    ring.add({ id: "gw-c" });
+    const joined = ring.rebalance(tags, original);
+    expect(joined.length).toBeGreaterThan(0);
+    expect(joined.length).toBeLessThan(tags.length * 0.5);
+    expect(joined.every((change) => change.to === "gw-c")).toBe(true);
+
+    const withThird = ring.assign(tags);
+    ring.remove("gw-c");
+    const left = ring.rebalance(tags, withThird);
+    expect(left.length).toBeGreaterThan(0);
+    expect(left.every((change) => change.from === "gw-c")).toBe(true);
+    expect(ring.assign(tags)).toEqual(original);
+  });
+
+  it("is deterministic regardless of node insertion order", () => {
+    const first = new ConsistentHashRing(
+      [{ id: "gw-c" }, { id: "gw-a" }, { id: "gw-b" }],
+      32,
+    );
+    const second = new ConsistentHashRing(
+      [{ id: "gw-b" }, { id: "gw-c" }, { id: "gw-a" }],
+      32,
+    );
+    const keys = Array.from({ length: 100 }, (_, index) => `tag-${index}`);
+    expect(first.assign(keys)).toEqual(second.assign(keys));
+  });
+
+  it("supports round-robin, weighted, and least-connections selection", () => {
+    const roundRobin = new ServerLoadBalancer([
+      { id: "a" },
+      { id: "b", healthy: false },
+      { id: "c" },
+    ]);
+    const rr = Array.from({ length: 4 }, () => {
+      const lease = roundRobin.acquire();
+      const id = lease.target.id;
+      lease.release();
+      lease.release();
+      return id;
+    });
+    expect(rr).toEqual(["a", "c", "a", "c"]);
+    expect(roundRobin.snapshot().map((target) => target.activeConnections)).toEqual([
+      0,
+      0,
+      0,
+    ]);
+
+    const weighted = new ServerLoadBalancer(
+      [
+        { id: "a", weight: 1 },
+        { id: "b", weight: 2 },
+      ],
+      "weighted",
+    );
+    const weightedIds = Array.from({ length: 6 }, () => {
+      const lease = weighted.acquire();
+      lease.release();
+      return lease.target.id;
+    });
+    expect(weightedIds.filter((id) => id === "a")).toHaveLength(2);
+    expect(weightedIds.filter((id) => id === "b")).toHaveLength(4);
+
+    const least = new ServerLoadBalancer(
+      [
+        { id: "small", weight: 1, activeConnections: 2 },
+        { id: "large", weight: 4, activeConnections: 4 },
+      ],
+      "least-connections",
+    );
+    expect(least.acquire().target.id).toBe("large");
+  });
+
+  it("keeps active leases attached when a target is refreshed", () => {
+    const balancer = new ServerLoadBalancer(
+      [{ id: "api-a", weight: 1 }],
+      "least-connections",
+    );
+    const lease = balancer.acquire();
+
+    balancer.upsert({ id: "api-a", weight: 4, healthy: true });
+    lease.release();
+
+    expect(balancer.snapshot()).toEqual([
+      {
+        id: "api-a",
+        weight: 4,
+        healthy: true,
+        activeConnections: 0,
+      },
+    ]);
+    expect(() =>
+      balancer.upsert({ id: "api-a", activeConnections: -1 }),
+    ).toThrow(/non-negative integer/);
+  });
+
+  it("routes historian writes and federates sorted reads with explicit failures", async () => {
+    const partitions = ["a", "b", "c"].map(
+      (id): HistorianPartition & { writes: HistorianPoint[]; querySpy: ReturnType<typeof vi.fn> } => {
+        const writes: HistorianPoint[] = [];
+        const querySpy = vi.fn(async (_query: HistorianQuery) => writes);
+        return {
+          id,
+          writes,
+          querySpy,
+          async write(point) {
+            writes.push(point);
+          },
+          query: querySpy,
+        };
+      },
+    );
+    const historian = new PartitionedHistorian(partitions);
+    const first = {
+      tag: "area/temp",
+      timestamp: new Date("2026-01-01T00:00:02Z"),
+      value: 20,
+    };
+    const second = {
+      tag: "area/pressure",
+      timestamp: new Date("2026-01-01T00:00:01Z"),
+      value: 4,
+    };
+    await historian.write(first);
+    await historian.write(second);
+
+    const routed = historian.route(first.tag);
+    expect(partitions.find((partition) => partition.id === routed.id)!.writes).toContain(first);
+    const selected = await historian.query({
+      from: new Date("2026-01-01T00:00:00Z"),
+      to: new Date("2026-01-01T00:01:00Z"),
+      tags: [first.tag],
+    });
+    expect(selected.failures).toEqual([]);
+    expect(partitions.filter((partition) => partition.querySpy.mock.calls.length)).toHaveLength(1);
+
+    partitions.forEach((partition) => partition.querySpy.mockClear());
+    partitions[1].querySpy.mockRejectedValueOnce(new Error("shard unavailable"));
+    const federated = await historian.query({
+      from: new Date("2026-01-01T00:00:00Z"),
+      to: new Date("2026-01-01T00:01:00Z"),
+    });
+    expect(federated.points.map((point) => point.timestamp.toISOString())).toEqual(
+      [...federated.points]
+        .sort((left, right) => left.timestamp.getTime() - right.timestamp.getTime())
+        .map((point) => point.timestamp.toISOString()),
+    );
+    expect(federated.failures).toEqual([
+      { partitionId: "b", error: "shard unavailable" },
+    ]);
+  });
+
+  it("moves historian tags only to a joining partition during scale-out", () => {
+    const partition = (id: string): HistorianPartition => ({
+      id,
+      write: async () => undefined,
+      query: async () => [],
+    });
+    const before = new PartitionedHistorian([partition("a"), partition("b")]);
+    const after = new PartitionedHistorian([
+      partition("a"),
+      partition("b"),
+      partition("c"),
+    ]);
+    const tags = Array.from({ length: 1_000 }, (_, index) => `tag-${index}`);
+    const changes = tags.filter(
+      (tag) => before.route(tag).id !== after.route(tag).id,
+    );
+    expect(changes.length).toBeGreaterThan(0);
+    expect(changes.length).toBeLessThan(tags.length * 0.5);
+    expect(changes.every((tag) => after.route(tag).id === "c")).toBe(true);
+  });
+
+  it("fans out only to a key's partition and isolates subscriber failures", async () => {
+    const bus = new PartitionedEventFanout(8);
+    const partition = bus.partitionFor("tag-7");
+    const delivered: string[] = [];
+    bus.subscribe(
+      "telemetry",
+      "partition-owner",
+      async () => {
+        delivered.push("partition-owner");
+      },
+      [partition],
+    );
+    bus.subscribe(
+      "telemetry",
+      "other-partition",
+      async () => {
+        delivered.push("other");
+      },
+      [(partition + 1) % 8],
+    );
+    bus.subscribe("telemetry", "failed-replica", async () => {
+      throw new Error("consumer stopped");
+    });
+
+    const receipt = await bus.publish({
+      topic: "telemetry",
+      key: "tag-7",
+      payload: { value: 42 },
+    });
+    expect(delivered).toEqual(["partition-owner"]);
+    expect(receipt).toEqual({
+      partition,
+      delivered: 1,
+      failures: [
+        { subscriberId: "failed-replica", error: "consumer stopped" },
+      ],
+    });
+  });
+
+  it("preserves publish order within a topic partition", async () => {
+    const bus = new PartitionedEventFanout(1);
+    const seen: number[] = [];
+    let releaseFirst!: () => void;
+    let markEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      markEntered = resolve;
+    });
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    bus.subscribe("events", "ordered-consumer", async (event) => {
+      const sequence = (event.payload as { sequence: number }).sequence;
+      seen.push(sequence);
+      if (sequence === 1) {
+        markEntered();
+        await firstGate;
+      }
+    });
+    const first = bus.publish({
+      topic: "events",
+      key: "same-partition",
+      payload: { sequence: 1 },
+    });
+    await entered;
+    const second = bus.publish({
+      topic: "events",
+      key: "same-partition",
+      payload: { sequence: 2 },
+    });
+    await Promise.resolve();
+    expect(seen).toEqual([1]);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(seen).toEqual([1, 2]);
+  });
+});

--- a/server/scaling/hash.ts
+++ b/server/scaling/hash.ts
@@ -1,0 +1,68 @@
+import { createHash } from "node:crypto";
+
+/**
+ * JSON encoding with recursively sorted object keys. Distributed peers use this
+ * before hashing so insertion order cannot change an integrity result.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === undefined) {
+    return "null";
+  }
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (value instanceof Date) {
+    return JSON.stringify(value.toISOString());
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, child]) => child !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries
+    .map(([key, child]) => `${JSON.stringify(key)}:${canonicalJson(child)}`)
+    .join(",")}}`;
+}
+
+export function sha256Hex(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/** A stable unsigned 64-bit hash suitable for rings and rollout buckets. */
+export function hash64(value: string): bigint {
+  return BigInt(`0x${sha256Hex(value).slice(0, 16)}`);
+}
+
+/**
+ * RFC-6962-style binary Merkle root. Leaves and branches are domain separated
+ * so a leaf cannot be confused with an internal node.
+ */
+export function merkleRoot(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    return sha256Hex(Buffer.from([0]));
+  }
+
+  let level = values.map((value) =>
+    sha256Hex(Buffer.concat([Buffer.from([0]), Buffer.from(canonicalJson(value))])),
+  );
+  while (level.length > 1) {
+    const next: string[] = [];
+    for (let index = 0; index < level.length; index += 2) {
+      const left = level[index];
+      const right = level[index + 1] ?? left;
+      next.push(
+        sha256Hex(
+          Buffer.concat([
+            Buffer.from([1]),
+            Buffer.from(left, "hex"),
+            Buffer.from(right, "hex"),
+          ]),
+        ),
+      );
+    }
+    level = next;
+  }
+  return level[0];
+}

--- a/server/scaling/horizontal-runtime.ts
+++ b/server/scaling/horizontal-runtime.ts
@@ -1,0 +1,170 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  ConsistentHashRing,
+  PartitionedEventFanout,
+  PartitionedHistorian,
+  ServerLoadBalancer,
+} from "./horizontal";
+
+export interface HorizontalRuntimeHealth {
+  healthy: boolean;
+  degraded?: boolean;
+  message?: string;
+  details?: Readonly<Record<string, unknown>>;
+}
+
+export interface HorizontalScaleBindings {
+  gatewayRing: ConsistentHashRing;
+  loadBalancer: ServerLoadBalancer;
+  historian: PartitionedHistorian;
+  eventFanout: PartitionedEventFanout;
+  healthCheck: () =>
+    | HorizontalRuntimeHealth
+    | Promise<HorizontalRuntimeHealth>;
+}
+
+export interface HorizontalScaleFactories {
+  ConsistentHashRing: typeof ConsistentHashRing;
+  ServerLoadBalancer: typeof ServerLoadBalancer;
+  PartitionedHistorian: typeof PartitionedHistorian;
+  PartitionedEventFanout: typeof PartitionedEventFanout;
+}
+
+interface BindingsModule {
+  default?: HorizontalScaleBindings;
+  horizontalScaleBindings?: HorizontalScaleBindings;
+  createHorizontalScaleBindings?: (
+    factories: HorizontalScaleFactories,
+  ) => HorizontalScaleBindings | Promise<HorizontalScaleBindings>;
+}
+
+export const horizontalScaleFactories: HorizontalScaleFactories = {
+  ConsistentHashRing,
+  ServerLoadBalancer,
+  PartitionedHistorian,
+  PartitionedEventFanout,
+};
+
+/**
+ * Production composition root for horizontal scaling.
+ *
+ * Enabling the feature requires a deployment bindings module. Missing or
+ * incomplete database, message-bus, and health bindings stop startup rather
+ * than falling back to an in-memory topology.
+ */
+export class HorizontalScaleRuntime {
+  private configured?: HorizontalScaleBindings;
+  private initialized = false;
+  private enabledByConfiguration = false;
+
+  configure(bindings: HorizontalScaleBindings): void {
+    if (this.initialized) {
+      throw new Error("horizontal scaling runtime is already initialized");
+    }
+    validateBindings(bindings);
+    this.configured = bindings;
+    this.enabledByConfiguration = true;
+  }
+
+  isEnabled(): boolean {
+    return (
+      this.enabledByConfiguration ||
+      process.env.HORIZONTAL_SCALING_ENABLED === "true"
+    );
+  }
+
+  isRequired(): boolean {
+    return process.env.HORIZONTAL_SCALING_REQUIRED === "true";
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized || !this.isEnabled()) return;
+    const bindings = this.configured ?? (await this.loadBindingsModule());
+    validateBindings(bindings);
+    this.configured = bindings;
+    this.initialized = true;
+  }
+
+  bindings(): Readonly<HorizontalScaleBindings> {
+    if (!this.initialized || !this.configured) {
+      throw new Error("horizontal scaling runtime is not initialized");
+    }
+    return this.configured;
+  }
+
+  async health(): Promise<HorizontalRuntimeHealth> {
+    if (!this.isEnabled()) return { healthy: true, message: "disabled" };
+    if (!this.initialized || !this.configured) {
+      return { healthy: false, message: "enabled but not initialized" };
+    }
+    try {
+      return await this.configured.healthCheck();
+    } catch (error) {
+      return {
+        healthy: false,
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async loadBindingsModule(): Promise<HorizontalScaleBindings> {
+    const modulePath = process.env.HORIZONTAL_SCALING_BINDINGS_MODULE;
+    if (!modulePath) {
+      throw new Error(
+        "HORIZONTAL_SCALING_BINDINGS_MODULE is required when horizontal scaling is enabled",
+      );
+    }
+    const loaded = (await import(
+      pathToFileURL(resolve(modulePath)).href
+    )) as BindingsModule;
+    const bindings = loaded.createHorizontalScaleBindings
+      ? await loaded.createHorizontalScaleBindings(horizontalScaleFactories)
+      : loaded.horizontalScaleBindings ?? loaded.default;
+    if (!bindings) {
+      throw new Error(
+        "horizontal scaling bindings module must export createHorizontalScaleBindings, horizontalScaleBindings, or default",
+      );
+    }
+    return bindings;
+  }
+}
+
+function validateBindings(
+  bindings: HorizontalScaleBindings,
+): asserts bindings is HorizontalScaleBindings {
+  requireMethods(bindings?.gatewayRing, ["owner"], "gateway ring");
+  requireMethods(bindings?.loadBalancer, ["acquire"], "server load balancer");
+  requireMethods(bindings?.historian, ["write", "query"], "partitioned historian");
+  requireMethods(
+    bindings?.eventFanout,
+    ["publish", "subscribe"],
+    "partitioned event fan-out",
+  );
+  if (typeof bindings?.healthCheck !== "function") {
+    throw new Error("horizontal scaling binding requires a health check");
+  }
+}
+
+function requireMethods(
+  value: unknown,
+  methods: readonly string[],
+  name: string,
+): void {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    methods.some(
+      (method) =>
+        typeof (value as Record<string, unknown>)[method] !== "function",
+    )
+  ) {
+    throw new Error(`horizontal scaling bindings require ${name}`);
+  }
+}
+
+export const horizontalScaleRuntime = new HorizontalScaleRuntime();

--- a/server/scaling/horizontal.ts
+++ b/server/scaling/horizontal.ts
@@ -1,0 +1,543 @@
+import { hash64 } from "./hash";
+
+export interface RingNode {
+  id: string;
+  virtualNodes?: number;
+}
+
+export interface AssignmentChange {
+  key: string;
+  from?: string;
+  to: string;
+}
+
+interface RingPoint {
+  hash: bigint;
+  nodeId: string;
+  replica: number;
+}
+
+/**
+ * Consistent-hash ring used to assign tag namespaces to gateways. Adding or
+ * removing a node only moves keys whose clockwise owner changed.
+ */
+export class ConsistentHashRing {
+  private readonly nodes = new Map<string, Required<RingNode>>();
+  private points: RingPoint[] = [];
+
+  constructor(
+    nodes: readonly RingNode[] = [],
+    private readonly defaultVirtualNodes = 128,
+  ) {
+    if (!Number.isInteger(defaultVirtualNodes) || defaultVirtualNodes < 1) {
+      throw new Error("defaultVirtualNodes must be a positive integer");
+    }
+    for (const node of nodes) {
+      this.add(node);
+    }
+  }
+
+  add(node: RingNode): void {
+    if (!node.id.trim()) {
+      throw new Error("ring node id cannot be empty");
+    }
+    const virtualNodes = node.virtualNodes ?? this.defaultVirtualNodes;
+    if (!Number.isInteger(virtualNodes) || virtualNodes < 1) {
+      throw new Error(`virtualNodes for ${node.id} must be a positive integer`);
+    }
+    this.nodes.set(node.id, { id: node.id, virtualNodes });
+    this.rebuild();
+  }
+
+  remove(nodeId: string): boolean {
+    const removed = this.nodes.delete(nodeId);
+    if (removed) {
+      this.rebuild();
+    }
+    return removed;
+  }
+
+  nodeIds(): string[] {
+    return [...this.nodes.keys()].sort();
+  }
+
+  owner(key: string): string {
+    if (this.points.length === 0) {
+      throw new Error("cannot assign a key without gateway nodes");
+    }
+    const target = hash64(key);
+    let low = 0;
+    let high = this.points.length;
+    while (low < high) {
+      const middle = Math.floor((low + high) / 2);
+      if (this.points[middle].hash < target) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return this.points[low === this.points.length ? 0 : low].nodeId;
+  }
+
+  assign(keys: readonly string[]): Map<string, string> {
+    return new Map(keys.map((key) => [key, this.owner(key)]));
+  }
+
+  rebalance(
+    keys: readonly string[],
+    previous: ReadonlyMap<string, string>,
+  ): AssignmentChange[] {
+    const changes: AssignmentChange[] = [];
+    for (const key of keys) {
+      const to = this.owner(key);
+      const from = previous.get(key);
+      if (from !== to) {
+        changes.push(from === undefined ? { key, to } : { key, from, to });
+      }
+    }
+    return changes.sort((left, right) => left.key.localeCompare(right.key));
+  }
+
+  private rebuild(): void {
+    this.points = [];
+    for (const node of this.nodes.values()) {
+      for (let replica = 0; replica < node.virtualNodes; replica += 1) {
+        this.points.push({
+          hash: hash64(`${node.id}\0${replica}`),
+          nodeId: node.id,
+          replica,
+        });
+      }
+    }
+    this.points.sort(
+      (left, right) =>
+        Number(left.hash - right.hash) ||
+        left.nodeId.localeCompare(right.nodeId) ||
+        left.replica - right.replica,
+    );
+  }
+}
+
+export type LoadBalancingStrategy =
+  | "round-robin"
+  | "weighted"
+  | "least-connections";
+
+export interface LoadBalancedTarget {
+  id: string;
+  weight?: number;
+  healthy?: boolean;
+  activeConnections?: number;
+}
+
+export interface TargetLease {
+  target: Readonly<Required<LoadBalancedTarget>>;
+  release(): void;
+}
+
+interface TargetState extends Required<LoadBalancedTarget> {
+  currentWeight: number;
+}
+
+/**
+ * Server-side selector. `acquire` increments connection count and returns an
+ * idempotent lease so least-connections remains correct across failures.
+ */
+export class ServerLoadBalancer {
+  private readonly targets = new Map<string, TargetState>();
+  private roundRobinIndex = 0;
+
+  constructor(
+    targets: readonly LoadBalancedTarget[],
+    private strategy: LoadBalancingStrategy = "round-robin",
+  ) {
+    for (const target of targets) {
+      this.upsert(target);
+    }
+  }
+
+  setStrategy(strategy: LoadBalancingStrategy): void {
+    this.strategy = strategy;
+  }
+
+  upsert(target: LoadBalancedTarget): void {
+    const weight = target.weight ?? 1;
+    if (!target.id.trim()) {
+      throw new Error("load-balancer target id cannot be empty");
+    }
+    if (!Number.isFinite(weight) || weight <= 0) {
+      throw new Error(`weight for ${target.id} must be greater than zero`);
+    }
+    if (
+      target.activeConnections !== undefined &&
+      (!Number.isSafeInteger(target.activeConnections) ||
+        target.activeConnections < 0)
+    ) {
+      throw new Error(
+        `activeConnections for ${target.id} must be a non-negative integer`,
+      );
+    }
+    const previous = this.targets.get(target.id);
+    if (previous) {
+      // Leases retain this object by identity. Mutating it in place ensures a
+      // lease acquired before a health/weight refresh still decrements the
+      // live counter when it is released.
+      previous.weight = weight;
+      previous.healthy = target.healthy ?? previous.healthy;
+      if (target.activeConnections !== undefined) {
+        previous.activeConnections = target.activeConnections;
+      }
+      return;
+    }
+    this.targets.set(target.id, {
+      id: target.id,
+      weight,
+      healthy: target.healthy ?? true,
+      activeConnections: target.activeConnections ?? 0,
+      currentWeight: 0,
+    });
+  }
+
+  remove(targetId: string): boolean {
+    return this.targets.delete(targetId);
+  }
+
+  setHealthy(targetId: string, healthy: boolean): void {
+    this.required(targetId).healthy = healthy;
+  }
+
+  snapshot(): ReadonlyArray<Readonly<Required<LoadBalancedTarget>>> {
+    return [...this.targets.values()]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map(({ currentWeight: _ignored, ...target }) => ({ ...target }));
+  }
+
+  acquire(): TargetLease {
+    const target = this.select();
+    target.activeConnections += 1;
+    let released = false;
+    return {
+      target: this.publicTarget(target),
+      release: () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        target.activeConnections = Math.max(0, target.activeConnections - 1);
+      },
+    };
+  }
+
+  private select(): TargetState {
+    const healthy = [...this.targets.values()]
+      .filter((target) => target.healthy)
+      .sort((left, right) => left.id.localeCompare(right.id));
+    if (healthy.length === 0) {
+      throw new Error("no healthy load-balancer targets");
+    }
+
+    if (this.strategy === "least-connections") {
+      return healthy.reduce((best, candidate) => {
+        const bestLoad = best.activeConnections / best.weight;
+        const candidateLoad = candidate.activeConnections / candidate.weight;
+        return candidateLoad < bestLoad ? candidate : best;
+      });
+    }
+
+    if (this.strategy === "weighted") {
+      const totalWeight = healthy.reduce(
+        (total, target) => total + target.weight,
+        0,
+      );
+      for (const target of healthy) {
+        target.currentWeight += target.weight;
+      }
+      const selected = healthy.reduce((best, candidate) =>
+        candidate.currentWeight > best.currentWeight ? candidate : best,
+      );
+      selected.currentWeight -= totalWeight;
+      return selected;
+    }
+
+    const selected = healthy[this.roundRobinIndex % healthy.length];
+    this.roundRobinIndex = (this.roundRobinIndex + 1) % healthy.length;
+    return selected;
+  }
+
+  private required(targetId: string): TargetState {
+    const target = this.targets.get(targetId);
+    if (!target) {
+      throw new Error(`unknown load-balancer target: ${targetId}`);
+    }
+    return target;
+  }
+
+  private publicTarget(target: TargetState): Required<LoadBalancedTarget> {
+    return {
+      id: target.id,
+      weight: target.weight,
+      healthy: target.healthy,
+      activeConnections: target.activeConnections,
+    };
+  }
+}
+
+export interface HistorianPoint<T = unknown> {
+  tag: string;
+  timestamp: Date;
+  value: T;
+  quality?: string;
+}
+
+export interface HistorianQuery {
+  from: Date;
+  to: Date;
+  tags?: readonly string[];
+}
+
+export interface HistorianPartition {
+  id: string;
+  write(point: HistorianPoint): Promise<void>;
+  query(query: HistorianQuery): Promise<readonly HistorianPoint[]>;
+}
+
+export interface FederatedHistorianResult {
+  points: HistorianPoint[];
+  failures: Array<{ partitionId: string; error: string }>;
+}
+
+/**
+ * Partitions historian writes by tag hash and federates reads across only the
+ * shards that can contain the requested tags. Partial failures are explicit.
+ */
+export class PartitionedHistorian {
+  private readonly partitions: readonly HistorianPartition[];
+  private readonly partitionsById: ReadonlyMap<string, HistorianPartition>;
+  private readonly ring: ConsistentHashRing;
+
+  constructor(partitions: readonly HistorianPartition[]) {
+    if (partitions.length === 0) {
+      throw new Error("at least one historian partition is required");
+    }
+    const ids = new Set(partitions.map((partition) => partition.id));
+    if (ids.size !== partitions.length) {
+      throw new Error("historian partition ids must be unique");
+    }
+    this.partitions = [...partitions].sort((left, right) =>
+      left.id.localeCompare(right.id),
+    );
+    this.partitionsById = new Map(
+      this.partitions.map((partition) => [partition.id, partition]),
+    );
+    this.ring = new ConsistentHashRing(
+      this.partitions.map((partition) => ({ id: partition.id })),
+    );
+  }
+
+  route(tag: string): HistorianPartition {
+    return this.partitionsById.get(this.ring.owner(tag))!;
+  }
+
+  async write(point: HistorianPoint): Promise<string> {
+    const partition = this.route(point.tag);
+    await partition.write(point);
+    return partition.id;
+  }
+
+  async query(query: HistorianQuery): Promise<FederatedHistorianResult> {
+    if (query.to < query.from) {
+      throw new Error("historian query end must not precede start");
+    }
+    const candidates: Array<{
+      partition: HistorianPartition;
+      query: HistorianQuery;
+    }> = [];
+    if (query.tags?.length) {
+      const grouped = new Map<
+        string,
+        { partition: HistorianPartition; tags: string[] }
+      >();
+      for (const tag of [...new Set(query.tags)]) {
+        const partition = this.route(tag);
+        const group = grouped.get(partition.id) ?? { partition, tags: [] };
+        group.tags.push(tag);
+        grouped.set(partition.id, group);
+      }
+      for (const group of [...grouped.values()].sort((left, right) =>
+        left.partition.id.localeCompare(right.partition.id),
+      )) {
+        candidates.push({
+          partition: group.partition,
+          query: { ...query, tags: group.tags.sort() },
+        });
+      }
+    } else {
+      candidates.push(
+        ...this.partitions.map((partition) => ({ partition, query })),
+      );
+    }
+    const settled = await Promise.allSettled(
+      candidates.map((candidate) =>
+        Promise.resolve().then(() =>
+          candidate.partition.query(candidate.query),
+        ),
+      ),
+    );
+    const points: HistorianPoint[] = [];
+    const failures: FederatedHistorianResult["failures"] = [];
+    settled.forEach((result, index) => {
+      if (result.status === "fulfilled") {
+        points.push(...result.value);
+      } else {
+        failures.push({
+          partitionId: candidates[index].partition.id,
+          error: errorMessage(result.reason),
+        });
+      }
+    });
+    points.sort(
+      (left, right) =>
+        left.timestamp.getTime() - right.timestamp.getTime() ||
+        left.tag.localeCompare(right.tag),
+    );
+    return { points, failures };
+  }
+}
+
+export interface PartitionedEvent<T = unknown> {
+  topic: string;
+  key: string;
+  payload: T;
+}
+
+export type PartitionHandler<T = unknown> = (
+  event: PartitionedEvent<T>,
+  partition: number,
+) => void | Promise<void>;
+
+export interface FanoutReceipt {
+  partition: number;
+  delivered: number;
+  failures: Array<{ subscriberId: string; error: string }>;
+}
+
+interface Subscription {
+  id: string;
+  partitions?: ReadonlySet<number>;
+  handler: PartitionHandler;
+}
+
+/** In-process reference bus whose transport boundary can be replaced by NATS/Kafka. */
+export class PartitionedEventFanout {
+  private readonly subscriptions = new Map<string, Map<string, Subscription>>();
+  private readonly partitionTails = new Map<string, Promise<void>>();
+
+  constructor(readonly partitionCount: number) {
+    if (!Number.isInteger(partitionCount) || partitionCount < 1) {
+      throw new Error("partitionCount must be a positive integer");
+    }
+  }
+
+  partitionFor(key: string): number {
+    return Number(hash64(key) % BigInt(this.partitionCount));
+  }
+
+  subscribe(
+    topic: string,
+    subscriberId: string,
+    handler: PartitionHandler,
+    partitions?: readonly number[],
+  ): () => void {
+    if (!topic || !subscriberId) {
+      throw new Error("topic and subscriberId are required");
+    }
+    const selected = partitions
+      ? new Set(
+          partitions.map((partition) => {
+            if (
+              !Number.isInteger(partition) ||
+              partition < 0 ||
+              partition >= this.partitionCount
+            ) {
+              throw new Error(`invalid event partition: ${partition}`);
+            }
+            return partition;
+          }),
+        )
+      : undefined;
+    const byTopic =
+      this.subscriptions.get(topic) ?? new Map<string, Subscription>();
+    if (byTopic.has(subscriberId)) {
+      throw new Error(`duplicate subscriber ${subscriberId} for ${topic}`);
+    }
+    byTopic.set(subscriberId, {
+      id: subscriberId,
+      partitions: selected,
+      handler,
+    });
+    this.subscriptions.set(topic, byTopic);
+    return () => {
+      byTopic.delete(subscriberId);
+      if (byTopic.size === 0) {
+        this.subscriptions.delete(topic);
+      }
+    };
+  }
+
+  async publish<T>(event: PartitionedEvent<T>): Promise<FanoutReceipt> {
+    const partition = this.partitionFor(event.key);
+    const orderedKey = `${event.topic}\0${partition}`;
+    const previous = this.partitionTails.get(orderedKey) ?? Promise.resolve();
+    let receipt!: FanoutReceipt;
+    const delivery = previous.then(async () => {
+      receipt = await this.deliver(event, partition);
+    });
+    const tail = delivery.catch(() => undefined);
+    this.partitionTails.set(orderedKey, tail);
+    await delivery;
+    if (this.partitionTails.get(orderedKey) === tail) {
+      this.partitionTails.delete(orderedKey);
+    }
+    return receipt;
+  }
+
+  private async deliver<T>(
+    event: PartitionedEvent<T>,
+    partition: number,
+  ): Promise<FanoutReceipt> {
+    const subscriptions = [
+      ...(this.subscriptions.get(event.topic)?.values() ?? []),
+    ]
+      .filter(
+        (subscription) =>
+          !subscription.partitions ||
+          subscription.partitions.has(partition),
+      )
+      .sort((left, right) => left.id.localeCompare(right.id));
+    const results = await Promise.allSettled(
+      subscriptions.map((subscription) =>
+        Promise.resolve().then(() =>
+          subscription.handler(event, partition),
+        ),
+      ),
+    );
+    const failures: FanoutReceipt["failures"] = [];
+    results.forEach((result, index) => {
+      if (result.status === "rejected") {
+        failures.push({
+          subscriberId: subscriptions[index].id,
+          error: errorMessage(result.reason),
+        });
+      }
+    });
+    return {
+      partition,
+      delivered: subscriptions.length - failures.length,
+      failures,
+    };
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary

Adds production-oriented horizontal scaling primitives as a standalone module:

- deterministic consistent-hash gateway assignment with explicit rebalance plans;
- round-robin, smooth weighted, and least-connections server load balancing;
- partition-aware historian writes and federated reads with visible shard failures; and
- ordered partitioned event fan-out with per-consumer failure reporting.

## Why

The repository had no executable implementation for the horizontal-scaling
architecture described by ADR-0014. Deployments therefore had no shared,
deterministic ownership or partitioning model and no way to distinguish a
complete historian result from a partial one.

## Implementation

`server/scaling/horizontal.ts` contains storage- and transport-neutral
algorithms and interfaces. `server/scaling/hash.ts` supplies canonical,
process-independent hashing. Deployment adapters can bind these interfaces to
their database and message bus without importing any other issue branch.

`server/scaling/horizontal-runtime.ts` is the standalone production
composition root. It loads a deployment bindings module, validates the gateway
ring, load balancer, historian, event fan-out, and health contracts, and fails
startup closed when horizontal scaling is enabled without complete bindings.
The server initializes it before accepting traffic and exposes its real health
and readiness state.

The accompanying architecture guide documents membership-change ordering and
the requirement that two ring generations never write the same tag
concurrently.

## Validation

- `npx vitest run server/scaling/__tests__/horizontal.test.ts server/scaling/__tests__/horizontal-runtime.test.ts server/__tests__/startup-singleton-imports.test.ts` — 14 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — passed

The branch contains two signed commits based directly on `main` and only the
horizontal implementation, production composition/health wiring, focused
tests, and its guide.

Closes #222
