### PR TITLE
Add durable offline edge resilience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ nul
 # local dev database (test artifact)
 dev-database.sqlite
 *.sqlite
+.data/
 
 # test coverage output
 coverage/

--- a/docs/architecture/offline-edge-resilience.md
+++ b/docs/architecture/offline-edge-resilience.md
@@ -1,0 +1,49 @@
+# Offline and edge resilience
+
+This document is the executable companion to
+[ADR-0014](../decisions/ADR-0014-production-scale-architecture.md) for issue
+[#224](https://github.com/NickFlach/0xSCADA/issues/224).
+
+`server/gateway/store-and-forward.ts` preserves the existing
+`StoreAndForwardService.store(data, driverId)` entry point while making the
+queue durable and the reconnect path verifiable:
+
+- `JsonFileEdgeQueue` persists snapshots using fsync plus atomic rename; a
+  `DurableEdgeQueue` port permits SQLite or another local store.
+- Capacity is fail-closed: unacknowledged records are never silently evicted.
+- Every recovered record is checked with SHA-256, and every forwarded batch
+  requires the upstream to echo its Merkle root before records are removed.
+- Reconnect attempts use capped exponential backoff.
+- Telemetry conflicts use deterministic last-writer-wins ordering.
+  Configuration conflicts merge independently versioned leaf fields.
+- `LocalEdgeProcessor` hooks run after the local durable commit even while the
+  upstream is unavailable.
+- Divergences are emitted and can be sent to an injected durable
+  `DivergenceReporter`.
+
+Only JSON values that round-trip without coercion are accepted. Non-finite
+numbers, dates, maps, class instances, cycles, accessors, symbols,
+prototype-mutating keys, and dotted configuration field names are rejected
+before commit.
+
+Production must inject an `EdgeUpstreamTransport`. The default environment
+transport contains no socket and reports reachable only during development or
+when connectivity simulation is explicitly enabled. Upstream outages are
+degraded health while local durability remains available; queue corruption,
+capacity exhaustion, failed initialization, and persistence errors are hard
+health failures.
+
+## Verification
+
+Run:
+
+```bash
+npx vitest run server/gateway/__tests__/store-and-forward.test.ts
+npm run typecheck
+npm run build
+```
+
+The focused suite covers restart recovery, tamper detection, capacity,
+reconnect backoff, acknowledgment validation, Merkle mismatch, offline local
+processing, conflict resolution, queue serialization safety, and persistence
+failure handling.

--- a/docs/architecture/offline-edge-resilience.md
+++ b/docs/architecture/offline-edge-resilience.md
@@ -33,12 +33,26 @@ degraded health while local durability remains available; queue corruption,
 capacity exhaustion, failed initialization, and persistence errors are hard
 health failures.
 
+`server/gateway/store-and-forward-runtime.ts` is the production composition
+root. Set `EDGE_STORE_FORWARD_ENABLED=true` and
+`EDGE_STORE_FORWARD_BINDINGS_MODULE=/absolute/path/to/edge-bindings.js`. The
+module must export `createEdgeStoreAndForwardBindings`,
+`edgeStoreAndForwardBindings`, or a default binding with a real `transport`.
+The factory form receives `JsonFileEdgeQueue` for deployment composition.
+Startup installs the binding before the shared service initializes and fails
+closed for missing, incomplete, or `EnvironmentEdgeTransport` bindings.
+
+The readiness check reports the actual queue status, production-binding state,
+pending records, retry state, storage errors, and divergence count. A lost
+upstream is explicitly `degraded`; failed durability or initialization is
+`unhealthy`.
+
 ## Verification
 
 Run:
 
 ```bash
-npx vitest run server/gateway/__tests__/store-and-forward.test.ts
+npx vitest run server/gateway/__tests__/store-and-forward.test.ts server/gateway/__tests__/store-and-forward-runtime.test.ts server/__tests__/startup-singleton-imports.test.ts
 npm run typecheck
 npm run build
 ```

--- a/server/__tests__/startup-singleton-imports.test.ts
+++ b/server/__tests__/startup-singleton-imports.test.ts
@@ -52,6 +52,7 @@ describe("startup singleton module identity", () => {
         "./simulator",
         "./agents",
         "./gateway/store-and-forward",
+        "./gateway/store-and-forward-runtime",
         "./bridge",
         "./gateway",
         "./services/flux",
@@ -64,6 +65,7 @@ describe("startup singleton module identity", () => {
       modules: [
         "../simulator",
         "../gateway/store-and-forward",
+        "../gateway/store-and-forward-runtime",
         "../bridge",
       ],
     },

--- a/server/gateway/__tests__/store-and-forward-runtime.test.ts
+++ b/server/gateway/__tests__/store-and-forward-runtime.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  EnvironmentEdgeTransport,
+  MemoryEdgeQueue,
+  StoreAndForwardService,
+  type EdgeUpstreamTransport,
+} from "../store-and-forward";
+import {
+  EdgeStoreAndForwardRuntime,
+  type EdgeStoreAndForwardBindings,
+} from "../store-and-forward-runtime";
+
+function transport(): EdgeUpstreamTransport {
+  return {
+    isReachable: async () => false,
+    forward: async () => {
+      throw new Error("offline");
+    },
+  };
+}
+
+describe("edge store-and-forward production runtime", () => {
+  it("installs a real transport before the shared service starts", async () => {
+    const configure = vi.fn(
+      (
+        config: ConstructorParameters<typeof StoreAndForwardService>[0],
+        dependencies: ConstructorParameters<typeof StoreAndForwardService>[1],
+      ) => new StoreAndForwardService(config, dependencies),
+    );
+    const runtime = new EdgeStoreAndForwardRuntime(configure);
+    const upstream = transport();
+    runtime.configure({
+      config: { storagePath: "unused-in-composition-test.json" },
+      transport: upstream,
+      dependencies: { queue: new MemoryEdgeQueue() },
+    });
+
+    await runtime.initialize();
+
+    expect(runtime.isInitialized()).toBe(true);
+    expect(runtime.bindings().transport).toBe(upstream);
+    expect(configure).toHaveBeenCalledOnce();
+    expect(configure.mock.calls[0]?.[1]).toMatchObject({
+      transport: upstream,
+    });
+  });
+
+  it("fails closed when the upstream transport contract is incomplete", () => {
+    const incomplete = {
+      transport: { isReachable: async () => true },
+    } as unknown as EdgeStoreAndForwardBindings;
+    expect(() => new EdgeStoreAndForwardRuntime().configure(incomplete)).toThrow(
+      /upstream transport/,
+    );
+  });
+
+  it("refuses the environment-only simulation transport in production", async () => {
+    const runtime = new EdgeStoreAndForwardRuntime();
+    runtime.configure({ transport: new EnvironmentEdgeTransport() });
+    await expect(runtime.initialize()).rejects.toThrow(
+      /cannot use EnvironmentEdgeTransport/,
+    );
+  });
+});

--- a/server/gateway/__tests__/store-and-forward.test.ts
+++ b/server/gateway/__tests__/store-and-forward.test.ts
@@ -1,0 +1,365 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  JsonFileEdgeQueue,
+  MemoryEdgeQueue,
+  QueueCapacityError,
+  QueueIntegrityError,
+  StoreAndForwardService,
+  mergeConfigurationConflict,
+  resolveTelemetryConflict,
+  type EdgeUpstreamTransport,
+  type ForwardBatch,
+} from "../store-and-forward";
+
+const services: StoreAndForwardService[] = [];
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.allSettled(services.splice(0).map((service) => service.shutdown()));
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+function unavailableTransport(): EdgeUpstreamTransport {
+  return {
+    isReachable: async () => false,
+    forward: async () => {
+      throw new Error("offline");
+    },
+  };
+}
+
+function service(
+  options: ConstructorParameters<typeof StoreAndForwardService>[0] = {},
+  dependencies: ConstructorParameters<typeof StoreAndForwardService>[1] = {},
+): StoreAndForwardService {
+  const created = new StoreAndForwardService(
+    {
+      heartbeatInterval: 60_000,
+      retryInterval: 10,
+      maxRetryInterval: 40,
+      ...options,
+    },
+    {
+      queue: new MemoryEdgeQueue(),
+      transport: unavailableTransport(),
+      ...dependencies,
+    },
+  );
+  services.push(created);
+  return created;
+}
+
+describe("durable edge resilience (#224)", () => {
+  it("restores committed records after process restart", async () => {
+    const queue = new MemoryEdgeQueue();
+    const first = service(
+      {},
+      {
+        queue,
+        transport: unavailableTransport(),
+        idFactory: () => "record-1",
+        now: () => new Date("2026-07-28T12:00:00Z"),
+      },
+    );
+    await first.initialize();
+    await first.store({ value: 42 }, "driver-1");
+    expect(first.getStatus().pendingRecords).toBe(1);
+    await first.shutdown();
+
+    const second = service(
+      {},
+      { queue, transport: unavailableTransport() },
+    );
+    await second.initialize();
+    expect(second.pending()).toEqual([
+      expect.objectContaining({
+        id: "record-1",
+        data: { value: 42 },
+        driverId: "driver-1",
+      }),
+    ]);
+  });
+
+  it("persists an atomic JSON queue and rejects tampering on recovery", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "0xscada-edge-"));
+    temporaryDirectories.push(directory);
+    const storagePath = join(directory, "queue.json");
+    const first = service(
+      { storagePath },
+      {
+        queue: new JsonFileEdgeQueue(storagePath),
+        transport: unavailableTransport(),
+        idFactory: () => "protected",
+      },
+    );
+    await first.initialize();
+    await first.store({ pressure: 12 }, "plc");
+    await first.shutdown();
+
+    const payload = JSON.parse(await readFile(storagePath, "utf8")) as {
+      records: Array<{ data: unknown }>;
+    };
+    payload.records[0].data = { pressure: 999 };
+    await writeFile(storagePath, JSON.stringify(payload), "utf8");
+
+    const recovered = service(
+      { storagePath },
+      {
+        queue: new JsonFileEdgeQueue(storagePath),
+        transport: unavailableTransport(),
+      },
+    );
+    await expect(recovered.initialize()).rejects.toBeInstanceOf(
+      QueueIntegrityError,
+    );
+  });
+
+  it("round-trips JSON data losslessly and rejects values JSON would coerce", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "0xscada-edge-json-"));
+    temporaryDirectories.push(directory);
+    const storagePath = join(directory, "queue.json");
+    const dependencies = {
+      queue: new JsonFileEdgeQueue(storagePath),
+      transport: unavailableTransport(),
+      idFactory: () => "json-safe",
+    };
+    const first = service({ storagePath }, dependencies);
+    await first.initialize();
+    await expect(first.store({ reading: Number.NaN })).rejects.toThrow(
+      /finite JSON numbers/,
+    );
+    await expect(
+      first.store({ observedAt: new Date("2026-07-28T12:00:00Z") }),
+    ).rejects.toThrow(/plain JSON objects/);
+    const expected = {
+      readings: [0, 12.5, null, true],
+      labels: { area: "north", unit: "psi" },
+    };
+    await first.store(expected);
+    await first.shutdown();
+
+    const recovered = service(
+      { storagePath },
+      {
+        queue: new JsonFileEdgeQueue(storagePath),
+        transport: unavailableTransport(),
+      },
+    );
+    await recovered.initialize();
+    expect(recovered.pending()[0].data).toEqual(expected);
+  });
+
+  it("uses capped exponential reconnect backoff", async () => {
+    const fixedNow = new Date("2026-07-28T12:00:00Z");
+    const edge = service(
+      {},
+      {
+        transport: unavailableTransport(),
+        now: () => new Date(fixedNow),
+      },
+    );
+    await edge.initialize();
+    expect(edge.getStatus()).toMatchObject({
+      consecutiveFailures: 1,
+      nextRetryAt: new Date(fixedNow.getTime() + 10),
+    });
+    await edge.runConnectivityCycle();
+    expect(edge.getStatus()).toMatchObject({
+      consecutiveFailures: 2,
+      nextRetryAt: new Date(fixedNow.getTime() + 20),
+    });
+    await edge.runConnectivityCycle();
+    expect(edge.getStatus()).toMatchObject({
+      consecutiveFailures: 3,
+      nextRetryAt: new Date(fixedNow.getTime() + 40),
+    });
+    await edge.runConnectivityCycle();
+    expect(edge.getStatus().nextRetryAt).toEqual(
+      new Date(fixedNow.getTime() + 40),
+    );
+  });
+
+  it("automatically drains verified batches after reconnect", async () => {
+    let reachable = false;
+    const forwarded: ForwardBatch[] = [];
+    const transport: EdgeUpstreamTransport = {
+      isReachable: async () => reachable,
+      forward: async (batch) => {
+        forwarded.push(batch);
+        return {
+          acknowledgedIds: batch.records.map((record) => record.id),
+          verifiedMerkleRoot: batch.merkleRoot,
+        };
+      },
+    };
+    let id = 0;
+    const edge = service(
+      { forwardBatchSize: 2 },
+      {
+        transport,
+        idFactory: () => `record-${++id}`,
+      },
+    );
+    await edge.initialize();
+    await edge.store({ value: 1 });
+    await edge.store({ value: 2 });
+    await edge.store({ value: 3 });
+    reachable = true;
+
+    expect(await edge.runConnectivityCycle()).toBe(true);
+    expect(edge.getStatus()).toMatchObject({
+      isConnected: true,
+      pendingRecords: 0,
+      consecutiveFailures: 0,
+    });
+    expect(forwarded.map((batch) => batch.records.length)).toEqual([2, 1]);
+    expect(forwarded.every((batch) => /^[0-9a-f]{64}$/.test(batch.merkleRoot))).toBe(
+      true,
+    );
+  });
+
+  it("keeps every record when upstream integrity verification disagrees", async () => {
+    const transport: EdgeUpstreamTransport = {
+      isReachable: async () => true,
+      forward: async (batch) => ({
+        acknowledgedIds: batch.records.map((record) => record.id),
+        verifiedMerkleRoot: "tampered-root",
+      }),
+    };
+    const edge = service({}, { transport, idFactory: () => "record-1" });
+    const divergences = vi.fn();
+    edge.on("divergence", divergences);
+    await edge.initialize();
+    await edge.store({ value: 7 });
+
+    expect(edge.getStatus()).toMatchObject({
+      isConnected: false,
+      pendingRecords: 1,
+      divergenceCount: 1,
+    });
+    expect(divergences).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "integrity",
+        resolution: "retry-local",
+      }),
+    );
+  });
+
+  it("continues local processing while offline", async () => {
+    const process = vi.fn(async () => undefined);
+    const edge = service(
+      {},
+      {
+        transport: unavailableTransport(),
+        localProcessors: [{ process }],
+      },
+    );
+    await edge.initialize();
+    await edge.store({ alarm: "high temperature" });
+    expect(process).toHaveBeenCalledOnce();
+    expect(edge.getStatus()).toMatchObject({
+      isConnected: false,
+      pendingRecords: 1,
+    });
+  });
+
+  it("fails closed at capacity rather than deleting older industrial data", async () => {
+    let id = 0;
+    const edge = service(
+      { maxLocalStorage: 1 },
+      { idFactory: () => `record-${++id}` },
+    );
+    await edge.initialize();
+    await edge.store({ value: "first" });
+    await expect(edge.store({ value: "second" })).rejects.toBeInstanceOf(
+      QueueCapacityError,
+    );
+    expect(edge.pending().map((record) => record.data)).toEqual([
+      { value: "first" },
+    ]);
+  });
+
+  it("resolves telemetry by LWW and configuration per field", () => {
+    const older = {
+      data: { value: 1 },
+      timestamp: new Date("2026-07-28T11:00:00Z"),
+      origin: "edge",
+    };
+    const newer = {
+      data: { value: 2 },
+      timestamp: new Date("2026-07-28T12:00:00Z"),
+      origin: "cloud",
+    };
+    expect(resolveTelemetryConflict(older, newer)).toEqual(newer);
+
+    const merged = mergeConfigurationConflict(
+      {
+        data: { alarm: { high: 90, low: 5 } },
+        timestamp: new Date("2026-07-28T12:00:00Z"),
+        origin: "edge",
+        fieldVersions: {
+          "alarm.high": {
+            timestamp: new Date("2026-07-28T12:00:00Z"),
+            origin: "edge",
+          },
+          "alarm.low": {
+            timestamp: new Date("2026-07-28T10:00:00Z"),
+            origin: "edge",
+          },
+        },
+      },
+      {
+        data: { alarm: { high: 80, low: 10 }, display: { units: "C" } },
+        timestamp: new Date("2026-07-28T11:00:00Z"),
+        origin: "cloud",
+      },
+    );
+    expect(merged.data).toEqual({
+      alarm: { high: 90, low: 10 },
+      display: { units: "C" },
+    });
+  });
+
+  it("rejects ambiguous and prototype-mutating configuration fields", () => {
+    const malicious = JSON.parse(
+      '{"__proto__":{"edgePolluted":"yes"}}',
+    ) as Record<string, unknown>;
+    expect(() =>
+      mergeConfigurationConflict(
+        {
+          data: {},
+          timestamp: new Date("2026-07-28T11:00:00Z"),
+          origin: "edge",
+        },
+        {
+          data: malicious,
+          timestamp: new Date("2026-07-28T12:00:00Z"),
+          origin: "cloud",
+        },
+      ),
+    ).toThrow(/forbidden key|invalid configuration field/);
+    expect(({} as { edgePolluted?: string }).edgePolluted).toBeUndefined();
+
+    expect(() =>
+      mergeConfigurationConflict(
+        {
+          data: { "alarm.high": 90 },
+          timestamp: new Date("2026-07-28T11:00:00Z"),
+          origin: "edge",
+        },
+        {
+          data: { alarm: { high: 80 } },
+          timestamp: new Date("2026-07-28T12:00:00Z"),
+          origin: "cloud",
+        },
+      ),
+    ).toThrow(/invalid configuration field/);
+  });
+});

--- a/server/gateway/store-and-forward-runtime.ts
+++ b/server/gateway/store-and-forward-runtime.ts
@@ -1,0 +1,151 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  EnvironmentEdgeTransport,
+  JsonFileEdgeQueue,
+  configureStoreAndForwardService,
+  type EdgeUpstreamTransport,
+  type LocalEdgeProcessor,
+  type StoreAndForwardConfig,
+  type StoreAndForwardDependencies,
+  type StoreAndForwardService,
+} from "./store-and-forward";
+
+export interface EdgeStoreAndForwardBindings {
+  config?: Partial<StoreAndForwardConfig>;
+  transport: EdgeUpstreamTransport;
+  localProcessors?: readonly LocalEdgeProcessor[];
+  dependencies?: Omit<
+    StoreAndForwardDependencies,
+    "transport" | "localProcessors"
+  >;
+}
+
+export interface EdgeStoreAndForwardFactories {
+  JsonFileEdgeQueue: typeof JsonFileEdgeQueue;
+}
+
+interface BindingsModule {
+  default?: EdgeStoreAndForwardBindings;
+  edgeStoreAndForwardBindings?: EdgeStoreAndForwardBindings;
+  createEdgeStoreAndForwardBindings?: (
+    factories: EdgeStoreAndForwardFactories,
+  ) =>
+    | EdgeStoreAndForwardBindings
+    | Promise<EdgeStoreAndForwardBindings>;
+}
+
+type StoreAndForwardConfigurator = (
+  config: Partial<StoreAndForwardConfig>,
+  dependencies: StoreAndForwardDependencies,
+) => StoreAndForwardService;
+
+export const edgeStoreAndForwardFactories: EdgeStoreAndForwardFactories = {
+  JsonFileEdgeQueue,
+};
+
+/**
+ * Production composition root for the durable edge queue.
+ *
+ * The queue remains available with its local durable defaults, but explicitly
+ * enabling production synchronization requires a deployment module that
+ * supplies a real upstream transport. Startup fails closed if that binding is
+ * absent or still uses the environment-only simulation transport.
+ */
+export class EdgeStoreAndForwardRuntime {
+  private configured?: EdgeStoreAndForwardBindings;
+  private initialized = false;
+  private enabledByConfiguration = false;
+
+  constructor(
+    private readonly configureService: StoreAndForwardConfigurator =
+      configureStoreAndForwardService,
+  ) {}
+
+  configure(bindings: EdgeStoreAndForwardBindings): void {
+    if (this.initialized) {
+      throw new Error("edge store-and-forward runtime is already initialized");
+    }
+    validateBindings(bindings);
+    this.configured = bindings;
+    this.enabledByConfiguration = true;
+  }
+
+  isEnabled(): boolean {
+    return (
+      this.enabledByConfiguration ||
+      process.env.EDGE_STORE_FORWARD_ENABLED === "true"
+    );
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized || !this.isEnabled()) return;
+    const bindings = this.configured ?? (await this.loadBindingsModule());
+    validateBindings(bindings);
+    if (bindings.transport instanceof EnvironmentEdgeTransport) {
+      throw new Error(
+        "production edge synchronization cannot use EnvironmentEdgeTransport",
+      );
+    }
+    this.configureService(bindings.config ?? {}, {
+      ...(bindings.dependencies ?? {}),
+      transport: bindings.transport,
+      localProcessors: bindings.localProcessors,
+    });
+    this.configured = bindings;
+    this.initialized = true;
+  }
+
+  bindings(): Readonly<EdgeStoreAndForwardBindings> {
+    if (!this.initialized || !this.configured) {
+      throw new Error("edge store-and-forward runtime is not initialized");
+    }
+    return this.configured;
+  }
+
+  private async loadBindingsModule(): Promise<EdgeStoreAndForwardBindings> {
+    const modulePath = process.env.EDGE_STORE_FORWARD_BINDINGS_MODULE;
+    if (!modulePath) {
+      throw new Error(
+        "EDGE_STORE_FORWARD_BINDINGS_MODULE is required when production edge synchronization is enabled",
+      );
+    }
+    const loaded = (await import(
+      pathToFileURL(resolve(modulePath)).href
+    )) as BindingsModule;
+    const bindings = loaded.createEdgeStoreAndForwardBindings
+      ? await loaded.createEdgeStoreAndForwardBindings(
+          edgeStoreAndForwardFactories,
+        )
+      : loaded.edgeStoreAndForwardBindings ?? loaded.default;
+    if (!bindings) {
+      throw new Error(
+        "edge bindings module must export createEdgeStoreAndForwardBindings, edgeStoreAndForwardBindings, or default",
+      );
+    }
+    return bindings;
+  }
+}
+
+function validateBindings(
+  bindings: EdgeStoreAndForwardBindings,
+): asserts bindings is EdgeStoreAndForwardBindings {
+  const transport = bindings?.transport as unknown;
+  if (
+    !transport ||
+    typeof transport !== "object" ||
+    typeof (transport as Record<string, unknown>).isReachable !== "function" ||
+    typeof (transport as Record<string, unknown>).forward !== "function"
+  ) {
+    throw new Error(
+      "edge store-and-forward bindings require an upstream transport",
+    );
+  }
+}
+
+export const edgeStoreAndForwardRuntime =
+  new EdgeStoreAndForwardRuntime();

--- a/server/gateway/store-and-forward.ts
+++ b/server/gateway/store-and-forward.ts
@@ -1,29 +1,55 @@
 /**
- * Edge Store-and-Forward Module
- * 
- * Handles local data storage during network outages and forwards data
- * when connectivity is restored. Works with the gateway manager to
- * ensure no industrial data is lost during edge deployment scenarios.
- * 
- * Issue: #279 — Health manager and edge store-and-forward disconnected
+ * Durable edge store-and-forward service.
+ *
+ * Network and storage mechanisms are ports: production can use the included
+ * atomic JSON queue or provide SQLite, NATS, or cloud transports without
+ * changing retry, integrity, or conflict semantics.
  */
 
-import { EventEmitter } from 'events';
-import { log, logError } from '../logger';
+import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { log, logError } from "../logger";
+import {
+  canonicalJson,
+  merkleRoot,
+  sha256Hex,
+} from "../scaling/hash";
 
 export interface StoreAndForwardConfig {
-  maxLocalStorage: number; // Max records to store locally
-  forwardBatchSize: number; // Records per batch when forwarding
-  heartbeatInterval: number; // Connectivity check interval (ms)
-  retryInterval: number; // Failed forward retry interval (ms)
+  maxLocalStorage: number;
+  forwardBatchSize: number;
+  heartbeatInterval: number;
+  retryInterval: number;
+  maxRetryInterval: number;
+  storagePath: string;
+}
+
+export type EdgeRecordKind = "telemetry" | "configuration";
+
+export interface FieldVersion {
+  timestamp: Date;
+  origin: string;
 }
 
 export interface StoredRecord {
   id: string;
   timestamp: Date;
-  data: any;
+  data: unknown;
   attempts: number;
   driverId?: string;
+  kind: EdgeRecordKind;
+  origin: string;
+  fieldVersions?: Record<string, FieldVersion>;
+  checksum: string;
+}
+
+export interface StoreOptions {
+  kind?: EdgeRecordKind;
+  origin?: string;
+  timestamp?: Date;
+  fieldVersions?: Readonly<Record<string, FieldVersion>>;
 }
 
 export interface ConnectivityStatus {
@@ -31,199 +57,1135 @@ export interface ConnectivityStatus {
   lastSuccessfulForward: Date | null;
   pendingRecords: number;
   lastError?: string;
+  storageError?: string;
+  consecutiveFailures: number;
+  nextRetryAt: Date | null;
+  divergenceCount: number;
+}
+
+export interface EdgeHealthStatus {
+  healthy: boolean;
+  degraded: boolean;
+  message: string;
+}
+
+export interface DurableEdgeQueue {
+  load(): Promise<readonly StoredRecord[]>;
+  save(records: readonly StoredRecord[]): Promise<void>;
+}
+
+interface SerializedRecord
+  extends Omit<StoredRecord, "timestamp" | "fieldVersions"> {
+  timestamp: string;
+  fieldVersions?: Record<string, { timestamp: string; origin: string }>;
+}
+
+interface QueueFile {
+  version: 1;
+  records: SerializedRecord[];
+}
+
+/**
+ * Crash-safe single-file queue: write complete snapshot, then atomically rename.
+ * A database-backed adapter can implement the same contract for larger queues.
+ */
+export class JsonFileEdgeQueue implements DurableEdgeQueue {
+  constructor(readonly path: string) {}
+
+  async load(): Promise<readonly StoredRecord[]> {
+    let contents: string;
+    try {
+      contents = await readFile(this.path, "utf8");
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    }
+    const parsed = JSON.parse(contents) as Partial<QueueFile>;
+    if (parsed.version !== 1 || !Array.isArray(parsed.records)) {
+      throw new Error(`unsupported or corrupt edge queue: ${this.path}`);
+    }
+    return parsed.records.map(deserializeRecord);
+  }
+
+  async save(records: readonly StoredRecord[]): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true });
+    const temporary = `${this.path}.${process.pid}.${randomUUID()}.tmp`;
+    const payload: QueueFile = {
+      version: 1,
+      records: records.map(serializeRecord),
+    };
+    try {
+      const handle = await open(temporary, "wx");
+      try {
+        await handle.writeFile(`${canonicalJson(payload)}\n`, "utf8");
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+      await rename(temporary, this.path);
+    } catch (error) {
+      await rm(temporary, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+}
+
+/** Deterministic queue adapter for tests and embedders with their own durability. */
+export class MemoryEdgeQueue implements DurableEdgeQueue {
+  private records: StoredRecord[];
+  constructor(initial: readonly StoredRecord[] = []) {
+    this.records = initial.map(cloneRecord);
+  }
+  async load(): Promise<readonly StoredRecord[]> {
+    return this.records.map(cloneRecord);
+  }
+  async save(records: readonly StoredRecord[]): Promise<void> {
+    this.records = records.map(cloneRecord);
+  }
+}
+
+export interface EdgeReplicaValue {
+  data: unknown;
+  timestamp: Date;
+  origin: string;
+  fieldVersions?: Readonly<Record<string, FieldVersion>>;
+}
+
+export interface UpstreamConflict {
+  recordId: string;
+  remote: EdgeReplicaValue;
+}
+
+export interface ForwardBatch {
+  records: readonly StoredRecord[];
+  merkleRoot: string;
+}
+
+export interface ForwardBatchResult {
+  acknowledgedIds: readonly string[];
+  verifiedMerkleRoot: string;
+  conflicts?: readonly UpstreamConflict[];
+}
+
+export interface EdgeUpstreamTransport {
+  isReachable(signal?: AbortSignal): Promise<boolean>;
+  forward(
+    batch: ForwardBatch,
+    signal?: AbortSignal,
+  ): Promise<ForwardBatchResult>;
+}
+
+/**
+ * Backwards-compatible default transport. It has no sockets; deployments should
+ * inject their actual HTTP/NATS transport. Environment state only controls the
+ * local reference implementation's availability.
+ */
+export class EnvironmentEdgeTransport implements EdgeUpstreamTransport {
+  async isReachable(): Promise<boolean> {
+    return (
+      process.env.NODE_ENV === "development" ||
+      process.env.SIMULATE_CONNECTIVITY === "true"
+    );
+  }
+
+  async forward(batch: ForwardBatch): Promise<ForwardBatchResult> {
+    return {
+      acknowledgedIds: batch.records.map((record) => record.id),
+      verifiedMerkleRoot: batch.merkleRoot,
+    };
+  }
+}
+
+export interface LocalEdgeProcessor {
+  process(record: Readonly<StoredRecord>): void | Promise<void>;
+}
+
+export interface DivergenceReporter {
+  report(divergence: Readonly<DivergenceReport>): void | Promise<void>;
+}
+
+export interface DivergenceReport {
+  type: "integrity" | "telemetry-conflict" | "configuration-conflict";
+  recordId?: string;
+  resolution: "retry-local" | "local-wins" | "remote-wins" | "merged";
+  detail: string;
+  detectedAt: Date;
+}
+
+export interface StoreAndForwardDependencies {
+  queue?: DurableEdgeQueue;
+  transport?: EdgeUpstreamTransport;
+  now?: () => Date;
+  idFactory?: () => string;
+  localProcessors?: readonly LocalEdgeProcessor[];
+  divergenceReporter?: DivergenceReporter;
+}
+
+export class QueueCapacityError extends Error {
+  constructor(readonly capacity: number) {
+    super(`edge queue capacity of ${capacity} records has been reached`);
+    this.name = "QueueCapacityError";
+  }
+}
+
+export class QueueIntegrityError extends Error {
+  constructor(readonly recordId: string) {
+    super(`edge queue integrity verification failed for record ${recordId}`);
+    this.name = "QueueIntegrityError";
+  }
 }
 
 export class StoreAndForwardService extends EventEmitter {
-  private localStore: Map<string, StoredRecord> = new Map();
+  private readonly localStore = new Map<string, StoredRecord>();
   private isConnected = false;
-  private heartbeatTimer?: NodeJS.Timeout;
-  private forwardTimer?: NodeJS.Timeout;
+  private timer?: NodeJS.Timeout;
   private lastSuccessfulForward: Date | null = null;
-  private config: StoreAndForwardConfig;
+  private lastError?: string;
+  private lastStorageError?: string;
+  private consecutiveFailures = 0;
+  private nextRetryAt: Date | null = null;
+  private divergenceCount = 0;
+  private initialized = false;
+  private stopped = true;
+  private operation: Promise<void> = Promise.resolve();
+  private readonly config: StoreAndForwardConfig;
+  private readonly queue: DurableEdgeQueue;
+  private readonly transport: EdgeUpstreamTransport;
+  private readonly now: () => Date;
+  private readonly idFactory: () => string;
+  private readonly localProcessors: readonly LocalEdgeProcessor[];
+  private readonly divergenceReporter?: DivergenceReporter;
 
-  constructor(config?: Partial<StoreAndForwardConfig>) {
+  constructor(
+    config?: Partial<StoreAndForwardConfig>,
+    dependencies: StoreAndForwardDependencies = {},
+  ) {
     super();
     this.config = {
-      maxLocalStorage: 10000,
+      maxLocalStorage: 10_000,
       forwardBatchSize: 100,
-      heartbeatInterval: 30000, // 30 seconds
-      retryInterval: 60000, // 1 minute
-      ...config
+      heartbeatInterval: 30_000,
+      retryInterval: 1_000,
+      maxRetryInterval: 60_000,
+      storagePath:
+        process.env.STORE_AND_FORWARD_PATH ??
+        join(process.cwd(), ".data", "store-and-forward-queue.json"),
+      ...config,
     };
+    validateConfig(this.config);
+    this.queue =
+      dependencies.queue ?? new JsonFileEdgeQueue(this.config.storagePath);
+    this.transport = dependencies.transport ?? new EnvironmentEdgeTransport();
+    this.now = dependencies.now ?? (() => new Date());
+    this.idFactory = dependencies.idFactory ?? randomUUID;
+    this.localProcessors = dependencies.localProcessors ?? [];
+    this.divergenceReporter = dependencies.divergenceReporter;
   }
 
-  /**
-   * Initialize the store-and-forward service
-   */
   async initialize(): Promise<void> {
-    log('Initializing store-and-forward service');
-    this.startHeartbeat();
-    this.emit('initialized');
+    if (this.initialized) {
+      return;
+    }
+    const loaded = (await this.queue.load()).map(cloneRecord);
+    for (const record of loaded) {
+      validateStoredRecord(record);
+      assertRecordIntegrity(record);
+    }
+    const ids = new Set<string>();
+    for (const record of loaded) {
+      if (ids.has(record.id)) {
+        throw new Error(`duplicate record ${record.id} in durable edge queue`);
+      }
+      ids.add(record.id);
+    }
+    this.localStore.clear();
+    for (const record of loaded) {
+      this.localStore.set(record.id, record);
+    }
+    this.initialized = true;
+    this.stopped = false;
+    log(`Store-and-forward initialized with ${this.localStore.size} queued records`);
+    this.emit("initialized");
+    await this.runConnectivityCycle();
   }
 
-  /**
-   * Stop the service and clean up timers
-   */
   async shutdown(): Promise<void> {
-    log('Shutting down store-and-forward service');
-    if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer);
+    this.stopped = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
     }
-    if (this.forwardTimer) {
-      clearInterval(this.forwardTimer);
+    await this.operation;
+    if (this.initialized) {
+      await this.persist();
     }
-    this.emit('shutdown');
+    this.nextRetryAt = null;
+    this.isConnected = false;
+    this.initialized = false;
+    this.localStore.clear();
+    this.emit("shutdown");
   }
 
   /**
-   * Store data locally with automatic forwarding when connected
+   * Durably commits before local processing or upstream forwarding. Queue
+   * pressure is fail-closed: existing industrial data is never evicted.
    */
-  async store(data: any, driverId?: string): Promise<void> {
-    const record: StoredRecord = {
-      id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      timestamp: new Date(),
-      data,
-      attempts: 0,
-      driverId
-    };
+  async store(
+    data: unknown,
+    driverId?: string,
+    options: StoreOptions = {},
+  ): Promise<void> {
+    this.assertInitialized();
+    await this.serialized(async () => {
+      if (this.stopped) {
+        throw new Error("store-and-forward service is shutting down");
+      }
+      if (this.localStore.size >= this.config.maxLocalStorage) {
+        throw new QueueCapacityError(this.config.maxLocalStorage);
+      }
+      const timestamp = options.timestamp
+        ? new Date(options.timestamp)
+        : this.now();
+      const kind = options.kind ?? "telemetry";
+      const origin = options.origin ?? driverId ?? "edge";
+      assertValidDate(timestamp, "record timestamp");
+      if (kind !== "telemetry" && kind !== "configuration") {
+        throw new Error(`unsupported edge record kind: ${String(kind)}`);
+      }
+      if (!origin.trim()) {
+        throw new Error("edge record origin cannot be empty");
+      }
+      assertJsonSafe(data, "$.data");
+      if (kind === "configuration") {
+        if (!isPlainObject(data)) {
+          throw new Error("configuration records must contain a JSON object");
+        }
+        validateConfigurationObject(data);
+      }
+      if (options.fieldVersions) {
+        validateFieldVersions(options.fieldVersions);
+      }
+      const recordWithoutChecksum: Omit<StoredRecord, "checksum"> = {
+        id: this.idFactory(),
+        timestamp,
+        data: structuredClone(data),
+        attempts: 0,
+        driverId,
+        kind,
+        origin,
+        fieldVersions: options.fieldVersions
+          ? cloneFieldVersions(options.fieldVersions)
+          : undefined,
+      };
+      const record: StoredRecord = {
+        ...recordWithoutChecksum,
+        checksum: recordChecksum(recordWithoutChecksum),
+      };
+      this.localStore.set(record.id, record);
+      try {
+        await this.persist();
+      } catch (error) {
+        this.localStore.delete(record.id);
+        throw error;
+      }
+      this.emit("stored", cloneRecord(record));
+      await this.processLocally(record);
+    });
 
-    // Check storage limits
-    if (this.localStore.size >= this.config.maxLocalStorage) {
-      // Remove oldest record
-      const oldestKey = Array.from(this.localStore.keys())[0];
-      this.localStore.delete(oldestKey);
-      log(`Store-and-forward: Removed oldest record due to storage limit`);
-    }
-
-    this.localStore.set(record.id, record);
-    
-    // Try to forward immediately if connected
     if (this.isConnected) {
-      await this.forwardBatch();
+      try {
+        await this.synchronizeNow();
+        if (!this.isConnected) {
+          this.schedule(this.currentBackoffMs());
+        }
+      } catch (error) {
+        this.recordConnectionFailure(error);
+        this.schedule(this.currentBackoffMs());
+      }
     }
   }
 
-  /**
-   * Get current connectivity and storage status
-   */
   getStatus(): ConnectivityStatus {
     return {
       isConnected: this.isConnected,
-      lastSuccessfulForward: this.lastSuccessfulForward,
+      lastSuccessfulForward: this.lastSuccessfulForward
+        ? new Date(this.lastSuccessfulForward)
+        : null,
       pendingRecords: this.localStore.size,
-      lastError: undefined // Could be enhanced to track last error
+      lastError: this.lastError,
+      storageError: this.lastStorageError,
+      consecutiveFailures: this.consecutiveFailures,
+      nextRetryAt: this.nextRetryAt ? new Date(this.nextRetryAt) : null,
+      divergenceCount: this.divergenceCount,
     };
   }
 
-  /**
-   * Check if the service is healthy
-   */
-  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
-    const pendingCount = this.localStore.size;
-    const isOverloaded = pendingCount > this.config.maxLocalStorage * 0.8;
-    
-    if (isOverloaded) {
+  pending(): StoredRecord[] {
+    return [...this.localStore.values()].map(cloneRecord);
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  async healthCheck(): Promise<EdgeHealthStatus> {
+    if (!this.initialized) {
       return {
         healthy: false,
-        message: `Store-and-forward overloaded: ${pendingCount} pending records`
+        degraded: false,
+        message: "Store-and-forward is not initialized",
       };
     }
-
+    const pendingCount = this.localStore.size;
+    if (this.lastStorageError) {
+      return {
+        healthy: false,
+        degraded: false,
+        message: `Store-and-forward persistence failed: ${this.lastStorageError}`,
+      };
+    }
+    if (pendingCount >= this.config.maxLocalStorage * 0.8) {
+      return {
+        healthy: false,
+        degraded: false,
+        message: `Store-and-forward overloaded: ${pendingCount} pending records`,
+      };
+    }
+    if (this.lastError && this.consecutiveFailures > 0) {
+      return {
+        // Loss of upstream connectivity is the operating condition this queue
+        // exists to tolerate. Surface it as degraded text without making an
+        // otherwise durable edge node permanently unready.
+        healthy: true,
+        degraded: true,
+        message: `Store-and-forward offline/degraded: ${this.lastError}; ${pendingCount} pending records`,
+      };
+    }
     return {
       healthy: true,
-      message: `Store-and-forward healthy: ${pendingCount} pending records`
+      degraded: false,
+      message: `Store-and-forward healthy: ${pendingCount} pending records`,
     };
   }
 
   /**
-   * Force connectivity check
+   * One deterministic connectivity/backoff step. Public so schedulers and tests
+   * can drive it without waiting on wall-clock timers.
    */
-  async checkConnectivity(): Promise<boolean> {
+  async runConnectivityCycle(signal?: AbortSignal): Promise<boolean> {
+    if (this.stopped) {
+      return false;
+    }
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
     try {
-      // Simple connectivity check - could be enhanced to check actual upstream services
-      // For now, we'll simulate connectivity based on environment
-      const simulateConnectivity = process.env.NODE_ENV === 'development' || 
-                                   process.env.SIMULATE_CONNECTIVITY !== 'false';
-      
-      this.isConnected = simulateConnectivity;
-      this.emit('connectivity-changed', this.isConnected);
-      
-      if (this.isConnected && this.localStore.size > 0) {
-        await this.forwardBatch();
+      const reachable = await this.transport.isReachable(signal);
+      if (this.stopped) {
+        return false;
       }
-      
-      return this.isConnected;
+      if (!reachable) {
+        throw new Error("upstream is unreachable");
+      }
+      const changed = !this.isConnected;
+      this.isConnected = true;
+      this.consecutiveFailures = 0;
+      this.lastError = undefined;
+      if (changed) {
+        this.emit("connectivity-changed", true);
+      }
+      await this.synchronizeNow(signal);
+      if (!this.isConnected) {
+        this.schedule(this.currentBackoffMs());
+        return false;
+      }
+      this.schedule(this.config.heartbeatInterval);
+      return true;
     } catch (error) {
-      logError('Store-and-forward connectivity check failed', error as any);
-      this.isConnected = false;
-      this.emit('connectivity-changed', false);
+      this.recordConnectionFailure(error);
+      this.schedule(this.currentBackoffMs());
       return false;
     }
   }
 
-  /**
-   * Forward a batch of stored records
-   */
-  private async forwardBatch(): Promise<void> {
-    if (!this.isConnected || this.localStore.size === 0) {
+  async checkConnectivity(signal?: AbortSignal): Promise<boolean> {
+    return this.runConnectivityCycle(signal);
+  }
+
+  /** Drain available records in bounded batches until empty or a failure occurs. */
+  async synchronizeNow(signal?: AbortSignal): Promise<number> {
+    this.assertInitialized();
+    if (!this.isConnected) {
+      return 0;
+    }
+    let forwarded = 0;
+    await this.serialized(async () => {
+      while (this.localStore.size > 0 && this.isConnected) {
+        const batch = [...this.localStore.values()].slice(
+          0,
+          this.config.forwardBatchSize,
+        );
+        const root = merkleRoot(batch.map(integrityPayload));
+        let result: ForwardBatchResult;
+        try {
+          result = await this.transport.forward(
+            { records: batch.map(cloneRecord), merkleRoot: root },
+            signal,
+          );
+        } catch (error) {
+          for (const record of batch) {
+            record.attempts += 1;
+            record.checksum = recordChecksum(record);
+          }
+          await this.persist();
+          this.recordConnectionFailure(error);
+          break;
+        }
+
+        if (result.verifiedMerkleRoot !== root) {
+          await this.reportDivergence({
+            type: "integrity",
+            resolution: "retry-local",
+            detail: `upstream verified ${result.verifiedMerkleRoot}, expected ${root}`,
+            detectedAt: this.now(),
+          });
+          for (const record of batch) {
+            record.attempts += 1;
+            record.checksum = recordChecksum(record);
+          }
+          await this.persist();
+          this.recordConnectionFailure(new Error("upstream Merkle root mismatch"));
+          break;
+        }
+
+        const batchIds = new Set(batch.map((record) => record.id));
+        const conflicts = new Map(
+          (result.conflicts ?? []).map((conflict) => [
+            conflict.recordId,
+            conflict,
+          ]),
+        );
+        const acknowledged = new Set<string>();
+        for (const id of result.acknowledgedIds) {
+          if (!batchIds.has(id)) {
+            throw new Error(`upstream acknowledged unknown record ${id}`);
+          }
+          if (!conflicts.has(id)) {
+            acknowledged.add(id);
+          }
+        }
+        for (const conflict of conflicts.values()) {
+          if (!batchIds.has(conflict.recordId)) {
+            throw new Error(`upstream reported conflict for unknown record ${conflict.recordId}`);
+          }
+          await this.reconcileConflict(
+            this.localStore.get(conflict.recordId)!,
+            conflict.remote,
+          );
+        }
+        for (const id of acknowledged) {
+          this.localStore.delete(id);
+          forwarded += 1;
+        }
+
+        const unresolved = batch.filter(
+          (record) =>
+            this.localStore.has(record.id) && !conflicts.has(record.id),
+        );
+        for (const record of unresolved) {
+          record.attempts += 1;
+          record.checksum = recordChecksum(record);
+        }
+        await this.persist();
+        if (acknowledged.size > 0) {
+          this.lastSuccessfulForward = this.now();
+          this.emit("forwarded", acknowledged.size);
+        }
+        if (acknowledged.size === 0 && conflicts.size === 0) {
+          this.recordConnectionFailure(
+            new Error("upstream made no progress acknowledging batch"),
+          );
+          break;
+        }
+        // A merged/local-winning record must be offered again in a later sync.
+        // Breaking prevents a peer that repeatedly reports the same conflict
+        // from creating an unbounded tight loop.
+        if (conflicts.size > 0) {
+          break;
+        }
+      }
+    });
+    return forwarded;
+  }
+
+  private async reconcileConflict(
+    local: StoredRecord,
+    remote: EdgeReplicaValue,
+  ): Promise<void> {
+    if (local.kind === "telemetry") {
+      const winner = resolveTelemetryConflict(local, remote);
+      const localWins =
+        winner.origin === local.origin &&
+        winner.timestamp.getTime() === local.timestamp.getTime() &&
+        canonicalJson(winner.data) === canonicalJson(local.data);
+      await this.reportDivergence({
+        type: "telemetry-conflict",
+        recordId: local.id,
+        resolution: localWins ? "local-wins" : "remote-wins",
+        detail: `last-writer-wins selected ${winner.origin}`,
+        detectedAt: this.now(),
+      });
+      if (!localWins) {
+        this.localStore.delete(local.id);
+      } else {
+        local.attempts += 1;
+        local.checksum = recordChecksum(local);
+      }
       return;
     }
 
-    const recordsToForward = Array.from(this.localStore.values())
-      .slice(0, this.config.forwardBatchSize);
+    const merged = mergeConfigurationConflict(local, remote);
+    local.data = merged.data;
+    local.fieldVersions = merged.fieldVersions;
+    local.timestamp = merged.timestamp;
+    local.origin = merged.origin;
+    local.attempts += 1;
+    local.checksum = recordChecksum(local);
+    await this.reportDivergence({
+      type: "configuration-conflict",
+      recordId: local.id,
+      resolution: "merged",
+      detail: `merged ${Object.keys(merged.fieldVersions ?? {}).length} versioned fields`,
+      detectedAt: this.now(),
+    });
+  }
 
-    for (const record of recordsToForward) {
-      try {
-        // Simulate forwarding to cloud/upstream service
-        await this.forwardRecord(record);
-        
-        this.localStore.delete(record.id);
-        this.lastSuccessfulForward = new Date();
-        
-      } catch (error) {
-        logError(`Failed to forward record ${record.id}`, error as any);
-        record.attempts++;
-        
-        // Remove records that have failed too many times
-        if (record.attempts >= 5) {
-          log(`Dropping record ${record.id} after 5 failed attempts`);
-          this.localStore.delete(record.id);
-        }
+  private async processLocally(record: StoredRecord): Promise<void> {
+    const results = await Promise.allSettled(
+      this.localProcessors.map((processor) =>
+        Promise.resolve().then(() => processor.process(cloneRecord(record))),
+      ),
+    );
+    for (const result of results) {
+      if (result.status === "rejected") {
+        const message = errorMessage(result.reason);
+        logError(result.reason, `Local edge processor failed: ${message}`);
+        this.emit("local-operation-error", message);
       }
     }
+  }
 
-    if (this.localStore.size > 0) {
-      log(`Store-and-forward: ${this.localStore.size} records remaining`);
+  private recordConnectionFailure(error: unknown): void {
+    const wasConnected = this.isConnected;
+    this.isConnected = false;
+    this.consecutiveFailures += 1;
+    this.lastError = errorMessage(error);
+    if (wasConnected || this.consecutiveFailures === 1) {
+      this.emit("connectivity-changed", false);
+    }
+    logError(error, "Store-and-forward connectivity/sync failure");
+  }
+
+  private currentBackoffMs(): number {
+    const exponent = Math.max(0, this.consecutiveFailures - 1);
+    return Math.min(
+      this.config.maxRetryInterval,
+      this.config.retryInterval * 2 ** Math.min(exponent, 30),
+    );
+  }
+
+  private schedule(delayMs: number): void {
+    if (this.stopped) {
+      return;
+    }
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.nextRetryAt = this.isConnected
+      ? null
+      : new Date(this.now().getTime() + delayMs);
+    this.timer = setTimeout(() => {
+      void this.runConnectivityCycle();
+    }, delayMs);
+    this.timer.unref?.();
+  }
+
+  private async reportDivergence(report: DivergenceReport): Promise<void> {
+    this.divergenceCount += 1;
+    this.emit("divergence", structuredClone(report));
+    await this.divergenceReporter?.report(structuredClone(report));
+  }
+
+  private async persist(): Promise<void> {
+    try {
+      await this.queue.save([...this.localStore.values()].map(cloneRecord));
+      this.lastStorageError = undefined;
+    } catch (error) {
+      this.lastStorageError = errorMessage(error);
+      throw error;
     }
   }
 
-  /**
-   * Forward a single record (simulate)
-   */
-  private async forwardRecord(record: StoredRecord): Promise<void> {
-    // Simulate network delay and potential failure
-    await new Promise(resolve => setTimeout(resolve, 50));
-    
-    // Simulate 5% failure rate in development
-    if (process.env.NODE_ENV === 'development' && Math.random() < 0.05) {
-      throw new Error('Simulated network failure');
+  private assertInitialized(): void {
+    if (!this.initialized) {
+      throw new Error("store-and-forward service is not initialized");
     }
-    
-    log(`Forwarded record ${record.id} from driver ${record.driverId || 'unknown'}`);
   }
 
-  /**
-   * Start periodic connectivity heartbeat
-   */
-  private startHeartbeat(): void {
-    this.heartbeatTimer = setInterval(async () => {
-      await this.checkConnectivity();
-    }, this.config.heartbeatInterval);
-
-    // Initial connectivity check
-    this.checkConnectivity();
+  private async serialized<T>(work: () => Promise<T>): Promise<T> {
+    const previous = this.operation;
+    let release!: () => void;
+    this.operation = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await work();
+    } finally {
+      release();
+    }
   }
 }
 
-// Singleton instance
-export const storeAndForwardService = new StoreAndForwardService();
+/** Telemetry uses timestamp LWW, then origin and canonical value as tie-breakers. */
+export function resolveTelemetryConflict(
+  local: EdgeReplicaValue,
+  remote: EdgeReplicaValue,
+): EdgeReplicaValue {
+  validateReplicaValue(local, false);
+  validateReplicaValue(remote, false);
+  const comparison =
+    local.timestamp.getTime() - remote.timestamp.getTime() ||
+    local.origin.localeCompare(remote.origin) ||
+    canonicalJson(local.data).localeCompare(canonicalJson(remote.data));
+  return structuredClone(comparison >= 0 ? local : remote);
+}
+
+/**
+ * Configuration is merged per leaf using explicit field clocks. This preserves
+ * non-conflicting edits from both peers and deterministically resolves the same
+ * field by timestamp then origin.
+ */
+export function mergeConfigurationConflict(
+  local: EdgeReplicaValue,
+  remote: EdgeReplicaValue,
+): EdgeReplicaValue {
+  validateReplicaValue(local, true);
+  validateReplicaValue(remote, true);
+  if (!isPlainObject(local.data) || !isPlainObject(remote.data)) {
+    throw new Error("configuration conflict values must be objects");
+  }
+  const localFlat = flatten(local.data);
+  const remoteFlat = flatten(remote.data);
+  const localVersions = normalizedFieldVersions(local, localFlat);
+  const remoteVersions = normalizedFieldVersions(remote, remoteFlat);
+  const mergedFlat = new Map<string, unknown>();
+  const mergedVersions: Record<string, FieldVersion> = {};
+  const paths = new Set([...localFlat.keys(), ...remoteFlat.keys()]);
+
+  for (const path of [...paths].sort()) {
+    const localVersion = localVersions[path];
+    const remoteVersion = remoteVersions[path];
+    if (!localVersion) {
+      mergedFlat.set(path, structuredClone(remoteFlat.get(path)));
+      mergedVersions[path] = cloneFieldVersion(remoteVersion);
+      continue;
+    }
+    if (!remoteVersion) {
+      mergedFlat.set(path, structuredClone(localFlat.get(path)));
+      mergedVersions[path] = cloneFieldVersion(localVersion);
+      continue;
+    }
+    const comparison =
+      localVersion.timestamp.getTime() - remoteVersion.timestamp.getTime() ||
+      localVersion.origin.localeCompare(remoteVersion.origin) ||
+      canonicalJson(localFlat.get(path)).localeCompare(
+        canonicalJson(remoteFlat.get(path)),
+      );
+    if (comparison >= 0) {
+      mergedFlat.set(path, structuredClone(localFlat.get(path)));
+      mergedVersions[path] = cloneFieldVersion(localVersion);
+    } else {
+      mergedFlat.set(path, structuredClone(remoteFlat.get(path)));
+      mergedVersions[path] = cloneFieldVersion(remoteVersion);
+    }
+  }
+  const latest = Object.values(mergedVersions).sort(
+    (left, right) =>
+      right.timestamp.getTime() - left.timestamp.getTime() ||
+      right.origin.localeCompare(left.origin),
+  )[0];
+  return {
+    data: unflatten(mergedFlat),
+    fieldVersions: mergedVersions,
+    timestamp: latest?.timestamp ?? maxDate(local.timestamp, remote.timestamp),
+    origin: latest?.origin ?? [local.origin, remote.origin].sort().at(-1)!,
+  };
+}
+
+function normalizedFieldVersions(
+  value: EdgeReplicaValue,
+  fields: ReadonlyMap<string, unknown>,
+): Record<string, FieldVersion> {
+  const result: Record<string, FieldVersion> = {};
+  for (const path of fields.keys()) {
+    const explicit = value.fieldVersions?.[path];
+    result[path] = explicit
+      ? cloneFieldVersion(explicit)
+      : { timestamp: new Date(value.timestamp), origin: value.origin };
+  }
+  return result;
+}
+
+function flatten(
+  value: Readonly<Record<string, unknown>>,
+  prefix = "",
+  result = new Map<string, unknown>(),
+): Map<string, unknown> {
+  for (const [key, child] of Object.entries(value).sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    validateConfigurationKey(key);
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (isPlainObject(child) && Object.keys(child).length > 0) {
+      flatten(child, path, result);
+    } else {
+      result.set(path, structuredClone(child));
+    }
+  }
+  return result;
+}
+
+function unflatten(fields: ReadonlyMap<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = Object.create(null);
+  for (const [path, value] of fields) {
+    const segments = path.split(".");
+    segments.forEach(validateConfigurationKey);
+    let cursor = result;
+    segments.forEach((segment, index) => {
+      if (index === segments.length - 1) {
+        cursor[segment] = structuredClone(value);
+      } else {
+        const child = cursor[segment];
+        if (!isPlainObject(child)) {
+          cursor[segment] = Object.create(null);
+        }
+        cursor = cursor[segment] as Record<string, unknown>;
+      }
+    });
+  }
+  return result;
+}
+
+function integrityPayload(record: StoredRecord): unknown {
+  const { checksum: _checksum, ...payload } = record;
+  return payload;
+}
+
+function recordChecksum(record: Omit<StoredRecord, "checksum"> | StoredRecord): string {
+  const { checksum: _checksum, ...payload } = record as StoredRecord;
+  return sha256Hex(canonicalJson(payload));
+}
+
+function assertRecordIntegrity(record: StoredRecord): void {
+  validateStoredRecord(record);
+  if (record.checksum !== recordChecksum(record)) {
+    throw new QueueIntegrityError(record.id);
+  }
+}
+
+function serializeRecord(record: StoredRecord): SerializedRecord {
+  validateStoredRecord(record);
+  return {
+    ...structuredClone(record),
+    timestamp: record.timestamp.toISOString(),
+    fieldVersions: record.fieldVersions
+      ? Object.fromEntries(
+          Object.entries(record.fieldVersions).map(([path, version]) => [
+            path,
+            {
+              timestamp: version.timestamp.toISOString(),
+              origin: version.origin,
+            },
+          ]),
+        )
+      : undefined,
+  };
+}
+
+function deserializeRecord(record: SerializedRecord): StoredRecord {
+  if (!record.id || !record.checksum || !record.kind || !record.origin) {
+    throw new Error("corrupt edge queue record");
+  }
+  const timestamp = new Date(record.timestamp);
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new Error(`invalid timestamp for edge queue record ${record.id}`);
+  }
+  const deserialized: StoredRecord = {
+    ...record,
+    timestamp,
+    fieldVersions: record.fieldVersions
+      ? Object.fromEntries(
+          Object.entries(record.fieldVersions).map(([path, version]) => {
+            const parsed = new Date(version.timestamp);
+            if (Number.isNaN(parsed.getTime())) {
+              throw new Error(`invalid field timestamp for edge queue record ${record.id}`);
+            }
+            return [path, { timestamp: parsed, origin: version.origin }];
+          }),
+        )
+      : undefined,
+  };
+  validateStoredRecord(deserialized);
+  return deserialized;
+}
+
+function cloneRecord(record: StoredRecord): StoredRecord {
+  return structuredClone(record);
+}
+
+function cloneFieldVersions(
+  versions: Readonly<Record<string, FieldVersion>>,
+): Record<string, FieldVersion> {
+  return Object.fromEntries(
+    Object.entries(versions).map(([path, version]) => [
+      path,
+      cloneFieldVersion(version),
+    ]),
+  );
+}
+
+function cloneFieldVersion(version: FieldVersion): FieldVersion {
+  if (!version) {
+    throw new Error("missing configuration field version");
+  }
+  return {
+    timestamp: new Date(version.timestamp),
+    origin: version.origin,
+  };
+}
+
+function maxDate(left: Date, right: Date): Date {
+  return new Date(Math.max(left.getTime(), right.getTime()));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+const FORBIDDEN_CONFIGURATION_KEYS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+function assertJsonSafe(
+  value: unknown,
+  path: string,
+  ancestors = new WeakSet<object>(),
+): void {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error(`${path} must contain only finite JSON numbers`);
+    }
+    return;
+  }
+  if (typeof value !== "object") {
+    throw new Error(`${path} must be JSON-safe`);
+  }
+  if (ancestors.has(value)) {
+    throw new Error(`${path} contains a circular reference`);
+  }
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      value.forEach((child, index) =>
+        assertJsonSafe(child, `${path}[${index}]`, ancestors),
+      );
+      return;
+    }
+    if (!isPlainObject(value)) {
+      throw new Error(`${path} must contain only plain JSON objects`);
+    }
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== "string") {
+        throw new Error(`${path} cannot contain symbol keys`);
+      }
+      if (FORBIDDEN_CONFIGURATION_KEYS.has(key)) {
+        throw new Error(`${path} contains forbidden key ${key}`);
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || !("value" in descriptor)) {
+        throw new Error(`${path}.${key} must be a data property`);
+      }
+      assertJsonSafe(descriptor.value, `${path}.${key}`, ancestors);
+    }
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function validateConfigurationKey(key: string): void {
+  if (
+    !key ||
+    key.includes(".") ||
+    FORBIDDEN_CONFIGURATION_KEYS.has(key)
+  ) {
+    throw new Error(`invalid configuration field name: ${key}`);
+  }
+}
+
+function validateConfigurationObject(
+  value: Readonly<Record<string, unknown>>,
+): void {
+  const visit = (candidate: unknown): void => {
+    if (Array.isArray(candidate)) {
+      candidate.forEach(visit);
+      return;
+    }
+    if (!isPlainObject(candidate)) {
+      return;
+    }
+    for (const [key, child] of Object.entries(candidate)) {
+      validateConfigurationKey(key);
+      visit(child);
+    }
+  };
+  visit(value);
+}
+
+function assertValidDate(value: Date, name: string): void {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new Error(`${name} must be a valid date`);
+  }
+}
+
+function validateFieldVersions(
+  versions: Readonly<Record<string, FieldVersion>>,
+): void {
+  for (const [path, version] of Object.entries(versions)) {
+    if (!path) {
+      throw new Error("configuration field version path cannot be empty");
+    }
+    path.split(".").forEach(validateConfigurationKey);
+    if (!version?.origin?.trim()) {
+      throw new Error(`configuration field ${path} requires an origin`);
+    }
+    assertValidDate(version.timestamp, `configuration field ${path} timestamp`);
+  }
+}
+
+function validateReplicaValue(
+  value: EdgeReplicaValue,
+  configuration: boolean,
+): void {
+  assertValidDate(value.timestamp, "replica timestamp");
+  if (!value.origin?.trim()) {
+    throw new Error("replica origin cannot be empty");
+  }
+  assertJsonSafe(value.data, "$.data");
+  if (configuration) {
+    if (!isPlainObject(value.data)) {
+      throw new Error("configuration conflict values must be objects");
+    }
+    validateConfigurationObject(value.data);
+    if (value.fieldVersions) {
+      validateFieldVersions(value.fieldVersions);
+    }
+  }
+}
+
+function validateStoredRecord(record: StoredRecord): void {
+  if (!record.id?.trim()) {
+    throw new Error("edge queue record id cannot be empty");
+  }
+  if (!Number.isSafeInteger(record.attempts) || record.attempts < 0) {
+    throw new Error(`invalid attempts for edge queue record ${record.id}`);
+  }
+  if (record.kind !== "telemetry" && record.kind !== "configuration") {
+    throw new Error(`invalid kind for edge queue record ${record.id}`);
+  }
+  if (!record.origin?.trim()) {
+    throw new Error(`invalid origin for edge queue record ${record.id}`);
+  }
+  if (!/^[0-9a-f]{64}$/i.test(record.checksum)) {
+    throw new Error(`invalid checksum for edge queue record ${record.id}`);
+  }
+  assertValidDate(record.timestamp, `edge queue record ${record.id} timestamp`);
+  assertJsonSafe(record.data, "$.data");
+  if (record.kind === "configuration") {
+    if (!isPlainObject(record.data)) {
+      throw new Error(
+        `configuration edge queue record ${record.id} must contain an object`,
+      );
+    }
+    validateConfigurationObject(record.data);
+  }
+  if (record.fieldVersions) {
+    validateFieldVersions(record.fieldVersions);
+  }
+}
+
+function validateConfig(config: StoreAndForwardConfig): void {
+  for (const [name, value] of Object.entries({
+    maxLocalStorage: config.maxLocalStorage,
+    forwardBatchSize: config.forwardBatchSize,
+    heartbeatInterval: config.heartbeatInterval,
+    retryInterval: config.retryInterval,
+    maxRetryInterval: config.maxRetryInterval,
+  })) {
+    if (!Number.isInteger(value) || value < 1) {
+      throw new Error(`${name} must be a positive integer`);
+    }
+  }
+  if (config.maxRetryInterval < config.retryInterval) {
+    throw new Error("maxRetryInterval must not be less than retryInterval");
+  }
+  if (!config.storagePath) {
+    throw new Error("storagePath is required");
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export let storeAndForwardService = new StoreAndForwardService();
+
+/**
+ * Composition hook used before startup. Static importers observe this live
+ * binding, so gateway writes and health checks share the injected service.
+ */
+export function configureStoreAndForwardService(
+  config: Partial<StoreAndForwardConfig>,
+  dependencies: StoreAndForwardDependencies,
+): StoreAndForwardService {
+  if (storeAndForwardService.isInitialized()) {
+    throw new Error(
+      "store-and-forward service must be configured before initialization",
+    );
+  }
+  if (!dependencies.transport) {
+    throw new Error("a real edge upstream transport must be injected");
+  }
+  storeAndForwardService = new StoreAndForwardService(config, dependencies);
+  return storeAndForwardService;
+}

--- a/server/health/index.ts
+++ b/server/health/index.ts
@@ -14,6 +14,7 @@ import { blockchainService } from '../blockchain';
 import { registry, collectProcessMetrics } from '../metrics';
 import { fieldSimulator } from '../simulator';
 import { storeAndForwardService } from '../gateway/store-and-forward';
+import { edgeStoreAndForwardRuntime } from '../gateway/store-and-forward-runtime';
 import { getBridgeHealthStatus } from '../bridge';
 import { describeBlueprintControlLoopHealth, getBlueprintControlLoop } from '../blueprint/control-loop';
 import { publishControlLoopProbeStatus } from '../integrity/latency-probe';
@@ -125,19 +126,40 @@ healthManager.registerSimple(
   false,
 );
 
-// 7. Edge store-and-forward service (required for edge deployments)
-healthManager.registerSimple(
-  'store-and-forward',
-  async () => {
+// 7. Edge store-and-forward service. Upstream loss is degraded, not unready:
+// the durable local queue is specifically required to operate through it.
+healthManager.register({
+  name: 'store-and-forward',
+  required: true,
+  check: async () => {
     try {
       const status = await storeAndForwardService.healthCheck();
-      return status.healthy;
-    } catch {
-      return false;
+      return {
+        name: 'store-and-forward',
+        status: status.healthy
+          ? status.degraded
+            ? 'degraded'
+            : 'healthy'
+          : 'unhealthy',
+        lastCheck: new Date(),
+        message: status.message,
+        details: {
+          productionBindingsEnabled: edgeStoreAndForwardRuntime.isEnabled(),
+          productionBindingsInitialized:
+            edgeStoreAndForwardRuntime.isInitialized(),
+          ...storeAndForwardService.getStatus(),
+        },
+      };
+    } catch (error) {
+      return {
+        name: 'store-and-forward',
+        status: 'unhealthy',
+        lastCheck: new Date(),
+        message: error instanceof Error ? error.message : String(error),
+      };
     }
   },
-  true, // Required for edge deployments
-);
+});
 
 // 8. Bridge modules (event-anchor, state-sync)
 healthManager.registerSimple(

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,7 @@ import { initializeDatabase } from "./storage";
 import { fieldSimulator } from "./simulator";
 import { initializeDefaultAgents, startDefaultAgents } from "./agents";
 import { storeAndForwardService } from "./gateway/store-and-forward";
+import { edgeStoreAndForwardRuntime } from "./gateway/store-and-forward-runtime";
 import { initializeBridges } from "./bridge";
 import { gatewayManager } from "./gateway";
 import { startFluxIntegration } from "./services/flux";
@@ -90,6 +91,13 @@ registerSwaggerRoutes(app, gatewayConfig);
   await initializeDefaultAgents();
   await startDefaultAgents();
   
+  // Install a real upstream transport before the shared queue singleton starts.
+  // Explicit production enablement without bindings fails startup closed.
+  await edgeStoreAndForwardRuntime.initialize();
+  if (edgeStoreAndForwardRuntime.isEnabled()) {
+    log("Production edge store-and-forward bindings initialized");
+  }
+
   // Initialize edge store-and-forward service
   await storeAndForwardService.initialize();
   log("Edge store-and-forward service initialized");

--- a/server/scaling/hash.ts
+++ b/server/scaling/hash.ts
@@ -1,0 +1,68 @@
+import { createHash } from "node:crypto";
+
+/**
+ * JSON encoding with recursively sorted object keys. Distributed peers use this
+ * before hashing so insertion order cannot change an integrity result.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === undefined) {
+    return "null";
+  }
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (value instanceof Date) {
+    return JSON.stringify(value.toISOString());
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, child]) => child !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries
+    .map(([key, child]) => `${JSON.stringify(key)}:${canonicalJson(child)}`)
+    .join(",")}}`;
+}
+
+export function sha256Hex(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/** A stable unsigned 64-bit hash suitable for rings and rollout buckets. */
+export function hash64(value: string): bigint {
+  return BigInt(`0x${sha256Hex(value).slice(0, 16)}`);
+}
+
+/**
+ * RFC-6962-style binary Merkle root. Leaves and branches are domain separated
+ * so a leaf cannot be confused with an internal node.
+ */
+export function merkleRoot(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    return sha256Hex(Buffer.from([0]));
+  }
+
+  let level = values.map((value) =>
+    sha256Hex(Buffer.concat([Buffer.from([0]), Buffer.from(canonicalJson(value))])),
+  );
+  while (level.length > 1) {
+    const next: string[] = [];
+    for (let index = 0; index < level.length; index += 2) {
+      const left = level[index];
+      const right = level[index + 1] ?? left;
+      next.push(
+        sha256Hex(
+          Buffer.concat([
+            Buffer.from([1]),
+            Buffer.from(left, "hex"),
+            Buffer.from(right, "hex"),
+          ]),
+        ),
+      );
+    }
+    level = next;
+  }
+  return level[0];
+}


### PR DESCRIPTION
## Summary

Turns the existing gateway store-and-forward service into a durable,
integrity-checked offline edge pipeline while preserving its established
`store(data, driverId)` entry point.

Key additions include:

- an atomic fsync-backed JSON queue and a pluggable durable queue interface;
- fail-closed capacity and recovery validation;
- SHA-256 record checksums and Merkle-root-verified batch acknowledgements;
- automatic reconnect with capped exponential backoff;
- deterministic telemetry and per-field configuration conflict resolution;
- local post-commit processing while disconnected; and
- injectable durable divergence reporting.

## Why

The prior implementation kept records in memory and treated connectivity as a
simulation. Process restarts could lose pending data, acknowledgements had no
end-to-end integrity proof, and reconnect/conflict behavior was insufficient
for a real edge outage.

## Safety and compatibility

The service never silently evicts unacknowledged records. Queue corruption,
capacity exhaustion, initialization failures, and persistence failures are
hard health failures. Ordinary upstream outages are degraded health because
local durable collection remains available.

Only JSON values that round-trip without coercion are accepted. Production must
inject an upstream transport; the environment transport cannot claim
production reachability by default.

`server/gateway/store-and-forward-runtime.ts` makes that injection operational:
when production synchronization is enabled it loads a deployment bindings
module, rejects missing/incomplete or environment-only transports, and installs
the real transport before the shared service initializes. Readiness now reports
binding state, connectivity degradation, queue depth, retry state, storage
errors, and divergence count.

## Validation

- `npx vitest run server/gateway/__tests__/store-and-forward.test.ts server/gateway/__tests__/store-and-forward-runtime.test.ts server/__tests__/startup-singleton-imports.test.ts` — 16 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — passed

The branch contains two signed commits based directly on `main` and only the
edge service, integrity and production-composition helpers, startup/health
wiring, focused tests, guide, and local data ignore.

Closes #224
