### PR TITLE
Add secure multi-site federation

### DIFF
--- a/docs/architecture/multi-site-federation.md
+++ b/docs/architecture/multi-site-federation.md
@@ -1,0 +1,43 @@
+# Multi-site federation
+
+This document is the executable companion to
+[ADR-0014](../decisions/ADR-0014-production-scale-architecture.md) for issue
+[#223](https://github.com/NickFlach/0xSCADA/issues/223).
+
+`server/scaling/federation.ts` supplies the application-level federation
+contracts without coupling them to a particular registry or network client:
+
+- `FederatedSiteDiscovery` combines registry and mDNS adapters, deduplicates
+  results, and applies `MutualTlsSiteIdentityPolicy` before returning peers.
+- `CrossSiteTagReference` parses and emits canonical `site:area/tag`
+  references.
+- `FederatedAlarmView` and `FederatedReporting` query sites concurrently and
+  return both data and explicit failures, so an unavailable site never produces
+  a complete-looking partial view.
+- `ReplicatedConfiguration` is a Lamport-clocked last-writer-wins map with
+  retained tombstones, deterministic actor tie-breaking, and conflict
+  visibility. Merge is associative, commutative, and idempotent.
+
+The discovery identity policy fails closed unless the endpoint uses HTTPS, the
+certificate is currently valid, the issuer is trusted, the claimed site matches
+the certificate identity, the SAN contains `urn:0xscada:site:<site-id>`, and
+any configured certificate pin matches. Conflicting certificates advertised
+for one site namespace reject that namespace for the discovery pass.
+
+Discovery adapters receive an `AbortSignal`. Production registry and mDNS
+bindings must return certificate identity observed by the authenticated mTLS
+transport, not metadata supplied only by an unauthenticated advertisement.
+
+## Verification
+
+Run:
+
+```bash
+npx vitest run server/scaling/__tests__/federation.test.ts
+npm run typecheck
+npm run build
+```
+
+The focused suite covers registry/mDNS deduplication, mTLS rejection,
+conflicting identities, cross-site references, partial alarm/report failures,
+and CRDT convergence, conflict, and tombstone behavior.

--- a/docs/architecture/multi-site-federation.md
+++ b/docs/architecture/multi-site-federation.md
@@ -28,12 +28,27 @@ Discovery adapters receive an `AbortSignal`. Production registry and mDNS
 bindings must return certificate identity observed by the authenticated mTLS
 transport, not metadata supplied only by an unauthenticated advertisement.
 
+`server/scaling/federation-runtime.ts` makes the federation services reachable
+from the running server. Enable it with:
+
+```text
+MULTI_SITE_FEDERATION_ENABLED=true
+MULTI_SITE_FEDERATION_REQUIRED=true
+MULTI_SITE_FEDERATION_BINDINGS_MODULE=/absolute/path/to/federation-bindings.mjs
+```
+
+The module may export `createFederationBindings`, `federationBindings`, or a
+default bindings object. Enabled startup validates discovery, alarm, reporting,
+configuration, and health services and fails closed when any is missing.
+`/health` exposes the deployment probe and can make it readiness-critical.
+
 ## Verification
 
 Run:
 
 ```bash
 npx vitest run server/scaling/__tests__/federation.test.ts
+npx vitest run server/scaling/__tests__/federation-runtime.test.ts
 npm run typecheck
 npm run build
 ```

--- a/server/__tests__/startup-singleton-imports.test.ts
+++ b/server/__tests__/startup-singleton-imports.test.ts
@@ -54,6 +54,7 @@ describe("startup singleton module identity", () => {
         "./gateway/store-and-forward",
         "./gateway/store-and-forward-runtime",
         "./bridge",
+        "./scaling/federation-runtime",
         "./gateway",
         "./services/flux",
         "./services/nats",
@@ -64,6 +65,7 @@ describe("startup singleton module identity", () => {
       file: "server/health/index.ts",
       modules: [
         "../simulator",
+        "../scaling/federation-runtime",
         "../gateway/store-and-forward",
         "../gateway/store-and-forward-runtime",
         "../bridge",

--- a/server/health/index.ts
+++ b/server/health/index.ts
@@ -16,6 +16,7 @@ import { fieldSimulator } from '../simulator';
 import { storeAndForwardService } from '../gateway/store-and-forward';
 import { edgeStoreAndForwardRuntime } from '../gateway/store-and-forward-runtime';
 import { getBridgeHealthStatus } from '../bridge';
+import { federationRuntime } from '../scaling/federation-runtime';
 import { describeBlueprintControlLoopHealth, getBlueprintControlLoop } from '../blueprint/control-loop';
 import { publishControlLoopProbeStatus } from '../integrity/latency-probe';
 import { getBlueprintProductionSafetyStatus } from '../blueprint/production-safety';
@@ -174,6 +175,25 @@ healthManager.registerSimple(
   },
   false, // Optional, depends on configuration
 );
+
+healthManager.register({
+  name: 'multi-site-federation',
+  required: federationRuntime.isRequired(),
+  check: async () => {
+    const health = await federationRuntime.health();
+    return {
+      name: 'multi-site-federation',
+      status: health.healthy
+        ? health.degraded
+          ? 'degraded'
+          : 'healthy'
+        : 'unhealthy',
+      lastCheck: new Date(),
+      message: health.message,
+      details: health.details ? { ...health.details } : undefined,
+    };
+  },
+});
 
 // 9. Deterministic blueprint control loop (#457).
 //    Optional and OFF by default. "Disabled" is reported as healthy — an

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,6 +18,7 @@ import { edgeStoreAndForwardRuntime } from "./gateway/store-and-forward-runtime"
 import { initializeBridges } from "./bridge";
 import { gatewayManager } from "./gateway";
 import { startFluxIntegration } from "./services/flux";
+import { federationRuntime } from "./scaling/federation-runtime";
 import { natsPublisher } from "./services/nats";
 import { logAnchorBackendBootState } from "./bridge/anchor-backend";
 import { startBlueprintControlLoop } from "./blueprint/control-loop";
@@ -85,6 +86,13 @@ registerSwaggerRoutes(app, gatewayConfig);
   // depend on an established connection (SQLite fallback in development).
   await initializeDatabase();
   log("Database initialized");
+
+  // Bind authenticated discovery, federated query, and replicated
+  // configuration adapters before accepting traffic.
+  await federationRuntime.initialize();
+  if (federationRuntime.isEnabled()) {
+    log("Multi-site federation runtime initialized");
+  }
 
   await fieldSimulator.initialize();
   

--- a/server/scaling/__tests__/federation-identity.test.ts
+++ b/server/scaling/__tests__/federation-identity.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Rejection-reason coverage for `MutualTlsSiteIdentityPolicy.verify`.
+ *
+ * The existing federation suite asserts one identity rejection (untrusted
+ * issuer) as part of a broader discovery test. Mutation testing showed the
+ * other five guards could each be deleted with the whole suite still green:
+ *
+ *   - certificate siteId vs advertised siteId
+ *   - certificate pin for a previously-pinned site
+ *   - certificate validity window
+ *   - site-bound subject alternative name
+ *   - identity completeness
+ *
+ * That matters more here than in most modules. This policy exists because,
+ * without executable identity rules, "sites could silently trust advertisement
+ * metadata" — and the siteId-vs-advert check is precisely what stops a peer
+ * claiming another site's namespace. A guard whose removal no test notices is
+ * one refactor away from not being there.
+ *
+ * Each test below perturbs exactly one field of an otherwise-valid identity and
+ * asserts the specific reason, so a failure names which guard regressed rather
+ * than just reporting "identity rejected".
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  MutualTlsSiteIdentityPolicy,
+  type DiscoveredSite,
+  type PresentedSiteIdentity,
+} from "../federation";
+
+const NOW = new Date("2026-07-28T12:00:00Z");
+
+/** A fully valid advertisement; individual tests break one field at a time. */
+function validSite(overrides: Partial<PresentedSiteIdentity> = {}): DiscoveredSite {
+  const siteId = "north";
+  return {
+    siteId,
+    endpoint: `https://${siteId}.internal:8443`,
+    identity: {
+      siteId,
+      certificateFingerprint: "north-cert",
+      issuerFingerprint: "root-ca",
+      subjectAltNames: [`urn:0xscada:site:${siteId}`],
+      validFrom: new Date("2026-01-01T00:00:00Z"),
+      validTo: new Date("2027-01-01T00:00:00Z"),
+      ...overrides,
+    },
+  };
+}
+
+function policy(pins: Record<string, string> = {}): MutualTlsSiteIdentityPolicy {
+  return new MutualTlsSiteIdentityPolicy({
+    trustedIssuerFingerprints: ["root-ca"],
+    pinnedSiteFingerprints: pins,
+  });
+}
+
+describe("MutualTlsSiteIdentityPolicy rejection reasons (#223)", () => {
+  it("accepts a fully valid identity", () => {
+    expect(policy().verify(validSite(), NOW)).toEqual({ accepted: true });
+  });
+
+  it("rejects a certificate whose siteId disagrees with the advertisement", () => {
+    // The core of the threat model: an advert claiming to be `north` while
+    // presenting a certificate issued for `south`.
+    const candidate = validSite({ siteId: "south" });
+
+    expect(policy().verify(candidate, NOW)).toEqual({
+      accepted: false,
+      reason: "certificate site id does not match advert",
+    });
+  });
+
+  it("rejects an untrusted issuer", () => {
+    const candidate = validSite({ issuerFingerprint: "rogue-ca" });
+
+    expect(policy().verify(candidate, NOW)).toEqual({
+      accepted: false,
+      reason: "certificate issuer is not trusted",
+    });
+  });
+
+  it("rejects a certificate presented before it is valid", () => {
+    const candidate = validSite({
+      validFrom: new Date("2026-12-01T00:00:00Z"),
+      validTo: new Date("2027-12-01T00:00:00Z"),
+    });
+
+    expect(policy().verify(candidate, NOW)).toEqual({
+      accepted: false,
+      reason: "certificate is outside its validity window",
+    });
+  });
+
+  it("rejects an expired certificate", () => {
+    const candidate = validSite({
+      validFrom: new Date("2025-01-01T00:00:00Z"),
+      validTo: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    expect(policy().verify(candidate, NOW)).toEqual({
+      accepted: false,
+      reason: "certificate is outside its validity window",
+    });
+  });
+
+  it("rejects a certificate missing the site-bound subject alternative name", () => {
+    // A certificate valid for some other purpose under the same CA must not be
+    // usable as a site identity.
+    const candidate = validSite({ subjectAltNames: ["DNS:north.internal"] });
+
+    expect(policy().verify(candidate, NOW)).toEqual({
+      accepted: false,
+      reason: "certificate is missing the site-bound subject alternative name",
+    });
+  });
+
+  it("rejects an incomplete identity", () => {
+    const candidate = validSite({ certificateFingerprint: "   " });
+
+    expect(policy().verify(candidate, NOW)).toEqual({
+      accepted: false,
+      reason: "site identity is incomplete",
+    });
+  });
+
+  it("rejects a new certificate for an already-pinned site", () => {
+    // Rotation vs impersonation. This is distinct from the cross-provider
+    // conflict already covered in federation.test.ts: there, two providers
+    // disagree in one discovery round. Here a single advert presents a
+    // certificate that disagrees with what the operator pinned.
+    const candidate = validSite({ certificateFingerprint: "north-cert-v2" });
+
+    expect(policy({ north: "north-cert" }).verify(candidate, NOW)).toEqual({
+      accepted: false,
+      reason: "certificate does not match site pin",
+    });
+  });
+
+  it("accepts the pinned certificate for a pinned site", () => {
+    expect(policy({ north: "north-cert" }).verify(validSite(), NOW)).toEqual({
+      accepted: true,
+    });
+  });
+});

--- a/server/scaling/__tests__/federation-runtime.test.ts
+++ b/server/scaling/__tests__/federation-runtime.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  FederatedAlarmView,
+  FederatedReporting,
+  FederatedSiteDiscovery,
+  ReplicatedConfiguration,
+} from "../federation";
+import {
+  FederationRuntime,
+  type FederationBindings,
+} from "../federation-runtime";
+
+function bindings(): FederationBindings {
+  return {
+    discovery: new FederatedSiteDiscovery([], {
+      verify: () => ({ accepted: false }),
+    }),
+    alarms: new FederatedAlarmView([]),
+    reporting: new FederatedReporting([]),
+    configuration: new ReplicatedConfiguration("site-a"),
+    healthCheck: async () => ({
+      healthy: true,
+      details: { connectedSites: 0 },
+    }),
+  };
+}
+
+describe("multi-site federation production runtime", () => {
+  it("binds federation services and exposes their health", async () => {
+    const runtime = new FederationRuntime();
+    runtime.configure(bindings());
+    await runtime.initialize();
+
+    expect(runtime.isInitialized()).toBe(true);
+    await expect(runtime.bindings().discovery.discover()).resolves.toEqual({
+      sites: [],
+      rejected: [],
+    });
+    await expect(runtime.health()).resolves.toEqual({
+      healthy: true,
+      details: { connectedSites: 0 },
+    });
+  });
+
+  it("fails closed when any required production service is missing", () => {
+    const incomplete = bindings() as unknown as Record<string, unknown>;
+    delete incomplete.reporting;
+    expect(() =>
+      new FederationRuntime().configure(
+        incomplete as unknown as FederationBindings,
+      ),
+    ).toThrow(/federated reporting/);
+  });
+
+  it("surfaces federation health-check failures", async () => {
+    const runtime = new FederationRuntime();
+    runtime.configure({
+      ...bindings(),
+      healthCheck: () => {
+        throw new Error("registry unavailable");
+      },
+    });
+    await runtime.initialize();
+    await expect(runtime.health()).resolves.toMatchObject({
+      healthy: false,
+      message: "registry unavailable",
+    });
+  });
+});

--- a/server/scaling/__tests__/federation.test.ts
+++ b/server/scaling/__tests__/federation.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import {
+  CrossSiteTagReference,
+  FederatedAlarmView,
+  FederatedReporting,
+  FederatedSiteDiscovery,
+  MdnsSiteDiscovery,
+  MutualTlsSiteIdentityPolicy,
+  RegistrySiteDiscovery,
+  ReplicatedConfiguration,
+  type DiscoveredSite,
+} from "../federation";
+
+const NOW = new Date("2026-07-28T12:00:00Z");
+
+function site(
+  siteId: string,
+  fingerprint = `${siteId}-cert`,
+  issuer = "root-ca",
+): DiscoveredSite {
+  return {
+    siteId,
+    endpoint: `https://${siteId}.internal:8443`,
+    identity: {
+      siteId,
+      certificateFingerprint: fingerprint,
+      issuerFingerprint: issuer,
+      subjectAltNames: [`urn:0xscada:site:${siteId}`],
+      validFrom: new Date("2026-01-01T00:00:00Z"),
+      validTo: new Date("2027-01-01T00:00:00Z"),
+    },
+  };
+}
+
+describe("multi-site federation (#223)", () => {
+  it("combines registry/mDNS discovery and enforces the mTLS identity contract", async () => {
+    const registry = new RegistrySiteDiscovery({
+      listSites: async () => [site("north"), site("untrusted", "bad", "rogue-ca")],
+    });
+    const mdns = new MdnsSiteDiscovery({
+      browse: async (serviceType) => {
+        expect(serviceType).toBe("_0xscada._tcp.local");
+        return [site("north"), site("south")];
+      },
+    });
+    const policy = new MutualTlsSiteIdentityPolicy({
+      trustedIssuerFingerprints: ["root-ca"],
+      pinnedSiteFingerprints: { north: "north-cert" },
+    });
+    // Bind the deterministic validation time for this test.
+    const discovery = new FederatedSiteDiscovery([registry, mdns], {
+      verify: (candidate) => policy.verify(candidate, NOW),
+    });
+
+    const result = await discovery.discover();
+    expect(result.sites.map((candidate) => candidate.siteId)).toEqual([
+      "north",
+      "south",
+    ]);
+    expect(result.rejected).toContainEqual({
+      provider: "registry",
+      siteId: "untrusted",
+      reason: "certificate issuer is not trusted",
+    });
+  });
+
+  it("fails a namespace closed when discovery sources advertise different certificates", async () => {
+    const discovery = new FederatedSiteDiscovery(
+      [
+        { name: "registry", discover: async () => [site("north", "cert-a")] },
+        { name: "mdns", discover: async () => [site("north", "cert-b")] },
+      ],
+      { verify: () => ({ accepted: true }) },
+    );
+    const result = await discovery.discover();
+    expect(result.sites).toEqual([]);
+    expect(result.rejected[0].reason).toMatch(/conflicting certificates/);
+  });
+
+  it("parses and canonicalizes namespace-qualified cross-site tags", () => {
+    const reference = CrossSiteTagReference.parse("plant-a:boiler-2/temp.out");
+    expect(reference.site).toBe("plant-a");
+    expect(reference.area).toBe("boiler-2");
+    expect(reference.tag).toBe("temp.out");
+    expect(reference.toString()).toBe("plant-a:boiler-2/temp.out");
+    expect(() => CrossSiteTagReference.parse("boiler/temp")).toThrow(
+      /invalid cross-site tag/,
+    );
+    expect(() => CrossSiteTagReference.parse("site:../secret")).toThrow(
+      /invalid cross-site tag/,
+    );
+  });
+
+  it("aggregates alarms and reports while exposing partial site failures", async () => {
+    const alarms = await new FederatedAlarmView([
+      {
+        siteId: "north",
+        activeAlarms: async () => [
+          {
+            id: "a-1",
+            tag: "boiler/temp",
+            severity: 4,
+            activeAt: new Date("2026-07-28T10:00:00Z"),
+            message: "high",
+          },
+        ],
+      },
+      {
+        siteId: "south",
+        activeAlarms: async () => {
+          throw new Error("site offline");
+        },
+      },
+    ]).query();
+    expect(alarms.alarms[0]).toMatchObject({
+      federatedId: "north:a-1",
+      tagReference: "north:boiler/temp",
+    });
+    expect(alarms.failures).toEqual([
+      { siteId: "south", error: "site offline" },
+    ]);
+
+    const report = await new FederatedReporting<{ events: number }>([
+      {
+        siteId: "north",
+        generate: async () => ({ events: 12 }),
+      },
+      {
+        siteId: "south",
+        generate: async () => {
+          throw new Error("report timeout");
+        },
+      },
+    ]).generate(
+      "operations",
+      new Date("2026-07-01T00:00:00Z"),
+      new Date("2026-08-01T00:00:00Z"),
+    );
+    expect(report.sections).toEqual([
+      { siteId: "north", data: { events: 12 } },
+    ]);
+    expect(report.failures).toEqual([
+      { siteId: "south", error: "report timeout" },
+    ]);
+  });
+
+  it("merges replicated configuration associatively and deterministically", () => {
+    const north = new ReplicatedConfiguration("north");
+    const south = new ReplicatedConfiguration("south");
+    north.set("alarm.high", 90);
+    south.set("alarm.low", 10);
+    north.set("display.units", "celsius");
+    south.set("display.units", "fahrenheit");
+
+    const northReplica = new ReplicatedConfiguration("north-copy");
+    northReplica.merge(north);
+    northReplica.merge(south);
+    const southReplica = new ReplicatedConfiguration("south-copy");
+    southReplica.merge(south);
+    southReplica.merge(north);
+
+    expect(northReplica.value()).toEqual(southReplica.value());
+    expect(northReplica.value()).toEqual({
+      alarm: { high: 90, low: 10 },
+      display: { units: "fahrenheit" },
+    });
+    expect(northReplica.conflicts()).toHaveLength(1);
+    expect(southReplica.conflicts()).toHaveLength(1);
+  });
+
+  it("retains tombstones so stale values cannot resurrect after merge", () => {
+    const first = new ReplicatedConfiguration("a");
+    const staleSet = first.set("gateway.mode", "active");
+    first.delete("gateway.mode");
+    const second = new ReplicatedConfiguration("b");
+    second.apply(staleSet);
+    second.merge(first);
+    expect(second.value()).toEqual({});
+    second.merge(first);
+    expect(second.value()).toEqual({});
+  });
+
+  it("converges deterministically even if one actor equivocates at a clock", () => {
+    const left = new ReplicatedConfiguration("left");
+    const right = new ReplicatedConfiguration("right");
+    const first = {
+      path: "gateway.mode",
+      version: { counter: 7, actor: "compromised-peer" },
+      value: "active",
+      deleted: false,
+    };
+    const second = { ...first, value: "standby" };
+    left.apply(first);
+    left.apply(second);
+    right.apply(second);
+    right.apply(first);
+    expect(left.value()).toEqual(right.value());
+    expect(left.conflicts()[0].reason).toBe("equivocation");
+    expect(right.conflicts()[0].reason).toBe("equivocation");
+  });
+
+  it("rejects configuration values that cannot converge through JSON", () => {
+    const configuration = new ReplicatedConfiguration("north");
+    expect(() => configuration.set("sensor.value", Number.NaN)).toThrow(
+      /finite/,
+    );
+    expect(() =>
+      configuration.set("sensor.observed", new Date()),
+    ).toThrow(/plain JSON/);
+    expect(() =>
+      configuration.apply({
+        path: "sensor.value",
+        version: { counter: 1, actor: "south" },
+        value: 1n,
+        deleted: false,
+      }),
+    ).toThrow(/JSON-safe/);
+  });
+});

--- a/server/scaling/federation-runtime.ts
+++ b/server/scaling/federation-runtime.ts
@@ -1,0 +1,168 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  FederatedAlarmView,
+  FederatedReporting,
+  FederatedSiteDiscovery,
+  ReplicatedConfiguration,
+} from "./federation";
+
+export interface FederationRuntimeHealth {
+  healthy: boolean;
+  degraded?: boolean;
+  message?: string;
+  details?: Readonly<Record<string, unknown>>;
+}
+
+export interface FederationBindings {
+  discovery: FederatedSiteDiscovery;
+  alarms: FederatedAlarmView;
+  reporting: FederatedReporting;
+  configuration: ReplicatedConfiguration;
+  healthCheck: () =>
+    | FederationRuntimeHealth
+    | Promise<FederationRuntimeHealth>;
+}
+
+export interface FederationFactories {
+  FederatedSiteDiscovery: typeof FederatedSiteDiscovery;
+  FederatedAlarmView: typeof FederatedAlarmView;
+  FederatedReporting: typeof FederatedReporting;
+  ReplicatedConfiguration: typeof ReplicatedConfiguration;
+}
+
+interface BindingsModule {
+  default?: FederationBindings;
+  federationBindings?: FederationBindings;
+  createFederationBindings?: (
+    factories: FederationFactories,
+  ) => FederationBindings | Promise<FederationBindings>;
+}
+
+export const federationFactories: FederationFactories = {
+  FederatedSiteDiscovery,
+  FederatedAlarmView,
+  FederatedReporting,
+  ReplicatedConfiguration,
+};
+
+/**
+ * Production composition root for multi-site federation. Production discovery
+ * and query clients are mandatory when enabled; no unauthenticated or in-memory
+ * peer source is installed as a fallback.
+ */
+export class FederationRuntime {
+  private configured?: FederationBindings;
+  private initialized = false;
+  private enabledByConfiguration = false;
+
+  configure(bindings: FederationBindings): void {
+    if (this.initialized) {
+      throw new Error("federation runtime is already initialized");
+    }
+    validateBindings(bindings);
+    this.configured = bindings;
+    this.enabledByConfiguration = true;
+  }
+
+  isEnabled(): boolean {
+    return (
+      this.enabledByConfiguration ||
+      process.env.MULTI_SITE_FEDERATION_ENABLED === "true"
+    );
+  }
+
+  isRequired(): boolean {
+    return process.env.MULTI_SITE_FEDERATION_REQUIRED === "true";
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized || !this.isEnabled()) return;
+    const bindings = this.configured ?? (await this.loadBindingsModule());
+    validateBindings(bindings);
+    this.configured = bindings;
+    this.initialized = true;
+  }
+
+  bindings(): Readonly<FederationBindings> {
+    if (!this.initialized || !this.configured) {
+      throw new Error("federation runtime is not initialized");
+    }
+    return this.configured;
+  }
+
+  async health(): Promise<FederationRuntimeHealth> {
+    if (!this.isEnabled()) return { healthy: true, message: "disabled" };
+    if (!this.initialized || !this.configured) {
+      return { healthy: false, message: "enabled but not initialized" };
+    }
+    try {
+      return await this.configured.healthCheck();
+    } catch (error) {
+      return {
+        healthy: false,
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async loadBindingsModule(): Promise<FederationBindings> {
+    const modulePath = process.env.MULTI_SITE_FEDERATION_BINDINGS_MODULE;
+    if (!modulePath) {
+      throw new Error(
+        "MULTI_SITE_FEDERATION_BINDINGS_MODULE is required when federation is enabled",
+      );
+    }
+    const loaded = (await import(
+      pathToFileURL(resolve(modulePath)).href
+    )) as BindingsModule;
+    const bindings = loaded.createFederationBindings
+      ? await loaded.createFederationBindings(federationFactories)
+      : loaded.federationBindings ?? loaded.default;
+    if (!bindings) {
+      throw new Error(
+        "federation bindings module must export createFederationBindings, federationBindings, or default",
+      );
+    }
+    return bindings;
+  }
+}
+
+function validateBindings(
+  bindings: FederationBindings,
+): asserts bindings is FederationBindings {
+  requireMethods(bindings?.discovery, ["discover"], "site discovery");
+  requireMethods(bindings?.alarms, ["query"], "federated alarm view");
+  requireMethods(bindings?.reporting, ["generate"], "federated reporting");
+  requireMethods(
+    bindings?.configuration,
+    ["merge", "value"],
+    "replicated configuration",
+  );
+  if (typeof bindings?.healthCheck !== "function") {
+    throw new Error("federation binding requires a health check");
+  }
+}
+
+function requireMethods(
+  value: unknown,
+  methods: readonly string[],
+  name: string,
+): void {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    methods.some(
+      (method) =>
+        typeof (value as Record<string, unknown>)[method] !== "function",
+    )
+  ) {
+    throw new Error(`federation bindings require ${name}`);
+  }
+}
+
+export const federationRuntime = new FederationRuntime();

--- a/server/scaling/federation.ts
+++ b/server/scaling/federation.ts
@@ -1,0 +1,688 @@
+import { canonicalJson } from "./hash";
+
+export interface PresentedSiteIdentity {
+  siteId: string;
+  certificateFingerprint: string;
+  issuerFingerprint: string;
+  subjectAltNames: readonly string[];
+  validFrom: Date;
+  validTo: Date;
+}
+
+export interface DiscoveredSite {
+  siteId: string;
+  endpoint: string;
+  identity: PresentedSiteIdentity;
+  metadata?: Readonly<Record<string, string>>;
+}
+
+export interface SiteDiscoveryProvider {
+  readonly name: string;
+  discover(signal?: AbortSignal): Promise<readonly DiscoveredSite[]>;
+}
+
+export interface SiteIdentityDecision {
+  accepted: boolean;
+  reason?: string;
+}
+
+export interface SiteIdentityPolicy {
+  verify(site: DiscoveredSite, now?: Date): SiteIdentityDecision;
+}
+
+/**
+ * mTLS contract for federation peers. The transport terminates TLS; this policy
+ * binds the presented certificate to the claimed site namespace.
+ */
+export class MutualTlsSiteIdentityPolicy implements SiteIdentityPolicy {
+  private readonly trustedIssuers: ReadonlySet<string>;
+  private readonly pinnedSites: ReadonlyMap<string, string>;
+
+  constructor(options: {
+    trustedIssuerFingerprints: readonly string[];
+    pinnedSiteFingerprints?: Readonly<Record<string, string>>;
+  }) {
+    this.trustedIssuers = new Set(
+      options.trustedIssuerFingerprints.map(normalizeFingerprint),
+    );
+    this.pinnedSites = new Map(
+      Object.entries(options.pinnedSiteFingerprints ?? {}).map(
+        ([siteId, fingerprint]) => [siteId, normalizeFingerprint(fingerprint)],
+      ),
+    );
+  }
+
+  verify(site: DiscoveredSite, now = new Date()): SiteIdentityDecision {
+    const identity = site.identity;
+    let endpoint: URL;
+    try {
+      endpoint = new URL(site.endpoint);
+    } catch {
+      return { accepted: false, reason: "site endpoint is not a valid URL" };
+    }
+    if (endpoint.protocol !== "https:") {
+      return { accepted: false, reason: "site endpoint does not require TLS" };
+    }
+    if (
+      !SITE_SEGMENT.test(site.siteId) ||
+      !identity.certificateFingerprint.trim()
+    ) {
+      return { accepted: false, reason: "site identity is incomplete" };
+    }
+    if (identity.siteId !== site.siteId) {
+      return { accepted: false, reason: "certificate site id does not match advert" };
+    }
+    if (
+      !this.trustedIssuers.has(normalizeFingerprint(identity.issuerFingerprint))
+    ) {
+      return { accepted: false, reason: "certificate issuer is not trusted" };
+    }
+    if (now < identity.validFrom || now > identity.validTo) {
+      return { accepted: false, reason: "certificate is outside its validity window" };
+    }
+    if (
+      !identity.subjectAltNames.includes(`urn:0xscada:site:${identity.siteId}`)
+    ) {
+      return {
+        accepted: false,
+        reason: "certificate is missing the site-bound subject alternative name",
+      };
+    }
+    const pinned = this.pinnedSites.get(site.siteId);
+    if (
+      pinned &&
+      pinned !== normalizeFingerprint(identity.certificateFingerprint)
+    ) {
+      return { accepted: false, reason: "certificate does not match site pin" };
+    }
+    return { accepted: true };
+  }
+}
+
+export interface DiscoveryResult {
+  sites: DiscoveredSite[];
+  rejected: Array<{
+    provider: string;
+    siteId: string;
+    reason: string;
+  }>;
+}
+
+/**
+ * Combines registry and local discovery providers. A namespace is accepted only
+ * if every accepted advertisement for it presents the same certificate.
+ */
+export class FederatedSiteDiscovery {
+  constructor(
+    private readonly providers: readonly SiteDiscoveryProvider[],
+    private readonly identityPolicy: SiteIdentityPolicy,
+  ) {}
+
+  async discover(signal?: AbortSignal): Promise<DiscoveryResult> {
+    const settled = await Promise.allSettled(
+      this.providers.map((provider) =>
+        Promise.resolve().then(() => provider.discover(signal)),
+      ),
+    );
+    const sites = new Map<string, DiscoveredSite>();
+    const conflictedNamespaces = new Set<string>();
+    const rejected: DiscoveryResult["rejected"] = [];
+
+    settled.forEach((result, providerIndex) => {
+      const provider = this.providers[providerIndex];
+      if (result.status === "rejected") {
+        rejected.push({
+          provider: provider.name,
+          siteId: "*",
+          reason: errorMessage(result.reason),
+        });
+        return;
+      }
+      for (const site of result.value) {
+        if (conflictedNamespaces.has(site.siteId)) {
+          rejected.push({
+            provider: provider.name,
+            siteId: site.siteId,
+            reason: "site namespace was rejected after conflicting certificates",
+          });
+          continue;
+        }
+        const decision = this.identityPolicy.verify(site);
+        if (!decision.accepted) {
+          rejected.push({
+            provider: provider.name,
+            siteId: site.siteId,
+            reason: decision.reason ?? "site identity rejected",
+          });
+          continue;
+        }
+        const existing = sites.get(site.siteId);
+        if (
+          existing &&
+          normalizeFingerprint(existing.identity.certificateFingerprint) !==
+            normalizeFingerprint(site.identity.certificateFingerprint)
+        ) {
+          sites.delete(site.siteId);
+          conflictedNamespaces.add(site.siteId);
+          rejected.push({
+            provider: provider.name,
+            siteId: site.siteId,
+            reason: "conflicting certificates advertised for site namespace",
+          });
+          continue;
+        }
+        if (
+          !existing ||
+          `${provider.name}\0${site.endpoint}` <
+            `${provider.name}\0${existing.endpoint}`
+        ) {
+          sites.set(site.siteId, site);
+        }
+      }
+    });
+
+    return {
+      sites: [...sites.values()].sort((left, right) =>
+        left.siteId.localeCompare(right.siteId),
+      ),
+      rejected,
+    };
+  }
+}
+
+export interface RegistryClient {
+  listSites(signal?: AbortSignal): Promise<readonly DiscoveredSite[]>;
+}
+
+export class RegistrySiteDiscovery implements SiteDiscoveryProvider {
+  readonly name = "registry";
+  constructor(private readonly client: RegistryClient) {}
+  discover(signal?: AbortSignal): Promise<readonly DiscoveredSite[]> {
+    return this.client.listSites(signal);
+  }
+}
+
+/** Adapter seam for an mDNS implementation such as multicast-dns/bonjour. */
+export interface MdnsBrowser {
+  browse(serviceType: string, signal?: AbortSignal): Promise<readonly DiscoveredSite[]>;
+}
+
+export class MdnsSiteDiscovery implements SiteDiscoveryProvider {
+  readonly name = "mdns";
+  constructor(
+    private readonly browser: MdnsBrowser,
+    private readonly serviceType = "_0xscada._tcp.local",
+  ) {}
+  discover(signal?: AbortSignal): Promise<readonly DiscoveredSite[]> {
+    return this.browser.browse(this.serviceType, signal);
+  }
+}
+
+const SITE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$/;
+const TAG_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,254}$/;
+
+/** Canonical namespace-qualified address: `site:area/tag`. */
+export class CrossSiteTagReference {
+  private constructor(
+    readonly site: string,
+    readonly area: string,
+    readonly tag: string,
+  ) {}
+
+  static parse(value: string): CrossSiteTagReference {
+    const separator = value.indexOf(":");
+    const slash = value.indexOf("/", separator + 1);
+    if (separator < 1 || slash <= separator + 1 || slash === value.length - 1) {
+      throw new Error(`invalid cross-site tag reference: ${value}`);
+    }
+    const [site, area, tag] = [
+      value.slice(0, separator),
+      value.slice(separator + 1, slash),
+      value.slice(slash + 1),
+    ];
+    if (
+      !SITE_SEGMENT.test(site) ||
+      !SITE_SEGMENT.test(area) ||
+      !TAG_SEGMENT.test(tag) ||
+      tag.includes("..")
+    ) {
+      throw new Error(`invalid cross-site tag reference: ${value}`);
+    }
+    return new CrossSiteTagReference(site, area, tag);
+  }
+
+  toString(): string {
+    return `${this.site}:${this.area}/${this.tag}`;
+  }
+}
+
+export interface SiteAlarm {
+  id: string;
+  tag: string;
+  severity: number;
+  activeAt: Date;
+  message: string;
+  acknowledged?: boolean;
+}
+
+export interface FederatedAlarm extends SiteAlarm {
+  siteId: string;
+  federatedId: string;
+  tagReference: string;
+}
+
+export interface AlarmSource {
+  siteId: string;
+  activeAlarms(signal?: AbortSignal): Promise<readonly SiteAlarm[]>;
+}
+
+export interface FederatedAlarmResult {
+  alarms: FederatedAlarm[];
+  failures: Array<{ siteId: string; error: string }>;
+}
+
+export class FederatedAlarmView {
+  constructor(private readonly sources: readonly AlarmSource[]) {}
+
+  async query(signal?: AbortSignal): Promise<FederatedAlarmResult> {
+    const sources = [...this.sources].sort((left, right) =>
+      left.siteId.localeCompare(right.siteId),
+    );
+    const settled = await Promise.allSettled(
+      sources.map((source) =>
+        Promise.resolve().then(() => source.activeAlarms(signal)),
+      ),
+    );
+    const alarms: FederatedAlarm[] = [];
+    const failures: FederatedAlarmResult["failures"] = [];
+    settled.forEach((result, index) => {
+      const source = sources[index];
+      if (result.status === "rejected") {
+        failures.push({
+          siteId: source.siteId,
+          error: errorMessage(result.reason),
+        });
+        return;
+      }
+      for (const alarm of result.value) {
+        const localTag = alarm.tag.replace(/^\/+/, "");
+        let tagReference: string;
+        try {
+          tagReference = CrossSiteTagReference.parse(
+            `${source.siteId}:${localTag}`,
+          ).toString();
+        } catch (error) {
+          failures.push({
+            siteId: source.siteId,
+            error: `invalid alarm tag ${alarm.tag}: ${errorMessage(error)}`,
+          });
+          continue;
+        }
+        alarms.push({
+          ...alarm,
+          siteId: source.siteId,
+          federatedId: `${source.siteId}:${alarm.id}`,
+          tagReference,
+        });
+      }
+    });
+    alarms.sort(
+      (left, right) =>
+        right.severity - left.severity ||
+        left.activeAt.getTime() - right.activeAt.getTime() ||
+        left.federatedId.localeCompare(right.federatedId),
+    );
+    return { alarms, failures };
+  }
+}
+
+export interface SiteReport<TSection = unknown> {
+  siteId: string;
+  generate(
+    reportType: string,
+    from: Date,
+    to: Date,
+    signal?: AbortSignal,
+  ): Promise<TSection>;
+}
+
+export interface FederatedReport<TSection = unknown> {
+  reportType: string;
+  from: Date;
+  to: Date;
+  sections: Array<{ siteId: string; data: TSection }>;
+  failures: Array<{ siteId: string; error: string }>;
+}
+
+export class FederatedReporting<TSection = unknown> {
+  constructor(private readonly sites: readonly SiteReport<TSection>[]) {}
+
+  async generate(
+    reportType: string,
+    from: Date,
+    to: Date,
+    signal?: AbortSignal,
+  ): Promise<FederatedReport<TSection>> {
+    if (!reportType.trim() || to < from) {
+      throw new Error("report type and a valid time range are required");
+    }
+    const sites = [...this.sites].sort((left, right) =>
+      left.siteId.localeCompare(right.siteId),
+    );
+    const settled = await Promise.allSettled(
+      sites.map((site) =>
+        Promise.resolve().then(() =>
+          site.generate(reportType, from, to, signal),
+        ),
+      ),
+    );
+    const sections: FederatedReport<TSection>["sections"] = [];
+    const failures: FederatedReport<TSection>["failures"] = [];
+    settled.forEach((result, index) => {
+      if (result.status === "fulfilled") {
+        sections.push({ siteId: sites[index].siteId, data: result.value });
+      } else {
+        failures.push({
+          siteId: sites[index].siteId,
+          error: errorMessage(result.reason),
+        });
+      }
+    });
+    return { reportType, from, to, sections, failures };
+  }
+}
+
+export interface LogicalVersion {
+  counter: number;
+  actor: string;
+}
+
+export interface ConfigurationOperation {
+  path: string;
+  version: LogicalVersion;
+  value?: unknown;
+  deleted: boolean;
+}
+
+export interface ConfigurationConflict {
+  path: string;
+  winner: ConfigurationOperation;
+  loser: ConfigurationOperation;
+  reason: "concurrent-write" | "equivocation";
+}
+
+/**
+ * LWW-map CRDT with Lamport clocks and actor-id tie breaking. Tombstones are
+ * retained, making merges associative, commutative, and idempotent.
+ */
+export class ReplicatedConfiguration {
+  private clock = 0;
+  private readonly cells = new Map<string, ConfigurationOperation>();
+  private readonly observedConflicts: ConfigurationConflict[] = [];
+
+  constructor(readonly actorId: string) {
+    if (!actorId.trim()) {
+      throw new Error("CRDT actor id cannot be empty");
+    }
+  }
+
+  set(path: string, value: unknown): ConfigurationOperation {
+    validateConfigPath(path);
+    if (value === undefined) {
+      throw new Error("configuration value cannot be undefined");
+    }
+    validateConfigurationValue(value, path);
+    const operation: ConfigurationOperation = {
+      path,
+      value: structuredClone(value),
+      deleted: false,
+      version: { counter: ++this.clock, actor: this.actorId },
+    };
+    this.cells.set(path, operation);
+    return cloneOperation(operation);
+  }
+
+  delete(path: string): ConfigurationOperation {
+    validateConfigPath(path);
+    const operation: ConfigurationOperation = {
+      path,
+      deleted: true,
+      version: { counter: ++this.clock, actor: this.actorId },
+    };
+    this.cells.set(path, operation);
+    return cloneOperation(operation);
+  }
+
+  apply(operation: ConfigurationOperation): boolean {
+    validateOperation(operation);
+    this.clock = Math.max(this.clock, operation.version.counter);
+    const incoming = cloneOperation(operation);
+    const current = this.cells.get(operation.path);
+    if (!current) {
+      this.cells.set(operation.path, incoming);
+      return true;
+    }
+    const comparison = compareVersions(incoming.version, current.version);
+    if (comparison === 0) {
+      const incomingCanonical = canonicalJson(incoming);
+      const currentCanonical = canonicalJson(current);
+      if (incomingCanonical === currentCanonical) {
+        return false;
+      }
+      const incomingWins = incomingCanonical > currentCanonical;
+      const winner = incomingWins ? incoming : current;
+      const loser = incomingWins ? current : incoming;
+      this.observedConflicts.push({
+        path: incoming.path,
+        winner: cloneOperation(winner),
+        loser: cloneOperation(loser),
+        reason: "equivocation",
+      });
+      if (incomingWins) {
+        this.cells.set(operation.path, incoming);
+      }
+      return incomingWins;
+    }
+    const winner = comparison > 0 ? incoming : current;
+    const loser = comparison > 0 ? current : incoming;
+    if (
+      incoming.version.counter === current.version.counter &&
+      canonicalJson(incoming) !== canonicalJson(current)
+    ) {
+      this.observedConflicts.push({
+        path: incoming.path,
+        winner: cloneOperation(winner),
+        loser: cloneOperation(loser),
+        reason: "concurrent-write",
+      });
+    }
+    if (comparison > 0) {
+      this.cells.set(operation.path, incoming);
+      return true;
+    }
+    return false;
+  }
+
+  merge(other: ReplicatedConfiguration): ConfigurationConflict[] {
+    const before = this.observedConflicts.length;
+    for (const operation of other.operations()) {
+      this.apply(operation);
+    }
+    return this.observedConflicts.slice(before).map(cloneConflict);
+  }
+
+  operations(): ConfigurationOperation[] {
+    return [...this.cells.values()]
+      .sort((left, right) => left.path.localeCompare(right.path))
+      .map(cloneOperation);
+  }
+
+  conflicts(): ConfigurationConflict[] {
+    return this.observedConflicts.map(cloneConflict);
+  }
+
+  value(): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const operation of this.operations()) {
+      if (operation.deleted || hiddenByParentTombstone(operation, this.cells)) {
+        continue;
+      }
+      setNestedValue(result, operation.path.split("."), operation.value);
+    }
+    return result;
+  }
+}
+
+function hiddenByParentTombstone(
+  operation: ConfigurationOperation,
+  cells: ReadonlyMap<string, ConfigurationOperation>,
+): boolean {
+  const segments = operation.path.split(".");
+  for (let length = 1; length < segments.length; length += 1) {
+    const parent = cells.get(segments.slice(0, length).join("."));
+    if (
+      parent?.deleted &&
+      compareVersions(parent.version, operation.version) >= 0
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function setNestedValue(
+  root: Record<string, unknown>,
+  path: readonly string[],
+  value: unknown,
+): void {
+  let cursor = root;
+  path.forEach((segment, index) => {
+    if (index === path.length - 1) {
+      cursor[segment] = structuredClone(value);
+      return;
+    }
+    const existing = cursor[segment];
+    if (
+      !existing ||
+      typeof existing !== "object" ||
+      Array.isArray(existing)
+    ) {
+      cursor[segment] = {};
+    }
+    cursor = cursor[segment] as Record<string, unknown>;
+  });
+}
+
+function compareVersions(left: LogicalVersion, right: LogicalVersion): number {
+  return (
+    left.counter - right.counter || left.actor.localeCompare(right.actor)
+  );
+}
+
+function validateOperation(operation: ConfigurationOperation): void {
+  validateConfigPath(operation.path);
+  if (
+    !Number.isSafeInteger(operation.version.counter) ||
+    operation.version.counter < 1 ||
+    !operation.version.actor.trim()
+  ) {
+    throw new Error("invalid CRDT logical version");
+  }
+  if (!operation.deleted && operation.value === undefined) {
+    throw new Error("non-delete CRDT operation requires a value");
+  }
+  if (!operation.deleted) {
+    validateConfigurationValue(operation.value, operation.path);
+  }
+}
+
+function validateConfigPath(path: string): void {
+  if (
+    !path ||
+    path.startsWith(".") ||
+    path.endsWith(".") ||
+    path.split(".").some((segment) => !SITE_SEGMENT.test(segment))
+  ) {
+    throw new Error(`invalid configuration path: ${path}`);
+  }
+}
+
+function validateConfigurationValue(
+  value: unknown,
+  path: string,
+  ancestors = new WeakSet<object>(),
+): void {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error(`configuration value at ${path} must be finite`);
+    }
+    return;
+  }
+  if (typeof value !== "object") {
+    throw new Error(`configuration value at ${path} must be JSON-safe`);
+  }
+  if (ancestors.has(value)) {
+    throw new Error(`configuration value at ${path} is circular`);
+  }
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      value.forEach((child, index) =>
+        validateConfigurationValue(child, `${path}[${index}]`, ancestors),
+      );
+      return;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error(
+        `configuration value at ${path} must use plain JSON objects`,
+      );
+    }
+    for (const key of Reflect.ownKeys(value)) {
+      if (
+        typeof key !== "string" ||
+        key === "__proto__" ||
+        key === "constructor" ||
+        key === "prototype"
+      ) {
+        throw new Error(`configuration value at ${path} has a forbidden key`);
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || !("value" in descriptor)) {
+        throw new Error(
+          `configuration value at ${path}.${key} must be a data property`,
+        );
+      }
+      validateConfigurationValue(
+        descriptor.value,
+        `${path}.${key}`,
+        ancestors,
+      );
+    }
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function cloneOperation(operation: ConfigurationOperation): ConfigurationOperation {
+  return structuredClone(operation);
+}
+
+function cloneConflict(conflict: ConfigurationConflict): ConfigurationConflict {
+  return structuredClone(conflict);
+}
+
+function normalizeFingerprint(value: string): string {
+  return value.replace(/:/g, "").toLowerCase();
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary

Adds a standalone multi-site federation layer with:

- registry and mDNS discovery adapters;
- fail-closed mutual-TLS site identity validation;
- canonical cross-site tag references;
- federated alarm and report aggregation with explicit partial failures; and
- a convergent Lamport-clocked replicated configuration map with tombstones and
  conflict visibility.

## Why

ADR-0014 described federation, but the repository lacked executable identity,
aggregation, and convergence rules. Without those shared rules, sites could
silently trust advertisement metadata, hide disconnected peers in partial
views, or resolve concurrent configuration updates differently.

## Implementation

`server/scaling/federation.ts` is independent of concrete network clients.
Discovery bindings receive an `AbortSignal` and must supply certificate
identity observed by their authenticated transport. Conflicting certificates
for one site namespace fail closed.

Alarm and report APIs return `{data, failures}`. Replicated configuration merge
is associative, commutative, and idempotent, with deterministic actor
tie-breaking and retained deletion tombstones.

`server/scaling/federation-runtime.ts` is the standalone production composition
root. It loads and validates deployment-provided discovery, alarms, reporting,
configuration, and health bindings; enabled but incomplete deployments stop
startup. The server initializes the runtime before accepting traffic and
publishes its actual health/readiness status.

## Validation

- `npx vitest run server/scaling/__tests__/federation.test.ts server/scaling/__tests__/federation-runtime.test.ts server/__tests__/startup-singleton-imports.test.ts` — 14 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — passed

The branch contains two signed commits based directly on `main` and only the
federation implementation, production composition/health wiring, focused
tests, and its guide.

Closes #223
