### PR TITLE
Add zero-downtime upgrade system

### DIFF
--- a/docs/architecture/zero-downtime-upgrades.md
+++ b/docs/architecture/zero-downtime-upgrades.md
@@ -1,0 +1,47 @@
+# Zero-downtime upgrade system
+
+This document is the executable companion to
+[ADR-0014](../decisions/ADR-0014-production-scale-architecture.md) for issue
+[#227](https://github.com/NickFlach/0xSCADA/issues/227).
+
+`server/scaling/upgrade.ts` provides:
+
+- `VersionCompatibilityMatrix`, which fails closed for every transition that
+  has not been deliberately certified.
+- `TypedFeatureFlags<Schema>`, with runtime validators, stable subject
+  hashing, percentage rollout, site targeting, and include/exclude overrides.
+- `ReversibleMigrationRunner`, whose append-only journal records migration and
+  rollback boundaries. A failed run rolls back the failing migration and every
+  migration applied in that run in reverse order.
+- `RollingCanaryOrchestrator`, which validates compatibility before its first
+  side effect, upgrades deterministic canaries, applies health gates, rolls the
+  remaining nodes, and restores every touched node to its original version
+  after failure.
+- `JsonFileUpgradeJournal`, an fsync-backed journal for a single controller.
+
+Startup recovery classifies incomplete migration and rollout journal entries
+before beginning new work. Journal write failures never skip a safety rollback.
+A controller restart health-checks a target-version node left drained, restores
+traffic only when healthy, and otherwise rolls it back to its recorded original
+version.
+
+Deployment adapters must make `drain`, `restoreTraffic`, and `rollback`
+idempotent because a call can fail after partially changing external state.
+Multi-controller deployments must bind the journal interfaces to a
+transactional store with leader election; the included JSON journal is for one
+controller and the in-memory journals are for tests or embedded use.
+
+## Verification
+
+Run:
+
+```bash
+npx vitest run server/scaling/__tests__/upgrade.test.ts
+npm run typecheck
+npm run build
+```
+
+The focused suite covers compatibility rejection before side effects, typed
+feature rollout, forward and reverse migrations, incomplete-journal recovery,
+journal failures, canary health failure, rollout restart recovery, and durable
+journal persistence.

--- a/docs/architecture/zero-downtime-upgrades.md
+++ b/docs/architecture/zero-downtime-upgrades.md
@@ -31,12 +31,34 @@ Multi-controller deployments must bind the journal interfaces to a
 transactional store with leader election; the included JSON journal is for one
 controller and the in-memory journals are for tests or embedded use.
 
+## Production runtime
+
+`server/scaling/upgrade-runtime.ts` is the application composition root. It is
+off by default. Set `ZERO_DOWNTIME_UPGRADES_ENABLED=true` and point
+`ZERO_DOWNTIME_UPGRADES_BINDINGS_MODULE` at a local module that exports one of:
+
+- `createZeroDowntimeUpgradeBindings(factories)`
+- `zeroDowntimeUpgradeBindings`
+- a default bindings object
+
+The binding must provide a deployment-adapter-backed
+`RollingCanaryOrchestrator`, its `VersionCompatibilityMatrix`, the exact durable
+`UpgradeJournal` used by that orchestrator, callable migration and feature-flag
+services, and an operational health probe. Startup fails closed when any
+binding is absent, the journal is volatile, or the orchestrator uses a different
+journal. This prevents a production rollout from silently losing restart
+recovery.
+
+Set `ZERO_DOWNTIME_UPGRADES_REQUIRED=true` to make the registered
+`zero-downtime-upgrades` health check readiness-critical. The check reports
+disabled, not-initialized, healthy, degraded, and failed controller states.
+
 ## Verification
 
 Run:
 
 ```bash
-npx vitest run server/scaling/__tests__/upgrade.test.ts
+npx vitest run server/scaling/__tests__/upgrade.test.ts server/scaling/__tests__/upgrade-runtime.test.ts server/__tests__/startup-singleton-imports.test.ts
 npm run typecheck
 npm run build
 ```
@@ -44,4 +66,6 @@ npm run build
 The focused suite covers compatibility rejection before side effects, typed
 feature rollout, forward and reverse migrations, incomplete-journal recovery,
 journal failures, canary health failure, rollout restart recovery, and durable
-journal persistence.
+journal persistence. Runtime tests additionally prove production binding
+validation, durable-journal identity, fail-closed startup, and controller health
+propagation.

--- a/server/__tests__/startup-singleton-imports.test.ts
+++ b/server/__tests__/startup-singleton-imports.test.ts
@@ -56,12 +56,14 @@ describe("startup singleton module identity", () => {
         "./gateway",
         "./services/flux",
         "./services/nats",
+        "./scaling/upgrade-runtime",
         "./bridge/anchor-backend",
       ],
     },
     {
       file: "server/health/index.ts",
       modules: [
+        "../scaling/upgrade-runtime",
         "../simulator",
         "../gateway/store-and-forward",
         "../bridge",

--- a/server/health/index.ts
+++ b/server/health/index.ts
@@ -18,6 +18,7 @@ import { getBridgeHealthStatus } from '../bridge';
 import { describeBlueprintControlLoopHealth, getBlueprintControlLoop } from '../blueprint/control-loop';
 import { publishControlLoopProbeStatus } from '../integrity/latency-probe';
 import { getBlueprintProductionSafetyStatus } from '../blueprint/production-safety';
+import { zeroDowntimeUpgradeRuntime } from '../scaling/upgrade-runtime';
 import type { Response } from 'express';
 // Tick-aware scheduler (#458): surface schedulingMode in /health and append
 // blueprint tick telemetry to /metrics.
@@ -203,6 +204,28 @@ healthManager.register({
 //     probes the kernel and never applies a policy. Real-time scheduling stays
 //     off unless a dedicated control process opts in via OXSCADA_RT_ENABLED.
 healthManager.register(createSchedulerCheck());
+
+// Zero-downtime upgrade controller. Disabled deployments report healthy;
+// enabled deployments expose their real controller/journal health. Operators
+// can make this readiness-critical with ZERO_DOWNTIME_UPGRADES_REQUIRED=true.
+healthManager.register({
+  name: 'zero-downtime-upgrades',
+  required: zeroDowntimeUpgradeRuntime.isRequired(),
+  check: async () => {
+    const status = await zeroDowntimeUpgradeRuntime.health();
+    return {
+      name: 'zero-downtime-upgrades',
+      status: status.healthy
+        ? status.degraded
+          ? 'degraded'
+          : 'healthy'
+        : 'unhealthy',
+      lastCheck: new Date(),
+      message: status.message,
+      details: status.details ? { ...status.details } : undefined,
+    };
+  },
+});
 
 // ── Sync health → Prometheus after each check cycle ──────────────────────────
 healthManager.onCheckComplete((result) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,6 +20,7 @@ import { startFluxIntegration } from "./services/flux";
 import { natsPublisher } from "./services/nats";
 import { logAnchorBackendBootState } from "./bridge/anchor-backend";
 import { startBlueprintControlLoop } from "./blueprint/control-loop";
+import { zeroDowntimeUpgradeRuntime } from "./scaling/upgrade-runtime";
 // Blueprint watchdog / safe-state composition root (#459). Off unless the
 // deployment supplies BLUEPRINT_SAFETY_BINDINGS[_FILE].
 import { blueprintSafetyHost } from "./blueprint/safety-host";
@@ -93,6 +94,14 @@ registerSwaggerRoutes(app, gatewayConfig);
   // Initialize edge store-and-forward service
   await storeAndForwardService.initialize();
   log("Edge store-and-forward service initialized");
+
+  // Bind the real deployment controller, durable journal, migrations, and
+  // feature flags before the API starts accepting traffic. Enabled deployments
+  // fail startup closed when any production upgrade binding is incomplete.
+  await zeroDowntimeUpgradeRuntime.initialize();
+  if (zeroDowntimeUpgradeRuntime.isEnabled()) {
+    log("Zero-downtime upgrade runtime initialized");
+  }
 
   // Initialize bridge modules (event-anchor, state-sync)
   await initializeBridges();

--- a/server/scaling/__tests__/upgrade-runtime.test.ts
+++ b/server/scaling/__tests__/upgrade-runtime.test.ts
@@ -1,0 +1,230 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  RollingCanaryOrchestrator,
+  VersionCompatibilityMatrix,
+  type DeploymentAdapter,
+  type UpgradeJournal,
+  type UpgradeJournalEntry,
+} from "../upgrade";
+import {
+  ZeroDowntimeUpgradeRuntime,
+  type ZeroDowntimeUpgradeBindings,
+} from "../upgrade-runtime";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("zero-downtime upgrade production runtime", () => {
+  it("binds production services and exposes their operational health", async () => {
+    const runtime = new ZeroDowntimeUpgradeRuntime();
+    const configured = bindings();
+
+    runtime.configure(configured);
+    await runtime.initialize();
+
+    expect(runtime.isEnabled()).toBe(true);
+    expect(runtime.isInitialized()).toBe(true);
+    expect(runtime.bindings().journal).toBe(configured.journal);
+    expect(runtime.bindings().orchestrator.usesJournal(configured.journal)).toBe(
+      true,
+    );
+    await expect(runtime.health()).resolves.toEqual({
+      healthy: true,
+      details: { controller: "leader" },
+    });
+  });
+
+  it("fails closed when enabled without a production bindings module", async () => {
+    vi.stubEnv("ZERO_DOWNTIME_UPGRADES_ENABLED", "true");
+    vi.stubEnv("ZERO_DOWNTIME_UPGRADES_BINDINGS_MODULE", "");
+    const runtime = new ZeroDowntimeUpgradeRuntime();
+
+    await expect(runtime.initialize()).rejects.toThrow(
+      /ZERO_DOWNTIME_UPGRADES_BINDINGS_MODULE is required/,
+    );
+    await expect(runtime.health()).resolves.toMatchObject({
+      healthy: false,
+      message: "enabled but not initialized",
+    });
+  });
+
+  it("loads an enabled deployment through the bindings-module factory", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "0xscada-upgrade-runtime-"));
+    try {
+      const modulePath = join(directory, "bindings.mjs");
+      await writeFile(
+        modulePath,
+        `export function createZeroDowntimeUpgradeBindings(factories) {
+  let sequence = 0;
+  const journal = {
+    durable: true,
+    entries: async () => [],
+    append: async (entry) => ({
+      ...entry,
+      sequence: ++sequence,
+      timestamp: new Date(),
+    }),
+  };
+  const compatibility = new factories.VersionCompatibilityMatrix([]);
+  const orchestrator = new factories.RollingCanaryOrchestrator(
+    {
+      instances: async () => [],
+      drain: async () => undefined,
+      deploy: async () => undefined,
+      waitUntilHealthy: async () => true,
+      restoreTraffic: async () => undefined,
+      rollback: async () => undefined,
+    },
+    compatibility,
+    journal,
+  );
+  return {
+    orchestrator,
+    compatibility,
+    journal,
+    migrations: { run: async () => [] },
+    featureFlags: { evaluate: () => false },
+    healthCheck: async () => ({
+      healthy: true,
+      message: "bindings module loaded",
+    }),
+  };
+}
+`,
+        "utf8",
+      );
+      vi.stubEnv("ZERO_DOWNTIME_UPGRADES_ENABLED", "true");
+      vi.stubEnv("ZERO_DOWNTIME_UPGRADES_BINDINGS_MODULE", modulePath);
+      const runtime = new ZeroDowntimeUpgradeRuntime();
+
+      await runtime.initialize();
+
+      expect(runtime.isInitialized()).toBe(true);
+      await expect(runtime.health()).resolves.toMatchObject({
+        healthy: true,
+        message: "bindings module loaded",
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an in-memory journal that cannot survive controller loss", () => {
+    const configured = bindings();
+    const volatileJournal: UpgradeJournal = {
+      ...configured.journal,
+      durable: false,
+    };
+
+    expect(() =>
+      new ZeroDowntimeUpgradeRuntime().configure({
+        ...configured,
+        journal: volatileJournal,
+      }),
+    ).toThrow(/require a durable journal/);
+  });
+
+  it("rejects an orchestrator wired to a different journal", () => {
+    const configured = bindings();
+    const otherJournal = durableJournal();
+    const mismatched = new RollingCanaryOrchestrator(
+      deploymentAdapter,
+      configured.compatibility,
+      otherJournal,
+    );
+
+    expect(() =>
+      new ZeroDowntimeUpgradeRuntime().configure({
+        ...configured,
+        orchestrator: mismatched,
+      }),
+    ).toThrow(/must use the configured durable journal/);
+  });
+
+  it("requires callable migration and feature-flag services", () => {
+    const configured = bindings();
+
+    expect(() =>
+      new ZeroDowntimeUpgradeRuntime().configure({
+        ...configured,
+        migrations: {},
+      }),
+    ).toThrow(/migration service/);
+    expect(() =>
+      new ZeroDowntimeUpgradeRuntime().configure({
+        ...configured,
+        featureFlags: {},
+      }),
+    ).toThrow(/feature-flag service/);
+  });
+
+  it("converts a throwing deployment health probe into unhealthy state", async () => {
+    const runtime = new ZeroDowntimeUpgradeRuntime();
+    runtime.configure({
+      ...bindings(),
+      healthCheck: async () => {
+        throw new Error("deployment controller unavailable");
+      },
+    });
+    await runtime.initialize();
+
+    await expect(runtime.health()).resolves.toEqual({
+      healthy: false,
+      message: "deployment controller unavailable",
+    });
+  });
+});
+
+function bindings(): ZeroDowntimeUpgradeBindings {
+  const journal = durableJournal();
+  const compatibility = new VersionCompatibilityMatrix([]);
+  return {
+    journal,
+    compatibility,
+    orchestrator: new RollingCanaryOrchestrator(
+      deploymentAdapter,
+      compatibility,
+      journal,
+    ),
+    migrations: {
+      run: async () => [],
+    },
+    featureFlags: {
+      evaluate: () => false,
+    },
+    healthCheck: async () => ({
+      healthy: true,
+      details: { controller: "leader" },
+    }),
+  };
+}
+
+function durableJournal(): UpgradeJournal {
+  const entries: UpgradeJournalEntry[] = [];
+  return {
+    durable: true,
+    entries: async () => structuredClone(entries),
+    append: async (entry) => {
+      const recorded: UpgradeJournalEntry = {
+        ...entry,
+        sequence: entries.length + 1,
+        timestamp: new Date(),
+      };
+      entries.push(recorded);
+      return structuredClone(recorded);
+    },
+  };
+}
+
+const deploymentAdapter: DeploymentAdapter = {
+  instances: async () => [],
+  drain: async () => undefined,
+  deploy: async () => undefined,
+  waitUntilHealthy: async () => true,
+  restoreTraffic: async () => undefined,
+  rollback: async () => undefined,
+};

--- a/server/scaling/__tests__/upgrade.test.ts
+++ b/server/scaling/__tests__/upgrade.test.ts
@@ -1,0 +1,421 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  InMemoryMigrationJournal,
+  InMemoryUpgradeJournal,
+  JsonFileUpgradeJournal,
+  MigrationExecutionError,
+  ReversibleMigrationRunner,
+  RollingCanaryOrchestrator,
+  TypedFeatureFlags,
+  VersionCompatibilityMatrix,
+  type DatabaseMigration,
+  type DeploymentAdapter,
+  type DeploymentInstance,
+  type MigrationJournal,
+} from "../upgrade";
+
+describe("zero-downtime upgrades (#227)", () => {
+  it("enforces a fail-closed version compatibility matrix", () => {
+    const matrix = new VersionCompatibilityMatrix([
+      { from: "1.0.0", to: "1.1.0", compatible: true },
+      {
+        from: "1.1.0",
+        to: "2.0.0",
+        compatible: false,
+        reason: "protocol v2 cannot speak to v1 peers",
+      },
+    ]);
+    expect(matrix.check("1.0.0", "1.1.0").compatible).toBe(true);
+    expect(() => matrix.assertCompatible("1.0.0", "2.0.0")).toThrow(
+      /uncertified/,
+    );
+    expect(() => matrix.assertCompatible("1.1.0", "2.0.0")).toThrow(
+      /protocol v2/,
+    );
+  });
+
+  it("provides typed, validated, stable gradual feature rollout", () => {
+    type Flags = { newHistorian: boolean; queryLimit: number };
+    const definitions = {
+      newHistorian: {
+        defaultValue: false,
+        validate: (value: unknown): value is boolean => typeof value === "boolean",
+      },
+      queryLimit: {
+        defaultValue: 100,
+        validate: (value: unknown): value is number =>
+          typeof value === "number" && Number.isInteger(value) && value > 0,
+      },
+    };
+    const first = new TypedFeatureFlags<Flags>(definitions);
+    const second = new TypedFeatureFlags<Flags>(definitions);
+    for (const flags of [first, second]) {
+      flags.configure("newHistorian", {
+        enabled: true,
+        value: true,
+        percentage: 25,
+        includeSubjects: ["canary"],
+        excludeSubjects: ["blocked"],
+        sites: ["north"],
+      });
+    }
+    expect(
+      first.evaluate("newHistorian", {
+        subjectId: "canary",
+        siteId: "north",
+      }),
+    ).toBe(true);
+    expect(
+      first.evaluate("newHistorian", {
+        subjectId: "blocked",
+        siteId: "north",
+      }),
+    ).toBe(false);
+    expect(
+      first.evaluate("newHistorian", {
+        subjectId: "canary",
+        siteId: "south",
+      }),
+    ).toBe(false);
+    for (let index = 0; index < 100; index += 1) {
+      const context = { subjectId: `operator-${index}`, siteId: "north" };
+      expect(first.evaluate("newHistorian", context)).toBe(
+        second.evaluate("newHistorian", context),
+      );
+    }
+    expect(() =>
+      first.configure("queryLimit", {
+        enabled: true,
+        value: -1,
+        percentage: 100,
+      }),
+    ).toThrow(/invalid value/);
+  });
+
+  it("journals migrations and rolls partial work back in reverse order", async () => {
+    const journal = new InMemoryMigrationJournal(
+      () => new Date("2026-07-28T12:00:00Z"),
+    );
+    const runner = new ReversibleMigrationRunner<string[]>(journal);
+    const events: string[] = [];
+    const migration = (
+      id: string,
+      fail = false,
+    ): DatabaseMigration<string[]> => ({
+      id,
+      up: async () => {
+        events.push(`up:${id}`);
+        if (fail) {
+          throw new Error("DDL rejected");
+        }
+      },
+      down: async () => {
+        events.push(`down:${id}`);
+      },
+    });
+
+    await expect(
+      runner.run([migration("001"), migration("002", true)], events),
+    ).rejects.toMatchObject<Partial<MigrationExecutionError>>({
+      failedMigration: "002",
+      rollbackFailures: [],
+    });
+    expect(events).toEqual(["up:001", "up:002", "down:002", "down:001"]);
+    expect((await journal.entries()).map((entry) => `${entry.migrationId}:${entry.status}`)).toEqual([
+      "001:started",
+      "001:applied",
+      "002:started",
+      "002:failed",
+      "002:rollback-started",
+      "002:rolled-back",
+      "001:rollback-started",
+      "001:rolled-back",
+    ]);
+  });
+
+  it("skips migrations already applied according to journal state", async () => {
+    const journal = new InMemoryMigrationJournal();
+    await journal.append({ migrationId: "001", status: "started" });
+    await journal.append({ migrationId: "001", status: "applied" });
+    const up = async () => {
+      throw new Error("must not run");
+    };
+    const applied = await new ReversibleMigrationRunner(journal).run(
+      [{ id: "001", up, down: async () => undefined }],
+      {},
+    );
+    expect(applied).toEqual([]);
+  });
+
+  it("recovers an interrupted migration before attempting it again", async () => {
+    const journal = new InMemoryMigrationJournal();
+    await journal.append({ migrationId: "001", status: "started" });
+    const calls: string[] = [];
+    const migration: DatabaseMigration<string[]> = {
+      id: "001",
+      up: async () => {
+        calls.push("up");
+      },
+      down: async () => {
+        calls.push("down");
+      },
+    };
+
+    await expect(
+      new ReversibleMigrationRunner(journal).run([migration], calls),
+    ).resolves.toEqual(["001"]);
+    expect(calls).toEqual(["down", "up"]);
+    expect(
+      (await journal.entries()).map((entry) => entry.status),
+    ).toEqual([
+      "started",
+      "rollback-started",
+      "rolled-back",
+      "started",
+      "applied",
+    ]);
+  });
+
+  it("runs rollback even when failure journaling is unavailable", async () => {
+    const durable = new InMemoryMigrationJournal();
+    const journal: MigrationJournal = {
+      entries: () => durable.entries(),
+      append: async (entry) => {
+        if (
+          entry.status === "failed" ||
+          entry.status === "rollback-started" ||
+          entry.status === "rolled-back"
+        ) {
+          throw new Error("journal unavailable");
+        }
+        return durable.append(entry);
+      },
+    };
+    const calls: string[] = [];
+    const migration: DatabaseMigration<string[]> = {
+      id: "001",
+      up: async () => {
+        calls.push("up");
+        throw new Error("partial DDL");
+      },
+      down: async () => {
+        calls.push("down");
+      },
+    };
+
+    const error = await new ReversibleMigrationRunner(journal)
+      .run([migration], calls)
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(MigrationExecutionError);
+    expect((error as MigrationExecutionError).rollbackFailures).not.toEqual([]);
+    expect(calls).toEqual(["up", "down"]);
+  });
+
+  it("runs canaries before rolling batches and restores traffic", async () => {
+    const fake = deployment([
+      { id: "a", version: "1.0.0", healthy: true, zone: "1" },
+      { id: "b", version: "1.0.0", healthy: true, zone: "2" },
+      { id: "c", version: "1.0.0", healthy: true, zone: "1" },
+    ]);
+    const orchestrator = new RollingCanaryOrchestrator(
+      fake.adapter,
+      new VersionCompatibilityMatrix([
+        { from: "1.0.0", to: "1.1.0", compatible: true },
+      ]),
+    );
+    const result = await orchestrator.execute({
+      targetVersion: "1.1.0",
+      canaryCount: 1,
+      batchSize: 2,
+      healthTimeoutMs: 1_000,
+    });
+    expect(result.succeeded).toBe(true);
+    expect(result.upgraded).toHaveLength(3);
+    expect(result.events.filter((event) => event.stage === "canary")).toHaveLength(2);
+    expect(result.events.filter((event) => event.stage === "rolling")).toHaveLength(4);
+    expect(fake.calls.filter((call) => call.startsWith("restore:"))).toHaveLength(3);
+    expect([...fake.versions.values()]).toEqual(["1.1.0", "1.1.0", "1.1.0"]);
+  });
+
+  it("rolls every changed node back when a health gate fails", async () => {
+    const fake = deployment(
+      [
+        { id: "a", version: "1.0.0", healthy: true },
+        { id: "b", version: "1.0.0", healthy: true },
+        { id: "c", version: "1.0.0", healthy: true },
+      ],
+      2,
+    );
+    const result = await new RollingCanaryOrchestrator(
+      fake.adapter,
+      new VersionCompatibilityMatrix([
+        { from: "1.0.0", to: "1.1.0", compatible: true },
+      ]),
+    ).execute({
+      targetVersion: "1.1.0",
+      canaryCount: 1,
+      batchSize: 1,
+      healthTimeoutMs: 1_000,
+    });
+    expect(result.succeeded).toBe(false);
+    expect(result.failure).toMatch(/health gate/);
+    expect(result.rollbackFailures).toEqual([]);
+    expect([...fake.versions.values()]).toEqual(["1.0.0", "1.0.0", "1.0.0"]);
+    expect(result.events.some((event) => event.stage === "rollback")).toBe(true);
+  });
+
+  it("restores a healthy target-version node left drained by a controller crash", async () => {
+    const journal = new InMemoryUpgradeJournal();
+    for (const status of ["drain-started", "deployed", "healthy"] as const) {
+      await journal.append({
+        targetVersion: "1.1.0",
+        instanceId: "a",
+        originalVersion: "1.0.0",
+        status,
+      });
+    }
+    let instance: DeploymentInstance = {
+      id: "a",
+      version: "1.1.0",
+      healthy: true,
+      trafficEnabled: false,
+    };
+    const calls: string[] = [];
+    const adapter: DeploymentAdapter = {
+      instances: async () => [{ ...instance }],
+      drain: async () => {
+        calls.push("drain");
+      },
+      deploy: async () => {
+        calls.push("deploy");
+      },
+      waitUntilHealthy: async () => {
+        calls.push("health");
+        return true;
+      },
+      restoreTraffic: async () => {
+        calls.push("restore");
+        instance = { ...instance, trafficEnabled: true };
+      },
+      rollback: async () => {
+        calls.push("rollback");
+      },
+    };
+
+    const result = await new RollingCanaryOrchestrator(
+      adapter,
+      new VersionCompatibilityMatrix([]),
+      journal,
+    ).execute({
+      targetVersion: "1.1.0",
+      canaryCount: 1,
+      batchSize: 1,
+      healthTimeoutMs: 1_000,
+    });
+
+    expect(result.succeeded).toBe(true);
+    expect(result.upgraded).toEqual([]);
+    expect(calls).toEqual(["health", "restore"]);
+    expect(result.events).toContainEqual(
+      expect.objectContaining({
+        stage: "recovery",
+        instanceId: "a",
+        outcome: "restored",
+      }),
+    );
+    expect((await journal.entries()).at(-1)?.status).toBe(
+      "traffic-restored",
+    );
+  });
+
+  it("persists upgrade progress in the fsync-backed file journal", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "0xscada-upgrade-"));
+    try {
+      const path = join(directory, "journal.json");
+      const journal = new JsonFileUpgradeJournal(
+        path,
+        () => new Date("2026-07-28T12:00:00Z"),
+      );
+      await journal.append({
+        targetVersion: "1.1.0",
+        instanceId: "a",
+        originalVersion: "1.0.0",
+        status: "drain-started",
+      });
+
+      const recovered = await new JsonFileUpgradeJournal(path).entries();
+      expect(recovered).toEqual([
+        {
+          targetVersion: "1.1.0",
+          instanceId: "a",
+          originalVersion: "1.0.0",
+          status: "drain-started",
+          sequence: 1,
+          timestamp: new Date("2026-07-28T12:00:00Z"),
+        },
+      ]);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("performs no deployment side effects for an incompatible target", async () => {
+    const fake = deployment([
+      { id: "a", version: "1.0.0", healthy: true },
+    ]);
+    await expect(
+      new RollingCanaryOrchestrator(
+        fake.adapter,
+        new VersionCompatibilityMatrix([]),
+      ).execute({
+        targetVersion: "2.0.0",
+        canaryCount: 1,
+        batchSize: 1,
+        healthTimeoutMs: 1_000,
+      }),
+    ).rejects.toThrow(/uncertified/);
+    expect(fake.calls).toEqual([]);
+  });
+});
+
+function deployment(
+  initial: readonly DeploymentInstance[],
+  failHealthCall?: number,
+): {
+  adapter: DeploymentAdapter;
+  calls: string[];
+  versions: Map<string, string>;
+} {
+  const calls: string[] = [];
+  const versions = new Map(initial.map((instance) => [instance.id, instance.version]));
+  let healthCalls = 0;
+  return {
+    calls,
+    versions,
+    adapter: {
+      instances: async () => initial,
+      drain: async (id) => {
+        calls.push(`drain:${id}`);
+      },
+      deploy: async (id, version) => {
+        calls.push(`deploy:${id}:${version}`);
+        versions.set(id, version);
+      },
+      waitUntilHealthy: async (id) => {
+        calls.push(`health:${id}`);
+        healthCalls += 1;
+        return healthCalls !== failHealthCall;
+      },
+      restoreTraffic: async (id) => {
+        calls.push(`restore:${id}`);
+      },
+      rollback: async (id, version) => {
+        calls.push(`rollback:${id}:${version}`);
+        versions.set(id, version);
+      },
+    },
+  };
+}

--- a/server/scaling/hash.ts
+++ b/server/scaling/hash.ts
@@ -1,0 +1,68 @@
+import { createHash } from "node:crypto";
+
+/**
+ * JSON encoding with recursively sorted object keys. Distributed peers use this
+ * before hashing so insertion order cannot change an integrity result.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === undefined) {
+    return "null";
+  }
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (value instanceof Date) {
+    return JSON.stringify(value.toISOString());
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, child]) => child !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries
+    .map(([key, child]) => `${JSON.stringify(key)}:${canonicalJson(child)}`)
+    .join(",")}}`;
+}
+
+export function sha256Hex(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/** A stable unsigned 64-bit hash suitable for rings and rollout buckets. */
+export function hash64(value: string): bigint {
+  return BigInt(`0x${sha256Hex(value).slice(0, 16)}`);
+}
+
+/**
+ * RFC-6962-style binary Merkle root. Leaves and branches are domain separated
+ * so a leaf cannot be confused with an internal node.
+ */
+export function merkleRoot(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    return sha256Hex(Buffer.from([0]));
+  }
+
+  let level = values.map((value) =>
+    sha256Hex(Buffer.concat([Buffer.from([0]), Buffer.from(canonicalJson(value))])),
+  );
+  while (level.length > 1) {
+    const next: string[] = [];
+    for (let index = 0; index < level.length; index += 2) {
+      const left = level[index];
+      const right = level[index + 1] ?? left;
+      next.push(
+        sha256Hex(
+          Buffer.concat([
+            Buffer.from([1]),
+            Buffer.from(left, "hex"),
+            Buffer.from(right, "hex"),
+          ]),
+        ),
+      );
+    }
+    level = next;
+  }
+  return level[0];
+}

--- a/server/scaling/upgrade-runtime.ts
+++ b/server/scaling/upgrade-runtime.ts
@@ -1,0 +1,194 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  JsonFileUpgradeJournal,
+  ReversibleMigrationRunner,
+  RollingCanaryOrchestrator,
+  TypedFeatureFlags,
+  VersionCompatibilityMatrix,
+  type UpgradeJournal,
+} from "./upgrade";
+
+export interface UpgradeRuntimeHealth {
+  healthy: boolean;
+  degraded?: boolean;
+  message?: string;
+  details?: Readonly<Record<string, unknown>>;
+}
+
+export interface ZeroDowntimeUpgradeBindings {
+  orchestrator: RollingCanaryOrchestrator;
+  compatibility: VersionCompatibilityMatrix;
+  journal: UpgradeJournal;
+  /** Deployment-owned services that run schema changes and evaluate rollouts. */
+  migrations: unknown;
+  featureFlags: unknown;
+  healthCheck: () =>
+    | UpgradeRuntimeHealth
+    | Promise<UpgradeRuntimeHealth>;
+}
+
+export interface ZeroDowntimeUpgradeFactories {
+  VersionCompatibilityMatrix: typeof VersionCompatibilityMatrix;
+  ReversibleMigrationRunner: typeof ReversibleMigrationRunner;
+  TypedFeatureFlags: typeof TypedFeatureFlags;
+  RollingCanaryOrchestrator: typeof RollingCanaryOrchestrator;
+  JsonFileUpgradeJournal: typeof JsonFileUpgradeJournal;
+}
+
+interface BindingsModule {
+  default?: ZeroDowntimeUpgradeBindings;
+  zeroDowntimeUpgradeBindings?: ZeroDowntimeUpgradeBindings;
+  createZeroDowntimeUpgradeBindings?: (
+    factories: ZeroDowntimeUpgradeFactories,
+  ) =>
+    | ZeroDowntimeUpgradeBindings
+    | Promise<ZeroDowntimeUpgradeBindings>;
+}
+
+export const zeroDowntimeUpgradeFactories: ZeroDowntimeUpgradeFactories = {
+  VersionCompatibilityMatrix,
+  ReversibleMigrationRunner,
+  TypedFeatureFlags,
+  RollingCanaryOrchestrator,
+  JsonFileUpgradeJournal,
+};
+
+/**
+ * Production composition root for zero-downtime upgrade services.
+ *
+ * An enabled deployment must supply an adapter-backed orchestrator, the exact
+ * durable journal used by that orchestrator, migration and feature-flag
+ * services, and an operational health probe. Incomplete bindings stop startup.
+ */
+export class ZeroDowntimeUpgradeRuntime {
+  private configured?: ZeroDowntimeUpgradeBindings;
+  private initialized = false;
+  private enabledByConfiguration = false;
+
+  configure(bindings: ZeroDowntimeUpgradeBindings): void {
+    if (this.initialized) {
+      throw new Error("zero-downtime upgrade runtime is already initialized");
+    }
+    validateBindings(bindings);
+    this.configured = bindings;
+    this.enabledByConfiguration = true;
+  }
+
+  isEnabled(): boolean {
+    return (
+      this.enabledByConfiguration ||
+      process.env.ZERO_DOWNTIME_UPGRADES_ENABLED === "true"
+    );
+  }
+
+  isRequired(): boolean {
+    return process.env.ZERO_DOWNTIME_UPGRADES_REQUIRED === "true";
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized || !this.isEnabled()) return;
+    const bindings = this.configured ?? (await this.loadBindingsModule());
+    validateBindings(bindings);
+    this.configured = bindings;
+    this.initialized = true;
+  }
+
+  bindings(): Readonly<ZeroDowntimeUpgradeBindings> {
+    if (!this.initialized || !this.configured) {
+      throw new Error("zero-downtime upgrade runtime is not initialized");
+    }
+    return this.configured;
+  }
+
+  async health(): Promise<UpgradeRuntimeHealth> {
+    if (!this.isEnabled()) return { healthy: true, message: "disabled" };
+    if (!this.initialized || !this.configured) {
+      return { healthy: false, message: "enabled but not initialized" };
+    }
+    try {
+      return await this.configured.healthCheck();
+    } catch (error) {
+      return {
+        healthy: false,
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async loadBindingsModule(): Promise<ZeroDowntimeUpgradeBindings> {
+    const modulePath = process.env.ZERO_DOWNTIME_UPGRADES_BINDINGS_MODULE;
+    if (!modulePath) {
+      throw new Error(
+        "ZERO_DOWNTIME_UPGRADES_BINDINGS_MODULE is required when zero-downtime upgrades are enabled",
+      );
+    }
+    const loaded = (await import(
+      pathToFileURL(resolve(modulePath)).href
+    )) as BindingsModule;
+    const bindings = loaded.createZeroDowntimeUpgradeBindings
+      ? await loaded.createZeroDowntimeUpgradeBindings(
+          zeroDowntimeUpgradeFactories,
+        )
+      : loaded.zeroDowntimeUpgradeBindings ?? loaded.default;
+    if (!bindings) {
+      throw new Error(
+        "zero-downtime upgrade bindings module must export createZeroDowntimeUpgradeBindings, zeroDowntimeUpgradeBindings, or default",
+      );
+    }
+    return bindings;
+  }
+}
+
+function validateBindings(
+  bindings: ZeroDowntimeUpgradeBindings,
+): asserts bindings is ZeroDowntimeUpgradeBindings {
+  requireMethods(bindings?.orchestrator, ["execute", "usesJournal"], "orchestrator");
+  requireMethods(
+    bindings?.compatibility,
+    ["assertCompatible"],
+    "version compatibility matrix",
+  );
+  requireMethods(bindings?.journal, ["entries", "append"], "upgrade journal");
+  if (!bindings?.journal.durable) {
+    throw new Error(
+      "zero-downtime upgrade bindings require a durable journal",
+    );
+  }
+  if (!bindings.orchestrator.usesJournal(bindings.journal)) {
+    throw new Error(
+      "upgrade orchestrator must use the configured durable journal",
+    );
+  }
+  requireMethods(bindings?.migrations, ["run"], "migration service");
+  requireMethods(bindings?.featureFlags, ["evaluate"], "feature-flag service");
+  if (typeof bindings?.healthCheck !== "function") {
+    throw new Error(
+      "zero-downtime upgrade binding requires a health check",
+    );
+  }
+}
+
+function requireMethods(
+  value: unknown,
+  methods: readonly string[],
+  name: string,
+): void {
+  if (
+    !value ||
+    (typeof value !== "object" && typeof value !== "function") ||
+    methods.some(
+      (method) =>
+        typeof (value as Record<string, unknown>)[method] !== "function",
+    )
+  ) {
+    throw new Error(`zero-downtime upgrade bindings require ${name}`);
+  }
+}
+
+export const zeroDowntimeUpgradeRuntime =
+  new ZeroDowntimeUpgradeRuntime();

--- a/server/scaling/upgrade.ts
+++ b/server/scaling/upgrade.ts
@@ -1,0 +1,1089 @@
+import { randomUUID } from "node:crypto";
+import {
+  mkdir,
+  open,
+  readFile,
+  rename,
+  rm,
+} from "node:fs/promises";
+import { dirname } from "node:path";
+import { canonicalJson, hash64 } from "./hash";
+
+export interface VersionTransition {
+  from: string;
+  to: string;
+  compatible: boolean;
+  reason?: string;
+}
+
+/**
+ * Explicit upgrade compatibility matrix. Missing transitions fail closed;
+ * callers must deliberately certify every rolling-upgrade edge.
+ */
+export class VersionCompatibilityMatrix {
+  private readonly transitions = new Map<string, VersionTransition>();
+
+  constructor(transitions: readonly VersionTransition[]) {
+    for (const transition of transitions) {
+      parseVersion(transition.from);
+      parseVersion(transition.to);
+      const key = transitionKey(transition.from, transition.to);
+      if (this.transitions.has(key)) {
+        throw new Error(`duplicate compatibility transition ${transition.from} -> ${transition.to}`);
+      }
+      this.transitions.set(key, { ...transition });
+    }
+  }
+
+  check(from: string, to: string): { compatible: boolean; reason?: string } {
+    parseVersion(from);
+    parseVersion(to);
+    if (from === to) {
+      return { compatible: true };
+    }
+    const transition = this.transitions.get(transitionKey(from, to));
+    if (!transition) {
+      return {
+        compatible: false,
+        reason: `uncertified version transition ${from} -> ${to}`,
+      };
+    }
+    return {
+      compatible: transition.compatible,
+      reason:
+        transition.reason ??
+        (transition.compatible
+          ? undefined
+          : `version transition ${from} -> ${to} is incompatible`),
+    };
+  }
+
+  assertCompatible(from: string, to: string): void {
+    const result = this.check(from, to);
+    if (!result.compatible) {
+      throw new Error(result.reason);
+    }
+  }
+}
+
+export interface FeatureFlagContext {
+  subjectId: string;
+  siteId?: string;
+  attributes?: Readonly<Record<string, string>>;
+}
+
+export interface FeatureFlagDefinition<T> {
+  defaultValue: T;
+  validate(value: unknown): value is T;
+}
+
+export interface FeatureFlagRollout<T> {
+  enabled: boolean;
+  value: T;
+  percentage: number;
+  includeSubjects?: readonly string[];
+  excludeSubjects?: readonly string[];
+  sites?: readonly string[];
+}
+
+type Definitions<Schema extends Record<string, unknown>> = {
+  [Key in keyof Schema]: FeatureFlagDefinition<Schema[Key]>;
+};
+
+/**
+ * Compile-time keyed and runtime validated feature flags. Rollout assignment is
+ * stable across processes because it hashes flag + subject into 10,000 buckets.
+ */
+export class TypedFeatureFlags<Schema extends Record<string, unknown>> {
+  private readonly rollouts = new Map<keyof Schema, FeatureFlagRollout<unknown>>();
+
+  constructor(private readonly definitions: Definitions<Schema>) {}
+
+  configure<Key extends keyof Schema>(
+    key: Key,
+    rollout: FeatureFlagRollout<Schema[Key]>,
+  ): void {
+    const definition = this.definitions[key];
+    if (!definition) {
+      throw new Error(`unknown feature flag: ${String(key)}`);
+    }
+    if (!definition.validate(rollout.value)) {
+      throw new Error(`invalid value for feature flag: ${String(key)}`);
+    }
+    if (
+      !Number.isFinite(rollout.percentage) ||
+      rollout.percentage < 0 ||
+      rollout.percentage > 100
+    ) {
+      throw new Error("feature flag percentage must be between 0 and 100");
+    }
+    this.rollouts.set(key, structuredClone(rollout));
+  }
+
+  evaluate<Key extends keyof Schema>(
+    key: Key,
+    context: FeatureFlagContext,
+  ): Schema[Key] {
+    const definition = this.definitions[key];
+    if (!definition) {
+      throw new Error(`unknown feature flag: ${String(key)}`);
+    }
+    const rollout = this.rollouts.get(key) as
+      | FeatureFlagRollout<Schema[Key]>
+      | undefined;
+    if (!rollout?.enabled || !context.subjectId) {
+      return structuredClone(definition.defaultValue);
+    }
+    if (rollout.excludeSubjects?.includes(context.subjectId)) {
+      return structuredClone(definition.defaultValue);
+    }
+    if (
+      rollout.sites?.length &&
+      (!context.siteId || !rollout.sites.includes(context.siteId))
+    ) {
+      return structuredClone(definition.defaultValue);
+    }
+    if (rollout.includeSubjects?.includes(context.subjectId)) {
+      return structuredClone(rollout.value);
+    }
+    const bucket = Number(
+      hash64(`${String(key)}\0${context.subjectId}`) % 10_000n,
+    );
+    return bucket < Math.round(rollout.percentage * 100)
+      ? structuredClone(rollout.value)
+      : structuredClone(definition.defaultValue);
+  }
+
+  snapshot(): Partial<{ [Key in keyof Schema]: FeatureFlagRollout<Schema[Key]> }> {
+    return Object.fromEntries(
+      [...this.rollouts.entries()].map(([key, value]) => [
+        key,
+        structuredClone(value),
+      ]),
+    ) as Partial<{ [Key in keyof Schema]: FeatureFlagRollout<Schema[Key]> }>;
+  }
+}
+
+export interface DatabaseMigration<Context> {
+  id: string;
+  up(context: Context): Promise<void>;
+  down(context: Context): Promise<void>;
+}
+
+export type MigrationJournalStatus =
+  | "started"
+  | "applied"
+  | "failed"
+  | "rollback-started"
+  | "rolled-back"
+  | "rollback-failed";
+
+export interface MigrationJournalEntry {
+  migrationId: string;
+  status: MigrationJournalStatus;
+  sequence: number;
+  timestamp: Date;
+  error?: string;
+}
+
+export interface MigrationJournal {
+  entries(): Promise<readonly MigrationJournalEntry[]>;
+  append(
+    entry: Omit<MigrationJournalEntry, "sequence" | "timestamp">,
+  ): Promise<MigrationJournalEntry>;
+}
+
+/** Durable implementations can back this contract with an append-only table. */
+export class InMemoryMigrationJournal implements MigrationJournal {
+  private readonly log: MigrationJournalEntry[] = [];
+  constructor(private readonly now: () => Date = () => new Date()) {}
+
+  async entries(): Promise<readonly MigrationJournalEntry[]> {
+    return structuredClone(this.log);
+  }
+
+  async append(
+    entry: Omit<MigrationJournalEntry, "sequence" | "timestamp">,
+  ): Promise<MigrationJournalEntry> {
+    const recorded: MigrationJournalEntry = {
+      ...entry,
+      sequence: this.log.length + 1,
+      timestamp: this.now(),
+    };
+    this.log.push(recorded);
+    return structuredClone(recorded);
+  }
+}
+
+export class MigrationExecutionError extends Error {
+  constructor(
+    message: string,
+    readonly failedMigration: string,
+    readonly rollbackFailures: readonly string[],
+  ) {
+    super(message);
+    this.name = "MigrationExecutionError";
+  }
+}
+
+/**
+ * Applies migrations once and automatically runs `down` in reverse order when
+ * an `up` fails. Every transition is journaled for crash recovery/audit.
+ */
+export class ReversibleMigrationRunner<Context> {
+  private running = false;
+
+  constructor(private readonly journal: MigrationJournal) {}
+
+  async run(
+    migrations: readonly DatabaseMigration<Context>[],
+    context: Context,
+  ): Promise<string[]> {
+    if (this.running) {
+      throw new Error("a migration run is already in progress");
+    }
+    this.running = true;
+    try {
+      return await this.runExclusive(migrations, context);
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async runExclusive(
+    migrations: readonly DatabaseMigration<Context>[],
+    context: Context,
+  ): Promise<string[]> {
+    const definitions = new Map<string, DatabaseMigration<Context>>();
+    for (const migration of migrations) {
+      if (!migration.id.trim() || definitions.has(migration.id)) {
+        throw new Error(`migration ids must be non-empty and unique: ${migration.id}`);
+      }
+      definitions.set(migration.id, migration);
+    }
+    await this.recoverIncomplete(definitions, context);
+    const existing = await this.journal.entries();
+    const appliedPreviously = currentAppliedMigrations(existing);
+    const appliedThisRun: DatabaseMigration<Context>[] = [];
+
+    for (const migration of migrations) {
+      if (appliedPreviously.has(migration.id)) {
+        continue;
+      }
+      await this.journal.append({
+        migrationId: migration.id,
+        status: "started",
+      });
+      try {
+        await migration.up(context);
+        await this.journal.append({
+          migrationId: migration.id,
+          status: "applied",
+        });
+        appliedThisRun.push(migration);
+      } catch (error) {
+        const journalFailures: string[] = [];
+        try {
+          await this.journal.append({
+            migrationId: migration.id,
+            status: "failed",
+            error: errorMessage(error),
+          });
+        } catch (journalError) {
+          journalFailures.push(
+            `${migration.id}: could not journal failure: ${errorMessage(journalError)}`,
+          );
+        }
+        // `up` may have made partial changes before throwing, so its `down`
+        // participates in recovery as well as all prior migrations.
+        const rollbackFailures = await this.rollback(
+          [...appliedThisRun, migration],
+          context,
+        );
+        throw new MigrationExecutionError(
+          `migration ${migration.id} failed: ${errorMessage(error)}`,
+          migration.id,
+          [...journalFailures, ...rollbackFailures],
+        );
+      }
+    }
+    return appliedThisRun.map((migration) => migration.id);
+  }
+
+  async rollback(
+    migrations: readonly DatabaseMigration<Context>[],
+    context: Context,
+  ): Promise<string[]> {
+    const failures: string[] = [];
+    for (const migration of [...migrations].reverse()) {
+      try {
+        await this.journal.append({
+          migrationId: migration.id,
+          status: "rollback-started",
+        });
+      } catch (error) {
+        failures.push(
+          `${migration.id}: could not journal rollback start: ${errorMessage(error)}`,
+        );
+      }
+      try {
+        await migration.down(context);
+        try {
+          await this.journal.append({
+            migrationId: migration.id,
+            status: "rolled-back",
+          });
+        } catch (error) {
+          failures.push(
+            `${migration.id}: rollback completed but could not be journaled: ${errorMessage(error)}`,
+          );
+        }
+      } catch (error) {
+        const failure = `${migration.id}: ${errorMessage(error)}`;
+        failures.push(failure);
+        try {
+          await this.journal.append({
+            migrationId: migration.id,
+            status: "rollback-failed",
+            error: errorMessage(error),
+          });
+        } catch (journalError) {
+          failures.push(
+            `${migration.id}: could not journal rollback failure: ${errorMessage(journalError)}`,
+          );
+        }
+      }
+    }
+    return failures;
+  }
+
+  private async recoverIncomplete(
+    definitions: ReadonlyMap<string, DatabaseMigration<Context>>,
+    context: Context,
+  ): Promise<void> {
+    const entries = await this.journal.entries();
+    const latest = latestMigrationStates(entries);
+    const incomplete = [...latest.entries()]
+      .filter(([, entry]) =>
+        (
+          [
+            "started",
+            "failed",
+            "rollback-started",
+            "rollback-failed",
+          ] as MigrationJournalStatus[]
+        ).includes(entry.status),
+      )
+      .sort((left, right) => right[1].sequence - left[1].sequence);
+
+    for (const [migrationId] of incomplete) {
+      const migration = definitions.get(migrationId);
+      if (!migration) {
+        throw new MigrationExecutionError(
+          `incomplete migration ${migrationId} cannot be recovered without its definition`,
+          migrationId,
+          [`${migrationId}: migration definition is unavailable`],
+        );
+      }
+      // `up` or `down` may have crossed its side-effect boundary before the
+      // process stopped. Recovery therefore requires an idempotent `down`.
+      const failures = await this.rollback([migration], context);
+      if (failures.length > 0) {
+        throw new MigrationExecutionError(
+          `incomplete migration ${migrationId} could not be recovered`,
+          migrationId,
+          failures,
+        );
+      }
+    }
+  }
+}
+
+export type UpgradeJournalStatus =
+  | "drain-started"
+  | "deployed"
+  | "healthy"
+  | "traffic-restored"
+  | "rollback-started"
+  | "rolled-back"
+  | "rollback-failed";
+
+export interface UpgradeJournalEntry {
+  targetVersion: string;
+  instanceId: string;
+  originalVersion: string;
+  status: UpgradeJournalStatus;
+  sequence: number;
+  timestamp: Date;
+  error?: string;
+}
+
+export interface UpgradeJournal {
+  /** True only when entries survive controller process loss. */
+  readonly durable: boolean;
+  entries(): Promise<readonly UpgradeJournalEntry[]>;
+  append(
+    entry: Omit<UpgradeJournalEntry, "sequence" | "timestamp">,
+  ): Promise<UpgradeJournalEntry>;
+}
+
+export class InMemoryUpgradeJournal implements UpgradeJournal {
+  readonly durable = false;
+  private readonly log: UpgradeJournalEntry[] = [];
+  constructor(private readonly now: () => Date = () => new Date()) {}
+
+  async entries(): Promise<readonly UpgradeJournalEntry[]> {
+    return structuredClone(this.log);
+  }
+
+  async append(
+    entry: Omit<UpgradeJournalEntry, "sequence" | "timestamp">,
+  ): Promise<UpgradeJournalEntry> {
+    const recorded: UpgradeJournalEntry = {
+      ...entry,
+      sequence: this.log.length + 1,
+      timestamp: this.now(),
+    };
+    validateUpgradeJournalEntry(recorded);
+    this.log.push(recorded);
+    return structuredClone(recorded);
+  }
+}
+
+interface SerializedUpgradeJournalEntry
+  extends Omit<UpgradeJournalEntry, "timestamp"> {
+  timestamp: string;
+}
+
+interface UpgradeJournalFile {
+  version: 1;
+  entries: SerializedUpgradeJournalEntry[];
+}
+
+/**
+ * Atomic, fsync-backed journal for a single upgrade controller process.
+ * Multi-controller deployments should bind `UpgradeJournal` to a transactional
+ * database that also provides leader election.
+ */
+export class JsonFileUpgradeJournal implements UpgradeJournal {
+  readonly durable = true;
+  private operation: Promise<void> = Promise.resolve();
+
+  constructor(
+    readonly path: string,
+    private readonly now: () => Date = () => new Date(),
+  ) {
+    if (!path) {
+      throw new Error("upgrade journal path is required");
+    }
+  }
+
+  async entries(): Promise<readonly UpgradeJournalEntry[]> {
+    let contents: string;
+    try {
+      contents = await readFile(this.path, "utf8");
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    }
+    const parsed = JSON.parse(contents) as Partial<UpgradeJournalFile>;
+    if (parsed.version !== 1 || !Array.isArray(parsed.entries)) {
+      throw new Error(`unsupported or corrupt upgrade journal: ${this.path}`);
+    }
+    const entries = parsed.entries.map((entry) => {
+      const deserialized: UpgradeJournalEntry = {
+        ...entry,
+        timestamp: new Date(entry.timestamp),
+      };
+      validateUpgradeJournalEntry(deserialized);
+      return deserialized;
+    });
+    entries.forEach((entry, index) => {
+      if (entry.sequence !== index + 1) {
+        throw new Error(
+          `non-contiguous upgrade journal sequence at ${entry.sequence}`,
+        );
+      }
+    });
+    return entries;
+  }
+
+  append(
+    entry: Omit<UpgradeJournalEntry, "sequence" | "timestamp">,
+  ): Promise<UpgradeJournalEntry> {
+    return this.serialized(async () => {
+      const existing = [...(await this.entries())];
+      const recorded: UpgradeJournalEntry = {
+        ...entry,
+        sequence: (existing.at(-1)?.sequence ?? 0) + 1,
+        timestamp: this.now(),
+      };
+      validateUpgradeJournalEntry(recorded);
+      await this.save([...existing, recorded]);
+      return structuredClone(recorded);
+    });
+  }
+
+  private async save(entries: readonly UpgradeJournalEntry[]): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true });
+    const temporary = `${this.path}.${process.pid}.${randomUUID()}.tmp`;
+    const payload: UpgradeJournalFile = {
+      version: 1,
+      entries: entries.map((entry) => ({
+        ...entry,
+        timestamp: entry.timestamp.toISOString(),
+      })),
+    };
+    try {
+      const handle = await open(temporary, "wx");
+      try {
+        await handle.writeFile(`${canonicalJson(payload)}\n`, "utf8");
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+      await rename(temporary, this.path);
+    } catch (error) {
+      await rm(temporary, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  private async serialized<T>(work: () => Promise<T>): Promise<T> {
+    const previous = this.operation;
+    let release!: () => void;
+    this.operation = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await work();
+    } finally {
+      release();
+    }
+  }
+}
+
+export interface DeploymentInstance {
+  id: string;
+  version: string;
+  healthy: boolean;
+  zone?: string;
+  /** Explicit false means the instance is drained from the traffic plane. */
+  trafficEnabled?: boolean;
+}
+
+export interface DeploymentAdapter {
+  instances(): Promise<readonly DeploymentInstance[]>;
+  drain(instanceId: string): Promise<void>;
+  deploy(instanceId: string, version: string): Promise<void>;
+  waitUntilHealthy(
+    instanceId: string,
+    version: string,
+    timeoutMs: number,
+  ): Promise<boolean>;
+  restoreTraffic(instanceId: string): Promise<void>;
+  rollback(instanceId: string, version: string): Promise<void>;
+}
+
+export interface RollingUpgradePlan {
+  targetVersion: string;
+  canaryCount: number;
+  batchSize: number;
+  healthTimeoutMs: number;
+}
+
+export type UpgradeStage =
+  | "canary"
+  | "rolling"
+  | "recovery"
+  | "rollback"
+  | "complete";
+
+export interface UpgradeEvent {
+  stage: UpgradeStage;
+  instanceId?: string;
+  fromVersion?: string;
+  toVersion?: string;
+  outcome: "started" | "healthy" | "failed" | "restored";
+  error?: string;
+}
+
+export interface UpgradeResult {
+  succeeded: boolean;
+  targetVersion: string;
+  upgraded: string[];
+  events: UpgradeEvent[];
+  failure?: string;
+  rollbackFailures: string[];
+}
+
+/**
+ * Canary-first rolling orchestrator. The compatibility matrix is checked before
+ * any drain/deploy side effect. A failed health gate rolls every changed node
+ * back to its original version.
+ */
+export class RollingCanaryOrchestrator {
+  private executing = false;
+
+  constructor(
+    private readonly adapter: DeploymentAdapter,
+    private readonly compatibility: VersionCompatibilityMatrix,
+    private readonly journal: UpgradeJournal = new InMemoryUpgradeJournal(),
+  ) {}
+
+  usesJournal(journal: UpgradeJournal): boolean {
+    return this.journal === journal;
+  }
+
+  async execute(plan: RollingUpgradePlan): Promise<UpgradeResult> {
+    if (this.executing) {
+      throw new Error("an upgrade is already in progress");
+    }
+    this.executing = true;
+    try {
+      return await this.executeExclusive(plan);
+    } finally {
+      this.executing = false;
+    }
+  }
+
+  private async executeExclusive(
+    plan: RollingUpgradePlan,
+  ): Promise<UpgradeResult> {
+    validateUpgradePlan(plan);
+    parseVersion(plan.targetVersion);
+    let instances = [...(await this.adapter.instances())].sort(
+      stableInstanceOrder,
+    );
+    validateDeploymentInstances(instances);
+    if (instances.length === 0) {
+      throw new Error("cannot run an upgrade without deployment instances");
+    }
+    const events: UpgradeEvent[] = [];
+    await this.reconcileInterrupted(instances, plan.healthTimeoutMs, events);
+    instances = [...(await this.adapter.instances())].sort(stableInstanceOrder);
+    validateDeploymentInstances(instances);
+    if (instances.some((instance) => !instance.healthy)) {
+      throw new Error("all deployment instances must be healthy before upgrade");
+    }
+    for (const instance of instances) {
+      this.compatibility.assertCompatible(instance.version, plan.targetVersion);
+    }
+
+    const originals = new Map(
+      instances.map((instance) => [instance.id, instance.version]),
+    );
+    const pending = instances.filter(
+      (instance) => instance.version !== plan.targetVersion,
+    );
+    const canaryCount = Math.min(plan.canaryCount, pending.length);
+    const canaries = pending.slice(0, canaryCount);
+    const remainder = pending.slice(canaryCount);
+    const changed: string[] = [];
+
+    const applyBatch = async (
+      batch: readonly DeploymentInstance[],
+      stage: "canary" | "rolling",
+    ): Promise<void> => {
+      for (const instance of batch) {
+        events.push({
+          stage,
+          instanceId: instance.id,
+          fromVersion: instance.version,
+          toVersion: plan.targetVersion,
+          outcome: "started",
+        });
+        try {
+          // Persist intent before crossing the first traffic-plane side effect.
+          await this.journal.append({
+            targetVersion: plan.targetVersion,
+            instanceId: instance.id,
+            originalVersion: instance.version,
+            status: "drain-started",
+          });
+          changed.push(instance.id);
+          await this.adapter.drain(instance.id);
+          await this.adapter.deploy(instance.id, plan.targetVersion);
+          await this.journal.append({
+            targetVersion: plan.targetVersion,
+            instanceId: instance.id,
+            originalVersion: instance.version,
+            status: "deployed",
+          });
+          const healthy = await this.adapter.waitUntilHealthy(
+            instance.id,
+            plan.targetVersion,
+            plan.healthTimeoutMs,
+          );
+          if (!healthy) {
+            throw new Error(`health gate timed out for ${instance.id}`);
+          }
+          await this.journal.append({
+            targetVersion: plan.targetVersion,
+            instanceId: instance.id,
+            originalVersion: instance.version,
+            status: "healthy",
+          });
+          await this.adapter.restoreTraffic(instance.id);
+          await this.journal.append({
+            targetVersion: plan.targetVersion,
+            instanceId: instance.id,
+            originalVersion: instance.version,
+            status: "traffic-restored",
+          });
+          events.push({
+            stage,
+            instanceId: instance.id,
+            fromVersion: instance.version,
+            toVersion: plan.targetVersion,
+            outcome: "healthy",
+          });
+        } catch (error) {
+          events.push({
+            stage,
+            instanceId: instance.id,
+            fromVersion: instance.version,
+            toVersion: plan.targetVersion,
+            outcome: "failed",
+            error: errorMessage(error),
+          });
+          throw error;
+        }
+      }
+    };
+
+    try {
+      await applyBatch(canaries, "canary");
+      for (let index = 0; index < remainder.length; index += plan.batchSize) {
+        await applyBatch(remainder.slice(index, index + plan.batchSize), "rolling");
+      }
+      events.push({ stage: "complete", outcome: "healthy" });
+      return {
+        succeeded: true,
+        targetVersion: plan.targetVersion,
+        upgraded: [...changed],
+        events,
+        rollbackFailures: [],
+      };
+    } catch (error) {
+      const rollbackFailures: string[] = [];
+      for (const instanceId of [...changed].reverse()) {
+        const original = originals.get(instanceId)!;
+        events.push({
+          stage: "rollback",
+          instanceId,
+          fromVersion: plan.targetVersion,
+          toVersion: original,
+          outcome: "started",
+        });
+        try {
+          await this.journal.append({
+            targetVersion: plan.targetVersion,
+            instanceId,
+            originalVersion: original,
+            status: "rollback-started",
+          });
+        } catch (journalError) {
+          rollbackFailures.push(
+            `${instanceId}: could not journal rollback start: ${errorMessage(journalError)}`,
+          );
+        }
+        try {
+          await this.adapter.rollback(instanceId, original);
+          await this.adapter.restoreTraffic(instanceId);
+          try {
+            await this.journal.append({
+              targetVersion: plan.targetVersion,
+              instanceId,
+              originalVersion: original,
+              status: "rolled-back",
+            });
+          } catch (journalError) {
+            rollbackFailures.push(
+              `${instanceId}: rollback completed but could not be journaled: ${errorMessage(journalError)}`,
+            );
+          }
+          events.push({
+            stage: "rollback",
+            instanceId,
+            fromVersion: plan.targetVersion,
+            toVersion: original,
+            outcome: "restored",
+          });
+        } catch (rollbackError) {
+          const failure = `${instanceId}: ${errorMessage(rollbackError)}`;
+          rollbackFailures.push(failure);
+          try {
+            await this.journal.append({
+              targetVersion: plan.targetVersion,
+              instanceId,
+              originalVersion: original,
+              status: "rollback-failed",
+              error: errorMessage(rollbackError),
+            });
+          } catch (journalError) {
+            rollbackFailures.push(
+              `${instanceId}: could not journal rollback failure: ${errorMessage(journalError)}`,
+            );
+          }
+          events.push({
+            stage: "rollback",
+            instanceId,
+            fromVersion: plan.targetVersion,
+            toVersion: original,
+            outcome: "failed",
+            error: errorMessage(rollbackError),
+          });
+        }
+      }
+      return {
+        succeeded: false,
+        targetVersion: plan.targetVersion,
+        upgraded: [...changed],
+        events,
+        failure: errorMessage(error),
+        rollbackFailures,
+      };
+    }
+  }
+
+  private async reconcileInterrupted(
+    instances: readonly DeploymentInstance[],
+    healthTimeoutMs: number,
+    events: UpgradeEvent[],
+  ): Promise<void> {
+    const latest = latestUpgradeStates(await this.journal.entries());
+    for (const instance of instances) {
+      const entry = latest.get(instance.id);
+      const incomplete =
+        entry &&
+        entry.status !== "traffic-restored" &&
+        entry.status !== "rolled-back";
+      if (!incomplete && instance.trafficEnabled !== false) {
+        continue;
+      }
+      events.push({
+        stage: "recovery",
+        instanceId: instance.id,
+        fromVersion: instance.version,
+        toVersion: entry?.targetVersion ?? instance.version,
+        outcome: "started",
+      });
+      try {
+        if (!entry) {
+          if (!instance.healthy) {
+            throw new Error(
+              `drained instance ${instance.id} is unhealthy and has no recovery journal`,
+            );
+          }
+          await this.adapter.restoreTraffic(instance.id);
+        } else if (
+          entry.status === "rollback-started" ||
+          entry.status === "rollback-failed"
+        ) {
+          await this.recoverOriginal(entry);
+        } else if (instance.version === entry.targetVersion) {
+          const healthy = await this.adapter.waitUntilHealthy(
+            instance.id,
+            entry.targetVersion,
+            healthTimeoutMs,
+          );
+          if (healthy) {
+            await this.journal.append({
+              targetVersion: entry.targetVersion,
+              instanceId: entry.instanceId,
+              originalVersion: entry.originalVersion,
+              status: "healthy",
+            });
+            await this.adapter.restoreTraffic(instance.id);
+            await this.journal.append({
+              targetVersion: entry.targetVersion,
+              instanceId: entry.instanceId,
+              originalVersion: entry.originalVersion,
+              status: "traffic-restored",
+            });
+          } else {
+            await this.recoverOriginal(entry);
+          }
+        } else {
+          // A crash before/inside deploy left the node at its old or an
+          // indeterminate version. Restore the certified original and traffic.
+          await this.recoverOriginal(entry);
+        }
+        events.push({
+          stage: "recovery",
+          instanceId: instance.id,
+          fromVersion: instance.version,
+          toVersion: entry?.targetVersion ?? instance.version,
+          outcome: "restored",
+        });
+      } catch (error) {
+        events.push({
+          stage: "recovery",
+          instanceId: instance.id,
+          fromVersion: instance.version,
+          toVersion: entry?.targetVersion ?? instance.version,
+          outcome: "failed",
+          error: errorMessage(error),
+        });
+        throw error;
+      }
+    }
+  }
+
+  private async recoverOriginal(entry: UpgradeJournalEntry): Promise<void> {
+    await this.journal.append({
+      targetVersion: entry.targetVersion,
+      instanceId: entry.instanceId,
+      originalVersion: entry.originalVersion,
+      status: "rollback-started",
+    });
+    try {
+      await this.adapter.rollback(entry.instanceId, entry.originalVersion);
+      await this.adapter.restoreTraffic(entry.instanceId);
+      await this.journal.append({
+        targetVersion: entry.targetVersion,
+        instanceId: entry.instanceId,
+        originalVersion: entry.originalVersion,
+        status: "rolled-back",
+      });
+    } catch (error) {
+      try {
+        await this.journal.append({
+          targetVersion: entry.targetVersion,
+          instanceId: entry.instanceId,
+          originalVersion: entry.originalVersion,
+          status: "rollback-failed",
+          error: errorMessage(error),
+        });
+      } catch {
+        // Preserve the recovery failure that identifies the side effect.
+      }
+      throw error;
+    }
+  }
+}
+
+function currentAppliedMigrations(
+  entries: readonly MigrationJournalEntry[],
+): Set<string> {
+  const states = latestMigrationStates(entries);
+  return new Set(
+    [...states.entries()]
+      .filter(([, entry]) => entry.status === "applied")
+      .map(([id]) => id),
+  );
+}
+
+function latestMigrationStates(
+  entries: readonly MigrationJournalEntry[],
+): Map<string, MigrationJournalEntry> {
+  const states = new Map<string, MigrationJournalEntry>();
+  for (const entry of [...entries].sort(
+    (left, right) => left.sequence - right.sequence,
+  )) {
+    states.set(entry.migrationId, entry);
+  }
+  return states;
+}
+
+function latestUpgradeStates(
+  entries: readonly UpgradeJournalEntry[],
+): Map<string, UpgradeJournalEntry> {
+  const states = new Map<string, UpgradeJournalEntry>();
+  for (const entry of [...entries].sort(
+    (left, right) => left.sequence - right.sequence,
+  )) {
+    validateUpgradeJournalEntry(entry);
+    states.set(entry.instanceId, entry);
+  }
+  return states;
+}
+
+function validateUpgradeJournalEntry(entry: UpgradeJournalEntry): void {
+  parseVersion(entry.targetVersion);
+  parseVersion(entry.originalVersion);
+  if (!entry.instanceId?.trim()) {
+    throw new Error("upgrade journal instance id cannot be empty");
+  }
+  if (
+    !Number.isSafeInteger(entry.sequence) ||
+    entry.sequence < 1 ||
+    !(entry.timestamp instanceof Date) ||
+    Number.isNaN(entry.timestamp.getTime())
+  ) {
+    throw new Error("invalid upgrade journal sequence or timestamp");
+  }
+  const statuses: readonly UpgradeJournalStatus[] = [
+    "drain-started",
+    "deployed",
+    "healthy",
+    "traffic-restored",
+    "rollback-started",
+    "rolled-back",
+    "rollback-failed",
+  ];
+  if (!statuses.includes(entry.status)) {
+    throw new Error(`invalid upgrade journal status: ${String(entry.status)}`);
+  }
+}
+
+function validateDeploymentInstances(
+  instances: readonly DeploymentInstance[],
+): void {
+  const ids = new Set<string>();
+  for (const instance of instances) {
+    if (!instance.id?.trim() || ids.has(instance.id)) {
+      throw new Error(
+        `deployment instance ids must be non-empty and unique: ${instance.id}`,
+      );
+    }
+    ids.add(instance.id);
+    parseVersion(instance.version);
+  }
+}
+
+function validateUpgradePlan(plan: RollingUpgradePlan): void {
+  if (
+    !Number.isInteger(plan.canaryCount) ||
+    plan.canaryCount < 1 ||
+    !Number.isInteger(plan.batchSize) ||
+    plan.batchSize < 1 ||
+    !Number.isFinite(plan.healthTimeoutMs) ||
+    plan.healthTimeoutMs <= 0
+  ) {
+    throw new Error("canaryCount, batchSize, and healthTimeoutMs must be positive");
+  }
+}
+
+function stableInstanceOrder(
+  left: DeploymentInstance,
+  right: DeploymentInstance,
+): number {
+  const leftHash = hash64(`${left.zone ?? ""}\0${left.id}`);
+  const rightHash = hash64(`${right.zone ?? ""}\0${right.id}`);
+  return Number(leftHash - rightHash) || left.id.localeCompare(right.id);
+}
+
+function transitionKey(from: string, to: string): string {
+  return `${from}\0${to}`;
+}
+
+function parseVersion(version: string): readonly [number, number, number] {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(version);
+  if (!match) {
+    throw new Error(`invalid semantic version: ${version}`);
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}


### PR DESCRIPTION
## Summary

Adds a standalone zero-downtime upgrade toolkit:

- a fail-closed version compatibility matrix;
- typed, validated, deterministic feature-flag rollouts;
- reversible database migrations with append-only recovery journaling;
- health-gated deterministic canary and rolling deployment orchestration; and
- an fsync-backed single-controller upgrade journal;
- an env-gated production bindings-module composition root; and
- startup plus readiness-health integration for the configured controller.

## Why

The repository lacked executable safety boundaries for rolling version
transitions. An uncertified mixed-version deployment, interrupted migration, or
controller restart during a drain/deploy boundary could otherwise leave nodes
or schema state partially upgraded without a deterministic recovery path.

## Safety model

Compatibility is checked before the first deployment side effect. Migration
failures roll back the failing migration and every migration applied during the
same run in reverse order. The rollout journal records drain, deploy, health,
traffic restoration, and rollback boundaries so restart recovery can either
restore healthy target nodes or return them to their recorded original
versions.

Deployment adapters must implement idempotent drain, traffic restoration, and
rollback operations. Multi-controller deployments bind the journal interface
to transactional storage with leader election.

## Production wiring

`ZERO_DOWNTIME_UPGRADES_ENABLED=true` activates startup composition through
`ZERO_DOWNTIME_UPGRADES_BINDINGS_MODULE`. Enabled deployments fail startup
closed unless the module supplies a deployment-backed orchestrator, version
compatibility matrix, callable migration and feature-flag services, operational
health, and the exact durable journal used by the orchestrator. The application
initializes this runtime before serving traffic and registers
`zero-downtime-upgrades` health; `ZERO_DOWNTIME_UPGRADES_REQUIRED=true` makes it
readiness-critical.

## Validation

- `npx vitest run server/scaling/__tests__/upgrade.test.ts server/scaling/__tests__/upgrade-runtime.test.ts server/__tests__/startup-singleton-imports.test.ts` — 21 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — passed

The branch contains two signed commits based directly on `main` and remains
scoped to the upgrade engine, production composition/startup/health wiring,
focused tests, deterministic hash helper, and operator guide.

Closes #227
