### PR TITLE
feat(sre): add production monitoring and playbooks (#226)

### DIFF
--- a/docs/operations/slo-catalog.md
+++ b/docs/operations/slo-catalog.md
@@ -1,0 +1,68 @@
+# Production SLO and SLI Catalog
+
+The executable catalog is `CRITICAL_PATH_SLOS` in
+`server/services/sre/index.ts`. `GET /api/governance/sre/slos` returns the same
+definitions. The catalog uses good-event ratios so each objective can be fed by
+counter deltas from Prometheus or another telemetry backend.
+
+| SLO id | Critical path | Good event | Objective/window | Owner |
+|---|---|---|---|---|
+| `tag-ingest-freshness` | Device → gateway → event pipeline | Good-quality update accepted within 1 second | 99.9% / 30d | edge-platform |
+| `control-loop-confirmation` | Tick → batch → sign → anchor → confirmation | Round trip ≤ 4.8 seconds and each recorded stage within budget | 99.9% / 30d | integrity-platform |
+| `api-tag-read-availability` | Client → API → cache/historian | Non-5xx authorized read within 500 ms | 99.95% / 30d | control-plane |
+| `websocket-delivery` | Event pipeline → WebSocket → subscriber | Eligible event delivered within 2 seconds | 99.9% / 30d | control-plane |
+| `historian-durability` | Event pipeline → historian → verification | Accepted write remains readable and Merkle-verifiable | 99.999% / 30d | data-platform |
+| `gateway-failover-rto` | Heartbeat loss → drain → rebalance → telemetry | All affected shards fresh within 60 seconds | 99% / 90d | edge-platform |
+| `database-recovery-rto` | DB incident → failover/restore → verified writes | Verified service restored within 15 minutes with RPO ≤ 60 seconds | 99% / 90d | data-platform |
+
+## Error-budget evaluation
+
+For events inside the rolling window:
+
+```text
+SLI                    = good events / total events
+allowed bad events     = total events × (1 - objective)
+burn rate              = observed bad events / allowed bad events
+error budget remaining = max(0, 1 - burn rate)
+```
+
+- `healthy`: less than half of the available error budget is consumed;
+- `warning`: 50–100% is consumed;
+- `breached`: 100% or more is consumed;
+- `no-data`: no eligible events; this must alert on telemetry coverage and must
+  not be treated as success.
+
+Evaluate an aggregated counter window with:
+
+```http
+POST /api/governance/sre/slos/tag-ingest-freshness/evaluate
+Content-Type: application/json
+
+{
+  "observations": [
+    {
+      "timestamp": "2026-07-28T12:00:00.000Z",
+      "goodEvents": 999500,
+      "totalEvents": 1000000
+    }
+  ]
+}
+```
+
+Counter samples must be non-negative integers and `goodEvents` cannot exceed
+`totalEvents`. The evaluator ignores valid samples outside the SLO window and
+rejects malformed timestamps or counters.
+
+## Alerting and release policy
+
+- Page the owning team for `breached` on tag ingestion, control-loop,
+  durability, or recovery objectives.
+- Create an urgent ticket for `warning`; page if warning persists for two
+  evaluation intervals.
+- Page telemetry owners if a critical SLO is `no-data` for two scrape intervals.
+- Freeze non-remediation changes when a critical-path budget is exhausted.
+- Unfreeze only after the incident commander records mitigation, the SLI
+  returns to baseline, and a recovery projection shows positive budget.
+
+All SLO alerts must include SLO id, window, burn rate, owner, affected site/tag
+scope, dashboard link, and the catalog runbook path.

--- a/docs/operations/sre-playbooks/automated-remediation.md
+++ b/docs/operations/sre-playbooks/automated-remediation.md
@@ -1,0 +1,87 @@
+# Automated Remediation Operations
+
+`AutoRemediationEngine` runs only injected, registered actions. It does not
+execute arbitrary shell text. `RemediationRuntime` composes two bounded adapter
+contracts:
+
+- `createGatewayFailoverAction`: inspect, drain/rebalance, verify tag coverage,
+  and restore previous assignments if verification fails;
+- `createScaleOutAction`: increase replicas under an operator-supplied hard
+  maximum, verify ready replicas, and roll back on failure.
+
+The runtime remains unavailable until the deployment injects at least one
+adapter and a durable `RemediationAuditSink`. Supply this with the
+`remediation` option to `registerRoutes`; `JsonlRemediationAuditSink` is the
+built-in persistent-volume implementation. An unconfigured runtime returns
+503 instead of simulating success.
+
+Execution is exposed at:
+
+```http
+POST /api/governance/sre/remediations/execute
+X-API-Key: <key with sre.remediate and operator grants>
+Content-Type: application/json
+
+{
+  "actionId": "scale-out",
+  "context": {
+    "component": "api",
+    "desiredReplicas": 4,
+    "maximumReplicas": 6
+  },
+  "idempotencyKey": "INC-1234:scale-out:api:apply-1",
+  "dryRun": false
+}
+```
+
+The route authenticates and authorizes before parsing the body. `approvedBy`
+is bound to the server-owned API-key principal and cannot be supplied by the
+caller. Requests default to `dryRun: true`.
+
+## Required execution sequence
+
+1. Correlate the alert to an incident and choose a stable idempotency key, such
+   as `INC-1234:gateway-failover:gw-07`.
+2. Run with `dryRun: true`. The engine evaluates the same safety precondition
+   used by a real execution but performs no mutation.
+3. Review scope, risk, desired state, hard maximum, and available failover
+   capacity.
+4. Execute with a new apply key, such as
+   `INC-1234:gateway-failover:gw-07:apply-1`.
+5. Retain the result and engine audit entry with the incident.
+6. Escalate any `blocked`, `failed`, or `rolled-back` result.
+
+Reusing the same key and identical request returns the original result without
+executing again. Reusing the key for different context is rejected.
+
+## Safety controls
+
+- action allowlist;
+- automatic risk ceiling (high-risk actions require `approvedBy`);
+- action-specific precondition and hard bounds;
+- per-action/resource cooldown;
+- global executions-per-hour limit;
+- post-change verification;
+- rollback where the adapter supports it;
+- bounded audit and idempotency history.
+
+A dry run does not reserve an apply key or bypass cooldown. Use a distinct key
+for apply. `approvedBy` is an identity record, not an authorization mechanism;
+the caller must authenticate and authorize it before invoking the engine.
+
+## Result handling
+
+| Status | Meaning | Operator response |
+|---|---|---|
+| `planned` | Dry-run checks passed | Review and apply with a new key |
+| `skipped` | Desired state already holds or action changed nothing | Verify alert clears; investigate noisy trigger |
+| `blocked` | Allowlist, risk, safety, cooldown, or rate limit stopped action | Do not bypass; escalate to incident commander |
+| `succeeded` | Mutation completed and verification passed | Monitor SLI through one full evaluation interval |
+| `rolled-back` | Verification failed; prior state restored | Escalate and use manual runbook |
+| `failed` | Precheck/execution failed, or rollback unavailable/failed | Treat state as unknown; page owning team |
+
+The process-local engine audit log is operational telemetry. The production
+runtime does not acknowledge a result until its configured durable audit sink
+accepts it. If persistence fails after an action, the idempotent result is
+preserved so retrying the same key records the original outcome without
+re-executing the mutation.

--- a/docs/operations/sre-playbooks/database-recovery.md
+++ b/docs/operations/sre-playbooks/database-recovery.md
@@ -1,56 +1,81 @@
-# Database Recovery Playbook
+# Historian Database Recovery Runbook
 
-## Symptoms
-- Historian queries failing or timing out
-- `HealthManager` reporting database unhealthy
-- Event pipeline backing up (store-and-forward activating)
+**Objectives:** verified read/write service within 15 minutes and recovery
+point no older than 60 seconds (`database-recovery-rto`).
 
-## Diagnostic Steps
+Database promotion, destructive repair, and point-in-time restore are high-risk
+actions. The incident commander and data-platform owner must approve them.
 
-1. **Check database connectivity**
-   ```bash
-   curl http://localhost:3000/api/health | jq '.database'
-   ```
+## Stabilize
 
-2. **Check disk space**
-   ```bash
-   df -h /var/lib/0xscada/data
-   ```
+1. Declare the incident and notify site operators of historian/control impact.
+2. Freeze schema changes, retention jobs, and deploys.
+3. If split brain or corruption is possible, fence writes before failover.
+4. Keep the event pipeline/store-and-forward accepting durable queued events.
+5. Capture UTC time, primary/replica roles, replication lag, WAL position,
+   connection count, disk/inode usage, and last verified backup.
 
-3. **Check active connections**
-   ```bash
-   # PostgreSQL
-   SELECT count(*) FROM pg_stat_activity;
-   ```
+Never promote a replica until the old primary is fenced or independently
+confirmed down.
 
-## Recovery Procedures
+## Diagnose
 
-### Connection Pool Exhaustion
-1. Restart connection pool: `POST /api/admin/db/pool/reset`
-2. Check for long-running queries and terminate
-3. Increase pool size if recurring
+Classify the failure:
 
-### Corrupted Data Partition
-1. Identify affected time partition
-2. Verify Merkle root against blockchain anchor
-3. Restore from last known-good snapshot
-4. Replay events from store-and-forward queue
-5. Verify integrity: compare Merkle roots
+- **pool exhaustion:** database accepts direct queries but application
+  connections are saturated;
+- **capacity:** disk/inodes/connections/IOPS exhausted;
+- **primary loss:** primary unreachable, replica healthy and within RPO;
+- **logical corruption:** queries succeed but data or integrity proof is wrong;
+- **regional/storage loss:** neither primary nor local replica is usable.
 
-### Full Database Failover
-1. Promote read replica to primary
-2. Update connection strings via feature flag
-3. Verify write capability
-4. Rebuild replica from new primary
-5. Update DNS/load balancer targets
+For PostgreSQL, capture read-only diagnostics such as `pg_stat_activity`,
+`pg_stat_replication`, recovery state, replay timestamp, and database size.
+Use credential-safe tooling; never paste secrets into incident chat.
 
-### Data Loss Verification
-1. Compare local Merkle root with blockchain-anchored root
-2. If mismatch: identify divergence point
-3. Replay from store-and-forward or federation peers
-4. Document in post-mortem
+## Recovery paths
 
-## Prevention
-- Monitor disk usage alerts at 80% threshold
-- Automated partition pruning per retention policy
-- Regular backup verification (weekly)
+### Pool exhaustion
+
+1. Identify leaking/long-running clients and stop the source.
+2. Cancel only confirmed non-critical queries.
+3. Recycle the application pool once; do not repeatedly restart it.
+4. Verify connection count, query latency, and new historian writes.
+5. Use the capacity plan before raising connection limits.
+
+### Primary failover
+
+1. Fence the old primary.
+2. Confirm candidate replay lag meets the 60-second RPO.
+3. Record promotion approval and candidate WAL/replay position.
+4. Promote exactly one candidate using the database platform's supported flow.
+5. Route a canary writer, then verify read-after-write and integrity proof.
+6. Switch production writers and readers.
+7. Rebuild redundancy; never attach the old primary as writable.
+
+### Point-in-time restore
+
+1. Restore the last verified backup into an isolated target.
+2. Replay logs to the last consistent point before corruption.
+3. Compare restored Merkle roots/anchors and sample business-critical tags.
+4. Record the exact recovery point and quantified loss window.
+5. Fence the corrupt system, approve the cutover, and route canary traffic.
+6. Replay queued events with deduplication and sequence validation.
+
+## Verification
+
+- new writes are durable and readable from the normal API path;
+- sample queries cover critical tags and retention boundaries;
+- Merkle roots/proofs verify before and after queued replay;
+- replication is healthy and a new recovery point exists;
+- queued-event age and depth decrease;
+- achieved RTO/RPO is recorded as a good or bad SLO event;
+- site operator confirms historian-dependent workflows.
+
+If integrity cannot be proven, service is not recovered even if queries return.
+Escalate as SEV-1 and involve the security/integrity owner.
+
+## Follow-up
+
+Verify a fresh backup, restore HA, remove temporary routing, rotate exposed
+credentials, and attach diagnostic/recovery evidence to the postmortem.

--- a/docs/operations/sre-playbooks/escalation-policy.md
+++ b/docs/operations/sre-playbooks/escalation-policy.md
@@ -1,0 +1,57 @@
+# On-Call Escalation Policy
+
+## Roles
+
+- **Primary on-call:** acknowledges, triages, and starts the incident record.
+- **Secondary on-call:** joins when the primary does not acknowledge or when a
+  second technical workstream is needed.
+- **Incident commander (IC):** owns severity, safety, coordination, and
+  communication; does not perform risky repair while commanding.
+- **Site/operator liaison:** coordinates control-room impact and confirms
+  process safety.
+- **Communications lead:** owns internal/external updates for SEV-1 and SEV-2.
+- **Service owner:** supplies component expertise and owns follow-up actions.
+
+## Severity and response targets
+
+| Severity | Examples | Acknowledge | IC assigned | Update cadence |
+|---|---|---:|---:|---:|
+| SEV-1 | Safety impact, confirmed data loss, multi-site control loss, integrity compromise | 5 min | 10 min | 15 min |
+| SEV-2 | Critical path unavailable/degraded, SLO exhausted, single-site failover failure | 15 min | 20 min | 30 min |
+| SEV-3 | Limited degradation with safe workaround | 60 min | As needed | 2 hours |
+| SEV-4 | No production impact | 1 business day | No | At resolution |
+
+## Escalation ladder
+
+1. Page primary and create the incident record.
+2. At half the acknowledgement target, page secondary.
+3. At the target, page the service owner and on-call manager; assign an IC.
+4. For SEV-1, or any possible process-safety impact, notify the site/operator
+   liaison immediately. The operator retains authority over physical process
+   control.
+5. At twice the target without mitigation, escalate to engineering leadership
+   and the continuity/security lead as applicable.
+6. Engage the security lead immediately for credential compromise, unexpected
+   cross-zone access, integrity proof failure, or suspected malicious activity.
+7. Engage legal/privacy/compliance through the approved internal channel when
+   notification obligations may apply; engineers do not make disclosure
+   determinations themselves.
+
+If paging infrastructure is unavailable, use the maintained offline call tree.
+The call tree contains personal data and is intentionally not stored in this
+repository.
+
+## Handoff requirements
+
+The outgoing responder must state:
+
+- incident id, severity, IC, and current owner;
+- affected sites/tags and process-safety state;
+- current hypothesis and evidence;
+- actions attempted, idempotency keys, and exact results;
+- SLO/error-budget impact;
+- next action and next update deadline.
+
+SEV-1/2 incidents require a postmortem within 48 hours. SEV-3 incidents require
+one when the same failure recurs, the budget impact is material, or the service
+owner requests it.

--- a/docs/operations/sre-playbooks/gateway-failover.md
+++ b/docs/operations/sre-playbooks/gateway-failover.md
@@ -1,43 +1,78 @@
-# Gateway Failover Playbook
+# Gateway Failover Runbook
 
-## Symptoms
-- Tags reporting stale values
-- WebSocket disconnections spike
-- Shard manager reporting node offline
-- Health manager gateway heartbeat timeout
+**Objective:** restore fresh telemetry for all affected shards within 60
+seconds of confirmed heartbeat loss (`gateway-failover-rto`).
 
-## Automatic Remediation
-The auto-remediation engine handles most gateway failures:
-1. Detects heartbeat timeout (3 missed intervals)
-2. Marks gateway as `draining`
-3. Shard manager rebalances tags to healthy gateways
-4. Load balancer stops routing to failed node
-5. Alerts on-call if auto-remediation fails after 3 attempts
+## Trigger and false-positive checks
 
-## Manual Recovery
+Trigger after three missed heartbeat intervals or confirmed process exit.
+Before failover, check:
 
-### Single Gateway Failure
-1. Check gateway process: `systemctl status 0xscada-gateway@{id}`
-2. Check network connectivity to SCADA devices
-3. Restart gateway: `systemctl restart 0xscada-gateway@{id}`
-4. Verify shard reassignment: `GET /api/scaling/shards`
-5. Confirm tag data flowing: check historian for gaps
+- monitoring path is healthy and time is synchronized;
+- the gateway is not in an approved maintenance/drain window;
+- failure is not a shared device-network outage;
+- at least one healthy peer has capacity for every affected shard;
+- store-and-forward is active at disconnected edge nodes.
 
-### Multiple Gateway Failure
-1. **Priority:** Ensure critical safety tags have coverage
-2. Check common cause (network, DNS, certificate expiry)
-3. Spin up emergency gateway instances
-4. Force shard rebalance: `POST /api/scaling/rebalance`
-5. Enable store-and-forward for affected edge nodes
+If no healthy peer has capacity, automation must block. Page the incident
+commander and use the site's degraded-operation procedure.
 
-### Gateway Certificate Expiry
-1. Check cert: `openssl x509 -in /etc/0xscada/gateway.crt -noout -dates`
-2. Renew via CA or auto-renewal system
-3. Restart gateway with new certificate
-4. Verify mTLS handshake with server
+## Capture before mutation
+
+Record gateway id, certificate expiry, last heartbeat, assigned shards, tag
+freshness, queue depth, peer capacity, and current routing/assignment version.
+Preserve gateway logs. Do not restart before this evidence is captured unless a
+site safety procedure requires it.
+
+## Automated path
+
+Use `createGatewayFailoverAction` through the configured
+`AutoRemediationEngine`:
+
+1. dry-run with `INCIDENT:gateway-failover:GATEWAY:plan`;
+2. confirm the plan reports affected shards and a healthy peer count ≥ 2;
+3. apply with `INCIDENT:gateway-failover:GATEWAY:apply-1`;
+4. retain the result in the incident.
+
+The action drains/rebalances, verifies coverage, and restores previous
+assignments if verification fails. `blocked`, `failed`, or `rolled-back`
+requires manual escalation.
+
+## Manual path
+
+1. Mark the failed gateway unavailable in the authoritative shard/routing
+   control plane.
+2. Reassign only its shards to healthy peers within their capacity limits.
+3. Confirm new owners have the correct device credentials and network reach.
+4. Start or confirm store-and-forward replay using sequence/integrity checks.
+5. Quarantine the failed gateway from routing until its root cause is known.
+6. Repair/restart it, but reintroduce it in a drained state.
+7. Move a small canary shard back; verify freshness and duplicate suppression.
+8. Rebalance the remaining shards gradually.
+
+Do not manually edit multiple replicas of assignment state. Use the
+authoritative control plane and retain its before/after revision.
 
 ## Verification
-- All shards assigned to active gateways
-- No historian data gaps > 1 minute
-- WebSocket reconnection count returns to baseline
-- Store-and-forward queues draining
+
+- every shard has exactly one active owner;
+- critical tags are fresh and good quality;
+- `gateway-failover-rto` records a good event, or the miss is recorded;
+- no duplicate or out-of-order historian writes;
+- Merkle/integrity verification passes across replayed events;
+- edge queues decrease monotonically;
+- WebSocket reconnect/error rate returns to baseline;
+- HA capacity is restored after the failed node returns.
+
+If any verification fails, stop rebalancing, preserve current state, and
+escalate. Do not repeatedly cycle failover with new idempotency keys.
+
+## Common causes
+
+- expired/revoked gateway certificate: rotate through the approved PKI flow and
+  validate mTLS before reintroduction;
+- device-network outage: keep local autonomy/store-and-forward active and
+  involve the site network owner;
+- process crash/resource exhaustion: collect dump/resource metrics, then use
+  the [scaling runbook](scaling-runbook.md);
+- bad deployment: roll back the deployment before returning shards.

--- a/docs/operations/sre-playbooks/incident-response.md
+++ b/docs/operations/sre-playbooks/incident-response.md
@@ -1,55 +1,89 @@
-# Incident Response Playbook
+# Incident Response Runbook
 
-## Severity Levels
+Use this runbook for production alerts, operator reports, and exhausted critical
+SLO budgets. Process safety takes priority over service restoration. Site
+operators retain authority over physical control and safe-state decisions.
 
-| Level | Description | Response Time | Escalation |
-|-------|-------------|---------------|------------|
-| SEV-1 | Data loss, safety system failure | 5 min | Immediate page |
-| SEV-2 | Major functionality degraded | 15 min | On-call engineer |
-| SEV-3 | Minor functionality impacted | 1 hour | Next business day |
-| SEV-4 | Cosmetic / low impact | 4 hours | Backlog |
+## First five minutes
 
-## Response Steps
+1. Acknowledge the page and create an incident id.
+2. Record UTC start time, alert source, affected site(s), and current operator.
+3. If process safety may be affected, contact the site/operator liaison and
+   follow the site's safe-state procedure before changing software.
+4. Assign severity using the
+   [escalation policy](escalation-policy.md); page secondary at half the
+   acknowledgement target.
+5. Freeze deployments to affected components. Preserve logs and avoid restarts
+   until volatile evidence and current assignments are captured.
 
-### 1. Acknowledge
-- Claim the incident in the alerting system
-- Join the incident channel
-- Start the incident timer
+## Severity
 
-### 2. Assess
-- Check health dashboard: `/api/health`
-- Review recent deployments and changes
-- Identify affected components (gateway, server, historian, blockchain)
-- Determine blast radius (number of tags/sites affected)
+| Level | Impact | Acknowledge |
+|---|---|---:|
+| SEV-1 | Safety impact, confirmed data loss, integrity compromise, or multi-site control loss | 5 min |
+| SEV-2 | Critical path unavailable/degraded, exhausted SLO, or failed site failover | 15 min |
+| SEV-3 | Limited degradation with a safe workaround | 60 min |
+| SEV-4 | No production impact | 1 business day |
 
-### 3. Mitigate
-- Apply auto-remediation if available
-- If gateway: check shard manager status, fail over to healthy nodes
-- If database: initiate read-replica failover (see database-recovery.md)
-- If network: verify federation heartbeats, enable store-and-forward
+## Establish blast radius
 
-### 4. Communicate
-- Update status page every 15 minutes for SEV-1/2
-- Notify affected site operators
-- Keep incident channel updated
+Record:
 
-### 5. Resolve
-- Confirm metrics return to baseline
-- Verify no data loss (Merkle root comparison)
-- Stand down on-call escalation
+- sites, gateways, shards, tags, and subscribers affected;
+- earliest and latest known-good event timestamps;
+- store-and-forward queue depth and oldest queued event;
+- database read/write status and last verified backup;
+- relevant SLO id, SLI, burn rate, and remaining budget;
+- recent deploy/config/certificate/network changes;
+- whether telemetry itself is absent (`no-data` is not healthy).
 
-### 6. Post-Mortem
-- Schedule within 48 hours for SEV-1/2
-- Use post-mortem template (see post-mortem-template.md)
-- Track action items to completion
+Use `/api/health`, component metrics, and
+`GET /api/governance/sre/slos`. Evaluate known counter deltas with
+`POST /api/governance/sre/slos/:sloId/evaluate`.
 
-## SLO/SLI Definitions
+## Mitigate
 
-| Service | SLI | SLO |
-|---------|-----|-----|
-| Tag reads | Latency p99 | < 100ms |
-| Event ingestion | Availability | 99.9% |
-| Alarm delivery | Latency p95 | < 500ms |
-| Blockchain anchoring | Success rate | 99.5% |
-| WebSocket connections | Availability | 99.9% |
-| Historian queries | Latency p95 | < 2s |
+Choose the narrowest reversible action:
+
+- stale tags or gateway heartbeat loss:
+  [gateway failover](gateway-failover.md);
+- database write/read failure:
+  [database recovery](database-recovery.md);
+- sustained capacity saturation:
+  [scaling](scaling-runbook.md);
+- supported self-healing action:
+  [automated remediation](automated-remediation.md).
+
+Always dry-run automation first. A blocked precondition is a safety decision,
+not an obstacle to bypass. High-risk remediation requires an authenticated
+approver and IC acknowledgement.
+
+## Communicate
+
+Every update states:
+
+- UTC timestamp and incident severity;
+- user/operator impact and process-safety state;
+- affected scope;
+- mitigation completed and its verification;
+- current hypothesis, confidence, and next action;
+- next update time.
+
+SEV-1 updates are every 15 minutes; SEV-2 every 30 minutes. Never state that
+data is intact until historian reads and integrity proofs are verified.
+
+## Recovery and closure
+
+Do not resolve until:
+
+1. the affected SLI remains at baseline for one evaluation interval;
+2. all shards/tags are fresh and store-and-forward queues are draining;
+3. historian writes are readable and integrity-verifiable;
+4. rollback/failover state is documented and redundancy restored;
+5. the site operator confirms normal operating state;
+6. monitoring and paging are active;
+7. the IC records remaining risk and owns follow-up.
+
+Schedule a SEV-1/2 review within 48 hours using
+[the postmortem template](post-mortem-template.md). Attach remediation
+idempotency keys and audit results.

--- a/docs/operations/sre-playbooks/post-mortem-template.md
+++ b/docs/operations/sre-playbooks/post-mortem-template.md
@@ -1,60 +1,110 @@
-# Post-Mortem: [INCIDENT TITLE]
+# Postmortem: [incident title]
 
-**Date:** YYYY-MM-DD  
-**Severity:** SEV-X  
-**Duration:** X hours Y minutes  
-**Author:** [Name]  
-**Reviewers:** [Names]
+- **Incident id:**
+- **Date/time (UTC):**
+- **Severity:**
+- **Incident commander:**
+- **Technical leads:**
+- **Site/operator liaison:**
+- **Authors/reviewers:**
+- **Status:** Draft / Reviewed / Actions accepted
 
-## Summary
-_One paragraph describing what happened, the impact, and the resolution._
+## Executive summary
 
-## Timeline (all times UTC)
-
-| Time | Event |
-|------|-------|
-| HH:MM | First alert fired |
-| HH:MM | On-call acknowledged |
-| HH:MM | Root cause identified |
-| HH:MM | Mitigation applied |
-| HH:MM | Service restored |
-| HH:MM | All-clear declared |
+In plain language: what happened, who/what was affected, duration, root cause,
+mitigation, and current risk. Do not assign individual blame.
 
 ## Impact
-- **Tags affected:** X
-- **Sites affected:** X
-- **Data loss:** Yes/No (duration if yes)
-- **SLO impact:** X% of monthly error budget consumed
 
-## Root Cause
-_Detailed technical explanation of why the incident occurred._
+- Sites/tags/subscribers affected:
+- Process-safety impact and operator action:
+- Data loss or unverified interval:
+- Customer/operator-visible symptoms:
+- Financial/compliance/security impact:
 
-## Detection
-- How was the incident detected? (Alert / Customer report / Manual observation)
-- Time to detect: X minutes
-- Could detection be improved?
+### SLO impact
 
-## Response
-- What remediation steps were taken?
-- Did auto-remediation trigger? Was it effective?
-- What manual steps were required?
+| SLO id | Window | Bad/total events | Burn rate | Budget consumed | Good/bad recovery event |
+|---|---|---:|---:|---:|---|
+| | | | | | |
 
-## Lessons Learned
+## Detection and response metrics
 
-### What went well
-1. 
+| Metric | UTC/duration |
+|---|---|
+| Failure began / earliest known impact | |
+| First detection | |
+| Page sent / acknowledged | |
+| IC assigned | |
+| Mitigation began | |
+| Service restored | |
+| Integrity/recovery verified | |
 
-### What went poorly
-1. 
+Explain any gap between failure, detection, page, mitigation, and verification.
 
-### Where we got lucky
-1. 
+## Timeline (UTC)
 
-## Action Items
+| Time | Actor/system | Observation, decision, or action | Evidence/result |
+|---|---|---|---|
+| | | | |
 
-| Action | Owner | Priority | Due Date | Status |
-|--------|-------|----------|----------|--------|
-| | | | | |
+Include deployment/config revisions and remediation idempotency/execution ids.
 
-## Supporting Data
-_Links to dashboards, logs, graphs, or other evidence._
+## Technical root cause
+
+Describe the failure mechanism and evidence. Distinguish:
+
+- triggering event;
+- direct technical cause;
+- conditions that allowed the cause to create impact;
+- why redundancy or controls did not prevent impact;
+- why detection/response took as long as it did.
+
+Avoid “human error” as a root cause; identify the system condition that made an
+error possible or harmful.
+
+## Recovery and verification
+
+- mitigation and why it was chosen;
+- dry-run/precondition/approval records;
+- rollback attempted and result;
+- tag freshness, database read/write, queue replay, and integrity verification;
+- achieved RTO/RPO;
+- how redundancy and alerting were restored.
+
+## What helped / what hindered / where risk remained
+
+### Helped
+
+-
+
+### Hindered
+
+-
+
+### Risk or luck
+
+-
+
+## Corrective actions
+
+| Action | Type (prevent/detect/mitigate) | Owner | Priority | Due | Verification/acceptance test | Status |
+|---|---|---|---|---|---|---|
+| | | | | | | |
+
+Every action needs one accountable owner and a testable completion condition.
+Track actions outside this document and link the records.
+
+## Evidence
+
+Link immutable dashboards/queries, logs, alert payloads, configuration and
+deployment revisions, capacity/compliance reports, audit records, and operator
+notes. Redact credentials and regulated personal data.
+
+## Review sign-off
+
+- Service owner:
+- Incident commander:
+- Site/operator representative (when applicable):
+- Security/compliance reviewer (when applicable):
+- Action tracker:

--- a/docs/operations/sre-playbooks/scaling-runbook.md
+++ b/docs/operations/sre-playbooks/scaling-runbook.md
@@ -1,47 +1,81 @@
 # Scaling Runbook
 
-## When to Scale
+Use this runbook for sustained saturation, forecasted growth, or reduced
+failover reserve. Prefer horizontal scale-out. Scale-down and storage changes
+need explicit review because they can reduce redundancy or destroy data.
 
-| Indicator | Threshold | Action |
-|-----------|-----------|--------|
-| CPU utilization | > 70% sustained 15min | Add server instance |
-| Memory utilization | > 80% | Add server instance or increase instance size |
-| Tags per gateway | > 50,000 | Add gateway instance |
-| Event queue depth | > 10,000 | Add pipeline workers |
-| Query latency p95 | > 2s | Add historian replica |
-| WebSocket connections | > 10,000 per server | Add server instance |
+## Triggers
 
-## Horizontal Scale-Out
+| Signal | Trigger | Required duration/action |
+|---|---:|---|
+| Tags per gateway | 70% of planned limit | Plan another gateway before 80% |
+| CPU | 70% | Scale after 15 minutes if queue/latency agrees |
+| Memory | 75% | Scale after 15 minutes; investigate leak first |
+| Storage | 70% | Provision before 80%; do not wait for exhaustion |
+| Error budget | 50% consumed | Freeze nonessential load; review capacity |
+| Queue age/depth | Increasing for 10 minutes | Scale consumers if downstream is healthy |
 
-### Adding a Gateway
-1. Provision instance (see capacity-planning-guide.md for sizing)
-2. Install gateway package, configure certificates
-3. Register with shard manager: `POST /api/scaling/gateways`
-4. Shard manager auto-rebalances within 60s
-5. Verify tags migrating: `GET /api/scaling/shards?gateway={id}`
+A single hot metric is not sufficient. Confirm it correlates with queueing,
+latency, workload, or forecast growth.
 
-### Adding a Server Instance
-1. Provision instance behind load balancer
-2. Configure database connection, event pipeline consumer group
-3. Add to load balancer pool: update LB config
-4. Health check passes → traffic begins routing
-5. Monitor for 15min, verify even distribution
+## Build the plan
 
-### Adding Historian Capacity
-1. Add new storage partition or read replica
-2. Update partition config: `POST /api/historian/partitions`
-3. Future writes go to new partition; reads federate across all
+Send observed workload and history to
+`POST /api/governance/capacity/plan`. Review all three strategies and replace
+reference cloud rates with contracted rates before financial approval. For
+production, default to balanced; use performance for rapid/low-confidence
+growth, and cost-optimized only for stable, high-confidence demand.
 
-## Vertical Scale-Up
-1. Snapshot current state
-2. Drain connections: set node to `draining` in LB
-3. Resize instance
-4. Restore and restart
-5. Re-enable in LB
+## Automated scale-out
 
-## Scale-Down
-1. Set node to `draining` in load balancer
-2. Wait for drain timeout (default 30s)
-3. Verify all connections migrated
-4. Remove from shard manager / load balancer
-5. Terminate instance
+`createScaleOutAction` requires `component`, `desiredReplicas`, and
+`maximumReplicas`.
+
+1. Confirm current desired/ready replicas and per-instance load.
+2. Check quotas, placement capacity, database/event-bus connection limits, and
+   certificate/secret availability.
+3. Dry-run with a stable incident/change idempotency key.
+4. Verify desired replicas do not exceed the approved maximum.
+5. Apply with a distinct key.
+6. The action succeeds only when ready replicas reach desired state; otherwise
+   it restores the previous replica count.
+
+## Component checks
+
+### Gateway
+
+Register the new identity/certificate, prove device-network reachability, start
+drained, move a canary shard, then rebalance. Verify no tag has multiple active
+owners and no historian duplicates are introduced.
+
+### API/WebSocket
+
+Add the instance to the correct consumer group, start outside the load-balancer
+pool, pass readiness, then admit a small traffic percentage. Verify session
+reconnects, event ordering, p95/p99 latency, and connection distribution.
+
+### Historian
+
+Provision storage/partition/replica through the database platform. Verify
+backup policy, retention, query federation, integrity proofs, and IOPS before
+routing writes. Do not use application replica scaling as a substitute for
+database capacity.
+
+## Scale-down
+
+1. Confirm the 30-day forecast plus failover reserve still fits.
+2. Freeze rebalancing and capture current assignments.
+3. Drain one instance; wait for connections/partitions/shards to reach zero.
+4. Observe one full SLI interval.
+5. Remove the instance from discovery, then deprovision.
+6. Stop immediately if error budget, queue age, or per-instance utilization
+   crosses its trigger.
+
+Never scale below two gateway/API instances in an HA workload or remove the
+last verified database replica.
+
+## Completion
+
+Update the retained capacity plan with actual replica count and cost, verify all
+critical SLOs, restore alerting, and record plan/automation ids in the change or
+incident.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "drizzle-zod": "^0.8.3",
         "ethers": "^6.16.0",
         "express": "^4.18.0",
+        "express-rate-limit": "^8.6.1",
         "hardhat": "^3.11.1",
         "ioredis": "^5.11.1",
         "js-yaml": "^4.2.0",
@@ -5287,6 +5288,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "drizzle-zod": "^0.8.3",
     "ethers": "^6.16.0",
     "express": "^4.18.0",
+    "express-rate-limit": "^8.6.1",
     "hardhat": "^3.11.1",
     "ioredis": "^5.11.1",
     "js-yaml": "^4.2.0",

--- a/server/middleware/__tests__/control-route-policy.test.ts
+++ b/server/middleware/__tests__/control-route-policy.test.ts
@@ -152,6 +152,7 @@ describe("control route policy inventory", () => {
       expect.arrayContaining([
         "anchor-backend-control",
         "safe-state-resume",
+        "sre-remediation-control",
         "tuning-proposal-decision",
         "tuning-control",
         "alarm-control",
@@ -163,6 +164,13 @@ describe("control route policy inventory", () => {
         "marketplace-control",
       ]),
     );
+  });
+
+  it("requires the dedicated SRE remediation scope", () => {
+    expect(mutationPolicyFor(
+      "POST",
+      "/api/governance/sre/remediations/execute",
+    )?.scopes).toEqual(["sre.remediate"]);
   });
 
   it("keeps agent-marketplace mutations off the generic write scope", () => {

--- a/server/middleware/control-route-policy.ts
+++ b/server/middleware/control-route-policy.ts
@@ -43,6 +43,12 @@ export const CONTROL_ROUTE_POLICIES: readonly ControlRoutePolicy[] = Object.free
     description: "Resume a blueprint from a fail-closed safe state.",
   },
   {
+    id: "sre-remediation-control",
+    pathPrefix: "/api/governance/sre/remediations",
+    scopes: Object.freeze(["sre.remediate"]),
+    description: "Dry-run or execute bounded, audited SRE remediation actions.",
+  },
+  {
     id: "tuning-proposal-decision",
     pathPrefix: "/api/tuning/proposals",
     scopes: Object.freeze(["tuning.approve"]),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -28,6 +28,11 @@ import { tuningService } from "./services/tuning";
 import { marketplaceRoutes } from "./routes/marketplace";
 import { marketplaceService } from "./services/marketplace";
 import { nlQueryService } from "./services/nlquery";
+import { sreReadinessRoutes } from "./routes/sre-readiness";
+import {
+  configureRemediationRuntime,
+  type RemediationRuntimeConfiguration,
+} from "./services/sre";
 import { governanceRoutes } from "./routes/governance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
@@ -49,6 +54,7 @@ import { cachedEventBridge } from "./websocket/cached-event-bridge";
 import type { WebSocketAuthOptions } from "./websocket/upgrade-auth";
 
 export interface RouteRegistrationOptions {
+  remediation?: RemediationRuntimeConfiguration;
   websocketAuth?: WebSocketAuthOptions;
 }
 
@@ -81,7 +87,11 @@ export async function registerRoutes(
   // ADR-0013 [13.4] (#215). PID tuning deliberately does NOT live under
   // /api/pid: that prefix belongs to the P&ID diagram surface the client
   // already calls (client/src/pages/pid-view.tsx -> /api/pid/diagrams/:id).
+  if (options.remediation !== undefined) {
+    configureRemediationRuntime(options.remediation);
+  }
   app.use("/api/tuning", tuningRoutes);
+  app.use("/api/governance", sreReadinessRoutes);  // ADR-0014 [14.6] (#226)
   app.use("/api/marketplace", marketplaceRoutes);  // ADR-0013 [13.6] (#217)
   app.use("/api/governance", governanceRoutes);
   app.use("/api/security", securityRoutes);

--- a/server/routes/__tests__/sre-readiness.test.ts
+++ b/server/routes/__tests__/sre-readiness.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import type { Server } from 'node:http';
+import { _resetControlPlaneAuthCache } from '../../middleware/control-plane-auth';
+import { remediationRuntime } from '../../services/sre';
+import { sreReadinessRoutes } from '../sre-readiness';
+
+let server: Server;
+let baseUrl: string;
+let replicas = 1;
+const persistRemediation = vi.fn(async () => undefined);
+const originalApiKeys = process.env.API_KEYS;
+
+beforeAll(async () => {
+  process.env.API_KEYS = [
+    'sre-key:on-call-operator:sre.remediate+operator',
+    'read-key:read-only:read',
+  ].join(',');
+  _resetControlPlaneAuthCache();
+  remediationRuntime.configure({
+    scaleOut: {
+      currentReplicas: async () => replicas,
+      setReplicas: async (_component, value) => { replicas = value; },
+      readyReplicas: async () => replicas,
+    },
+    auditSink: { append: persistRemediation },
+    policy: { cooldownMs: 0 },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/governance', sreReadinessRoutes);
+  await new Promise<void>(resolve => {
+    server = app.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (typeof address !== 'object' || address === null) throw new Error('Test server did not bind');
+  baseUrl = `http://127.0.0.1:${address.port}/api/governance`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => error ? reject(error) : resolve());
+  });
+  if (originalApiKeys === undefined) delete process.env.API_KEYS;
+  else process.env.API_KEYS = originalApiKeys;
+  _resetControlPlaneAuthCache();
+});
+
+describe('governance SLO routes', () => {
+  it('lists critical-path definitions and evaluates observations', async () => {
+    const catalogResponse = await fetch(`${baseUrl}/sre/slos`);
+    const catalog = await catalogResponse.json();
+    expect(catalogResponse.status).toBe(200);
+    expect(catalog.slos.length).toBeGreaterThanOrEqual(7);
+
+    const response = await fetch(`${baseUrl}/sre/slos/tag-ingest-freshness/evaluate`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        observations: [{
+          timestamp: new Date().toISOString(),
+          goodEvents: 9_990,
+          totalEvents: 10_000,
+        }],
+      }),
+    });
+    const evaluation = await response.json();
+    expect(response.status).toBe(200);
+    expect(evaluation).toMatchObject({
+      sloId: 'tag-ingest-freshness',
+      status: 'breached',
+      goodEvents: 9_990,
+      totalEvents: 10_000,
+    });
+  });
+});
+
+describe('governance SRE remediation routes', () => {
+  const executeUrl = () => `${baseUrl}/sre/remediations/execute`;
+  const request = (apiKey?: string, body: unknown = {}) => fetch(executeUrl(), {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(apiKey === undefined ? {} : { 'x-api-key': apiKey }),
+    },
+    body: JSON.stringify(body),
+  });
+
+  it('authenticates and authorizes before parsing remediation input', async () => {
+    expect((await request()).status).toBe(401);
+    expect((await request('read-key')).status).toBe(403);
+  });
+
+  it('defaults to dry-run and executes only a bounded, durably audited apply request', async () => {
+    const context = { component: 'api', desiredReplicas: 3, maximumReplicas: 4 };
+    const dryRun = await request('sre-key', {
+      actionId: 'scale-out',
+      context,
+      idempotencyKey: 'route-scale-plan',
+      approvedBy: 'attacker-controlled',
+    });
+    expect(dryRun.status).toBe(200);
+    expect(await dryRun.json()).toMatchObject({ status: 'planned', dryRun: true });
+    expect(replicas).toBe(1);
+
+    const apply = await request('sre-key', {
+      actionId: 'scale-out',
+      context,
+      idempotencyKey: 'route-scale-apply',
+      dryRun: false,
+    });
+    const result = await apply.json();
+    expect(apply.status).toBe(200);
+    expect(result).toMatchObject({ status: 'succeeded', dryRun: false, changed: true });
+    expect(replicas).toBe(3);
+    expect(persistRemediation).toHaveBeenCalledWith(expect.objectContaining({
+      executionId: result.executionId,
+      status: 'succeeded',
+      approvedBy: 'on-call-operator',
+    }));
+  });
+});

--- a/server/routes/__tests__/sre-remediation-auth.test.ts
+++ b/server/routes/__tests__/sre-remediation-auth.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Pins the *composition* of the remediation guard.
+ *
+ * `requireRemediationOperator` requires BOTH:
+ *
+ *   requireControlPlaneAccess({ roles: ['operator'], scopes: ['sre.remediate'] })
+ *
+ * The existing suite proves a guard is present — removing it entirely fails
+ * two tests — but only ever authenticates with `sre-key`, which holds the role
+ * and the scope together. Mutation testing showed either half could be dropped
+ * on its own with every test still green:
+ *
+ *   drop `scopes: ['sre.remediate']`, keep the role   -> 3 passed
+ *   drop `roles: ['operator']`, keep the scope        -> 3 passed
+ *
+ * That matters on this route because it can fail over gateways and change
+ * replica counts in production. The central `mutationAuthorizationMiddleware`
+ * policy still backstops the scope, so a degraded route guard is not currently
+ * exploitable — but a guard that silently decays to role-only is one refactor
+ * from being the only thing standing there.
+ *
+ * These tests exercise each half in isolation, in both directions, mirroring
+ * what #620 established for `nlquery.read`.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import type { Server } from 'node:http';
+
+import { _resetControlPlaneAuthCache } from '../../middleware/control-plane-auth';
+import { remediationRuntime } from '../../services/sre';
+import { sreReadinessRoutes } from '../sre-readiness';
+
+let server: Server;
+let baseUrl: string;
+let replicas = 1;
+const originalApiKeys = process.env.API_KEYS;
+
+beforeAll(async () => {
+  process.env.API_KEYS = [
+    // Holds both halves — the control, and what the existing suite uses.
+    'both-key:on-call-operator:sre.remediate+operator',
+    // Holds the SCOPE but confers no operator role.
+    'scope-only-key:scope-only:sre.remediate',
+    // Confers the operator ROLE but lacks the remediation scope.
+    'role-only-key:role-only:operator',
+  ].join(',');
+  _resetControlPlaneAuthCache();
+
+  remediationRuntime.configure({
+    scaleOut: {
+      currentReplicas: async () => replicas,
+      setReplicas: async (_component, value) => {
+        replicas = value;
+      },
+      readyReplicas: async () => replicas,
+    },
+    auditSink: { append: vi.fn(async () => undefined) },
+    policy: { cooldownMs: 0 },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/governance', sreReadinessRoutes);
+  await new Promise<void>(resolve => {
+    server = app.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (typeof address !== 'object' || address === null) {
+    throw new Error('Test server did not bind');
+  }
+  baseUrl = `http://127.0.0.1:${address.port}/api/governance`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => (error ? reject(error) : resolve()));
+  });
+  if (originalApiKeys === undefined) delete process.env.API_KEYS;
+  else process.env.API_KEYS = originalApiKeys;
+  _resetControlPlaneAuthCache();
+});
+
+/** A well-formed dry-run apply; authorization is decided before it is parsed. */
+const body = {
+  actionId: 'scale-out',
+  context: { component: 'api', desiredReplicas: 2, maximumReplicas: 4 },
+  idempotencyKey: 'auth-composition-probe',
+  dryRun: true,
+};
+
+function execute(apiKey?: string) {
+  return fetch(`${baseUrl}/sre/remediations/execute`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(apiKey === undefined ? {} : { 'x-api-key': apiKey }),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function status(apiKey?: string) {
+  return fetch(`${baseUrl}/sre/remediations/status`, {
+    headers: apiKey === undefined ? {} : { 'x-api-key': apiKey },
+  });
+}
+
+describe('remediation guard requires the scope AND the operator role', () => {
+  it('accepts a principal holding both', async () => {
+    expect((await execute('both-key')).status).toBe(200);
+    expect((await status('both-key')).status).toBe(200);
+  });
+
+  it('rejects a principal with sre.remediate but no operator role', async () => {
+    // Pins `roles: ['operator']`. Without it this would be 200.
+    expect((await execute('scope-only-key')).status).toBe(403);
+    expect((await status('scope-only-key')).status).toBe(403);
+  });
+
+  it('rejects an operator without the sre.remediate scope', async () => {
+    // Pins `scopes: ['sre.remediate']`. Without it this would be 200 — a
+    // generic operator could fail over gateways.
+    expect((await execute('role-only-key')).status).toBe(403);
+    expect((await status('role-only-key')).status).toBe(403);
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    expect((await execute()).status).toBe(401);
+    expect((await status()).status).toBe(401);
+  });
+});

--- a/server/routes/__tests__/sre-remediation-auth.test.ts
+++ b/server/routes/__tests__/sre-remediation-auth.test.ts
@@ -128,4 +128,26 @@ describe('remediation guard requires the scope AND the operator role', () => {
     expect((await execute()).status).toBe(401);
     expect((await status()).status).toBe(401);
   });
+
+  it('rate-limits both authenticated remediation endpoints', async () => {
+    const firstExecute = await execute('both-key');
+    expect(firstExecute.status).toBe(200);
+    expect(firstExecute.headers.get('x-ratelimit-limit')).toBe('10');
+
+    let executeResponse = firstExecute;
+    for (let request = 0; request < 10; request += 1) {
+      executeResponse = await execute('both-key');
+    }
+    expect(executeResponse.status).toBe(429);
+
+    const firstStatus = await status('both-key');
+    expect(firstStatus.status).toBe(200);
+    expect(firstStatus.headers.get('x-ratelimit-limit')).toBe('60');
+
+    let statusResponse = firstStatus;
+    for (let request = 0; request < 60; request += 1) {
+      statusResponse = await status('both-key');
+    }
+    expect(statusResponse.status).toBe(429);
+  });
 });

--- a/server/routes/sre-readiness.ts
+++ b/server/routes/sre-readiness.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import { z } from 'zod';
 import {
   RemediationAuditPersistenceError,
@@ -47,13 +48,27 @@ const requireRemediationOperator = requireControlPlaneAccess({
   roles: ['operator'],
   scopes: ['sre.remediate'],
 });
+// Pair a per-process fail-safe with the shared limiter so requests remain
+// bounded if its backend degrades. Both guards run before authentication.
 const remediationStatusRateLimit = rateLimitMiddleware({
   windowMs: 60_000,
   maxRequests: 60,
 });
+const remediationStatusProcessRateLimit = expressRateLimit({
+  windowMs: 60_000,
+  limit: 60,
+  standardHeaders: false,
+  legacyHeaders: true,
+});
 const remediationExecuteRateLimit = rateLimitMiddleware({
   windowMs: 60_000,
   maxRequests: 10,
+});
+const remediationExecuteProcessRateLimit = expressRateLimit({
+  windowMs: 60_000,
+  limit: 10,
+  standardHeaders: false,
+  legacyHeaders: true,
 });
 
 function errorMessage(error: unknown): string {
@@ -81,6 +96,7 @@ router.post('/sre/slos/:sloId/evaluate', (req, res) => {
 
 router.get(
   '/sre/remediations/status',
+  remediationStatusProcessRateLimit,
   remediationStatusRateLimit,
   requireRemediationOperator,
   (_req, res) => {
@@ -91,6 +107,7 @@ router.get(
 
 router.post(
   '/sre/remediations/execute',
+  remediationExecuteProcessRateLimit,
   remediationExecuteRateLimit,
   requireRemediationOperator,
   async (req, res) => {

--- a/server/routes/sre-readiness.ts
+++ b/server/routes/sre-readiness.ts
@@ -10,6 +10,7 @@ import {
   controlPlanePrincipal,
   requireControlPlaneAccess,
 } from '../middleware/control-plane-auth';
+import { rateLimitMiddleware } from '../middleware/api-gateway';
 
 const router = Router();
 
@@ -46,6 +47,14 @@ const requireRemediationOperator = requireControlPlaneAccess({
   roles: ['operator'],
   scopes: ['sre.remediate'],
 });
+const remediationStatusRateLimit = rateLimitMiddleware({
+  windowMs: 60_000,
+  maxRequests: 60,
+});
+const remediationExecuteRateLimit = rateLimitMiddleware({
+  windowMs: 60_000,
+  maxRequests: 10,
+});
 
 function errorMessage(error: unknown): string {
   if (error instanceof z.ZodError) {
@@ -70,30 +79,40 @@ router.post('/sre/slos/:sloId/evaluate', (req, res) => {
   }
 });
 
-router.get('/sre/remediations/status', requireRemediationOperator, (_req, res) => {
-  const status = remediationRuntime.status();
-  res.status(status.configured ? 200 : 503).json(status);
-});
+router.get(
+  '/sre/remediations/status',
+  remediationStatusRateLimit,
+  requireRemediationOperator,
+  (_req, res) => {
+    const status = remediationRuntime.status();
+    res.status(status.configured ? 200 : 503).json(status);
+  },
+);
 
-router.post('/sre/remediations/execute', requireRemediationOperator, async (req, res) => {
-  try {
-    const request = RemediationExecuteSchema.parse(req.body);
-    const principal = controlPlanePrincipal(req);
-    const result = await remediationRuntime.execute({
-      ...request,
-      // Approval/audit identity is always server-bound. A body/header supplied
-      // identity cannot authorize its own remediation.
-      approvedBy: principal.name,
-    });
-    res.json(result);
-  } catch (error) {
-    const status = error instanceof RemediationRuntimeUnavailableError
-      ? 503
-      : error instanceof RemediationAuditPersistenceError
-        ? 500
-        : 400;
-    res.status(status).json({ error: errorMessage(error) });
-  }
-});
+router.post(
+  '/sre/remediations/execute',
+  remediationExecuteRateLimit,
+  requireRemediationOperator,
+  async (req, res) => {
+    try {
+      const request = RemediationExecuteSchema.parse(req.body);
+      const principal = controlPlanePrincipal(req);
+      const result = await remediationRuntime.execute({
+        ...request,
+        // Approval/audit identity is always server-bound. A body/header supplied
+        // identity cannot authorize its own remediation.
+        approvedBy: principal.name,
+      });
+      res.json(result);
+    } catch (error) {
+      const status = error instanceof RemediationRuntimeUnavailableError
+        ? 503
+        : error instanceof RemediationAuditPersistenceError
+          ? 500
+          : 400;
+      res.status(status).json({ error: errorMessage(error) });
+    }
+  },
+);
 
 export { router as sreReadinessRoutes };

--- a/server/routes/sre-readiness.ts
+++ b/server/routes/sre-readiness.ts
@@ -1,0 +1,99 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import {
+  RemediationAuditPersistenceError,
+  RemediationRuntimeUnavailableError,
+  remediationRuntime,
+  sloRegistry,
+} from '../services/sre';
+import {
+  controlPlanePrincipal,
+  requireControlPlaneAccess,
+} from '../middleware/control-plane-auth';
+
+const router = Router();
+
+const SloEvaluationSchema = z.object({
+  observations: z.array(z.object({
+    timestamp: z.string().datetime({ offset: true }),
+    goodEvents: z.number().int().nonnegative(),
+    totalEvents: z.number().int().nonnegative(),
+  })),
+});
+
+const RemediationExecuteSchema = z.discriminatedUnion('actionId', [
+  z.object({
+    actionId: z.literal('gateway-failover'),
+    context: z.object({
+      gatewayId: z.string().trim().min(1).max(200),
+    }),
+    idempotencyKey: z.string().trim().min(1).max(200),
+    dryRun: z.boolean().default(true),
+  }),
+  z.object({
+    actionId: z.literal('scale-out'),
+    context: z.object({
+      component: z.string().trim().min(1).max(200),
+      desiredReplicas: z.number().int().min(1).max(10_000),
+      maximumReplicas: z.number().int().min(1).max(10_000),
+    }),
+    idempotencyKey: z.string().trim().min(1).max(200),
+    dryRun: z.boolean().default(true),
+  }),
+]);
+
+const requireRemediationOperator = requireControlPlaneAccess({
+  roles: ['operator'],
+  scopes: ['sre.remediate'],
+});
+
+function errorMessage(error: unknown): string {
+  if (error instanceof z.ZodError) {
+    return error.issues
+      .map(issue => `${issue.path.join('.') || 'request'}: ${issue.message}`)
+      .join('; ');
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+router.get('/sre/slos', (_req, res) => {
+  res.json({ slos: sloRegistry.list() });
+});
+
+router.post('/sre/slos/:sloId/evaluate', (req, res) => {
+  try {
+    const request = SloEvaluationSchema.parse(req.body);
+    res.json(sloRegistry.evaluate(req.params.sloId, request.observations));
+  } catch (error) {
+    const status = error instanceof Error && error.message.startsWith('Unknown SLO') ? 404 : 400;
+    res.status(status).json({ error: errorMessage(error) });
+  }
+});
+
+router.get('/sre/remediations/status', requireRemediationOperator, (_req, res) => {
+  const status = remediationRuntime.status();
+  res.status(status.configured ? 200 : 503).json(status);
+});
+
+router.post('/sre/remediations/execute', requireRemediationOperator, async (req, res) => {
+  try {
+    const request = RemediationExecuteSchema.parse(req.body);
+    const principal = controlPlanePrincipal(req);
+    const result = await remediationRuntime.execute({
+      ...request,
+      // Approval/audit identity is always server-bound. A body/header supplied
+      // identity cannot authorize its own remediation.
+      approvedBy: principal.name,
+    });
+    res.json(result);
+  } catch (error) {
+    const status = error instanceof RemediationRuntimeUnavailableError
+      ? 503
+      : error instanceof RemediationAuditPersistenceError
+        ? 500
+        : 400;
+    res.status(status).json({ error: errorMessage(error) });
+  }
+});
+
+export { router as sreReadinessRoutes };

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -100,6 +100,9 @@ export { tuningService } from './tuning';
 export * from './marketplace';
 export { marketplaceService } from './marketplace';
 
+// ── Production SRE Service (ADR-0014 [14.6], #226) ──────────────────────────
+export * from './sre';
+
 // ── NL Process Query Service (ADR-0013 [13.5], #216) ─────────────────────────
 // Exported by name rather than with `export *`: the module's public surface
 // includes generic bound names (MAX_RESULT_ITEMS, tokenize, ...) that would be
@@ -277,7 +280,8 @@ export const serviceRegistry = {
   ubiquity: () => import('./ubiquity'),
   l2Rollup: () => import('./l2-rollup'),
   optimization: () => import('./optimization'),
-  spc: () => import('./spc')
+  spc: () => import('./spc'),
+  sre: () => import('./sre')
 } as const;
 
 export type ServiceName = keyof typeof serviceRegistry;

--- a/server/services/sre/__tests__/sre.test.ts
+++ b/server/services/sre/__tests__/sre.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AutoRemediationEngine,
+  CRITICAL_PATH_SLOS,
+  RemediationAuditPersistenceError,
+  RemediationRuntime,
+  RemediationRuntimeUnavailableError,
+  SloRegistry,
+  createGatewayFailoverAction,
+  createScaleOutAction,
+  type RemediationAction,
+} from '../index';
+
+const NOW = new Date('2026-07-28T12:00:00.000Z');
+const now = () => new Date(NOW);
+
+describe('SloRegistry', () => {
+  it('defines every ADR-0014 critical path with an owner, metric, and runbook', () => {
+    const registry = new SloRegistry();
+    const definitions = registry.list();
+
+    expect(definitions.map(item => item.id)).toEqual(expect.arrayContaining([
+      'tag-ingest-freshness',
+      'control-loop-confirmation',
+      'api-tag-read-availability',
+      'websocket-delivery',
+      'historian-durability',
+      'gateway-failover-rto',
+      'database-recovery-rto',
+    ]));
+    expect(definitions.every(item =>
+      item.owner.length > 0
+      && item.sli.metric.includes('/')
+      && item.sli.goodEvent.length > 0
+      && item.runbook.endsWith('.md'))).toBe(true);
+  });
+
+  it('evaluates a rolling error budget and excludes out-of-window samples', () => {
+    const registry = new SloRegistry(CRITICAL_PATH_SLOS, { now });
+    const result = registry.evaluate('tag-ingest-freshness', [
+      { timestamp: '2026-07-28T11:00:00.000Z', goodEvents: 9_995, totalEvents: 10_000 },
+      { timestamp: '2026-01-01T00:00:00.000Z', goodEvents: 0, totalEvents: 1_000_000 },
+    ]);
+
+    expect(result.totalEvents).toBe(10_000);
+    expect(result.sli).toBe(0.9995);
+    expect(result.badEvents).toBe(5);
+    expect(result.burnRate).toBeCloseTo(0.5);
+    expect(result.errorBudgetRemaining).toBeCloseTo(0.5);
+    expect(result.status).toBe('warning');
+  });
+
+  it('reports no-data honestly and rejects invalid counters', () => {
+    const registry = new SloRegistry(CRITICAL_PATH_SLOS, { now });
+    expect(registry.evaluate('historian-durability', [])).toMatchObject({
+      status: 'no-data',
+      sli: null,
+      totalEvents: 0,
+    });
+    expect(() => registry.evaluate('historian-durability', [{
+      timestamp: NOW.toISOString(),
+      goodEvents: 2,
+      totalEvents: 1,
+    }])).toThrow(/good <= total/);
+  });
+});
+
+describe('AutoRemediationEngine', () => {
+  it('dry-runs without side effects and then executes with a distinct key', async () => {
+    let replicas = 2;
+    const setReplicas = vi.fn(async (_component: string, desired: number) => {
+      replicas = desired;
+    });
+    const action = createScaleOutAction({
+      currentReplicas: async () => replicas,
+      setReplicas,
+      readyReplicas: async () => replicas,
+    });
+    const engine = new AutoRemediationEngine([action], { cooldownMs: 0 }, { now });
+    const context = { component: 'gateway', desiredReplicas: 4, maximumReplicas: 6 };
+
+    const plan = await engine.execute({
+      actionId: 'scale-out',
+      context,
+      idempotencyKey: 'scale-gateway-plan-1',
+      dryRun: true,
+    });
+    expect(plan.status).toBe('planned');
+    expect(setReplicas).not.toHaveBeenCalled();
+
+    const result = await engine.execute({
+      actionId: 'scale-out',
+      context,
+      idempotencyKey: 'scale-gateway-apply-1',
+    });
+    expect(result).toMatchObject({ status: 'succeeded', changed: true, verified: true });
+    expect(setReplicas).toHaveBeenCalledTimes(1);
+    expect(replicas).toBe(4);
+  });
+
+  it('reuses idempotent results and rejects key collisions', async () => {
+    let replicas = 1;
+    const action = createScaleOutAction({
+      currentReplicas: async () => replicas,
+      setReplicas: async (_component, desired) => { replicas = desired; },
+      readyReplicas: async () => replicas,
+    });
+    const engine = new AutoRemediationEngine([action], { cooldownMs: 0 }, { now });
+    const request = {
+      actionId: 'scale-out',
+      context: { component: 'api', desiredReplicas: 2, maximumReplicas: 4 },
+      idempotencyKey: 'incident-123-scale',
+    };
+
+    const first = await engine.execute(request);
+    const replay = await engine.execute(request);
+    expect(first.reused).toBe(false);
+    expect(replay.reused).toBe(true);
+    expect(replay.executionId).toBe(first.executionId);
+    await expect(engine.execute({
+      ...request,
+      context: { ...request.context, desiredReplicas: 3 },
+    })).rejects.toThrow(/already used/);
+  });
+
+  it('blocks failover when no healthy peer can accept shards', async () => {
+    const failover = vi.fn();
+    const action = createGatewayFailoverAction({
+      inspect: async () => ({ healthy: false, activeGatewayCount: 1, affectedShardCount: 8 }),
+      failover,
+      verifyCoverage: async () => true,
+      restore: async () => undefined,
+    });
+    const engine = new AutoRemediationEngine([action], { cooldownMs: 0 }, { now });
+
+    const result = await engine.execute({
+      actionId: 'gateway-failover',
+      context: { gatewayId: 'gw-1' },
+      idempotencyKey: 'incident-456-failover',
+    });
+    expect(result.status).toBe('blocked');
+    expect(result.message).toMatch(/no healthy peer/i);
+    expect(failover).not.toHaveBeenCalled();
+  });
+
+  it('rolls back a change that fails post-change verification', async () => {
+    let replicas = 2;
+    const action = createScaleOutAction({
+      currentReplicas: async () => replicas,
+      setReplicas: async (_component, desired) => { replicas = desired; },
+      readyReplicas: async () => 0,
+    });
+    const engine = new AutoRemediationEngine([action], { cooldownMs: 0 }, { now });
+
+    const result = await engine.execute({
+      actionId: 'scale-out',
+      context: { component: 'historian', desiredReplicas: 4, maximumReplicas: 5 },
+      idempotencyKey: 'incident-789-scale',
+    });
+    expect(result).toMatchObject({
+      status: 'rolled-back',
+      changed: false,
+      verified: false,
+      rollbackAttempted: true,
+    });
+    expect(replicas).toBe(2);
+  });
+
+  it('rechecks desired state immediately before mutation and never scales down', async () => {
+    const setReplicas = vi.fn(async () => undefined);
+    let inspection = 0;
+    const action = createScaleOutAction({
+      currentReplicas: async () => {
+        inspection += 1;
+        return inspection === 1 ? 1 : 5;
+      },
+      setReplicas,
+      readyReplicas: async () => 5,
+    });
+    const engine = new AutoRemediationEngine([action], { cooldownMs: 0 }, { now });
+    const result = await engine.execute({
+      actionId: 'scale-out',
+      context: { component: 'api', desiredReplicas: 3, maximumReplicas: 4 },
+      idempotencyKey: 'concurrent-scale-out',
+    });
+    expect(result).toMatchObject({ status: 'skipped', changed: false });
+    expect(result.message).toMatch(/scale-down is forbidden/);
+    expect(setReplicas).not.toHaveBeenCalled();
+  });
+
+  it('requires an approver above the automatic risk ceiling', async () => {
+    const dangerous: RemediationAction<Record<string, never>> = {
+      id: 'promote-database',
+      description: 'Promote a replica',
+      risk: 'high',
+      scope: () => 'primary',
+      precondition: async () => ({ needed: true, safe: true, reason: 'primary unavailable' }),
+      execute: async () => ({ changed: true, message: 'promoted' }),
+    };
+    const engine = new AutoRemediationEngine(
+      [dangerous],
+      { maxAutomaticRisk: 'medium', cooldownMs: 0 },
+      { now },
+    );
+
+    const blocked = await engine.execute({
+      actionId: dangerous.id,
+      context: {},
+      idempotencyKey: 'db-promote-unapproved',
+    });
+    expect(blocked.status).toBe('blocked');
+    const approved = await engine.execute({
+      actionId: dangerous.id,
+      context: {},
+      idempotencyKey: 'db-promote-approved',
+      approvedBy: 'incident-commander@example.com',
+    });
+    expect(approved.status).toBe('succeeded');
+    expect(engine.getAuditLog()).toHaveLength(2);
+  });
+
+  it('enforces the configured action allowlist', async () => {
+    const action = createScaleOutAction({
+      currentReplicas: async () => 1,
+      setReplicas: async () => undefined,
+      readyReplicas: async () => 2,
+    });
+    const engine = new AutoRemediationEngine(
+      [action],
+      { allowedActionIds: [], cooldownMs: 0 },
+      { now },
+    );
+    const result = await engine.execute({
+      actionId: action.id,
+      context: { component: 'api', desiredReplicas: 2, maximumReplicas: 3 },
+      idempotencyKey: 'not-allowlisted',
+    });
+    expect(result.status).toBe('blocked');
+    expect(result.message).toMatch(/allowlist/);
+  });
+
+  it('starts cooldown at mutation time after a slow precondition', async () => {
+    let clock = 0;
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    let firstPrecondition = true;
+    const execute = vi.fn(async () => ({ changed: true, message: 'changed' }));
+    const action: RemediationAction<Record<string, never>> = {
+      id: 'slow-check',
+      description: 'slow precondition',
+      risk: 'low',
+      scope: () => 'shared',
+      precondition: async () => {
+        if (firstPrecondition) {
+          firstPrecondition = false;
+          await gate;
+        }
+        return { needed: true, safe: true, reason: 'needed' };
+      },
+      execute,
+    };
+    const engine = new AutoRemediationEngine(
+      [action],
+      { cooldownMs: 60_000 },
+      { now: () => new Date(clock) },
+    );
+
+    const first = engine.execute({
+      actionId: action.id,
+      context: {},
+      idempotencyKey: 'slow-first',
+    });
+    clock = 10 * 60_000;
+    release();
+    expect((await first).status).toBe('succeeded');
+    const second = await engine.execute({
+      actionId: action.id,
+      context: {},
+      idempotencyKey: 'slow-second',
+    });
+    expect(second.status).toBe('blocked');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('snapshots request context and cached results across async boundaries', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    let observed = 0;
+    const action: RemediationAction<{ desired: number }> = {
+      id: 'snapshot',
+      description: 'snapshot input',
+      risk: 'low',
+      scope: () => 'shared',
+      precondition: async () => {
+        await gate;
+        return { needed: true, safe: true, reason: 'needed' };
+      },
+      execute: async context => {
+        observed = context.desired;
+        return { changed: true, message: 'changed' };
+      },
+    };
+    const engine = new AutoRemediationEngine([action], { cooldownMs: 0 }, { now });
+    const context = { desired: 2 };
+    const request = { actionId: action.id, context, idempotencyKey: 'snapshot-1' };
+    const running = engine.execute(request);
+    context.desired = 99;
+    release();
+    const result = await running;
+    expect(observed).toBe(2);
+    result.status = 'failed';
+    expect((await engine.execute({ ...request, context: { desired: 2 } })).status).toBe('succeeded');
+  });
+});
+
+describe('RemediationRuntime', () => {
+  it('fails closed until adapters are configured and durably audits execution', async () => {
+    const runtime = new RemediationRuntime();
+    await expect(runtime.execute({
+      actionId: 'scale-out',
+      context: { component: 'api', desiredReplicas: 2, maximumReplicas: 3 },
+      idempotencyKey: 'runtime-unconfigured',
+    })).rejects.toBeInstanceOf(RemediationRuntimeUnavailableError);
+
+    let replicas = 1;
+    const append = vi.fn(async () => undefined);
+    runtime.configure({
+      scaleOut: {
+        currentReplicas: async () => replicas,
+        setReplicas: async (_component, value) => { replicas = value; },
+        readyReplicas: async () => replicas,
+      },
+      auditSink: { append },
+      policy: { cooldownMs: 0 },
+    });
+    const result = await runtime.execute({
+      actionId: 'scale-out',
+      context: { component: 'api', desiredReplicas: 2, maximumReplicas: 3 },
+      idempotencyKey: 'runtime-configured',
+    });
+    expect(result.status).toBe('succeeded');
+    expect(runtime.status()).toMatchObject({
+      configured: true,
+      actions: [{ id: 'scale-out' }],
+    });
+    expect(append).toHaveBeenCalledWith(expect.objectContaining({
+      executionId: result.executionId,
+      status: 'succeeded',
+    }));
+  });
+
+  it('surfaces durable audit failure after preserving the idempotent action result', async () => {
+    let replicas = 1;
+    let failAudit = true;
+    const runtime = new RemediationRuntime();
+    runtime.configure({
+      scaleOut: {
+        currentReplicas: async () => replicas,
+        setReplicas: async (_component, value) => { replicas = value; },
+        readyReplicas: async () => replicas,
+      },
+      auditSink: {
+        append: async () => {
+          if (failAudit) throw new Error('disk unavailable');
+        },
+      },
+      policy: { cooldownMs: 0 },
+    });
+    const request = {
+      actionId: 'scale-out',
+      context: { component: 'api', desiredReplicas: 2, maximumReplicas: 3 },
+      idempotencyKey: 'audit-retry',
+    };
+    await expect(runtime.execute(request)).rejects.toBeInstanceOf(RemediationAuditPersistenceError);
+    expect(replicas).toBe(2);
+    failAudit = false;
+    const replay = await runtime.execute(request);
+    expect(replay).toMatchObject({ status: 'succeeded', reused: true });
+  });
+});

--- a/server/services/sre/index.ts
+++ b/server/services/sre/index.ts
@@ -1,0 +1,951 @@
+/**
+ * Production SRE primitives (ADR-0014, issue #226).
+ *
+ * This module provides executable SLO/error-budget evaluation and a guarded
+ * remediation engine.  System I/O is injected through adapters: tests and
+ * operators can therefore exercise the complete safety flow without embedding
+ * shell commands or cloud credentials in the service.
+ */
+import { createHash } from 'node:crypto';
+import { mkdir, open } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+export type SloStatus = 'healthy' | 'warning' | 'breached' | 'no-data';
+
+export interface SloDefinition {
+  id: string;
+  name: string;
+  criticalPath: string;
+  description: string;
+  sli: {
+    metric: string;
+    goodEvent: string;
+    unit: 'ratio';
+  };
+  /** Fraction of good events required over the rolling window. */
+  objective: number;
+  windowDays: number;
+  warningBurnRate: number;
+  criticalBurnRate: number;
+  owner: string;
+  runbook: string;
+}
+
+export interface SliObservation {
+  timestamp: string;
+  goodEvents: number;
+  totalEvents: number;
+}
+
+export interface SloEvaluation {
+  sloId: string;
+  status: SloStatus;
+  windowStart: string;
+  windowEnd: string;
+  objective: number;
+  sli: number | null;
+  goodEvents: number;
+  totalEvents: number;
+  badEvents: number;
+  allowedBadEvents: number;
+  errorBudgetConsumed: number;
+  errorBudgetRemaining: number;
+  burnRate: number;
+}
+
+/**
+ * Critical-path objectives.  `goodEvent` is intentionally precise enough to
+ * turn every row into a Prometheus recording rule or an event counter.
+ */
+export const CRITICAL_PATH_SLOS: readonly SloDefinition[] = Object.freeze([
+  {
+    id: 'tag-ingest-freshness',
+    name: 'Tag ingestion freshness',
+    criticalPath: 'device → gateway → event pipeline',
+    description: 'Accepted, good-quality tag updates reach the event pipeline within 1 second.',
+    sli: {
+      metric: 'scada_tag_ingest_fresh_total / scada_tag_ingest_total',
+      goodEvent: 'update accepted with good quality and end-to-end ingest latency <= 1s',
+      unit: 'ratio',
+    },
+    objective: 0.999,
+    windowDays: 30,
+    warningBurnRate: 0.5,
+    criticalBurnRate: 1,
+    owner: 'edge-platform',
+    runbook: 'docs/operations/sre-playbooks/gateway-failover.md',
+  },
+  {
+    id: 'control-loop-confirmation',
+    name: 'Control-loop confirmation latency',
+    criticalPath: 'tick → batch → sign → anchor → confirmation',
+    description: 'Integrity pipeline events are confirmed within the configured round-trip budget.',
+    sli: {
+      metric: 'scada_integrity_round_trip_within_slo_total / scada_integrity_round_trip_total',
+      goodEvent: 'round-trip duration <= 4.8s and every recorded stage is within its stage budget',
+      unit: 'ratio',
+    },
+    objective: 0.999,
+    windowDays: 30,
+    warningBurnRate: 0.5,
+    criticalBurnRate: 1,
+    owner: 'integrity-platform',
+    runbook: 'docs/blockchain/validator-monitoring.md',
+  },
+  {
+    id: 'api-tag-read-availability',
+    name: 'Tag read API availability',
+    criticalPath: 'operator/client → API → cache or historian',
+    description: 'Authorized tag reads complete successfully without a server error.',
+    sli: {
+      metric: 'scada_api_tag_read_good_total / scada_api_tag_read_total',
+      goodEvent: 'HTTP response is non-5xx and completes within 500ms',
+      unit: 'ratio',
+    },
+    objective: 0.9995,
+    windowDays: 30,
+    warningBurnRate: 0.5,
+    criticalBurnRate: 1,
+    owner: 'control-plane',
+    runbook: 'docs/operations/sre-playbooks/incident-response.md',
+  },
+  {
+    id: 'websocket-delivery',
+    name: 'Realtime subscription delivery',
+    criticalPath: 'event pipeline → WebSocket fan-out → subscribed client',
+    description: 'Eligible events reach connected subscribers within 2 seconds.',
+    sli: {
+      metric: 'scada_websocket_delivery_good_total / scada_websocket_delivery_total',
+      goodEvent: 'event delivered to an authenticated connected subscriber within 2s',
+      unit: 'ratio',
+    },
+    objective: 0.999,
+    windowDays: 30,
+    warningBurnRate: 0.5,
+    criticalBurnRate: 1,
+    owner: 'control-plane',
+    runbook: 'docs/operations/sre-playbooks/scaling-runbook.md',
+  },
+  {
+    id: 'historian-durability',
+    name: 'Historian write durability',
+    criticalPath: 'event pipeline → historian → integrity verification',
+    description: 'Accepted historian writes remain readable and integrity-verifiable.',
+    sli: {
+      metric: 'scada_historian_verified_writes_total / scada_historian_accepted_writes_total',
+      goodEvent: 'accepted write is readable and its Merkle proof verifies after persistence',
+      unit: 'ratio',
+    },
+    objective: 0.99999,
+    windowDays: 30,
+    warningBurnRate: 0.5,
+    criticalBurnRate: 1,
+    owner: 'data-platform',
+    runbook: 'docs/operations/sre-playbooks/database-recovery.md',
+  },
+  {
+    id: 'gateway-failover-rto',
+    name: 'Gateway failover recovery objective',
+    criticalPath: 'heartbeat loss → drain → shard rebalance → fresh telemetry',
+    description: 'A single gateway loss restores tag coverage in at most 60 seconds.',
+    sli: {
+      metric: 'scada_gateway_failover_within_rto_total / scada_gateway_failover_total',
+      goodEvent: 'all affected shards produce fresh telemetry <= 60s after confirmed heartbeat loss',
+      unit: 'ratio',
+    },
+    objective: 0.99,
+    windowDays: 90,
+    warningBurnRate: 0.5,
+    criticalBurnRate: 1,
+    owner: 'edge-platform',
+    runbook: 'docs/operations/sre-playbooks/gateway-failover.md',
+  },
+  {
+    id: 'database-recovery-rto',
+    name: 'Historian database recovery objective',
+    criticalPath: 'database incident → failover/restore → verified writes',
+    description: 'Database recovery restores verified writes in at most 15 minutes.',
+    sli: {
+      metric: 'scada_database_recovery_within_rto_total / scada_database_recovery_total',
+      goodEvent: 'verified read/write service restored <= 15m with RPO <= 60s',
+      unit: 'ratio',
+    },
+    objective: 0.99,
+    windowDays: 90,
+    warningBurnRate: 0.5,
+    criticalBurnRate: 1,
+    owner: 'data-platform',
+    runbook: 'docs/operations/sre-playbooks/database-recovery.md',
+  },
+]);
+
+export class SloRegistry {
+  private readonly definitions: ReadonlyMap<string, SloDefinition>;
+  private readonly now: () => Date;
+
+  constructor(
+    definitions: readonly SloDefinition[] = CRITICAL_PATH_SLOS,
+    options: { now?: () => Date } = {},
+  ) {
+    const byId = new Map<string, SloDefinition>();
+    for (const definition of definitions) {
+      if (byId.has(definition.id)) throw new Error(`Duplicate SLO id: ${definition.id}`);
+      if (!Number.isFinite(definition.objective)
+        || definition.objective <= 0
+        || definition.objective >= 1) {
+        throw new Error(`SLO ${definition.id} objective must be between 0 and 1`);
+      }
+      if (!Number.isFinite(definition.windowDays) || definition.windowDays <= 0) {
+        throw new Error(`SLO ${definition.id} windowDays must be positive`);
+      }
+      if (!Number.isFinite(definition.warningBurnRate)
+        || !Number.isFinite(definition.criticalBurnRate)
+        || definition.warningBurnRate <= 0
+        || definition.criticalBurnRate <= definition.warningBurnRate) {
+        throw new Error(`SLO ${definition.id} burn-rate thresholds are invalid`);
+      }
+      byId.set(definition.id, { ...definition, sli: { ...definition.sli } });
+    }
+    this.definitions = byId;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  list(): readonly SloDefinition[] {
+    return [...this.definitions.values()].map(item => ({ ...item, sli: { ...item.sli } }));
+  }
+
+  get(id: string): SloDefinition | undefined {
+    const definition = this.definitions.get(id);
+    return definition === undefined ? undefined : { ...definition, sli: { ...definition.sli } };
+  }
+
+  evaluate(id: string, observations: readonly SliObservation[]): SloEvaluation {
+    const definition = this.definitions.get(id);
+    if (definition === undefined) throw new Error(`Unknown SLO: ${id}`);
+    const windowEndDate = this.now();
+    const windowStartDate = new Date(
+      windowEndDate.getTime() - definition.windowDays * 24 * 60 * 60 * 1000,
+    );
+    let goodEvents = 0;
+    let totalEvents = 0;
+    for (const observation of observations) {
+      const timestamp = Date.parse(observation.timestamp);
+      if (!Number.isFinite(timestamp)) {
+        throw new Error(`Observation timestamp is invalid: ${observation.timestamp}`);
+      }
+      if (!Number.isSafeInteger(observation.goodEvents)
+        || !Number.isSafeInteger(observation.totalEvents)
+        || observation.goodEvents < 0
+        || observation.totalEvents < 0
+        || observation.goodEvents > observation.totalEvents) {
+        throw new Error('Observation event counts must be non-negative integers with good <= total');
+      }
+      if (timestamp >= windowStartDate.getTime() && timestamp <= windowEndDate.getTime()) {
+        if (!Number.isSafeInteger(goodEvents + observation.goodEvents)
+          || !Number.isSafeInteger(totalEvents + observation.totalEvents)) {
+          throw new Error('Aggregated observation counters exceed the safe integer range');
+        }
+        goodEvents += observation.goodEvents;
+        totalEvents += observation.totalEvents;
+      }
+    }
+    if (totalEvents === 0) {
+      return {
+        sloId: id,
+        status: 'no-data',
+        windowStart: windowStartDate.toISOString(),
+        windowEnd: windowEndDate.toISOString(),
+        objective: definition.objective,
+        sli: null,
+        goodEvents: 0,
+        totalEvents: 0,
+        badEvents: 0,
+        allowedBadEvents: 0,
+        errorBudgetConsumed: 0,
+        errorBudgetRemaining: 1,
+        burnRate: 0,
+      };
+    }
+    const badEvents = totalEvents - goodEvents;
+    const allowedBadEvents = totalEvents * (1 - definition.objective);
+    const sli = goodEvents / totalEvents;
+    const burnRate = allowedBadEvents === 0 ? 0 : badEvents / allowedBadEvents;
+    const errorBudgetConsumed = Math.max(0, burnRate);
+    const roundedBurnRate = Number(burnRate.toFixed(4));
+    const reaches = (threshold: number): boolean =>
+      burnRate + Number.EPSILON * 8 * Math.max(1, Math.abs(burnRate), Math.abs(threshold))
+        >= threshold;
+    const status: SloStatus = reaches(definition.criticalBurnRate)
+      ? 'breached'
+      : reaches(definition.warningBurnRate)
+        ? 'warning'
+        : 'healthy';
+    return {
+      sloId: id,
+      status,
+      windowStart: windowStartDate.toISOString(),
+      windowEnd: windowEndDate.toISOString(),
+      objective: definition.objective,
+      sli: Number(sli.toFixed(8)),
+      goodEvents,
+      totalEvents,
+      badEvents,
+      allowedBadEvents: Number(allowedBadEvents.toFixed(4)),
+      errorBudgetConsumed: Number(errorBudgetConsumed.toFixed(4)),
+      errorBudgetRemaining: Number(Math.max(0, 1 - errorBudgetConsumed).toFixed(4)),
+      burnRate: roundedBurnRate,
+    };
+  }
+}
+
+export type RemediationRisk = 'low' | 'medium' | 'high';
+export type RemediationStatus =
+  | 'planned'
+  | 'skipped'
+  | 'blocked'
+  | 'succeeded'
+  | 'failed'
+  | 'rolled-back';
+
+export interface RemediationPrecondition {
+  needed: boolean;
+  safe: boolean;
+  reason: string;
+}
+
+export interface RemediationOutcome {
+  changed: boolean;
+  message: string;
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface RemediationAction<Context = unknown> {
+  id: string;
+  description: string;
+  risk: RemediationRisk;
+  /** Affected resource key used for cooldown isolation. */
+  scope(context: Context): string;
+  precondition(context: Context): Promise<RemediationPrecondition>;
+  execute(context: Context): Promise<RemediationOutcome>;
+  verify?(context: Context, outcome: RemediationOutcome): Promise<boolean>;
+  rollback?(context: Context, outcome: RemediationOutcome): Promise<void>;
+}
+
+export interface RemediationRequest<Context = unknown> {
+  actionId: string;
+  context: Context;
+  idempotencyKey: string;
+  dryRun?: boolean;
+  /** Required for actions above the engine's automatic risk ceiling. */
+  approvedBy?: string;
+}
+
+export interface RemediationResult {
+  executionId: string;
+  actionId: string;
+  idempotencyKey: string;
+  /** Trusted caller identity supplied by the authenticated composition layer. */
+  approvedBy?: string;
+  status: RemediationStatus;
+  risk: RemediationRisk;
+  dryRun: boolean;
+  reused: boolean;
+  startedAt: string;
+  completedAt: string;
+  scope: string;
+  message: string;
+  changed: boolean;
+  verified: boolean;
+  rollbackAttempted: boolean;
+}
+
+export interface RemediationPolicy {
+  allowedActionIds?: readonly string[];
+  maxAutomaticRisk?: RemediationRisk;
+  cooldownMs?: number;
+  maxExecutionsPerHour?: number;
+  maxAuditEntries?: number;
+  maxCachedExecutions?: number;
+}
+
+interface CachedExecution {
+  fingerprint: string;
+  result: RemediationResult;
+}
+
+const RISK_RANK: Readonly<Record<RemediationRisk, number>> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+};
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value !== null && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function hash(value: unknown): string {
+  return createHash('sha256').update(stableJson(value)).digest('hex');
+}
+
+export class AutoRemediationEngine {
+  private readonly actions = new Map<string, RemediationAction<unknown>>();
+  private readonly allowedActionIds?: ReadonlySet<string>;
+  private readonly maxAutomaticRisk: RemediationRisk;
+  private readonly cooldownMs: number;
+  private readonly maxExecutionsPerHour: number;
+  private readonly maxAuditEntries: number;
+  private readonly maxCachedExecutions: number;
+  private readonly now: () => Date;
+  private readonly cached = new Map<string, CachedExecution>();
+  private readonly inFlight = new Map<string, { fingerprint: string; promise: Promise<RemediationResult> }>();
+  private readonly lastExecutionByScope = new Map<string, number>();
+  private readonly executionTimes: number[] = [];
+  private readonly auditLog: RemediationResult[] = [];
+
+  constructor(
+    actions: readonly RemediationAction<unknown>[] = [],
+    policy: RemediationPolicy = {},
+    options: { now?: () => Date } = {},
+  ) {
+    this.allowedActionIds = policy.allowedActionIds === undefined
+      ? undefined
+      : new Set(policy.allowedActionIds);
+    this.maxAutomaticRisk = policy.maxAutomaticRisk ?? 'medium';
+    this.cooldownMs = policy.cooldownMs ?? 5 * 60 * 1000;
+    this.maxExecutionsPerHour = policy.maxExecutionsPerHour ?? 20;
+    this.maxAuditEntries = policy.maxAuditEntries ?? 1_000;
+    this.maxCachedExecutions = policy.maxCachedExecutions ?? 10_000;
+    this.now = options.now ?? (() => new Date());
+    if (!Number.isFinite(this.cooldownMs) || this.cooldownMs < 0) {
+      throw new Error('cooldownMs must be non-negative');
+    }
+    if (!Number.isInteger(this.maxExecutionsPerHour) || this.maxExecutionsPerHour < 1) {
+      throw new Error('maxExecutionsPerHour must be a positive integer');
+    }
+    if (!Number.isInteger(this.maxAuditEntries) || this.maxAuditEntries < 1) {
+      throw new Error('maxAuditEntries must be a positive integer');
+    }
+    if (!Number.isInteger(this.maxCachedExecutions) || this.maxCachedExecutions < 1) {
+      throw new Error('maxCachedExecutions must be a positive integer');
+    }
+    for (const action of actions) this.register(action);
+  }
+
+  register<Context>(action: RemediationAction<Context>): void {
+    if (!action.id.trim()) throw new Error('Remediation action id is required');
+    if (this.actions.has(action.id)) throw new Error(`Duplicate remediation action: ${action.id}`);
+    this.actions.set(action.id, action as RemediationAction<unknown>);
+  }
+
+  listActions(): ReadonlyArray<Pick<RemediationAction, 'id' | 'description' | 'risk'>> {
+    return [...this.actions.values()].map(({ id, description, risk }) => ({ id, description, risk }));
+  }
+
+  getAuditLog(limit = 100): readonly RemediationResult[] {
+    if (!Number.isInteger(limit) || limit < 1) throw new Error('limit must be a positive integer');
+    return this.auditLog.slice(-limit).map(entry => ({ ...entry }));
+  }
+
+  async execute<Context>(request: RemediationRequest<Context>): Promise<RemediationResult> {
+    if (!request.idempotencyKey.trim() || request.idempotencyKey.length > 200) {
+      throw new Error('idempotencyKey must contain 1 to 200 characters');
+    }
+    const action = this.actions.get(request.actionId) as RemediationAction<Context> | undefined;
+    if (action === undefined) throw new Error(`Unknown remediation action: ${request.actionId}`);
+    let context: Context;
+    try {
+      context = structuredClone(request.context);
+    } catch {
+      throw new Error('remediation context must be structured-cloneable data');
+    }
+    const normalizedRequest: RemediationRequest<Context> = { ...request, context };
+    const fingerprint = hash({
+      actionId: normalizedRequest.actionId,
+      context: normalizedRequest.context,
+      dryRun: normalizedRequest.dryRun ?? false,
+      approvedBy: normalizedRequest.approvedBy ?? null,
+    });
+    const prior = this.cached.get(request.idempotencyKey);
+    if (prior !== undefined) {
+      if (prior.fingerprint !== fingerprint) {
+        throw new Error(`Idempotency key ${request.idempotencyKey} was already used for another request`);
+      }
+      return { ...prior.result, reused: true };
+    }
+    const running = this.inFlight.get(request.idempotencyKey);
+    if (running !== undefined) {
+      if (running.fingerprint !== fingerprint) {
+        throw new Error(`Idempotency key ${request.idempotencyKey} is in use by another request`);
+      }
+      return { ...(await running.promise), reused: true };
+    }
+
+    const promise = this.executeOnce(action, normalizedRequest);
+    this.inFlight.set(request.idempotencyKey, { fingerprint, promise });
+    try {
+      const result = await promise;
+      const cachedResult = structuredClone(result);
+      this.cached.delete(request.idempotencyKey);
+      this.cached.set(request.idempotencyKey, { fingerprint, result: cachedResult });
+      while (this.cached.size > this.maxCachedExecutions) {
+        const oldest = this.cached.keys().next().value as string | undefined;
+        if (oldest === undefined) break;
+        this.cached.delete(oldest);
+      }
+      return structuredClone(cachedResult);
+    } finally {
+      this.inFlight.delete(request.idempotencyKey);
+    }
+  }
+
+  private async executeOnce<Context>(
+    action: RemediationAction<Context>,
+    request: RemediationRequest<Context>,
+  ): Promise<RemediationResult> {
+    const started = this.now();
+    const scope = `${action.id}:${action.scope(request.context)}`;
+    const executionId = `rem-${hash({
+      actionId: action.id,
+      idempotencyKey: request.idempotencyKey,
+      startedAt: started.toISOString(),
+    }).slice(0, 16)}`;
+    const finish = (
+      partial: Pick<RemediationResult, 'status' | 'message' | 'changed' | 'verified' | 'rollbackAttempted'>,
+    ): RemediationResult => {
+      const result: RemediationResult = {
+        executionId,
+        actionId: action.id,
+        idempotencyKey: request.idempotencyKey,
+        approvedBy: request.approvedBy?.trim() || undefined,
+        risk: action.risk,
+        dryRun: request.dryRun ?? false,
+        reused: false,
+        startedAt: started.toISOString(),
+        completedAt: this.now().toISOString(),
+        scope,
+        ...partial,
+      };
+      this.appendAudit(result);
+      return result;
+    };
+
+    if (this.allowedActionIds !== undefined && !this.allowedActionIds.has(action.id)) {
+      return finish({
+        status: 'blocked',
+        message: `Action ${action.id} is not on the remediation allowlist`,
+        changed: false,
+        verified: false,
+        rollbackAttempted: false,
+      });
+    }
+    if (RISK_RANK[action.risk] > RISK_RANK[this.maxAutomaticRisk]
+      && !request.approvedBy?.trim()) {
+      return finish({
+        status: 'blocked',
+        message: `${action.risk}-risk action requires an approver identity`,
+        changed: false,
+        verified: false,
+        rollbackAttempted: false,
+      });
+    }
+
+    let precondition: RemediationPrecondition;
+    try {
+      precondition = await action.precondition(request.context);
+    } catch (error) {
+      return finish({
+        status: 'failed',
+        message: `Precondition failed: ${error instanceof Error ? error.message : String(error)}`,
+        changed: false,
+        verified: false,
+        rollbackAttempted: false,
+      });
+    }
+    if (!precondition.safe) {
+      return finish({
+        status: 'blocked',
+        message: precondition.reason,
+        changed: false,
+        verified: false,
+        rollbackAttempted: false,
+      });
+    }
+    if (!precondition.needed) {
+      return finish({
+        status: 'skipped',
+        message: precondition.reason,
+        changed: false,
+        verified: true,
+        rollbackAttempted: false,
+      });
+    }
+    if (request.dryRun) {
+      return finish({
+        status: 'planned',
+        message: `Dry run: ${precondition.reason}`,
+        changed: false,
+        verified: false,
+        rollbackAttempted: false,
+      });
+    }
+
+    // Apply cooldown and rate limits at mutation time. A slow precondition
+    // must not age out its own safety window before execution begins.
+    const nowMs = this.now().getTime();
+    const expiredScopeCutoff = nowMs - this.cooldownMs;
+    for (const [executedScope, timestamp] of this.lastExecutionByScope) {
+      if (timestamp <= expiredScopeCutoff) this.lastExecutionByScope.delete(executedScope);
+    }
+    const previousExecution = this.lastExecutionByScope.get(scope);
+    if (previousExecution !== undefined && nowMs - previousExecution < this.cooldownMs) {
+      return finish({
+        status: 'blocked',
+        message: `Cooldown active for ${scope}`,
+        changed: false,
+        verified: false,
+        rollbackAttempted: false,
+      });
+    }
+    const hourAgo = nowMs - 60 * 60 * 1000;
+    while (this.executionTimes.length > 0 && this.executionTimes[0] < hourAgo) {
+      this.executionTimes.shift();
+    }
+    if (this.executionTimes.length >= this.maxExecutionsPerHour) {
+      return finish({
+        status: 'blocked',
+        message: 'Global remediation execution rate limit reached',
+        changed: false,
+        verified: false,
+        rollbackAttempted: false,
+      });
+    }
+    this.executionTimes.push(nowMs);
+    this.lastExecutionByScope.set(scope, nowMs);
+
+    let outcome: RemediationOutcome;
+    try {
+      outcome = await action.execute(request.context);
+    } catch (error) {
+      return finish({
+        status: 'failed',
+        message: `Execution failed: ${error instanceof Error ? error.message : String(error)}`,
+        changed: false,
+        verified: false,
+        rollbackAttempted: false,
+      });
+    }
+    if (!outcome.changed) {
+      return finish({
+        status: 'skipped',
+        message: outcome.message,
+        changed: false,
+        verified: true,
+        rollbackAttempted: false,
+      });
+    }
+
+    let verified = true;
+    if (action.verify !== undefined) {
+      try {
+        verified = await action.verify(request.context, outcome);
+      } catch {
+        verified = false;
+      }
+    }
+    if (verified) {
+      return finish({
+        status: 'succeeded',
+        message: outcome.message,
+        changed: true,
+        verified: true,
+        rollbackAttempted: false,
+      });
+    }
+    if (action.rollback === undefined) {
+      return finish({
+        status: 'failed',
+        message: `${outcome.message}; post-change verification failed and no rollback is available`,
+        changed: true,
+        verified: false,
+        rollbackAttempted: false,
+      });
+    }
+    try {
+      await action.rollback(request.context, outcome);
+      return finish({
+        status: 'rolled-back',
+        message: `${outcome.message}; verification failed and rollback completed`,
+        changed: false,
+        verified: false,
+        rollbackAttempted: true,
+      });
+    } catch (error) {
+      return finish({
+        status: 'failed',
+        message: `${outcome.message}; verification and rollback failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        changed: true,
+        verified: false,
+        rollbackAttempted: true,
+      });
+    }
+  }
+
+  private appendAudit(result: RemediationResult): void {
+    this.auditLog.push(result);
+    if (this.auditLog.length > this.maxAuditEntries) {
+      this.auditLog.splice(0, this.auditLog.length - this.maxAuditEntries);
+    }
+  }
+}
+
+export interface GatewayFailoverContext {
+  gatewayId: string;
+}
+
+export interface GatewayFailoverAdapter {
+  inspect(gatewayId: string): Promise<{
+    healthy: boolean;
+    activeGatewayCount: number;
+    affectedShardCount: number;
+  }>;
+  failover(gatewayId: string): Promise<{ previousAssignments: unknown }>;
+  verifyCoverage(gatewayId: string): Promise<boolean>;
+  restore(gatewayId: string, previousAssignments: unknown): Promise<void>;
+}
+
+export function createGatewayFailoverAction(
+  adapter: GatewayFailoverAdapter,
+): RemediationAction<GatewayFailoverContext> {
+  return {
+    id: 'gateway-failover',
+    description: 'Drain an unhealthy gateway and rebalance its shards to healthy peers.',
+    risk: 'medium',
+    scope: context => context.gatewayId,
+    precondition: async context => {
+      if (!context.gatewayId.trim()) return { needed: false, safe: false, reason: 'gatewayId is required' };
+      const state = await adapter.inspect(context.gatewayId);
+      if (state.healthy) return { needed: false, safe: true, reason: 'Gateway is already healthy' };
+      if (state.activeGatewayCount < 2) {
+        return {
+          needed: true,
+          safe: false,
+          reason: 'Failover blocked: no healthy peer gateway can receive the affected shards',
+        };
+      }
+      return {
+        needed: state.affectedShardCount > 0,
+        safe: true,
+        reason: `${state.affectedShardCount} shards require failover`,
+      };
+    },
+    execute: async context => {
+      const current = await adapter.inspect(context.gatewayId);
+      if (current.healthy || current.affectedShardCount === 0) {
+        return {
+          changed: false,
+          message: `Gateway ${context.gatewayId} no longer requires failover`,
+        };
+      }
+      if (current.activeGatewayCount < 2) {
+        throw new Error('Failover aborted: healthy peer capacity disappeared after precondition');
+      }
+      const result = await adapter.failover(context.gatewayId);
+      return {
+        changed: true,
+        message: `Gateway ${context.gatewayId} drained and shard rebalance requested`,
+        metadata: { previousAssignments: result.previousAssignments },
+      };
+    },
+    verify: context => adapter.verifyCoverage(context.gatewayId),
+    rollback: async (context, outcome) => {
+      await adapter.restore(context.gatewayId, outcome.metadata?.previousAssignments);
+    },
+  };
+}
+
+export interface ScaleOutContext {
+  component: string;
+  desiredReplicas: number;
+  maximumReplicas: number;
+}
+
+export interface ScaleOutAdapter {
+  currentReplicas(component: string): Promise<number>;
+  setReplicas(component: string, replicas: number): Promise<void>;
+  readyReplicas(component: string): Promise<number>;
+}
+
+export function createScaleOutAction(adapter: ScaleOutAdapter): RemediationAction<ScaleOutContext> {
+  return {
+    id: 'scale-out',
+    description: 'Increase replicas within an operator-supplied hard safety limit.',
+    risk: 'low',
+    scope: context => context.component,
+    precondition: async context => {
+      if (!context.component.trim()) return { needed: false, safe: false, reason: 'component is required' };
+      if (!Number.isInteger(context.desiredReplicas) || !Number.isInteger(context.maximumReplicas)) {
+        return { needed: false, safe: false, reason: 'Replica limits must be integers' };
+      }
+      if (context.desiredReplicas < 1 || context.desiredReplicas > context.maximumReplicas) {
+        return {
+          needed: false,
+          safe: false,
+          reason: 'desiredReplicas is outside the approved maximum',
+        };
+      }
+      const current = await adapter.currentReplicas(context.component);
+      if (context.desiredReplicas <= current) {
+        return { needed: false, safe: true, reason: `Already running ${current} replicas` };
+      }
+      return {
+        needed: true,
+        safe: true,
+        reason: `Scale ${context.component} from ${current} to ${context.desiredReplicas} replicas`,
+      };
+    },
+    execute: async context => {
+      const previousReplicas = await adapter.currentReplicas(context.component);
+      if (context.desiredReplicas <= previousReplicas) {
+        return {
+          changed: false,
+          message: `${context.component} already has ${previousReplicas} replicas; scale-down is forbidden`,
+        };
+      }
+      await adapter.setReplicas(context.component, context.desiredReplicas);
+      return {
+        changed: true,
+        message: `Scaled ${context.component} to ${context.desiredReplicas} replicas`,
+        metadata: { previousReplicas },
+      };
+    },
+    verify: async context => (await adapter.readyReplicas(context.component)) >= context.desiredReplicas,
+    rollback: async (context, outcome) => {
+      const previous = outcome.metadata?.previousReplicas;
+      if (!Number.isInteger(previous)) throw new Error('Rollback replica count is unavailable');
+      await adapter.setReplicas(context.component, previous as number);
+    },
+  };
+}
+
+export interface RemediationAuditSink {
+  append(result: RemediationResult): Promise<void>;
+}
+
+/** Durable append-only JSONL audit sink suitable for a mounted persistent volume. */
+export class JsonlRemediationAuditSink implements RemediationAuditSink {
+  readonly filePath: string;
+
+  constructor(filePath: string) {
+    if (!filePath.trim()) throw new Error('remediation audit file path is required');
+    this.filePath = resolve(filePath);
+  }
+
+  async append(result: RemediationResult): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const file = await open(this.filePath, 'a', 0o600);
+    try {
+      await file.writeFile(`${JSON.stringify(result)}\n`, 'utf8');
+      await file.sync();
+    } finally {
+      await file.close();
+    }
+  }
+}
+
+export interface RemediationRuntimeConfiguration {
+  gatewayFailover?: GatewayFailoverAdapter;
+  scaleOut?: ScaleOutAdapter;
+  auditSink: RemediationAuditSink;
+  policy?: RemediationPolicy;
+}
+
+export class RemediationRuntimeUnavailableError extends Error {
+  constructor() {
+    super('SRE remediation runtime is not configured with deployment adapters and a durable audit sink');
+    this.name = 'RemediationRuntimeUnavailableError';
+  }
+}
+
+export class RemediationAuditPersistenceError extends Error {
+  readonly result: RemediationResult;
+
+  constructor(result: RemediationResult, cause: unknown) {
+    super(`Remediation result could not be durably audited: ${
+      cause instanceof Error ? cause.message : String(cause)
+    }`);
+    this.name = 'RemediationAuditPersistenceError';
+    this.result = structuredClone(result);
+  }
+}
+
+/**
+ * Production composition boundary. The server exposes only the two bounded
+ * actions created here, and remains fail-closed until the deployment injects
+ * real gateway/scaler adapters plus a durable audit sink.
+ */
+export class RemediationRuntime {
+  private engine?: AutoRemediationEngine;
+  private auditSink?: RemediationAuditSink;
+  private persistenceTail: Promise<void> = Promise.resolve();
+
+  configure(configuration: RemediationRuntimeConfiguration): void {
+    if (this.engine !== undefined) throw new Error('SRE remediation runtime is already configured');
+    const actions: RemediationAction<unknown>[] = [];
+    if (configuration.gatewayFailover !== undefined) {
+      actions.push(createGatewayFailoverAction(configuration.gatewayFailover) as RemediationAction<unknown>);
+    }
+    if (configuration.scaleOut !== undefined) {
+      actions.push(createScaleOutAction(configuration.scaleOut) as RemediationAction<unknown>);
+    }
+    if (actions.length === 0) {
+      throw new Error('At least one remediation deployment adapter is required');
+    }
+    this.auditSink = configuration.auditSink;
+    this.engine = new AutoRemediationEngine(actions, {
+      ...configuration.policy,
+      allowedActionIds: configuration.policy?.allowedActionIds ?? actions.map(action => action.id),
+    });
+  }
+
+  status(): {
+    configured: boolean;
+    actions: ReadonlyArray<Pick<RemediationAction, 'id' | 'description' | 'risk'>>;
+  } {
+    return {
+      configured: this.engine !== undefined,
+      actions: this.engine?.listActions() ?? [],
+    };
+  }
+
+  async execute(request: RemediationRequest<unknown>): Promise<RemediationResult> {
+    if (this.engine === undefined || this.auditSink === undefined) {
+      throw new RemediationRuntimeUnavailableError();
+    }
+    const result = await this.engine.execute(request);
+    const auditCopy = structuredClone(result);
+    const persistence = this.persistenceTail.then(() => this.auditSink!.append(auditCopy));
+    this.persistenceTail = persistence.catch(() => undefined);
+    try {
+      await persistence;
+    } catch (error) {
+      throw new RemediationAuditPersistenceError(result, error);
+    }
+    return result;
+  }
+}
+
+export const sloRegistry = new SloRegistry();
+export const remediationRuntime = new RemediationRuntime();
+
+export function configureRemediationRuntime(configuration: RemediationRuntimeConfiguration): void {
+  remediationRuntime.configure(configuration);
+}


### PR DESCRIPTION
## Summary

- Defines production SLO/SLI objectives and error-budget evaluation for seven critical paths, with an operational SLO catalog.
- Adds bounded, idempotent gateway-failover and scale-out remediation actions with dry-run defaults, cooldowns, immediate pre-mutation checks, bounded caches, and durable audit-sink support.
- Adds role/scope-protected remediation and SLO governance endpoints plus incident, escalation, recovery, failover, scaling, remediation, and post-mortem playbooks.

Closes #226

## Safety and compatibility

- Remediation fails closed until production adapters and an audit sink are injected through route registration.
- Apply requests require an operator principal with `sre.remediate`; audit identity is derived from the authenticated principal rather than request input.
- The central mutation policy explicitly protects the remediation route family.
- The dedicated router and service export contain no compliance or capacity-planning implementation.

## Attribution

City-Agent: Codex

## Verification

```text
npx vitest run server/services/sre/__tests__/sre.test.ts server/routes/__tests__/sre-readiness.test.ts server/middleware/__tests__/control-route-policy.test.ts
# 3 files passed; 34 tests passed

npm run typecheck
# passed

npm run build:server
# passed

git diff --cached --check
# passed before commit
```

## Gate self-check

- [x] Every commit is signed off (`git commit -s` → `Signed-off-by` line, DCO)
- [x] The `City-Agent:` line above is filled in
- [x] `npx tsc --noEmit` is clean
- [x] No new `any` types
- [x] Barrel export and dynamic service registry updated
- [x] Tests added/updated for every claim in the summary
- [x] PR is scoped to a single issue
