### PR TITLE
feat(compliance): add certification toolkit (#225)

### DIFF
--- a/docs/compliance/assessment-guide.md
+++ b/docs/compliance/assessment-guide.md
@@ -1,0 +1,123 @@
+# Compliance Assessment Operations
+
+## Purpose and boundaries
+
+The toolkit automates evidence evaluation, IEC 62443 readiness levels, NIST CSF
+mapping, gap analysis, and audit-report assembly. It does not turn a platform
+feature into deployment evidence and does not replace an accredited assessor.
+Evidence must describe the deployed environment being assessed.
+
+## Evidence contract
+
+Each artifact has:
+
+```json
+{
+  "key": "access.defaultDeny",
+  "value": true,
+  "source": "cluster-policy-export/sha256:…",
+  "collectedAt": "2026-07-28T12:00:00.000Z",
+  "description": "Default-deny policies validated in all production namespaces"
+}
+```
+
+- `key` is one of the control-catalog evidence keys.
+- `value` must satisfy the key-specific contract returned as
+  `evidenceRequirements` by `GET /api/governance/compliance/rules`. Boolean
+  controls require the literal value `true`; a non-empty string such as
+  `"disabled"` is never treated as a passing attestation. Owner keys require a
+  non-negative identifier, `availability.capacityHeadroom` requires a positive
+  number, and `network.zoneInventory` requires a non-empty string list.
+- `source` identifies a reproducible export, query, or immutable artifact.
+- `collectedAt` is ISO-8601. When duplicate keys exist, the newest observation
+  wins.
+
+Collectors implement `EvidenceCollector`. A collector failure fails the scan;
+the toolkit does not silently continue with a partial source.
+
+Production deployments can inject collectors through
+`registerRoutes(..., { complianceCollectors: [...] })`. A concrete
+`JsonFileEvidenceCollector` is included for evidence snapshots mounted by
+deployment automation. Set `COMPLIANCE_EVIDENCE_FILE` to register that
+collector automatically at boot. The document shape is:
+
+```json
+{
+  "source": "cluster-policy-export/sha256:…",
+  "collectedAt": "2026-07-28T12:00:00.000Z",
+  "evidence": {
+    "access.rbacEnabled": true,
+    "network.zoneInventory": ["operations", "safety"]
+  }
+}
+```
+
+The file is re-read for every scan, is capped at 1 MiB by default, and invalid
+JSON or unsupported values fail the scan.
+
+## Run a scan
+
+```http
+POST /api/governance/compliance/scan
+Content-Type: application/json
+
+{
+  "scope": "full",
+  "frameworks": ["IEC-62443", "NIST-CSF"],
+  "targetSecurityLevel": 2,
+  "evidence": [
+    {
+      "key": "identity.adminMfa",
+      "value": true,
+      "source": "iam-policy-export/2026-07-28",
+      "collectedAt": "2026-07-28T12:00:00.000Z"
+    }
+  ]
+}
+```
+
+A `targeted` scan must supply `controlIds` (the legacy `rules` field is also
+accepted). Server-managed recurring scans are enabled with
+`COMPLIANCE_SCAN_INTERVAL_MS`; values below 60 seconds are ignored for safety.
+Collectors and the recurring timer start while server routes are registered,
+not after the first scan request. The API rejects `schedule: true` so it cannot
+pretend an in-memory request was durably scheduled.
+
+Interpretation:
+
+- `compliant`: every applicable control passed;
+- `non-compliant`: at least one control has negative evidence;
+- `incomplete`: no negative evidence, but at least one artifact is missing.
+
+## Review gaps
+
+`GET /api/governance/compliance/findings/:scanId` returns failed and unassessed
+controls separately, with missing keys, negative keys, severity, and
+remediation. Critical gaps should become owned work items before an external
+assessment. Do not rewrite `not-assessed` as `pass`.
+
+## Generate and retain the audit artifact
+
+```http
+POST /api/governance/compliance/reports/scan-0123456789abcdef
+Content-Type: application/json
+
+{
+  "organization": "Example Water Utility",
+  "auditor": "Internal Controls",
+  "scope": "Production gateways, API, historian, and integrity pipeline"
+}
+```
+
+The report contains an executive summary, framework summaries, all gaps, an
+evidence manifest, Markdown output, and a SHA-256 content digest. Retain:
+
+1. the JSON report;
+2. the evidence objects referenced in its manifest;
+3. the catalog version;
+4. the deployment/configuration commit;
+5. reviewer sign-off and any accepted-risk record.
+
+Verify the retained report digest before handing it to a certification body.
+The digest provides change detection, not signer identity; apply the
+organization's document-signing process when non-repudiation is required.

--- a/docs/compliance/iec-62443-mapping.md
+++ b/docs/compliance/iec-62443-mapping.md
@@ -1,78 +1,72 @@
-# IEC 62443 Compliance Mapping — 0xSCADA
+# IEC 62443 Assessment Mapping
 
-## Overview
+0xSCADA implements an automated, evidence-based readiness assessment for the
+IEC 62443 foundational requirements. It is an engineering aid for certification
+work; it does not assert that a deployment is certified. Only an accredited
+assessor can make that determination.
 
-This document maps 0xSCADA platform capabilities to IEC 62443 (Industrial Automation and Control Systems Security) requirements.
+The versioned catalog lives in
+`server/services/compliance/index.ts` (`COMPLIANCE_CATALOG_VERSION`). A control
+passes only when every required evidence key is present and positive. A
+negative observation is `fail`; absent evidence is `not-assessed`. Missing
+evidence is never counted as a pass.
 
-## Security Levels
+## Security-level calculation
 
-| Level | Description | 0xSCADA Support |
-|-------|-------------|-----------------|
-| SL 1 | Protection against casual/unintentional violation | ✅ Full |
-| SL 2 | Protection against intentional violation using simple means | ✅ Full |
-| SL 3 | Protection against sophisticated attack with moderate resources | ✅ Partial |
-| SL 4 | Protection against state-sponsored attack | 🔲 Planned |
+Security levels are cumulative:
 
-## Control Mapping
+- SL 1 evaluates the seven foundational-requirement controls.
+- SL 2 adds administrator/remote MFA and tested zone boundaries.
+- SL 3 adds vulnerability gates and managed key/certificate rotation.
+- SL 4 adds hardware-backed, non-exportable root keys.
 
-### FR 1 — Identification and Authentication
+`achievedSecurityLevel` is the highest level for which every control at that
+level and every lower level passes. One failed or unassessed SL 1 control means
+the automated result is SL 0, even if higher-level controls have evidence.
 
-| Requirement | 0xSCADA Implementation | Status |
-|-------------|----------------------|--------|
-| IAC-1: Human user identification | Unique user accounts with JWT | ✅ |
-| IAC-2: Software process identification | Service-to-service mTLS | ✅ |
-| IAC-3: Hardware device identification | Gateway certificate enrollment | ✅ |
-| IAC-7: Password-based authentication | bcrypt hashing, complexity rules | ✅ |
-| IAC-8: Certificate-based authentication | X.509 for gateway/federation | ✅ |
-| IAC-11: Multi-factor authentication | TOTP support for privileged access | ✅ |
+## Control and evidence mapping
 
-### FR 2 — Use Control (Authorization)
+| Toolkit control | FR | Level | Required evidence keys | Equivalent NIST CSF controls |
+|---|---|---:|---|---|
+| `IEC62443-FR1-IAC-1` | FR 1 Identification and authentication | 1 | `identity.uniqueUsers`, `identity.serviceAccountsInventoried` | `NIST-PR.AA-01` |
+| `IEC62443-FR2-UC-1` | FR 2 Use control | 1 | `access.rbacEnabled`, `access.defaultDeny` | `NIST-PR.AA-05` |
+| `IEC62443-FR3-SI-1` | FR 3 System integrity | 1 | `integrity.signedArtifacts`, `integrity.configurationAudit` | `NIST-PR.PS-06` |
+| `IEC62443-FR4-DC-1` | FR 4 Data confidentiality | 1 | `crypto.tlsEnabled`, `crypto.atRestEncryption` | `NIST-PR.DS-01`, `NIST-PR.DS-02` |
+| `IEC62443-FR5-RDF-1` | FR 5 Restricted data flow | 1 | `network.zoneInventory`, `network.defaultDenyPolicy` | `NIST-PR.IR-01` |
+| `IEC62443-FR6-TRE-1` | FR 6 Timely response to events | 1 | `monitoring.securityEvents`, `response.onCallOwned` | `NIST-DE.CM-01`, `NIST-RS.MA-01` |
+| `IEC62443-FR7-RA-1` | FR 7 Resource availability | 1 | `recovery.backupVerified`, `availability.capacityHeadroom` | `NIST-RC.RP-01` |
+| `IEC62443-SL2-IAC-2` | FR 1 Identification and authentication | 2 | `identity.adminMfa`, `identity.remoteMfa` | `NIST-PR.AA-03` |
+| `IEC62443-SL2-RDF-2` | FR 5 Restricted data flow | 2 | `network.policyTested` | `NIST-ID.RA-01` |
+| `IEC62443-SL3-SI-2` | FR 3 System integrity | 3 | `integrity.dependencyScan`, `integrity.imageScan` | `NIST-ID.RA-01`, `NIST-PR.PS-06` |
+| `IEC62443-SL3-DC-2` | FR 4 Data confidentiality | 3 | `crypto.rotationAutomated`, `crypto.revocationTested` | `NIST-PR.DS-01` |
+| `IEC62443-SL4-SI-3` | FR 3 System integrity | 4 | `integrity.hardwareBackedKeys` | `NIST-PR.PS-06` |
 
-| Requirement | 0xSCADA Implementation | Status |
-|-------------|----------------------|--------|
-| UC-1: Authorization enforcement | Role-based access control | ✅ |
-| UC-2: Wireless use control | N/A (IP-based) | N/A |
-| UC-6: Remote session termination | JWT expiry + active revocation | ✅ |
-| UC-8: Auditable events | Blockchain-backed audit trail | ✅ |
+Every scan returns the per-FR pass/applicable counts, its target and achieved
+security levels, the evidence manifest, and actionable gaps.
 
-### FR 3 — System Integrity
+## Example assessment
 
-| Requirement | 0xSCADA Implementation | Status |
-|-------------|----------------------|--------|
-| SI-1: Communication integrity | TLS 1.3 + message signing | ✅ |
-| SI-2: Malware protection | Container isolation, read-only FS | ✅ |
-| SI-3: Security functionality verification | Health manager + compliance scanner | ✅ |
-| SI-7: Input validation | Schema validation on all endpoints | ✅ |
+```ts
+import {
+  ComplianceScanner,
+  ObjectEvidenceCollector,
+} from '../../server/services/compliance';
 
-### FR 4 — Data Confidentiality
+const collector = new ObjectEvidenceCollector('iam-and-runtime', {
+  'identity.uniqueUsers': true,
+  'identity.serviceAccountsInventoried': true,
+  'access.rbacEnabled': true,
+  'access.defaultDeny': true,
+});
 
-| Requirement | 0xSCADA Implementation | Status |
-|-------------|----------------------|--------|
-| DC-1: Information confidentiality | AES-256 encryption at rest | ✅ |
-| DC-2: Network segmentation | VLAN-aware deployment, gateway isolation | ✅ |
+const scanner = new ComplianceScanner({ collectors: [collector] });
+const scan = await scanner.runScan({
+  frameworks: ['IEC-62443'],
+  targetSecurityLevel: 1,
+});
 
-### FR 5 — Restricted Data Flow
+console.log(scan.iec62443?.achievedSecurityLevel, scan.gaps);
+```
 
-| Requirement | 0xSCADA Implementation | Status |
-|-------------|----------------------|--------|
-| RDF-1: Network segmentation | DMZ architecture for OT/IT boundary | ✅ |
-| RDF-2: Zone boundary protection | Gateway acts as security boundary | ✅ |
-
-### FR 6 — Timely Response to Events
-
-| Requirement | 0xSCADA Implementation | Status |
-|-------------|----------------------|--------|
-| TRE-1: Audit log accessibility | Real-time log streaming + historian | ✅ |
-| TRE-2: Continuous monitoring | Health manager + anomaly detection | ✅ |
-
-### FR 7 — Resource Availability
-
-| Requirement | 0xSCADA Implementation | Status |
-|-------------|----------------------|--------|
-| RA-1: DoS protection | Rate limiting, connection pooling | ✅ |
-| RA-2: Resource management | Capacity planner + auto-scaling | ✅ |
-| RA-7: Backup/recovery | Historian snapshots + store-and-forward | ✅ |
-
-## Evidence Collection
-
-The compliance scanner (`server/compliance/compliance-scanner.ts`) automatically evaluates these controls and generates evidence for audit purposes.
+See [Compliance assessment operations](assessment-guide.md) for evidence
+provenance, API use, report generation, and review requirements.

--- a/docs/compliance/nist-csf-mapping.md
+++ b/docs/compliance/nist-csf-mapping.md
@@ -1,61 +1,56 @@
-# NIST Cybersecurity Framework Mapping — 0xSCADA
+# NIST Cybersecurity Framework 2.0 Mapping
 
-## Overview
+The compliance toolkit maps evidence across all six NIST CSF 2.0 functions.
+The mapping is a maintained engineering interpretation, not a certification or
+legal opinion. Catalog version and individual mapped IEC 62443 controls are
+included in every scan.
 
-Mapping of 0xSCADA capabilities to the NIST Cybersecurity Framework (CSF) v2.0 functions.
+## Automated control set
 
-## Function Mapping
+| Function | Toolkit control | Assessment intent | Required evidence |
+|---|---|---|---|
+| Govern | `NIST-GV.OC-01` | OT cybersecurity ownership and approved policy | `governance.securityOwner`, `governance.securityPolicyApproved` |
+| Identify | `NIST-ID.AM-01` | Current asset inventory with ownership | `assets.inventoryCurrent` |
+| Identify | `NIST-ID.RA-01` | Dependency and image vulnerability discovery | `integrity.dependencyScan`, `integrity.imageScan` |
+| Protect | `NIST-PR.AA-01` | Identity lifecycle management | `identity.uniqueUsers`, `identity.serviceAccountsInventoried` |
+| Protect | `NIST-PR.AA-03` | Strong privileged and remote authentication | `identity.adminMfa`, `identity.remoteMfa` |
+| Protect | `NIST-PR.AA-05` | Least privilege and deny by default | `access.rbacEnabled`, `access.defaultDeny` |
+| Protect | `NIST-PR.DS-01` | Protected data at rest | `crypto.atRestEncryption` |
+| Protect | `NIST-PR.DS-02` | Protected data in transit | `crypto.tlsEnabled` |
+| Protect | `NIST-PR.PS-06` | Software and configuration integrity | `integrity.signedArtifacts`, `integrity.configurationAudit` |
+| Protect | `NIST-PR.IR-01` | Network zones and allowlisted conduits | `network.zoneInventory`, `network.defaultDenyPolicy` |
+| Detect | `NIST-DE.CM-01` | Continuous security-event monitoring | `monitoring.securityEvents` |
+| Respond | `NIST-RS.MA-01` | Owned and exercised response process | `response.onCallOwned`, `response.exerciseCompleted` |
+| Recover | `NIST-RC.RP-01` | Verified backups and recovery exercises | `recovery.backupVerified`, `recovery.exerciseCompleted` |
 
-### IDENTIFY (ID)
+## Scoring
 
-| Category | Subcategory | 0xSCADA Implementation | Status |
-|----------|-------------|----------------------|--------|
-| Asset Management | ID.AM-1: Physical device inventory | Gateway auto-discovery, tag registry | ✅ |
-| Asset Management | ID.AM-2: Software inventory | Package manifest, dependency tracking | ✅ |
-| Asset Management | ID.AM-5: Resource prioritization | Tag priority classification | ✅ |
-| Risk Assessment | ID.RA-1: Vulnerability identification | Compliance scanner, dependency audit | ✅ |
-| Risk Assessment | ID.RA-5: Risk response identification | Auto-remediation rules | ✅ |
+Each function reports:
 
-### PROTECT (PR)
+- `passed`: controls whose complete evidence set is positive;
+- `assessed`: controls with either positive or negative evidence;
+- `total`: all applicable controls in the function;
+- `score`: passed controls divided by total controls.
 
-| Category | Subcategory | 0xSCADA Implementation | Status |
-|----------|-------------|----------------------|--------|
-| Access Control | PR.AC-1: Identity management | JWT + RBAC | ✅ |
-| Access Control | PR.AC-3: Remote access management | mTLS, VPN-aware deployment | ✅ |
-| Access Control | PR.AC-5: Network integrity | Gateway segmentation, TLS everywhere | ✅ |
-| Data Security | PR.DS-1: Data-at-rest protection | AES-256 encryption | ✅ |
-| Data Security | PR.DS-2: Data-in-transit protection | TLS 1.3 | ✅ |
-| Data Security | PR.DS-6: Integrity checking | Blockchain anchoring, Merkle verification | ✅ |
-| Maintenance | PR.MA-1: Maintenance performed | Zero-downtime upgrade system | ✅ |
-| Protective Tech | PR.PT-1: Audit/log records | Immutable blockchain audit trail | ✅ |
+Unassessed controls remain in the denominator. This prevents an incomplete
+evidence export from inflating the score.
 
-### DETECT (DE)
+## Example scan
 
-| Category | Subcategory | 0xSCADA Implementation | Status |
-|----------|-------------|----------------------|--------|
-| Anomalies | DE.AE-1: Baseline established | Predictive maintenance baselines | ✅ |
-| Anomalies | DE.AE-3: Event data collected | Event pipeline + historian | ✅ |
-| Anomalies | DE.AE-5: Incident alert thresholds | Alarm correlator, configurable thresholds | ✅ |
-| Monitoring | DE.CM-1: Network monitoring | Health manager, connection tracking | ✅ |
-| Monitoring | DE.CM-7: Unauthorized monitoring | Gateway anomaly detection | ✅ |
+```ts
+import { ComplianceScanner } from '../../server/services/compliance';
 
-### RESPOND (RS)
+const scanner = new ComplianceScanner();
+const result = await scanner.runScan('NIST-CSF', evidence);
 
-| Category | Subcategory | 0xSCADA Implementation | Status |
-|----------|-------------|----------------------|--------|
-| Response Planning | RS.RP-1: Response plan execution | SRE playbooks + auto-remediation | ✅ |
-| Communications | RS.CO-2: Incident reporting | Post-mortem templates, escalation | ✅ |
-| Mitigation | RS.MI-1: Incident containment | Gateway isolation, connection draining | ✅ |
-| Mitigation | RS.MI-3: Vulnerability mitigation | Rolling updates, feature flags | ✅ |
+for (const summary of result.nistCsf!.functions) {
+  console.log(summary.function, summary.score);
+}
+```
 
-### RECOVER (RC)
+The HTTP equivalent is `POST /api/governance/compliance/scan`; use
+`frameworks: ["NIST-CSF"]` and an `evidence` array. Generate a signed-content
+audit artifact with `POST /api/governance/compliance/reports/:scanId`.
 
-| Category | Subcategory | 0xSCADA Implementation | Status |
-|----------|-------------|----------------------|--------|
-| Recovery Planning | RC.RP-1: Recovery plan execution | Database recovery playbook | ✅ |
-| Improvements | RC.IM-1: Lessons learned | Post-mortem templates | ✅ |
-| Communications | RC.CO-3: Recovery communication | Incident response runbook | ✅ |
-
-## Automated Assessment
-
-Run `ComplianceScanner.runScan('NIST-CSF')` for automated evaluation against these controls.
+See [Compliance assessment operations](assessment-guide.md) for the complete
+request and evidence-handling procedure.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -29,6 +29,11 @@ import { marketplaceRoutes } from "./routes/marketplace";
 import { marketplaceService } from "./services/marketplace";
 import { nlQueryService } from "./services/nlquery";
 import { governanceRoutes } from "./routes/governance";
+import { complianceReadinessRoutes } from "./routes/compliance-readiness";
+import {
+  complianceService,
+  type EvidenceCollector,
+} from "./services/compliance";
 import { securityRoutes } from "./routes/security";
 import { geometryRoutes } from "./routes/geometry";
 import {
@@ -50,6 +55,7 @@ import type { WebSocketAuthOptions } from "./websocket/upgrade-auth";
 
 export interface RouteRegistrationOptions {
   websocketAuth?: WebSocketAuthOptions;
+  complianceCollectors?: readonly EvidenceCollector[];
 }
 
 export async function registerRoutes(
@@ -57,6 +63,11 @@ export async function registerRoutes(
   app: Express,
   options: RouteRegistrationOptions = {},
 ): Promise<Server> {
+  for (const collector of options.complianceCollectors ?? []) {
+    complianceService.registerCollector(collector);
+  }
+  // Start registered collectors and recurring scans at process boot.
+  await complianceService.initialize();
 
   // ==========================================================================
   // MODULAR ROUTES
@@ -83,6 +94,9 @@ export async function registerRoutes(
   // already calls (client/src/pages/pid-view.tsx -> /api/pid/diagrams/:id).
   app.use("/api/tuning", tuningRoutes);
   app.use("/api/marketplace", marketplaceRoutes);  // ADR-0013 [13.6] (#217)
+  // Mount before the legacy governance router so real scan results win over
+  // its historical placeholder handlers.
+  app.use("/api/governance", complianceReadinessRoutes);
   app.use("/api/governance", governanceRoutes);
   app.use("/api/security", securityRoutes);
   app.use("/api/geometry", geometryRoutes(getFluxPublisher()));

--- a/server/routes/__tests__/compliance-readiness.test.ts
+++ b/server/routes/__tests__/compliance-readiness.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import express from 'express';
+import type { Server } from 'node:http';
+import { complianceReadinessRoutes } from '../compliance-readiness';
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/governance', complianceReadinessRoutes);
+  await new Promise<void>(resolve => {
+    server = app.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (typeof address !== 'object' || address === null) throw new Error('Test server did not bind');
+  baseUrl = `http://127.0.0.1:${address.port}/api/governance`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => error ? reject(error) : resolve());
+  });
+});
+
+describe('governance compliance routes', () => {
+  it('exposes the versioned control catalog and typed evidence contract', async () => {
+    const response = await fetch(`${baseUrl}/compliance/rules?framework=IEC-62443`);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.catalogVersion).toBe('2026.1');
+    expect(body.rules.length).toBeGreaterThanOrEqual(7);
+    expect(body.rules.every((rule: { framework: string }) => rule.framework === 'IEC-62443'))
+      .toBe(true);
+    expect(body.evidenceRequirements['identity.adminMfa'].kind).toBe('true-attestation');
+  });
+
+  it('runs a real targeted evidence scan and generates its audit report', async () => {
+    const response = await fetch(`${baseUrl}/compliance/scan`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        scope: 'targeted',
+        frameworks: ['IEC-62443'],
+        targetSecurityLevel: 1,
+        controlIds: ['IEC62443-FR1-IAC-1'],
+        evidence: [
+          {
+            key: 'identity.uniqueUsers',
+            value: true,
+            source: 'iam-export',
+            collectedAt: '2026-07-28T12:00:00.000Z',
+          },
+          {
+            key: 'identity.serviceAccountsInventoried',
+            value: true,
+            source: 'cmdb-export',
+            collectedAt: '2026-07-28T12:00:00.000Z',
+          },
+        ],
+      }),
+    });
+    const scan = await response.json();
+    expect(response.status).toBe(200);
+    expect(scan).toMatchObject({
+      status: 'compliant',
+      complianceScore: 100,
+      summary: { total: 1, passed: 1, failed: 0, notAssessed: 0 },
+    });
+    expect(scan.iec62443.achievedSecurityLevel).toBe(0);
+
+    const reportResponse = await fetch(`${baseUrl}/compliance/reports/${scan.scanId}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ organization: 'Route Test Utility' }),
+    });
+    const report = await reportResponse.json();
+    expect(reportResponse.status).toBe(200);
+    expect(report.scanId).toBe(scan.scanId);
+    expect(report.scope).toBe('Targeted controls: IEC62443-FR1-IAC-1');
+    expect(report.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('rejects a scheduled request instead of pretending it was scheduled', async () => {
+    const response = await fetch(`${baseUrl}/compliance/scan`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ schedule: true }),
+    });
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/COMPLIANCE_SCAN_INTERVAL_MS/);
+  });
+});

--- a/server/routes/compliance-readiness.ts
+++ b/server/routes/compliance-readiness.ts
@@ -1,0 +1,132 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { complianceService } from '../services/compliance';
+
+const router = Router();
+
+const EvidenceValueSchema = z.union([
+  z.boolean(),
+  z.number().finite(),
+  z.string(),
+  z.array(z.string()),
+]);
+
+const ComplianceEvidenceSchema = z.object({
+  key: z.string().min(1),
+  value: EvidenceValueSchema,
+  source: z.string().min(1),
+  collectedAt: z.string().datetime({ offset: true }).optional(),
+  description: z.string().optional(),
+});
+
+const ComplianceScanSchema = z.object({
+  scope: z.enum(['full', 'incremental', 'targeted']).default('full'),
+  frameworks: z.array(z.enum(['IEC-62443', 'NIST-CSF'])).min(1)
+    .default(['IEC-62443', 'NIST-CSF']),
+  targetSecurityLevel: z.number().int().min(1).max(4).default(2),
+  evidence: z.array(ComplianceEvidenceSchema).default([]),
+  /** Legacy name retained for API compatibility; these are control ids. */
+  rules: z.array(z.string().min(1)).optional(),
+  controlIds: z.array(z.string().min(1)).optional(),
+  target: z.string().min(1).optional(),
+  schedule: z.boolean().default(false),
+}).superRefine((value, context) => {
+  if (value.schedule) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['schedule'],
+      message: 'Use COMPLIANCE_SCAN_INTERVAL_MS for server-managed recurring scans',
+    });
+  }
+  if (value.scope === 'targeted'
+    && value.controlIds === undefined
+    && value.rules === undefined
+    && value.target === undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['controlIds'],
+      message: 'A targeted scan requires controlIds, rules, or target',
+    });
+  }
+});
+
+const AuditReportSchema = z.object({
+  organization: z.string().min(1),
+  auditor: z.string().min(1).optional(),
+  scope: z.string().min(1).optional(),
+});
+
+function errorMessage(error: unknown): string {
+  if (error instanceof z.ZodError) {
+    return error.issues
+      .map(issue => `${issue.path.join('.') || 'request'}: ${issue.message}`)
+      .join('; ');
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+router.post('/compliance/scan', async (req, res) => {
+  try {
+    const request = ComplianceScanSchema.parse(req.body);
+    const selectedIds = request.controlIds
+      ?? request.rules
+      ?? (request.target === undefined ? undefined : [request.target]);
+    const result = await complianceService.scan({
+      frameworks: request.frameworks,
+      targetSecurityLevel: request.targetSecurityLevel as 1 | 2 | 3 | 4,
+      controlIds: selectedIds,
+      evidence: request.evidence.map(evidence => ({
+        ...evidence,
+        collectedAt: evidence.collectedAt ?? new Date().toISOString(),
+      })),
+    });
+    res.json(result);
+  } catch (error) {
+    res.status(400).json({ error: errorMessage(error) });
+  }
+});
+
+router.get('/compliance/scans', (req, res) => {
+  try {
+    const limit = z.coerce.number().int().min(1).max(100).default(20).parse(req.query.limit);
+    res.json({ scans: complianceService.getScans(limit) });
+  } catch (error) {
+    res.status(400).json({ error: errorMessage(error) });
+  }
+});
+
+router.get('/compliance/findings/:scanId', (req, res) => {
+  const scan = complianceService.getScan(req.params.scanId);
+  if (scan === undefined) {
+    res.status(404).json({ error: `Unknown compliance scan: ${req.params.scanId}` });
+    return;
+  }
+  res.json({ scanId: scan.scanId, findings: scan.gaps, summary: scan.summary });
+});
+
+router.get('/compliance/rules', (req, res) => {
+  try {
+    const framework = z.enum(['IEC-62443', 'NIST-CSF']).optional().parse(req.query.framework);
+    res.json({
+      catalogVersion: complianceService.getStatus().catalogVersion,
+      rules: complianceService.getControls(framework),
+      evidenceRequirements: complianceService.getEvidenceRequirements(),
+    });
+  } catch (error) {
+    res.status(400).json({ error: errorMessage(error) });
+  }
+});
+
+router.post('/compliance/reports/:scanId', (req, res) => {
+  try {
+    const options = AuditReportSchema.parse(req.body);
+    res.json(complianceService.generateAuditReport(req.params.scanId, options));
+  } catch (error) {
+    const status = error instanceof Error && error.message.startsWith('Unknown compliance scan')
+      ? 404
+      : 400;
+    res.status(status).json({ error: errorMessage(error) });
+  }
+});
+
+export { router as complianceReadinessRoutes };

--- a/server/services/compliance/__tests__/compliance-rollup.test.ts
+++ b/server/services/compliance/__tests__/compliance-rollup.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Pins the scan-level status rollup, and specifically the `incomplete` branch.
+ *
+ * `runScan` resolves a scan to:
+ *
+ *   failed > 0        -> 'non-compliant'
+ *   notAssessed > 0   -> 'incomplete'
+ *   otherwise         -> 'compliant'
+ *
+ * The existing suite asserts `compliant` and `non-compliant`, and asserts
+ * `summary.notAssessed` counts and per-control `not-assessed` statuses — but
+ * never the scan-level `incomplete`. Mutation testing confirmed the middle
+ * branch could be deleted entirely (collapsing unassessed scans to
+ * `compliant`) with all 14 tests still green.
+ *
+ * That is the one regression which reproduces the exact defect this module was
+ * written to remove: #605/#638 flagged the old service for fabricating results
+ * with `Math.random()`, and the fix was to distinguish "assessed and passing"
+ * from "never assessed". A rollup that reports `compliant` for controls it
+ * never looked at asserts compliance nobody measured — and on an IEC 62443 /
+ * NIST CSF surface that assertion ends up in an audit packet.
+ *
+ * Each case isolates one branch so a failure names which transition broke.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  COMPLIANCE_CONTROL_CATALOG,
+  COMPLIANCE_EVIDENCE_REQUIREMENTS,
+  ComplianceScanner,
+  type ComplianceEvidence,
+} from '../index';
+
+const FIXED_DATE = new Date('2026-07-28T12:00:00.000Z');
+const now = () => new Date(FIXED_DATE);
+
+function passingValue(key: string): ComplianceEvidence['value'] {
+  const requirement = COMPLIANCE_EVIDENCE_REQUIREMENTS[key];
+  if (requirement.kind === 'positive-number') return 30;
+  if (requirement.kind === 'non-empty-string') return 'security-operations';
+  if (requirement.kind === 'non-empty-string-list') return ['zone-a', 'zone-b'];
+  return true;
+}
+
+function evidenceFor(keys: readonly string[]): ComplianceEvidence[] {
+  return [...keys].sort().map(key => ({
+    key,
+    value: passingValue(key),
+    source: 'unit-test',
+    collectedAt: FIXED_DATE.toISOString(),
+  }));
+}
+
+function allEvidenceKeys(): string[] {
+  return [...new Set(COMPLIANCE_CONTROL_CATALOG.flatMap(control => control.evidenceKeys))].sort();
+}
+
+describe('compliance scan status rollup', () => {
+  it('reports incomplete — never compliant — when controls were not assessed', async () => {
+    // No evidence at all: nothing can pass, but nothing failed either. The
+    // scan must not present this as compliance.
+    const scan = await new ComplianceScanner({ now }).runScan({
+      frameworks: ['IEC-62443'],
+      evidence: [],
+    });
+
+    expect(scan.summary.notAssessed).toBeGreaterThan(0);
+    // Isolate the branch: with no failures, the only thing separating
+    // 'incomplete' from 'compliant' is the notAssessed count.
+    expect(scan.summary.failed).toBe(0);
+    expect(scan.status).toBe('incomplete');
+  });
+
+  it('still reports incomplete when some controls pass and others are unassessed', async () => {
+    // The partial case, which is what a real deployment looks like mid-rollout.
+    // Supply every evidence key for exactly one control — enough for that
+    // control to pass, leaving the rest unassessed. Passing controls must not
+    // mask the gap.
+    const iecControls = COMPLIANCE_CONTROL_CATALOG.filter(
+      control => control.evidenceKeys.length > 0,
+    );
+    const oneControl = iecControls[0];
+    const scan = await new ComplianceScanner({ now }).runScan({
+      frameworks: ['IEC-62443'],
+      evidence: evidenceFor(oneControl.evidenceKeys),
+    });
+
+    expect(scan.summary.passed).toBeGreaterThan(0);
+    expect(scan.summary.notAssessed).toBeGreaterThan(0);
+    expect(scan.summary.failed).toBe(0);
+    expect(scan.status).toBe('incomplete');
+  });
+
+  it('reports compliant only when every control was assessed and passed', async () => {
+    const scan = await new ComplianceScanner({ now }).runScan({
+      frameworks: ['IEC-62443'],
+      evidence: evidenceFor(allEvidenceKeys()),
+    });
+
+    expect(scan.summary.notAssessed).toBe(0);
+    expect(scan.summary.failed).toBe(0);
+    expect(scan.status).toBe('compliant');
+  });
+
+  it('a failure outranks an unassessed control', async () => {
+    // Both branches active at once: failed > 0 must win, so an operator is
+    // told about the failure rather than merely that the scan was partial.
+    const keys = allEvidenceKeys();
+    const failing: ComplianceEvidence[] = [
+      {
+        key: keys[0],
+        value: false,
+        source: 'unit-test',
+        collectedAt: FIXED_DATE.toISOString(),
+      },
+    ];
+
+    const scan = await new ComplianceScanner({ now }).runScan({
+      frameworks: ['IEC-62443'],
+      evidence: failing,
+    });
+
+    expect(scan.summary.failed).toBeGreaterThan(0);
+    expect(scan.summary.notAssessed).toBeGreaterThan(0);
+    expect(scan.status).toBe('non-compliant');
+  });
+});

--- a/server/services/compliance/__tests__/compliance-toolkit.test.ts
+++ b/server/services/compliance/__tests__/compliance-toolkit.test.ts
@@ -1,0 +1,301 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  COMPLIANCE_CONTROL_CATALOG,
+  COMPLIANCE_EVIDENCE_REQUIREMENTS,
+  ComplianceScanner,
+  ComplianceService,
+  JsonFileEvidenceCollector,
+  ObjectEvidenceCollector,
+  type ComplianceEvidence,
+  type EvidenceCollector,
+} from '../index';
+
+const FIXED_DATE = new Date('2026-07-28T12:00:00.000Z');
+const now = () => new Date(FIXED_DATE);
+
+function passingValue(key: string): ComplianceEvidence['value'] {
+  const requirement = COMPLIANCE_EVIDENCE_REQUIREMENTS[key];
+  if (requirement.kind === 'positive-number') return 30;
+  if (requirement.kind === 'non-empty-string') return 'security-operations';
+  if (requirement.kind === 'non-empty-string-list') return ['zone-a', 'zone-b'];
+  return true;
+}
+
+function evidenceForAll(value?: boolean): ComplianceEvidence[] {
+  const keys = new Set(COMPLIANCE_CONTROL_CATALOG.flatMap(control => control.evidenceKeys));
+  return [...keys].sort().map(key => ({
+    key,
+    value: value ?? passingValue(key),
+    source: 'unit-test',
+    collectedAt: FIXED_DATE.toISOString(),
+  }));
+}
+
+describe('ComplianceScanner', () => {
+  it('assesses IEC 62443 security levels from explicit evidence', async () => {
+    const scanner = new ComplianceScanner({ now });
+    const scan = await scanner.runScan({
+      frameworks: ['IEC-62443'],
+      targetSecurityLevel: 4,
+      evidence: evidenceForAll(),
+    });
+
+    expect(scan.status).toBe('compliant');
+    expect(scan.summary.failed).toBe(0);
+    expect(scan.summary.notAssessed).toBe(0);
+    expect(scan.complianceScore).toBe(100);
+    expect(scan.iec62443?.achievedSecurityLevel).toBe(4);
+    expect(scan.iec62443?.foundationalRequirements).toHaveLength(7);
+    expect(scan.scanId).toMatch(/^scan-[0-9a-f]{16}$/);
+  });
+
+  it('distinguishes missing evidence from negative evidence in gap analysis', async () => {
+    const scanner = new ComplianceScanner({ now });
+    const evidence = evidenceForAll().filter(item => item.key !== 'access.defaultDeny');
+    const mfa = evidence.find(item => item.key === 'identity.adminMfa');
+    if (mfa) mfa.value = false;
+
+    const scan = await scanner.runScan({
+      frameworks: ['IEC-62443'],
+      targetSecurityLevel: 2,
+      evidence,
+    });
+
+    const accessGap = scan.gaps.find(gap => gap.controlId === 'IEC62443-FR2-UC-1');
+    const mfaGap = scan.gaps.find(gap => gap.controlId === 'IEC62443-SL2-IAC-2');
+    expect(accessGap).toMatchObject({
+      status: 'not-assessed',
+      missingEvidenceKeys: ['access.defaultDeny'],
+    });
+    expect(mfaGap).toMatchObject({
+      status: 'fail',
+      failedEvidenceKeys: ['identity.adminMfa'],
+    });
+    expect(scan.status).toBe('non-compliant');
+    expect(scan.iec62443?.achievedSecurityLevel).toBe(0);
+  });
+
+  it('maps results across all six NIST CSF functions', async () => {
+    const scanner = new ComplianceScanner({ now });
+    const scan = await scanner.runScan('NIST-CSF', evidenceForAll());
+
+    expect(scan.nistCsf?.functions.map(item => item.function)).toEqual([
+      'Govern',
+      'Identify',
+      'Protect',
+      'Detect',
+      'Respond',
+      'Recover',
+    ]);
+    expect(scan.nistCsf?.functions.every(item => item.score === 100)).toBe(true);
+    expect(
+      scan.controls.find(control => control.controlId === 'NIST-PR.AA-01')?.mappedControlIds,
+    ).toContain('IEC62443-FR1-IAC-1');
+  });
+
+  it('collects and de-duplicates automated evidence deterministically', async () => {
+    const collector = new ObjectEvidenceCollector(
+      'deployment-config',
+      { 'identity.uniqueUsers': true, 'identity.serviceAccountsInventoried': true },
+      { now },
+    );
+    const scanner = new ComplianceScanner({ collectors: [collector], now });
+    const scan = await scanner.runScan({
+      frameworks: ['IEC-62443'],
+      targetSecurityLevel: 1,
+      controlIds: ['IEC62443-FR1-IAC-1'],
+      evidence: [{
+        key: 'identity.uniqueUsers',
+        value: false,
+        source: 'stale-snapshot',
+        collectedAt: '2026-07-27T12:00:00.000Z',
+      }],
+    });
+
+    expect(scan.status).toBe('compliant');
+    expect(scan.evidence).toHaveLength(2);
+    expect(scan.evidence.find(item => item.key === 'identity.uniqueUsers')?.source)
+      .toBe('deployment-config');
+  });
+
+  it('fails closed when an evidence collector fails', async () => {
+    const broken: EvidenceCollector = {
+      id: 'broken',
+      collect: async () => {
+        throw new Error('collector offline');
+      },
+    };
+    const scanner = new ComplianceScanner({ now });
+
+    await expect(scanner.runScan({ collectors: [broken] }))
+      .rejects.toThrow('Evidence collector broken failed: collector offline');
+  });
+
+  it('fails closed on false-like or wrongly typed evidence values', async () => {
+    const scanner = new ComplianceScanner({ now });
+    const scan = await scanner.runScan({
+      frameworks: ['IEC-62443'],
+      targetSecurityLevel: 2,
+      controlIds: ['IEC62443-SL2-IAC-2'],
+      evidence: [
+        {
+          key: 'identity.adminMfa',
+          value: 'disabled',
+          source: 'iam-export',
+          collectedAt: FIXED_DATE.toISOString(),
+        },
+        {
+          key: 'identity.remoteMfa',
+          value: true,
+          source: 'iam-export',
+          collectedAt: FIXED_DATE.toISOString(),
+        },
+      ],
+    });
+
+    expect(scan.status).toBe('non-compliant');
+    expect(scan.controls[0].invalidEvidence).toEqual([{
+      key: 'identity.adminMfa',
+      expected: 'true-attestation',
+      reason: 'expected the boolean value true',
+    }]);
+  });
+
+  it('does not overstate framework coverage for a passing targeted scan', async () => {
+    const scanner = new ComplianceScanner({ now });
+    const iec = await scanner.runScan({
+      frameworks: ['IEC-62443'],
+      targetSecurityLevel: 4,
+      controlIds: ['IEC62443-FR1-IAC-1'],
+      evidence: evidenceForAll(),
+    });
+    expect(iec.status).toBe('compliant');
+    expect(iec.summary.total).toBe(1);
+    expect(iec.iec62443?.achievedSecurityLevel).toBe(0);
+    expect(iec.iec62443?.foundationalRequirements)
+      .toContainEqual(expect.objectContaining({ family: 'FR 2 — Use control', status: 'not-assessed' }));
+    expect(scanner.generateAuditReport(iec, { organization: 'Targeted Test' }).scope)
+      .toBe('Targeted controls: IEC62443-FR1-IAC-1');
+
+    const nist = await scanner.runScan({
+      frameworks: ['NIST-CSF'],
+      controlIds: ['NIST-PR.AA-01'],
+      evidence: evidenceForAll(),
+    });
+    const protect = nist.nistCsf?.functions.find(item => item.function === 'Protect');
+    expect(protect?.passed).toBe(1);
+    expect(protect?.total).toBeGreaterThan(1);
+    expect(protect?.score).toBeLessThan(100);
+  });
+
+  it('generates a certification-ready, content-addressed audit report', async () => {
+    const scanner = new ComplianceScanner({ now });
+    const evidence = evidenceForAll();
+    evidence[0].source = 'unit-test | forged\n# row';
+    const scan = await scanner.runScan({
+      frameworks: ['IEC-62443', 'NIST-CSF'],
+      targetSecurityLevel: 2,
+      evidence,
+    });
+    const report = scanner.generateAuditReport(scan, {
+      organization: 'Example Water Utility',
+      auditor: 'Internal Audit',
+      scope: 'Production control and historian services',
+    });
+
+    expect(report.reportId).toMatch(/^audit-[0-9a-f]{16}$/);
+    expect(report.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(report.markdown).toContain('# IEC-62443 / NIST-CSF Compliance Audit Report');
+    expect(report.markdown).toContain('## Evidence manifest');
+    expect(report.markdown).toContain('does not replace, certification');
+    expect(report.markdown).toContain('unit-test \\| forged \\# row');
+    expect(report.markdown).not.toContain('\n# row');
+    expect(report.markdown).toContain('- **Auditor:** Internal Audit');
+    expect(report.evidenceManifest.length).toBeGreaterThan(10);
+  });
+});
+
+describe('ComplianceService', () => {
+  it('keeps bounded real scan history and resolves reports by scan id', async () => {
+    const scanner = new ComplianceScanner({ now });
+    const service = new ComplianceService({ scanner, maxHistory: 1 });
+    await service.initialize();
+    const first = await service.scan({
+      frameworks: ['NIST-CSF'],
+      evidence: evidenceForAll(),
+    });
+    const second = await service.scan({
+      frameworks: ['IEC-62443'],
+      evidence: evidenceForAll(false),
+    });
+
+    expect(service.getScans()).toHaveLength(1);
+    expect(service.getScan(first.scanId)).toBeUndefined();
+    expect(service.getScan(second.scanId)).toBeDefined();
+    second.controls[0].status = 'pass';
+    expect(service.getScan(second.scanId)?.controls[0].status).toBe('fail');
+    expect(service.generateAuditReport(second.scanId, { organization: 'Test Org' }).scanId)
+      .toBe(second.scanId);
+    service.shutdown();
+  });
+
+  it('registers a concrete deployment evidence file and recurring scan at initialization', async () => {
+    const directory = await mkdtemp(join(tmpdir(), '0xscada-compliance-'));
+    const evidenceFile = join(directory, 'evidence.json');
+    const previousFile = process.env.COMPLIANCE_EVIDENCE_FILE;
+    const previousInterval = process.env.COMPLIANCE_SCAN_INTERVAL_MS;
+    await writeFile(evidenceFile, JSON.stringify({
+      source: 'deployment-snapshot',
+      collectedAt: FIXED_DATE.toISOString(),
+      evidence: {
+        'identity.uniqueUsers': true,
+        'identity.serviceAccountsInventoried': true,
+      },
+    }));
+    process.env.COMPLIANCE_EVIDENCE_FILE = evidenceFile;
+    process.env.COMPLIANCE_SCAN_INTERVAL_MS = '60000';
+    const service = new ComplianceService({
+      scanner: new ComplianceScanner({ now }),
+      maxHistory: 2,
+    });
+    try {
+      await service.initialize();
+      expect(service.getStatus()).toMatchObject({
+        initialized: true,
+        collectors: ['deployment-evidence-file'],
+        recurringScanIntervalMs: 60_000,
+      });
+      const scan = await service.scan({
+        frameworks: ['IEC-62443'],
+        targetSecurityLevel: 1,
+        controlIds: ['IEC62443-FR1-IAC-1'],
+      });
+      expect(scan.status).toBe('compliant');
+      expect(scan.evidence.every(item => item.source === 'deployment-snapshot')).toBe(true);
+    } finally {
+      service.shutdown();
+      if (previousFile === undefined) delete process.env.COMPLIANCE_EVIDENCE_FILE;
+      else process.env.COMPLIANCE_EVIDENCE_FILE = previousFile;
+      if (previousInterval === undefined) delete process.env.COMPLIANCE_SCAN_INTERVAL_MS;
+      else process.env.COMPLIANCE_SCAN_INTERVAL_MS = previousInterval;
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects invalid evidence file values instead of coercing them', async () => {
+    const directory = await mkdtemp(join(tmpdir(), '0xscada-compliance-invalid-'));
+    const evidenceFile = join(directory, 'evidence.json');
+    await writeFile(evidenceFile, JSON.stringify({
+      evidence: { 'identity.adminMfa': { enabled: true } },
+    }));
+    try {
+      const collector = new JsonFileEvidenceCollector(evidenceFile);
+      await expect(collector.collect()).rejects.toThrow(/unsupported value type/);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/services/compliance/index.ts
+++ b/server/services/compliance/index.ts
@@ -1,282 +1,1342 @@
 /**
- * Compliance Service
- * 
- * Handles regulatory compliance and audit requirements for industrial systems.
- * Tracks compliance status, generates reports, and ensures adherence to standards.
- * 
- * Standards supported: IEC 62443, NIST, ISO 27001, SOX, GDPR
+ * Compliance certification toolkit (ADR-0014, issue #225).
+ *
+ * The previous service returned random pass/fail results.  This implementation
+ * evaluates an explicit evidence set against versioned IEC 62443 and NIST CSF
+ * control catalogs.  A missing artifact is deliberately reported as
+ * "not-assessed" rather than being treated as proof of compliance.
  */
-
-import { EventEmitter } from 'events';
+import { createHash } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import { readFile, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { log, logError } from '../../logger';
 
-export interface ComplianceRule {
-  id: string;
-  name: string;
-  description: string;
-  standard: string; // e.g., 'IEC62443', 'NIST', 'ISO27001'
-  severity: 'low' | 'medium' | 'high' | 'critical';
-  enabled: boolean;
-  lastCheck?: Date;
-  status: 'compliant' | 'non-compliant' | 'unknown';
+export type ComplianceFramework = 'IEC-62443' | 'NIST-CSF';
+export type ControlStatus = 'pass' | 'fail' | 'not-assessed';
+export type ComplianceSeverity = 'low' | 'medium' | 'high' | 'critical';
+export type EvidenceValue = boolean | number | string | readonly string[];
+
+export interface ComplianceEvidence {
+  /** Stable machine-readable evidence key, for example `identity.uniqueUsers`. */
+  key: string;
+  value: EvidenceValue;
+  source: string;
+  collectedAt: string;
+  description?: string;
 }
 
-export interface ComplianceViolation {
+export interface EvidenceCollector {
+  readonly id: string;
+  collect(): Promise<readonly ComplianceEvidence[]>;
+}
+
+export interface ComplianceControl {
   id: string;
-  ruleId: string;
+  framework: ComplianceFramework;
+  family: string;
+  title: string;
   description: string;
-  severity: 'low' | 'medium' | 'high' | 'critical';
-  timestamp: Date;
-  resolved: boolean;
-  resolvedAt?: Date;
+  severity: ComplianceSeverity;
+  evidenceKeys: readonly string[];
+  remediation: string;
+  /** IEC 62443 target security level for which this control becomes mandatory. */
+  securityLevel?: 1 | 2 | 3 | 4;
+  /** Equivalent controls in the other catalog. */
+  mappedControlIds: readonly string[];
+}
+
+export interface ControlEvaluation {
+  controlId: string;
+  framework: ComplianceFramework;
+  family: string;
+  title: string;
+  severity: ComplianceSeverity;
+  status: ControlStatus;
+  evidenceKeys: readonly string[];
+  satisfiedEvidenceKeys: readonly string[];
+  missingEvidenceKeys: readonly string[];
+  failedEvidenceKeys: readonly string[];
+  invalidEvidence: ReadonlyArray<{
+    key: string;
+    expected: ComplianceEvidenceKind;
+    reason: string;
+  }>;
+  rationale: string;
   remediation?: string;
+  securityLevel?: 1 | 2 | 3 | 4;
+  mappedControlIds: readonly string[];
 }
 
-export interface ComplianceReport {
-  id: string;
-  period: { start: Date; end: Date };
-  standard: string;
-  overallStatus: 'compliant' | 'non-compliant' | 'partial';
-  rulesChecked: number;
-  violations: ComplianceViolation[];
-  generatedAt: Date;
+export interface ComplianceGap {
+  controlId: string;
+  severity: ComplianceSeverity;
+  status: Exclude<ControlStatus, 'pass'>;
+  title: string;
+  missingEvidenceKeys: readonly string[];
+  failedEvidenceKeys: readonly string[];
+  invalidEvidence: ReadonlyArray<{
+    key: string;
+    expected: ComplianceEvidenceKind;
+    reason: string;
+  }>;
+  remediation: string;
 }
 
-export class ComplianceService extends EventEmitter {
-  private rules: Map<string, ComplianceRule> = new Map();
-  private violations: ComplianceViolation[] = [];
-  private isInitialized = false;
-  private checkTimer?: NodeJS.Timeout;
+export type ComplianceEvidenceKind =
+  | 'true-attestation'
+  | 'positive-number'
+  | 'non-empty-string'
+  | 'non-empty-string-list';
 
-  constructor() {
-    super();
+export interface ComplianceEvidenceRequirement {
+  kind: ComplianceEvidenceKind;
+  description: string;
+}
+
+export type ComplianceEvidenceRequirements =
+  Readonly<Record<string, ComplianceEvidenceRequirement>>;
+
+export interface Iec62443Assessment {
+  targetSecurityLevel: 1 | 2 | 3 | 4;
+  achievedSecurityLevel: 0 | 1 | 2 | 3 | 4;
+  foundationalRequirements: ReadonlyArray<{
+    family: string;
+    passed: number;
+    applicable: number;
+    status: ControlStatus;
+  }>;
+}
+
+export interface NistCsfMapping {
+  functions: ReadonlyArray<{
+    function: 'Govern' | 'Identify' | 'Protect' | 'Detect' | 'Respond' | 'Recover';
+    passed: number;
+    assessed: number;
+    total: number;
+    score: number;
+  }>;
+}
+
+export interface ComplianceScanRequest {
+  frameworks?: readonly ComplianceFramework[];
+  evidence?: readonly ComplianceEvidence[];
+  collectors?: readonly EvidenceCollector[];
+  targetSecurityLevel?: 1 | 2 | 3 | 4;
+  controlIds?: readonly string[];
+}
+
+export interface ComplianceScanResult {
+  scanId: string;
+  catalogVersion: string;
+  startedAt: string;
+  completedAt: string;
+  frameworks: readonly ComplianceFramework[];
+  targetSecurityLevel: 1 | 2 | 3 | 4;
+  status: 'compliant' | 'non-compliant' | 'incomplete';
+  complianceScore: number;
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    notAssessed: number;
+    criticalGaps: number;
+  };
+  controls: readonly ControlEvaluation[];
+  gaps: readonly ComplianceGap[];
+  evidence: readonly ComplianceEvidence[];
+  iec62443?: Iec62443Assessment;
+  nistCsf?: NistCsfMapping;
+}
+
+export interface ComplianceAuditReport {
+  reportId: string;
+  title: string;
+  organization: string;
+  auditor?: string;
+  generatedAt: string;
+  catalogVersion: string;
+  scanId: string;
+  frameworks: readonly ComplianceFramework[];
+  overallStatus: ComplianceScanResult['status'];
+  complianceScore: number;
+  executiveSummary: string;
+  scope: string;
+  assessment: ComplianceScanResult['summary'];
+  iec62443?: Iec62443Assessment;
+  nistCsf?: NistCsfMapping;
+  gaps: readonly ComplianceGap[];
+  evidenceManifest: ReadonlyArray<Pick<ComplianceEvidence, 'key' | 'source' | 'collectedAt'>>;
+  markdown: string;
+  /** SHA-256 digest over the report fields, excluding this digest. */
+  sha256: string;
+}
+
+export interface AuditReportOptions {
+  organization: string;
+  auditor?: string;
+  scope?: string;
+}
+
+export const COMPLIANCE_CATALOG_VERSION = '2026.1';
+
+const IEC_CONTROLS: readonly ComplianceControl[] = [
+  {
+    id: 'IEC62443-FR1-IAC-1',
+    framework: 'IEC-62443',
+    family: 'FR 1 — Identification and authentication control',
+    title: 'Unique human and service identities',
+    description: 'All users, services, and devices are uniquely identified before access.',
+    severity: 'critical',
+    securityLevel: 1,
+    evidenceKeys: ['identity.uniqueUsers', 'identity.serviceAccountsInventoried'],
+    remediation: 'Remove shared accounts and inventory service identities with accountable owners.',
+    mappedControlIds: ['NIST-PR.AA-01'],
+  },
+  {
+    id: 'IEC62443-FR2-UC-1',
+    framework: 'IEC-62443',
+    family: 'FR 2 — Use control',
+    title: 'Least-privilege role enforcement',
+    description: 'Authorization is role based and defaults to deny.',
+    severity: 'critical',
+    securityLevel: 1,
+    evidenceKeys: ['access.rbacEnabled', 'access.defaultDeny'],
+    remediation: 'Enable RBAC, remove wildcard privileges, and enforce deny-by-default authorization.',
+    mappedControlIds: ['NIST-PR.AA-05'],
+  },
+  {
+    id: 'IEC62443-FR3-SI-1',
+    framework: 'IEC-62443',
+    family: 'FR 3 — System integrity',
+    title: 'Software and configuration integrity',
+    description: 'Release artifacts and critical configuration are integrity verified.',
+    severity: 'critical',
+    securityLevel: 1,
+    evidenceKeys: ['integrity.signedArtifacts', 'integrity.configurationAudit'],
+    remediation: 'Sign release artifacts and enable immutable configuration change auditing.',
+    mappedControlIds: ['NIST-PR.PS-06'],
+  },
+  {
+    id: 'IEC62443-FR4-DC-1',
+    framework: 'IEC-62443',
+    family: 'FR 4 — Data confidentiality',
+    title: 'Protected data in transit and at rest',
+    description: 'Sensitive telemetry and credentials use approved cryptographic protection.',
+    severity: 'high',
+    securityLevel: 1,
+    evidenceKeys: ['crypto.tlsEnabled', 'crypto.atRestEncryption'],
+    remediation: 'Require authenticated TLS and encrypt sensitive persistence and backups.',
+    mappedControlIds: ['NIST-PR.DS-01', 'NIST-PR.DS-02'],
+  },
+  {
+    id: 'IEC62443-FR5-RDF-1',
+    framework: 'IEC-62443',
+    family: 'FR 5 — Restricted data flow',
+    title: 'Zones, conduits, and network policy',
+    description: 'OT assets are segmented into explicit zones with allowlisted conduits.',
+    severity: 'high',
+    securityLevel: 1,
+    evidenceKeys: ['network.zoneInventory', 'network.defaultDenyPolicy'],
+    remediation: 'Document security zones and enforce allowlisted network policy between conduits.',
+    mappedControlIds: ['NIST-PR.IR-01'],
+  },
+  {
+    id: 'IEC62443-FR6-TRE-1',
+    framework: 'IEC-62443',
+    family: 'FR 6 — Timely response to events',
+    title: 'Security monitoring and response ownership',
+    description: 'Security-relevant events are centrally observed and have an owned response path.',
+    severity: 'high',
+    securityLevel: 1,
+    evidenceKeys: ['monitoring.securityEvents', 'response.onCallOwned'],
+    remediation: 'Centralize security telemetry and assign a tested incident escalation path.',
+    mappedControlIds: ['NIST-DE.CM-01', 'NIST-RS.MA-01'],
+  },
+  {
+    id: 'IEC62443-FR7-RA-1',
+    framework: 'IEC-62443',
+    family: 'FR 7 — Resource availability',
+    title: 'Verified recovery capability',
+    description: 'Backups, failover, and resource exhaustion controls are tested.',
+    severity: 'critical',
+    securityLevel: 1,
+    evidenceKeys: ['recovery.backupVerified', 'availability.capacityHeadroom'],
+    remediation: 'Test restoration, retain immutable backups, and maintain documented capacity headroom.',
+    mappedControlIds: ['NIST-RC.RP-01'],
+  },
+  {
+    id: 'IEC62443-SL2-IAC-2',
+    framework: 'IEC-62443',
+    family: 'FR 1 — Identification and authentication control',
+    title: 'Multi-factor administrative authentication',
+    description: 'Privileged and remote access requires phishing-resistant multi-factor authentication.',
+    severity: 'critical',
+    securityLevel: 2,
+    evidenceKeys: ['identity.adminMfa', 'identity.remoteMfa'],
+    remediation: 'Require MFA for privileged and remote access and remove bypass paths.',
+    mappedControlIds: ['NIST-PR.AA-03'],
+  },
+  {
+    id: 'IEC62443-SL2-RDF-2',
+    framework: 'IEC-62443',
+    family: 'FR 5 — Restricted data flow',
+    title: 'Independently tested zone boundaries',
+    description: 'Network boundary policy is continuously tested for unintended paths.',
+    severity: 'high',
+    securityLevel: 2,
+    evidenceKeys: ['network.policyTested'],
+    remediation: 'Add automated network-policy tests and review all exceptions.',
+    mappedControlIds: ['NIST-ID.RA-01'],
+  },
+  {
+    id: 'IEC62443-SL3-SI-2',
+    framework: 'IEC-62443',
+    family: 'FR 3 — System integrity',
+    title: 'Active vulnerability and supply-chain controls',
+    description: 'Dependencies and deployed artifacts are scanned with enforced severity gates.',
+    severity: 'critical',
+    securityLevel: 3,
+    evidenceKeys: ['integrity.dependencyScan', 'integrity.imageScan'],
+    remediation: 'Scan dependencies and images on every release and block critical findings.',
+    mappedControlIds: ['NIST-ID.RA-01', 'NIST-PR.PS-06'],
+  },
+  {
+    id: 'IEC62443-SL3-DC-2',
+    framework: 'IEC-62443',
+    family: 'FR 4 — Data confidentiality',
+    title: 'Managed certificate and key rotation',
+    description: 'Certificates and cryptographic keys have enforced rotation and revocation.',
+    severity: 'high',
+    securityLevel: 3,
+    evidenceKeys: ['crypto.rotationAutomated', 'crypto.revocationTested'],
+    remediation: 'Automate certificate rotation and test emergency revocation.',
+    mappedControlIds: ['NIST-PR.DS-01'],
+  },
+  {
+    id: 'IEC62443-SL4-SI-3',
+    framework: 'IEC-62443',
+    family: 'FR 3 — System integrity',
+    title: 'Hardware-backed critical keys',
+    description: 'Root signing and anchoring keys are non-exportable and hardware protected.',
+    severity: 'critical',
+    securityLevel: 4,
+    evidenceKeys: ['integrity.hardwareBackedKeys'],
+    remediation: 'Move root keys into an HSM with non-exportable policy and dual control.',
+    mappedControlIds: ['NIST-PR.PS-06'],
+  },
+] as const;
+
+const NIST_CONTROLS: readonly ComplianceControl[] = [
+  {
+    id: 'NIST-GV.OC-01',
+    framework: 'NIST-CSF',
+    family: 'Govern',
+    title: 'Cybersecurity mission and ownership',
+    description: 'The organization defines OT cybersecurity responsibilities and risk ownership.',
+    severity: 'high',
+    evidenceKeys: ['governance.securityOwner', 'governance.securityPolicyApproved'],
+    remediation: 'Assign security ownership and approve a maintained OT security policy.',
+    mappedControlIds: [],
+  },
+  {
+    id: 'NIST-ID.AM-01',
+    framework: 'NIST-CSF',
+    family: 'Identify',
+    title: 'Asset inventory',
+    description: 'Hardware, software, services, and tags are inventoried with ownership.',
+    severity: 'high',
+    evidenceKeys: ['assets.inventoryCurrent'],
+    remediation: 'Create an automatically refreshed inventory with accountable owners.',
+    mappedControlIds: ['IEC62443-FR1-IAC-1'],
+  },
+  {
+    id: 'NIST-ID.RA-01',
+    framework: 'NIST-CSF',
+    family: 'Identify',
+    title: 'Vulnerability identification',
+    description: 'Vulnerabilities in dependencies, images, and network exposure are identified.',
+    severity: 'critical',
+    evidenceKeys: ['integrity.dependencyScan', 'integrity.imageScan'],
+    remediation: 'Run authenticated vulnerability scans and enforce remediation SLAs.',
+    mappedControlIds: ['IEC62443-SL3-SI-2'],
+  },
+  {
+    id: 'NIST-PR.AA-01',
+    framework: 'NIST-CSF',
+    family: 'Protect',
+    title: 'Identity management',
+    description: 'Identities and credentials are managed throughout their lifecycle.',
+    severity: 'critical',
+    evidenceKeys: ['identity.uniqueUsers', 'identity.serviceAccountsInventoried'],
+    remediation: 'Inventory identities, remove shared accounts, and automate deprovisioning.',
+    mappedControlIds: ['IEC62443-FR1-IAC-1'],
+  },
+  {
+    id: 'NIST-PR.AA-03',
+    framework: 'NIST-CSF',
+    family: 'Protect',
+    title: 'Authentication',
+    description: 'Privileged and remote users use strong multi-factor authentication.',
+    severity: 'critical',
+    evidenceKeys: ['identity.adminMfa', 'identity.remoteMfa'],
+    remediation: 'Require MFA for all privileged and remote authentication.',
+    mappedControlIds: ['IEC62443-SL2-IAC-2'],
+  },
+  {
+    id: 'NIST-PR.AA-05',
+    framework: 'NIST-CSF',
+    family: 'Protect',
+    title: 'Least privilege',
+    description: 'Permissions are least-privilege and deny by default.',
+    severity: 'critical',
+    evidenceKeys: ['access.rbacEnabled', 'access.defaultDeny'],
+    remediation: 'Implement RBAC and remove permissive default roles.',
+    mappedControlIds: ['IEC62443-FR2-UC-1'],
+  },
+  {
+    id: 'NIST-PR.DS-01',
+    framework: 'NIST-CSF',
+    family: 'Protect',
+    title: 'Data at rest protection',
+    description: 'Sensitive persisted data is encrypted and keys are managed.',
+    severity: 'high',
+    evidenceKeys: ['crypto.atRestEncryption'],
+    remediation: 'Encrypt historian, audit, credential, and backup data at rest.',
+    mappedControlIds: ['IEC62443-FR4-DC-1'],
+  },
+  {
+    id: 'NIST-PR.DS-02',
+    framework: 'NIST-CSF',
+    family: 'Protect',
+    title: 'Data in transit protection',
+    description: 'Sensitive data in transit uses authenticated encryption.',
+    severity: 'high',
+    evidenceKeys: ['crypto.tlsEnabled'],
+    remediation: 'Enforce authenticated TLS on external and inter-service communication.',
+    mappedControlIds: ['IEC62443-FR4-DC-1'],
+  },
+  {
+    id: 'NIST-PR.PS-06',
+    framework: 'NIST-CSF',
+    family: 'Protect',
+    title: 'Software integrity',
+    description: 'Software and configuration integrity is verified before deployment.',
+    severity: 'critical',
+    evidenceKeys: ['integrity.signedArtifacts', 'integrity.configurationAudit'],
+    remediation: 'Verify signed provenance and audit configuration changes.',
+    mappedControlIds: ['IEC62443-FR3-SI-1'],
+  },
+  {
+    id: 'NIST-PR.IR-01',
+    framework: 'NIST-CSF',
+    family: 'Protect',
+    title: 'Network resilience',
+    description: 'Networks and environments are protected from unauthorized logical access.',
+    severity: 'high',
+    evidenceKeys: ['network.zoneInventory', 'network.defaultDenyPolicy'],
+    remediation: 'Apply zones, conduits, and deny-by-default network policy.',
+    mappedControlIds: ['IEC62443-FR5-RDF-1'],
+  },
+  {
+    id: 'NIST-DE.CM-01',
+    framework: 'NIST-CSF',
+    family: 'Detect',
+    title: 'Continuous monitoring',
+    description: 'Security-relevant events are continuously monitored.',
+    severity: 'high',
+    evidenceKeys: ['monitoring.securityEvents'],
+    remediation: 'Collect security telemetry centrally and alert on control failures.',
+    mappedControlIds: ['IEC62443-FR6-TRE-1'],
+  },
+  {
+    id: 'NIST-RS.MA-01',
+    framework: 'NIST-CSF',
+    family: 'Respond',
+    title: 'Incident response execution',
+    description: 'An owned and tested incident response process is available.',
+    severity: 'high',
+    evidenceKeys: ['response.onCallOwned', 'response.exerciseCompleted'],
+    remediation: 'Assign on-call ownership and exercise incident procedures at least annually.',
+    mappedControlIds: ['IEC62443-FR6-TRE-1'],
+  },
+  {
+    id: 'NIST-RC.RP-01',
+    framework: 'NIST-CSF',
+    family: 'Recover',
+    title: 'Recovery plan execution',
+    description: 'Recovery plans and backups are tested against recovery objectives.',
+    severity: 'critical',
+    evidenceKeys: ['recovery.backupVerified', 'recovery.exerciseCompleted'],
+    remediation: 'Run restore exercises and retain evidence of achieved recovery objectives.',
+    mappedControlIds: ['IEC62443-FR7-RA-1'],
+  },
+] as const;
+
+function frozenControlCatalog(
+  controls: readonly ComplianceControl[],
+): readonly ComplianceControl[] {
+  return Object.freeze(controls.map(control => Object.freeze({
+    ...control,
+    evidenceKeys: Object.freeze([...control.evidenceKeys]),
+    mappedControlIds: Object.freeze([...control.mappedControlIds]),
+  })));
+}
+
+export const COMPLIANCE_CONTROL_CATALOG: readonly ComplianceControl[] = frozenControlCatalog([
+  ...IEC_CONTROLS,
+  ...NIST_CONTROLS,
+]);
+
+const TRUE_ATTESTATION = (description: string): ComplianceEvidenceRequirement => Object.freeze({
+  kind: 'true-attestation',
+  description,
+});
+
+function frozenEvidenceRequirements(
+  requirements: ComplianceEvidenceRequirements,
+): ComplianceEvidenceRequirements {
+  return Object.freeze(Object.fromEntries(
+    Object.entries(requirements).map(([key, requirement]) => [
+      key,
+      Object.freeze({ ...requirement }),
+    ]),
+  ));
+}
+
+/**
+ * Evidence is evaluated by key-specific contracts, not generic JavaScript
+ * truthiness. A non-empty value such as "disabled" must never prove a control.
+ */
+export const COMPLIANCE_EVIDENCE_REQUIREMENTS: ComplianceEvidenceRequirements = frozenEvidenceRequirements({
+  'identity.uniqueUsers': TRUE_ATTESTATION('Unique human identities are enforced.'),
+  'identity.serviceAccountsInventoried': TRUE_ATTESTATION('Service accounts have accountable inventory records.'),
+  'access.rbacEnabled': TRUE_ATTESTATION('Role-based authorization is enabled.'),
+  'access.defaultDeny': TRUE_ATTESTATION('Authorization defaults to deny.'),
+  'integrity.signedArtifacts': TRUE_ATTESTATION('Release artifacts have verified signatures.'),
+  'integrity.configurationAudit': TRUE_ATTESTATION('Critical configuration changes are immutably audited.'),
+  'crypto.tlsEnabled': TRUE_ATTESTATION('Authenticated TLS is enforced.'),
+  'crypto.atRestEncryption': TRUE_ATTESTATION('Sensitive persisted data is encrypted.'),
+  'network.zoneInventory': {
+    kind: 'non-empty-string-list',
+    description: 'The assessed zone identifiers.',
+  },
+  'network.defaultDenyPolicy': TRUE_ATTESTATION('Inter-zone traffic defaults to deny.'),
+  'monitoring.securityEvents': TRUE_ATTESTATION('Security-relevant events are centrally monitored.'),
+  'response.onCallOwned': {
+    kind: 'non-empty-string',
+    description: 'The accountable incident-response owner or team identifier.',
+  },
+  'recovery.backupVerified': TRUE_ATTESTATION('A backup restoration has been verified.'),
+  'availability.capacityHeadroom': {
+    kind: 'positive-number',
+    description: 'Measured available capacity headroom percentage.',
+  },
+  'identity.adminMfa': TRUE_ATTESTATION('Administrative access requires MFA.'),
+  'identity.remoteMfa': TRUE_ATTESTATION('Remote access requires MFA.'),
+  'network.policyTested': TRUE_ATTESTATION('Zone-boundary policy tests pass.'),
+  'integrity.dependencyScan': TRUE_ATTESTATION('Dependency scanning completed within policy.'),
+  'integrity.imageScan': TRUE_ATTESTATION('Deployed image scanning completed within policy.'),
+  'crypto.rotationAutomated': TRUE_ATTESTATION('Certificate and key rotation is automated.'),
+  'crypto.revocationTested': TRUE_ATTESTATION('Emergency revocation has been tested.'),
+  'integrity.hardwareBackedKeys': TRUE_ATTESTATION('Critical root keys are hardware-backed and non-exportable.'),
+  'governance.securityOwner': {
+    kind: 'non-empty-string',
+    description: 'The accountable OT security owner identifier.',
+  },
+  'governance.securityPolicyApproved': TRUE_ATTESTATION('The OT security policy is approved and current.'),
+  'assets.inventoryCurrent': TRUE_ATTESTATION('The owned asset inventory is current.'),
+  'response.exerciseCompleted': TRUE_ATTESTATION('An incident-response exercise completed within policy.'),
+  'recovery.exerciseCompleted': TRUE_ATTESTATION('A recovery exercise completed within policy.'),
+});
+
+const NIST_FUNCTIONS = ['Govern', 'Identify', 'Protect', 'Detect', 'Respond', 'Recover'] as const;
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value !== null && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(stableJson(value)).digest('hex');
+}
+
+const NEGATIVE_STRING_VALUES = new Set([
+  '0',
+  'disabled',
+  'false',
+  'fail',
+  'failed',
+  'no',
+  'none',
+  'n/a',
+  'na',
+  'not-applicable',
+  'not-configured',
+  'off',
+  'unknown',
+  'unassigned',
+]);
+
+function nonEmptyPositiveString(value: string): boolean {
+  const normalized = value.trim().toLowerCase().replace(/\s+/g, '-');
+  return normalized.length > 0 && !NEGATIVE_STRING_VALUES.has(normalized);
+}
+
+function evidenceEvaluation(
+  requirement: ComplianceEvidenceRequirement,
+  value: EvidenceValue,
+): { passed: boolean; reason: string } {
+  if (requirement.kind === 'true-attestation') {
+    return value === true
+      ? { passed: true, reason: 'true attestation supplied' }
+      : { passed: false, reason: 'expected the boolean value true' };
+  }
+  if (requirement.kind === 'positive-number') {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0
+      ? { passed: true, reason: 'positive measurement supplied' }
+      : { passed: false, reason: 'expected a finite number greater than zero' };
+  }
+  if (requirement.kind === 'non-empty-string') {
+    return typeof value === 'string' && nonEmptyPositiveString(value)
+      ? { passed: true, reason: 'owned identifier supplied' }
+      : { passed: false, reason: 'expected a non-empty, non-negative string identifier' };
+  }
+  const valid = Array.isArray(value)
+    && value.length > 0
+    && value.every(item => nonEmptyPositiveString(item));
+  return valid
+    ? { passed: true, reason: 'non-empty inventory supplied' }
+    : { passed: false, reason: 'expected a non-empty list of valid string identifiers' };
+}
+
+function assertIsoDate(value: string, field: string): void {
+  const timestampWithZone =
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
+  if (!timestampWithZone.test(value) || !Number.isFinite(Date.parse(value))) {
+    throw new Error(`${field} must be an ISO-8601 timestamp with a timezone`);
+  }
+}
+
+function normalizeFramework(value: string): ComplianceFramework {
+  const normalized = value.trim().toUpperCase().replace(/[_\s]/g, '-');
+  if (normalized === 'IEC62443' || normalized === 'IEC-62443') return 'IEC-62443';
+  if (normalized === 'NIST' || normalized === 'NIST-CSF') return 'NIST-CSF';
+  throw new Error(`Unsupported compliance framework: ${value}`);
+}
+
+function score(controls: readonly ControlEvaluation[]): number {
+  if (controls.length === 0) return 0;
+  const earned = controls.reduce((sum, control) => {
+    if (control.status === 'pass') return sum + 1;
+    if (control.status === 'not-assessed') return sum + 0;
+    return sum;
+  }, 0);
+  return Number(((earned / controls.length) * 100).toFixed(2));
+}
+
+export class ObjectEvidenceCollector implements EvidenceCollector {
+  readonly id: string;
+  private readonly evidence: Readonly<Record<string, EvidenceValue>>;
+  private readonly source: string;
+  private readonly now: () => Date;
+
+  constructor(
+    id: string,
+    evidence: Readonly<Record<string, EvidenceValue>>,
+    options: { source?: string; now?: () => Date } = {},
+  ) {
+    if (!id.trim()) throw new Error('collector id is required');
+    this.id = id;
+    this.evidence = evidence;
+    this.source = options.source ?? id;
+    this.now = options.now ?? (() => new Date());
   }
 
-  /**
-   * Initialize the compliance service
-   */
-  async initialize(): Promise<void> {
-    if (this.isInitialized) return;
-
-    log('Initializing compliance service');
-    
-    // Load default compliance rules
-    await this.loadDefaultRules();
-    
-    // Start periodic compliance checks
-    this.startPeriodicChecks();
-    
-    this.isInitialized = true;
-    this.emit('initialized');
-    log('Compliance service initialized');
+  async collect(): Promise<readonly ComplianceEvidence[]> {
+    const collectedAt = this.now().toISOString();
+    return Object.entries(this.evidence)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, value]) => ({ key, value, source: this.source, collectedAt }));
   }
+}
 
-  /**
-   * Add a compliance rule
-   */
-  addRule(rule: ComplianceRule): void {
-    this.rules.set(rule.id, rule);
-    log(`Compliance rule added: ${rule.name} (${rule.standard})`);
-  }
+function markdownText(value: string): string {
+  return value
+    .replace(/\r?\n/g, ' ')
+    .replace(/\\/g, '\\\\')
+    .replace(/([`*_{}[\]()#|>])/g, '\\$1');
+}
 
-  /**
-   * Check compliance for all active rules
-   */
-  async checkCompliance(): Promise<{ compliant: number; violations: number }> {
-    if (!this.isInitialized) {
-      throw new Error('Compliance service not initialized');
+export interface JsonEvidenceDocument {
+  source?: string;
+  collectedAt?: string;
+  evidence: Readonly<Record<string, EvidenceValue>>;
+}
+
+function isEvidenceValue(value: unknown): value is EvidenceValue {
+  return typeof value === 'boolean'
+    || (typeof value === 'number' && Number.isFinite(value))
+    || typeof value === 'string'
+    || (Array.isArray(value) && value.every(item => typeof item === 'string'));
+}
+
+/**
+ * Concrete production collector for a periodically refreshed, read-only
+ * evidence snapshot mounted by deployment automation.
+ */
+export class JsonFileEvidenceCollector implements EvidenceCollector {
+  readonly id: string;
+  readonly filePath: string;
+  private readonly maxBytes: number;
+
+  constructor(filePath: string, options: { id?: string; maxBytes?: number } = {}) {
+    if (!filePath.trim()) throw new Error('evidence file path is required');
+    this.filePath = resolve(filePath);
+    this.id = options.id?.trim() || `json-file:${this.filePath}`;
+    this.maxBytes = options.maxBytes ?? 1_048_576;
+    if (!Number.isInteger(this.maxBytes) || this.maxBytes < 1) {
+      throw new Error('maxBytes must be a positive integer');
     }
+  }
 
-    let compliant = 0;
-    let violationCount = 0;
-
-    for (const rule of this.rules.values()) {
-      if (!rule.enabled) continue;
-
-      try {
-        const isCompliant = await this.checkRule(rule);
-        rule.lastCheck = new Date();
-        rule.status = isCompliant ? 'compliant' : 'non-compliant';
-
-        if (isCompliant) {
-          compliant++;
-        } else {
-          violationCount++;
-          await this.recordViolation(rule);
+  async collect(): Promise<readonly ComplianceEvidence[]> {
+    const [contents, metadata] = await Promise.all([
+      readFile(this.filePath),
+      stat(this.filePath),
+    ]);
+    if (contents.byteLength > this.maxBytes) {
+      throw new Error(`evidence file exceeds ${this.maxBytes} bytes`);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(contents.toString('utf8'));
+    } catch (error) {
+      throw new Error(`invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('evidence file must contain an object document');
+    }
+    const document = parsed as Partial<JsonEvidenceDocument>;
+    if (document.evidence === null
+      || typeof document.evidence !== 'object'
+      || Array.isArray(document.evidence)) {
+      throw new Error('evidence file must contain an evidence object');
+    }
+    if (document.source !== undefined && typeof document.source !== 'string') {
+      throw new Error('evidence file source must be a string');
+    }
+    if (document.collectedAt !== undefined && typeof document.collectedAt !== 'string') {
+      throw new Error('evidence file collectedAt must be a string');
+    }
+    const source = document.source?.trim() || `file:${this.filePath}`;
+    const collectedAt = document.collectedAt ?? metadata.mtime.toISOString();
+    assertIsoDate(collectedAt, 'evidence file collectedAt');
+    return Object.entries(document.evidence)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => {
+        if (!key.trim()) throw new Error('evidence file contains an empty key');
+        if (!isEvidenceValue(value)) {
+          throw new Error(`evidence ${key} has an unsupported value type`);
         }
-      } catch (error) {
-        logError(`Failed to check compliance rule ${rule.id}`, error as any);
-        rule.status = 'unknown';
+        return { key, value, source, collectedAt };
+      });
+  }
+}
+
+export class ComplianceScanner {
+  private readonly catalog: readonly ComplianceControl[];
+  private readonly collectors: readonly EvidenceCollector[];
+  private readonly evidenceRequirements: ComplianceEvidenceRequirements;
+  private readonly now: () => Date;
+
+  constructor(options: {
+    catalog?: readonly ComplianceControl[];
+    collectors?: readonly EvidenceCollector[];
+    evidenceRequirements?: ComplianceEvidenceRequirements;
+    now?: () => Date;
+  } = {}) {
+    this.catalog = frozenControlCatalog(options.catalog ?? COMPLIANCE_CONTROL_CATALOG);
+    this.collectors = options.collectors ?? [];
+    this.evidenceRequirements = frozenEvidenceRequirements({
+      ...COMPLIANCE_EVIDENCE_REQUIREMENTS,
+      ...(options.evidenceRequirements ?? {}),
+    });
+    this.now = options.now ?? (() => new Date());
+    if (this.catalog.length === 0) throw new Error('Compliance control catalog cannot be empty');
+    const ids = new Set<string>();
+    for (const control of this.catalog) {
+      if (ids.has(control.id)) throw new Error(`Duplicate compliance control id: ${control.id}`);
+      ids.add(control.id);
+      if (control.evidenceKeys.length === 0) {
+        throw new Error(`Compliance control ${control.id} has no evidence requirements`);
+      }
+      for (const key of control.evidenceKeys) {
+        if (!Object.hasOwn(this.evidenceRequirements, key)) {
+          throw new Error(`Compliance control ${control.id} has no typed requirement for ${key}`);
+        }
       }
     }
-
-    log(`Compliance check completed: ${compliant} compliant, ${violationCount} violations`);
-    this.emit('compliance-checked', { compliant, violations: violationCount });
-
-    return { compliant, violations: violationCount };
   }
 
-  /**
-   * Generate compliance report for a period
-   */
-  async generateReport(
-    standard: string, 
-    period: { start: Date; end: Date }
-  ): Promise<ComplianceReport> {
-    const relevantRules = Array.from(this.rules.values())
-      .filter(rule => rule.standard === standard);
-    
-    const periodViolations = this.violations.filter(
-      v => v.timestamp >= period.start && v.timestamp <= period.end
+  getControls(framework?: ComplianceFramework): readonly ComplianceControl[] {
+    return this.catalog
+      .filter(control => framework === undefined || control.framework === framework)
+      .map(control => ({
+        ...control,
+        evidenceKeys: [...control.evidenceKeys],
+        mappedControlIds: [...control.mappedControlIds],
+      }));
+  }
+
+  getEvidenceRequirements(): ComplianceEvidenceRequirements {
+    return structuredClone(this.evidenceRequirements);
+  }
+
+  async runScan(
+    requestOrFramework: ComplianceScanRequest | ComplianceFramework | string = {},
+    suppliedEvidence: readonly ComplianceEvidence[] = [],
+  ): Promise<ComplianceScanResult> {
+    const request: ComplianceScanRequest = typeof requestOrFramework === 'string'
+      ? { frameworks: [normalizeFramework(requestOrFramework)], evidence: suppliedEvidence }
+      : requestOrFramework;
+    const frameworks: ComplianceFramework[] = [
+      ...new Set((request.frameworks ?? ['IEC-62443', 'NIST-CSF'])
+        .map(framework => normalizeFramework(framework))),
+    ];
+    if (frameworks.length === 0) throw new Error('At least one compliance framework is required');
+    const targetSecurityLevel = request.targetSecurityLevel ?? 2;
+    if (![1, 2, 3, 4].includes(targetSecurityLevel)) {
+      throw new Error('targetSecurityLevel must be between 1 and 4');
+    }
+
+    const startedAt = this.now().toISOString();
+    const collected = await this.collectEvidence([
+      ...this.collectors,
+      ...(request.collectors ?? []),
+    ], request.evidence ?? []);
+    const evidenceByKey = new Map(collected.map(item => [item.key, item]));
+    const requestedIds = request.controlIds === undefined ? undefined : new Set(request.controlIds);
+    if (requestedIds?.size === 0) throw new Error('controlIds cannot be empty when supplied');
+
+    const applicable = this.catalog.filter(control =>
+      frameworks.includes(control.framework)
+      && (requestedIds === undefined || requestedIds.has(control.id))
+      && (control.framework !== 'IEC-62443'
+        || control.securityLevel === undefined
+        || control.securityLevel <= targetSecurityLevel),
     );
-
-    const overallStatus = periodViolations.length === 0 ? 'compliant' : 
-                         periodViolations.some(v => v.severity === 'critical') ? 'non-compliant' : 
-                         'partial';
-
-    const report: ComplianceReport = {
-      id: `report-${Date.now()}`,
-      period,
-      standard,
-      overallStatus,
-      rulesChecked: relevantRules.length,
-      violations: periodViolations,
-      generatedAt: new Date()
-    };
-
-    log(`Generated compliance report for ${standard}: ${overallStatus}`);
-    return report;
-  }
-
-  /**
-   * Get current compliance status
-   */
-  getStatus(): {
-    initialized: boolean;
-    totalRules: number;
-    activeRules: number;
-    recentViolations: number;
-    lastCheck?: Date;
-  } {
-    const activeRules = Array.from(this.rules.values()).filter(r => r.enabled);
-    const recentViolations = this.violations
-      .filter(v => v.timestamp > new Date(Date.now() - 24 * 60 * 60 * 1000)) // Last 24h
-      .length;
-
-    const lastCheck = Math.max(...activeRules.map(r => r.lastCheck?.getTime() || 0));
-
-    return {
-      initialized: this.isInitialized,
-      totalRules: this.rules.size,
-      activeRules: activeRules.length,
-      recentViolations,
-      lastCheck: lastCheck > 0 ? new Date(lastCheck) : undefined
-    };
-  }
-
-  /**
-   * Health check for compliance service
-   */
-  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
-    if (!this.isInitialized) {
-      return {
-        healthy: false,
-        message: 'Compliance service not initialized'
-      };
+    if (requestedIds !== undefined) {
+      const found = new Set(applicable.map(control => control.id));
+      const unknown = [...requestedIds].filter(id => !found.has(id));
+      if (unknown.length > 0) throw new Error(`Unknown or out-of-scope control ids: ${unknown.join(', ')}`);
     }
 
-    const status = this.getStatus();
-    const criticalViolations = this.violations
-      .filter(v => v.severity === 'critical' && !v.resolved)
-      .length;
-
-    if (criticalViolations > 0) {
-      return {
-        healthy: false,
-        message: `Critical compliance violations: ${criticalViolations}`
-      };
-    }
-
+    const controls = applicable.map(control => this.evaluate(control, evidenceByKey));
+    const gaps = controls
+      .filter((control): control is ControlEvaluation & { status: 'fail' | 'not-assessed' } =>
+        control.status !== 'pass')
+      .map(control => ({
+        controlId: control.controlId,
+        severity: control.severity,
+        status: control.status,
+        title: control.title,
+        missingEvidenceKeys: control.missingEvidenceKeys,
+        failedEvidenceKeys: control.failedEvidenceKeys,
+        invalidEvidence: control.invalidEvidence,
+        remediation: control.remediation ?? 'Collect evidence and remediate the failed control.',
+      }));
+    const passed = controls.filter(control => control.status === 'pass').length;
+    const failed = controls.filter(control => control.status === 'fail').length;
+    const notAssessed = controls.filter(control => control.status === 'not-assessed').length;
+    const criticalGaps = gaps.filter(gap => gap.severity === 'critical').length;
+    const completedAt = this.now().toISOString();
+    const resultWithoutId = {
+      catalogVersion: COMPLIANCE_CATALOG_VERSION,
+      startedAt,
+      completedAt,
+      frameworks,
+      targetSecurityLevel,
+      status: (failed > 0 ? 'non-compliant' : notAssessed > 0 ? 'incomplete' : 'compliant') as
+        ComplianceScanResult['status'],
+      complianceScore: score(controls),
+      summary: { total: controls.length, passed, failed, notAssessed, criticalGaps },
+      controls,
+      gaps,
+      evidence: collected,
+      iec62443: frameworks.includes('IEC-62443')
+        ? this.buildIecAssessment(controls, targetSecurityLevel)
+        : undefined,
+      nistCsf: frameworks.includes('NIST-CSF') ? this.buildNistMapping(controls) : undefined,
+    };
     return {
-      healthy: true,
-      message: `Compliance service healthy: ${status.activeRules} rules monitored`
+      scanId: `scan-${digest(resultWithoutId).slice(0, 16)}`,
+      ...resultWithoutId,
     };
   }
 
-  // ── Private Methods ────────────────────────────────────────────────────────
-
-  /**
-   * Load default compliance rules
-   */
-  private async loadDefaultRules(): Promise<void> {
-    // IEC 62443 - Industrial security
-    this.addRule({
-      id: 'iec62443-access-control',
-      name: 'Access Control Implementation',
-      description: 'Verify proper access control mechanisms are in place',
-      standard: 'IEC62443',
-      severity: 'critical',
-      enabled: true,
-      status: 'unknown'
-    });
-
-    // NIST - Cybersecurity framework
-    this.addRule({
-      id: 'nist-logging',
-      name: 'Security Event Logging',
-      description: 'Ensure all security events are properly logged',
-      standard: 'NIST',
-      severity: 'high',
-      enabled: true,
-      status: 'unknown'
-    });
-
-    log('Default compliance rules loaded');
-  }
-
-  /**
-   * Check a specific compliance rule
-   */
-  private async checkRule(rule: ComplianceRule): Promise<boolean> {
-    // Simulate rule checking
-    await new Promise(resolve => setTimeout(resolve, 50));
-    
-    // For demo, randomly pass/fail rules
-    return Math.random() > 0.2; // 80% compliance rate
-  }
-
-  /**
-   * Record a compliance violation
-   */
-  private async recordViolation(rule: ComplianceRule): Promise<void> {
-    const violation: ComplianceViolation = {
-      id: `violation-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      ruleId: rule.id,
-      description: `Violation of ${rule.name}: ${rule.description}`,
-      severity: rule.severity,
-      timestamp: new Date(),
-      resolved: false
+  generateAuditReport(scan: ComplianceScanResult, options: AuditReportOptions): ComplianceAuditReport {
+    if (!options.organization.trim()) throw new Error('organization is required');
+    const generatedAt = this.now().toISOString();
+    const allApplicableControls = this.catalog.filter(control =>
+      scan.frameworks.includes(control.framework)
+      && (control.framework !== 'IEC-62443'
+        || control.securityLevel === undefined
+        || control.securityLevel <= scan.targetSecurityLevel));
+    const completeFrameworkScope = allApplicableControls.length === scan.controls.length
+      && allApplicableControls.every(control =>
+        scan.controls.some(evaluation => evaluation.controlId === control.id));
+    const scope = options.scope?.trim() || (completeFrameworkScope
+      ? `${scan.frameworks.join(' and ')} controls`
+      : `Targeted controls: ${scan.controls.map(control => control.controlId).join(', ')}`);
+    const executiveSummary = [
+      `${options.organization} was assessed against ${scan.frameworks.join(' and ')} catalog version ${scan.catalogVersion}.`,
+      `${scan.summary.passed} of ${scan.summary.total} applicable controls passed (${scan.complianceScore}%).`,
+      scan.summary.notAssessed > 0
+        ? `${scan.summary.notAssessed} controls lack sufficient evidence and must not be represented as compliant.`
+        : 'All applicable controls had sufficient evidence.',
+      `${scan.summary.failed} controls failed and ${scan.summary.criticalGaps} gaps are critical.`,
+    ].join(' ');
+    const base = {
+      title: `${scan.frameworks.join(' / ')} Compliance Audit Report`,
+      organization: options.organization.trim(),
+      auditor: options.auditor?.trim() || undefined,
+      generatedAt,
+      catalogVersion: scan.catalogVersion,
+      scanId: scan.scanId,
+      frameworks: scan.frameworks,
+      overallStatus: scan.status,
+      complianceScore: scan.complianceScore,
+      executiveSummary,
+      scope,
+      assessment: scan.summary,
+      iec62443: scan.iec62443,
+      nistCsf: scan.nistCsf,
+      gaps: scan.gaps,
+      evidenceManifest: scan.evidence.map(({ key, source, collectedAt }) => ({
+        key,
+        source,
+        collectedAt,
+      })),
     };
-
-    this.violations.push(violation);
-    this.emit('violation-detected', violation);
+    const reportId = `audit-${digest(base).slice(0, 16)}`;
+    const markdown = this.renderMarkdown(reportId, base);
+    const reportWithoutDigest = { reportId, ...base, markdown };
+    return { ...reportWithoutDigest, sha256: digest(reportWithoutDigest) };
   }
 
-  /**
-   * Start periodic compliance checks
-   */
-  private startPeriodicChecks(): void {
-    // Check compliance every hour
-    this.checkTimer = setInterval(() => {
-      this.checkCompliance().catch(error => {
-        logError('Periodic compliance check failed', error as any);
-      });
-    }, 60 * 60 * 1000);
+  private async collectEvidence(
+    collectors: readonly EvidenceCollector[],
+    supplied: readonly ComplianceEvidence[],
+  ): Promise<readonly ComplianceEvidence[]> {
+    const collected = [...supplied];
+    const collectorIds = new Set<string>();
+    for (const collector of collectors) {
+      if (typeof collector.id !== 'string' || !collector.id.trim()) {
+        throw new Error('evidence collector id is required');
+      }
+      if (collectorIds.has(collector.id)) {
+        throw new Error(`Duplicate evidence collector id: ${collector.id}`);
+      }
+      collectorIds.add(collector.id);
+    }
+    for (const item of supplied) {
+      if (!item.key.trim()) throw new Error('evidence key is required');
+      if (!item.source.trim()) throw new Error(`evidence source is required for ${item.key}`);
+      assertIsoDate(item.collectedAt, `evidence ${item.key}.collectedAt`);
+    }
+    const batches = await Promise.all(collectors.map(async collector => {
+      try {
+        return await collector.collect();
+      } catch (error) {
+        throw new Error(
+          `Evidence collector ${collector.id} failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }));
+    for (const batch of batches) collected.push(...batch);
 
-    // Initial check
-    setTimeout(() => this.checkCompliance(), 5000);
+    // Last writer wins by key.  Supplied evidence is inserted first and
+    // configured collectors can therefore refresh it with current observations.
+    const deduplicated = new Map<string, ComplianceEvidence>();
+    for (const item of collected) {
+      if (!item.key.trim()) throw new Error('evidence key is required');
+      if (typeof item.source !== 'string' || !item.source.trim()) {
+        throw new Error(`evidence source is required for ${item.key}`);
+      }
+      if (!isEvidenceValue(item.value)) {
+        throw new Error(`evidence ${item.key} has an unsupported value type`);
+      }
+      assertIsoDate(item.collectedAt, `evidence ${item.key}.collectedAt`);
+      const previous = deduplicated.get(item.key);
+      if (!previous || Date.parse(item.collectedAt) >= Date.parse(previous.collectedAt)) {
+        deduplicated.set(item.key, {
+          ...item,
+          value: Array.isArray(item.value) ? [...item.value] : item.value,
+        });
+      }
+    }
+    return [...deduplicated.values()].sort((a, b) => a.key.localeCompare(b.key));
+  }
+
+  private evaluate(
+    control: ComplianceControl,
+    evidence: ReadonlyMap<string, ComplianceEvidence>,
+  ): ControlEvaluation {
+    const missingEvidenceKeys: string[] = [];
+    const failedEvidenceKeys: string[] = [];
+    const satisfiedEvidenceKeys: string[] = [];
+    const invalidEvidence: Array<{
+      key: string;
+      expected: ComplianceEvidenceKind;
+      reason: string;
+    }> = [];
+    for (const key of control.evidenceKeys) {
+      const item = evidence.get(key);
+      if (item === undefined) missingEvidenceKeys.push(key);
+      else {
+        const requirement = this.evidenceRequirements[key];
+        const evaluation = evidenceEvaluation(requirement, item.value);
+        if (evaluation.passed) satisfiedEvidenceKeys.push(key);
+        else {
+          failedEvidenceKeys.push(key);
+          invalidEvidence.push({
+            key,
+            expected: requirement.kind,
+            reason: evaluation.reason,
+          });
+        }
+      }
+    }
+    const status: ControlStatus = failedEvidenceKeys.length > 0
+      ? 'fail'
+      : missingEvidenceKeys.length > 0
+        ? 'not-assessed'
+        : 'pass';
+    const rationale = status === 'pass'
+      ? `All ${control.evidenceKeys.length} required evidence items passed.`
+      : status === 'fail'
+        ? `Negative evidence: ${failedEvidenceKeys.join(', ')}.`
+        : `Evidence not collected: ${missingEvidenceKeys.join(', ')}.`;
+    return {
+      controlId: control.id,
+      framework: control.framework,
+      family: control.family,
+      title: control.title,
+      severity: control.severity,
+      status,
+      evidenceKeys: [...control.evidenceKeys],
+      satisfiedEvidenceKeys,
+      missingEvidenceKeys,
+      failedEvidenceKeys,
+      invalidEvidence,
+      rationale,
+      remediation: status === 'pass' ? undefined : control.remediation,
+      securityLevel: control.securityLevel,
+      mappedControlIds: [...control.mappedControlIds],
+    };
+  }
+
+  private buildIecAssessment(
+    controls: readonly ControlEvaluation[],
+    target: 1 | 2 | 3 | 4,
+  ): Iec62443Assessment {
+    const iecCatalog = this.catalog.filter(control =>
+      control.framework === 'IEC-62443'
+      && (control.securityLevel ?? 1) <= target);
+    const evaluations = new Map(
+      controls
+        .filter(control => control.framework === 'IEC-62443')
+        .map(control => [control.controlId, control]),
+    );
+    let achieved: 0 | 1 | 2 | 3 | 4 = 0;
+    for (const level of [1, 2, 3, 4] as const) {
+      if (level > target) break;
+      const required = iecCatalog.filter(control => (control.securityLevel ?? 1) <= level);
+      if (required.length > 0
+        && required.every(control => evaluations.get(control.id)?.status === 'pass')) {
+        achieved = level;
+      }
+      else break;
+    }
+    const families = [...new Set(iecCatalog.map(control => control.family))];
+    return {
+      targetSecurityLevel: target,
+      achievedSecurityLevel: achieved,
+      foundationalRequirements: families.map(family => {
+        const familyControls = iecCatalog.filter(control => control.family === family);
+        const statuses = familyControls.map(control => evaluations.get(control.id)?.status);
+        const passed = statuses.filter(status => status === 'pass').length;
+        const hasFailure = statuses.some(status => status === 'fail');
+        const hasUnknown = statuses.some(status => status === undefined || status === 'not-assessed');
+        return {
+          family,
+          passed,
+          applicable: familyControls.length,
+          status: hasFailure ? 'fail' : hasUnknown ? 'not-assessed' : 'pass',
+        };
+      }),
+    };
+  }
+
+  private buildNistMapping(controls: readonly ControlEvaluation[]): NistCsfMapping {
+    const nistCatalog = this.catalog.filter(control => control.framework === 'NIST-CSF');
+    const evaluations = new Map(
+      controls
+        .filter(control => control.framework === 'NIST-CSF')
+        .map(control => [control.controlId, control]),
+    );
+    return {
+      functions: NIST_FUNCTIONS.map(name => {
+        const functionControls = nistCatalog.filter(control => control.family === name);
+        const statuses = functionControls.map(control => evaluations.get(control.id)?.status);
+        const passed = statuses.filter(status => status === 'pass').length;
+        const assessed = statuses.filter(status => status !== undefined && status !== 'not-assessed').length;
+        return {
+          function: name,
+          passed,
+          assessed,
+          total: functionControls.length,
+          score: functionControls.length === 0
+            ? 0
+            : Number(((passed / functionControls.length) * 100).toFixed(2)),
+        };
+      }),
+    };
+  }
+
+  private renderMarkdown(
+    reportId: string,
+    report: Omit<ComplianceAuditReport, 'reportId' | 'markdown' | 'sha256'>,
+  ): string {
+    const gapRows = report.gaps.length === 0
+      ? '| — | — | — | No gaps identified |'
+      : report.gaps
+        .map(gap => `| ${markdownText(gap.controlId)} | ${gap.severity} | ${gap.status} | ${
+          markdownText(gap.remediation)
+        } |`)
+        .join('\n');
+    const evidenceRows = report.evidenceManifest.length === 0
+      ? '| — | — | — |'
+      : report.evidenceManifest
+        .map(item => `| ${markdownText(item.key)} | ${markdownText(item.source)} | ${
+          markdownText(item.collectedAt)
+        } |`)
+        .join('\n');
+    return [
+      `# ${markdownText(report.title)}`,
+      '',
+      `- **Report ID:** ${reportId}`,
+      `- **Organization:** ${markdownText(report.organization)}`,
+      ...(report.auditor === undefined
+        ? []
+        : [`- **Auditor:** ${markdownText(report.auditor)}`]),
+      `- **Generated:** ${report.generatedAt}`,
+      `- **Catalog:** ${report.catalogVersion}`,
+      `- **Scan:** ${report.scanId}`,
+      `- **Status:** ${report.overallStatus}`,
+      `- **Score:** ${report.complianceScore}%`,
+      '',
+      '## Executive summary',
+      '',
+      markdownText(report.executiveSummary),
+      '',
+      '## Scope',
+      '',
+      markdownText(report.scope),
+      '',
+      '## Gap analysis',
+      '',
+      '| Control | Severity | Status | Remediation |',
+      '|---|---|---|---|',
+      gapRows,
+      '',
+      '## Evidence manifest',
+      '',
+      '| Evidence key | Source | Collected at |',
+      '|---|---|---|',
+      evidenceRows,
+      '',
+      '> This automated assessment supports, but does not replace, certification by an accredited assessor.',
+      '',
+    ].join('\n');
   }
 }
 
-// Singleton instance
+/**
+ * Long-lived facade used by application routes and health reporting.  Scan
+ * history is deliberately bounded to avoid an unbounded process-local cache.
+ */
+export class ComplianceService extends EventEmitter {
+  private readonly scanner: ComplianceScanner;
+  private readonly maxHistory: number;
+  private readonly scanHistory = new Map<string, ComplianceScanResult>();
+  private readonly collectors = new Map<string, EvidenceCollector>();
+  private initialized = false;
+  private checkTimer?: NodeJS.Timeout;
+  private recurringScanIntervalMs?: number;
+
+  constructor(options: {
+    scanner?: ComplianceScanner;
+    maxHistory?: number;
+    collectors?: readonly EvidenceCollector[];
+  } = {}) {
+    super();
+    this.scanner = options.scanner ?? new ComplianceScanner();
+    this.maxHistory = options.maxHistory ?? 100;
+    if (!Number.isInteger(this.maxHistory) || this.maxHistory < 1) {
+      throw new Error('maxHistory must be a positive integer');
+    }
+    for (const collector of options.collectors ?? []) this.registerCollector(collector);
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+    const evidenceFile = process.env.COMPLIANCE_EVIDENCE_FILE?.trim();
+    if (evidenceFile && !this.collectors.has('deployment-evidence-file')) {
+      this.registerCollector(new JsonFileEvidenceCollector(evidenceFile, {
+        id: 'deployment-evidence-file',
+      }));
+    }
+    const configuredInterval = Number(process.env.COMPLIANCE_SCAN_INTERVAL_MS ?? 0);
+    if (Number.isFinite(configuredInterval) && configuredInterval >= 60_000) {
+      this.recurringScanIntervalMs = configuredInterval;
+      this.checkTimer = setInterval(() => {
+        this.scan({}).catch(error => logError(error, 'Periodic compliance scan failed'));
+      }, configuredInterval);
+      this.checkTimer.unref();
+    }
+    this.emit('initialized');
+    log('Compliance certification toolkit initialized');
+  }
+
+  shutdown(): void {
+    if (this.checkTimer !== undefined) clearInterval(this.checkTimer);
+    this.checkTimer = undefined;
+    this.recurringScanIntervalMs = undefined;
+    this.initialized = false;
+  }
+
+  registerCollector(collector: EvidenceCollector): () => void {
+    if (!collector.id.trim()) throw new Error('collector id is required');
+    if (this.collectors.has(collector.id)) {
+      throw new Error(`Duplicate evidence collector id: ${collector.id}`);
+    }
+    this.collectors.set(collector.id, collector);
+    return () => {
+      this.collectors.delete(collector.id);
+    };
+  }
+
+  getCollectors(): readonly string[] {
+    return [...this.collectors.keys()].sort();
+  }
+
+  async scan(request: ComplianceScanRequest = {}): Promise<ComplianceScanResult> {
+    if (!this.initialized) await this.initialize();
+    const result = await this.scanner.runScan({
+      ...request,
+      collectors: [
+        ...this.collectors.values(),
+        ...(request.collectors ?? []),
+      ],
+    });
+    const storedResult = structuredClone(result);
+    this.scanHistory.delete(storedResult.scanId);
+    this.scanHistory.set(storedResult.scanId, storedResult);
+    while (this.scanHistory.size > this.maxHistory) {
+      const oldest = this.scanHistory.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.scanHistory.delete(oldest);
+    }
+    this.emit('compliance-checked', structuredClone(storedResult));
+    if (storedResult.gaps.length > 0) {
+      this.emit('violation-detected', structuredClone(storedResult.gaps));
+    }
+    return structuredClone(storedResult);
+  }
+
+  async checkCompliance(evidence: readonly ComplianceEvidence[] = []): Promise<{
+    compliant: number;
+    violations: number;
+    notAssessed: number;
+  }> {
+    const scan = await this.scan({ evidence });
+    return {
+      compliant: scan.summary.passed,
+      violations: scan.summary.failed,
+      notAssessed: scan.summary.notAssessed,
+    };
+  }
+
+  getControls(framework?: ComplianceFramework): readonly ComplianceControl[] {
+    return this.scanner.getControls(framework);
+  }
+
+  getEvidenceRequirements(): ComplianceEvidenceRequirements {
+    return this.scanner.getEvidenceRequirements();
+  }
+
+  getScan(scanId: string): ComplianceScanResult | undefined {
+    const scan = this.scanHistory.get(scanId);
+    return scan === undefined ? undefined : structuredClone(scan);
+  }
+
+  getScans(limit = 20): readonly ComplianceScanResult[] {
+    if (!Number.isInteger(limit) || limit < 1) throw new Error('limit must be a positive integer');
+    return structuredClone([...this.scanHistory.values()].slice(-limit).reverse());
+  }
+
+  generateAuditReport(scanId: string, options: AuditReportOptions): ComplianceAuditReport {
+    const scan = this.scanHistory.get(scanId);
+    if (scan === undefined) throw new Error(`Unknown compliance scan: ${scanId}`);
+    return this.scanner.generateAuditReport(scan, options);
+  }
+
+  getStatus(): {
+    initialized: boolean;
+    catalogVersion: string;
+    totalRules: number;
+    collectors: readonly string[];
+    recurringScanIntervalMs?: number;
+    completedScans: number;
+    lastCheck?: Date;
+  } {
+    const latest = [...this.scanHistory.values()].at(-1);
+    return {
+      initialized: this.initialized,
+      catalogVersion: COMPLIANCE_CATALOG_VERSION,
+      totalRules: this.scanner.getControls().length,
+      collectors: this.getCollectors(),
+      recurringScanIntervalMs: this.recurringScanIntervalMs,
+      completedScans: this.scanHistory.size,
+      lastCheck: latest === undefined ? undefined : new Date(latest.completedAt),
+    };
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; message: string }> {
+    if (!this.initialized) {
+      return { healthy: false, message: 'Compliance service not initialized' };
+    }
+    const latest = [...this.scanHistory.values()].at(-1);
+    if (latest?.summary.criticalGaps) {
+      return {
+        healthy: false,
+        message: `${latest.summary.criticalGaps} critical compliance gaps in latest scan`,
+      };
+    }
+    return {
+      healthy: true,
+      message: `${this.scanner.getControls().length} controls available; ${this.scanHistory.size} scans retained`,
+    };
+  }
+}
+
 export const complianceService = new ComplianceService();


### PR DESCRIPTION
## Summary

- Replaces the legacy randomized compliance simulation with deterministic IEC 62443 and NIST CSF control catalogs, typed evidence contracts, security-level assessment, gap analysis, and immutable scan retention.
- Adds authenticated-system evidence collector registration, bounded JSON evidence ingestion, optional server-managed recurring scans, and fail-closed handling for missing or malformed evidence.
- Adds governance endpoints for scans, findings, control/evidence catalogs, and content-hashed audit reports, plus assessment and framework mapping documentation.

Closes #225

## Safety and compatibility

- Targeted scans assess only selected controls and do not overstate unassessed framework or security-level coverage.
- Legacy `rules` and `target` request fields remain accepted as control selectors.
- Scheduled requests are rejected unless scheduling is configured server-side.
- The dedicated router mounts before the legacy governance placeholders without changing unrelated governance behavior.

## Attribution

City-Agent: Codex

## Verification

```text
npx vitest run server/services/compliance/__tests__/compliance-toolkit.test.ts server/routes/__tests__/compliance-readiness.test.ts
# 2 files passed; 14 tests passed

npm run typecheck
# passed

npm run build:server
# passed

git diff --cached --check
# passed before commit
```

## Gate self-check

- [x] Every commit is signed off (`git commit -s` → `Signed-off-by` line, DCO)
- [x] The `City-Agent:` line above is filled in
- [x] `npx tsc --noEmit` is clean
- [x] No new `any` types
- [x] Existing compliance service export is preserved
- [x] Tests added/updated for every claim in the summary
- [x] PR is scoped to a single issue
