### PR TITLE
feat(capacity): add planning and cost model (#228)

### DIFF
--- a/docs/operations/capacity-planning-guide.md
+++ b/docs/operations/capacity-planning-guide.md
@@ -1,71 +1,130 @@
-# Capacity Planning Guide — 0xSCADA
+# Capacity Planning and Cost Modeling
 
-## Quick Reference
+The `CapacityPlanner` turns a tag workload into resource, topology, growth, and
+cloud-cost projections. All coefficients and rate cards are versioned and
+returned by `GET /api/governance/capacity/model`; projections are planning
+estimates, not cloud-provider quotes.
 
-| Tag Count | Tier | Gateways | Servers | CPU Cores | Memory | Storage (90d) |
-|-----------|------|----------|---------|-----------|--------|---------------|
-| 1,000 | Starter | 1 | 1 | 1 | 1 GB | 10 GB |
-| 10,000 | Starter | 1 | 1 | 1 | 1 GB | 10 GB |
-| 50,000 | Professional | 1 | 1 | 3 | 1 GB | 43 GB |
-| 100,000 | Professional | 2 | 1 | 5 | 1 GB | 86 GB |
-| 500,000 | Enterprise | 10 | 5 | 25 | 1 GB | 429 GB |
-| 1,000,000 | Hyperscale | 20 | 10 | 50 | 2 GB | 858 GB |
+## Required workload inputs
 
-## Resource Estimation
+| Field | Default | Meaning |
+|---|---:|---|
+| `tagCount` | required | Current configured tag count |
+| `sampleIntervalSeconds` | 1 | Average acquisition interval |
+| `retentionDays` | 90 | Online historian retention |
+| `headroomPercent` | 30 | Reserve applied to resources and topology |
+| `highAvailability` | true | Enforce at least two gateway and API instances |
+| `historianCopies` | 1 | Retained data copies, including replicas |
+| `subscriberFanout` | 1 | Average delivered subscriber copies per update |
 
-Per tag (approximate):
-- **CPU:** 0.05 millicores
-- **Memory:** 2 KB
-- **Storage:** 10 KB/day (historian)
-- **Bandwidth:** 50 bytes/sec (average, bidirectional)
+The default per-tag coefficients at a one-second interval are:
 
-## Cloud Cost Estimates (Monthly, USD)
+- CPU: 0.05 millicores;
+- resident memory: 2 KiB;
+- historian storage: 10 KiB/day;
+- ingress: 50 bytes/second;
+- egress: 50 bytes/second multiplied by subscriber fan-out.
 
-| Tag Count | AWS | Azure | GCP |
-|-----------|-----|-------|-----|
-| 10,000 | ~$150 | ~$150 | ~$145 |
-| 100,000 | ~$450 | ~$445 | ~$460 |
-| 500,000 | ~$2,200 | ~$2,150 | ~$2,250 |
-| 1,000,000 | ~$4,400 | ~$4,300 | ~$4,500 |
+CPU, storage, and bandwidth scale inversely with sample interval. Resident tag
+memory does not. Total resource estimates add a base service allocation and the
+requested headroom. Topology limits are 50,000 tags per gateway, 100,000 tags
+per API server, and 250,000 tags per historian shard before headroom.
 
-_Costs include compute, storage (90-day retention), and network egress. Actual costs vary._
+## Generate a complete plan
 
-## Scaling Strategy
+```http
+POST /api/governance/capacity/plan
+Content-Type: application/json
 
-### Starter (< 10k tags)
-- Single gateway, single server
-- SQLite or PostgreSQL
-- No sharding needed
-- Store-and-forward for edge resilience
+{
+  "workload": {
+    "tagCount": 125000,
+    "sampleIntervalSeconds": 1,
+    "retentionDays": 180,
+    "headroomPercent": 35,
+    "historianCopies": 2,
+    "subscriberFanout": 0.25
+  },
+  "history": [
+    { "timestamp": "2026-01-01T00:00:00.000Z", "tagCount": 90000 },
+    { "timestamp": "2026-02-01T00:00:00.000Z", "tagCount": 98000 },
+    { "timestamp": "2026-03-01T00:00:00.000Z", "tagCount": 107000 },
+    { "timestamp": "2026-04-01T00:00:00.000Z", "tagCount": 116000 },
+    { "timestamp": "2026-05-01T00:00:00.000Z", "tagCount": 125000 }
+  ],
+  "horizonMonths": 6,
+  "providers": ["aws", "azure", "gcp"]
+}
+```
 
-### Professional (10k–100k tags)
-- 1–2 gateways with shard manager
-- PostgreSQL with time partitioning
-- Load balancer for API/WebSocket
-- Automated benchmarking enabled
+The response contains:
 
-### Enterprise (100k–500k tags)
-- Sharded gateways (1 per 50k tags)
-- Distributed historian with partitioning
-- Multi-site federation
-- Full compliance toolkit
-- SRE playbooks and auto-remediation
+- `current`: resources and topology for the current workload;
+- `forecast`: least-squares growth trend, fit quality, and confidence;
+- `planning`: resources for the greater of current and forecast tag count;
+- `cloudCosts`: itemized compute, storage, egress, and load-balancer costs;
+- `scaling`: cost-optimized, balanced, and performance alternatives.
 
-### Hyperscale (500k+ tags)
-- 10+ sharded gateways
-- Horizontally scaled servers
-- Multi-region federation
-- Dedicated monitoring infrastructure
-- Custom capacity planning engagement
+The older root-level workload fields and `constraints.tagCount` are accepted for
+compatibility. A request without tag count fails; the API does not substitute
+placeholder usage.
 
-## Growth Forecasting
+## Cloud-cost assumptions
 
-Use `CapacityPlanner.forecastGrowth()` to project tag count growth based on historical data. Plan capacity 6 months ahead of projected need.
+The built-in AWS, Azure, and GCP cards are reference on-demand rates identified
+by version and region. Cost calculations use:
 
-## Cost Optimization
+1. the greater of CPU- or memory-required node count at target utilization;
+2. the minimum node count required by the planned topology;
+3. 730 compute hours per month;
+4. billable retained GiB;
+5. modeled subscriber egress GiB;
+6. one load balancer for an HA workload.
 
-1. **Right-size instances** — Use capacity planner recommendations
-2. **Reserved instances** — 1-year commitment saves 30-40%
-3. **Storage tiering** — Hot (30d) / Warm (90d) / Cold (1yr+)
-4. **Network optimization** — Compress historian data, batch WebSocket updates
-5. **Spot instances** — For non-critical batch processing (benchmarks, reports)
+Taxes, support plans, negotiated/committed-use discounts, managed-service
+premiums, inter-zone transfer, and backup API charges are excluded. Production
+financial review should construct `CapacityPlanner` with the organization's
+contracted `CloudRateCard` values.
+
+## Growth forecast
+
+`forecastGrowth(history, horizonMonths)` fits tag count against elapsed days
+using linear least squares. It returns slope, R², monthly and annualized growth,
+and the projected horizon count.
+
+Confidence is:
+
+- high: at least six points over 90 days with R² ≥ 0.8;
+- medium: at least three points over 30 days with R² ≥ 0.5;
+- low: anything less.
+
+Low confidence selects additional performance reserve. Forecasts may project a
+decline, but capacity planning never sizes below the current tag count.
+
+Use `POST /api/governance/capacity/forecast` when only a forecast is required.
+Retain raw historical points with the plan so reviewers can reproduce it.
+
+## Scaling trade-offs
+
+| Strategy | Headroom | Best use | Trade-off |
+|---|---:|---|---|
+| Cost optimized | 20% | Stable, high-confidence workloads | Lowest cost; least burst/failover reserve |
+| Balanced | 35% | Normal production OT workloads | Moderate reserve and spend |
+| Performance | 60% | Fast growth or uncertain forecast | Most resilience; highest idle cost |
+
+Every strategy preserves the workload's HA setting and shows monthly cost for
+all requested providers. Default scale triggers are 70% tags-per-gateway, 70%
+CPU, 75% memory, and 70% storage so provisioning can complete before exhaustion.
+
+## Operational review checklist
+
+Before approving a plan:
+
+1. validate tag count and sample intervals from observed inventory;
+2. include burst and alarm-storm fan-out, not only daily averages;
+3. choose historian copy count from the recovery policy;
+4. review data-sovereignty and provider-region constraints;
+5. replace reference prices with contracted prices;
+6. load-test the planned topology;
+7. schedule a monthly forecast refresh and trigger an immediate refresh after a
+   site acquisition, retention change, or large tag import.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -22,6 +22,7 @@ import { digitalTwinService } from "./services/twin";
 import { alarmCorrelationRoutes } from "./routes/alarm-correlation";
 import { alarmCorrelationService } from "./services/alarm-correlation";
 import { predictiveRoutes } from "./routes/predictive";
+import { capacityReadinessRoutes } from "./routes/capacity-readiness";
 import { predictiveMaintenanceService } from "./services/predictive";
 import { tuningRoutes } from "./routes/tuning";
 import { tuningService } from "./services/tuning";
@@ -75,6 +76,7 @@ export async function registerRoutes(
 
   // P1 Wiring: Intelligence, Governance, and Security modules
   app.use("/api/intelligence", intelligenceRoutes);
+  app.use("/api/governance", capacityReadinessRoutes);  // ADR-0014 [14.8] (#228)
   app.use("/api/twin", twinRoutes);  // ADR-0013 [13.3] (#214)
   app.use("/api/alarm-correlation", alarmCorrelationRoutes);  // ADR-0013 [13.2] (#213)
   app.use("/api/predictive", predictiveRoutes);  // ADR-0013 [13.1] (#212)

--- a/server/routes/__tests__/capacity-readiness.test.ts
+++ b/server/routes/__tests__/capacity-readiness.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import express from 'express';
+import type { Server } from 'node:http';
+import { capacityReadinessRoutes } from '../capacity-readiness';
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/governance', capacityReadinessRoutes);
+  await new Promise<void>(resolve => {
+    server = app.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (typeof address !== 'object' || address === null) throw new Error('Test server did not bind');
+  baseUrl = `http://127.0.0.1:${address.port}/api/governance`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => error ? reject(error) : resolve());
+  });
+});
+
+describe('governance capacity routes', () => {
+  it('returns a complete resource, forecast, provider-cost, and trade-off plan', async () => {
+    const response = await fetch(`${baseUrl}/capacity/plan`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        workload: {
+          tagCount: 100_000,
+          sampleIntervalSeconds: 1,
+          retentionDays: 90,
+        },
+        history: [
+          { timestamp: '2026-01-01T00:00:00.000Z', tagCount: 70_000 },
+          { timestamp: '2026-02-01T00:00:00.000Z', tagCount: 76_000 },
+          { timestamp: '2026-03-01T00:00:00.000Z', tagCount: 82_000 },
+          { timestamp: '2026-04-01T00:00:00.000Z', tagCount: 88_000 },
+        ],
+        horizonMonths: 6,
+        providers: ['aws', 'azure', 'gcp'],
+      }),
+    });
+    const plan = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(plan.current.totals.cpuCores).toBeGreaterThan(0);
+    expect(plan.current.totals.storageGiB).toBeGreaterThan(0);
+    expect(plan.forecast.projectedTagCount).toBeGreaterThan(100_000);
+    expect(plan.cloudCosts.map((item: { provider: string }) => item.provider))
+      .toEqual(['aws', 'azure', 'gcp']);
+    expect(plan.scaling.options).toHaveLength(3);
+  });
+
+  it('fails closed without a tag count and publishes its model assumptions', async () => {
+    const invalid = await fetch(`${baseUrl}/capacity/plan`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ timeHorizon: 'medium', scenario: 'growth', metrics: ['cpu'] }),
+    });
+    expect(invalid.status).toBe(400);
+    expect((await invalid.json()).error).toMatch(/tagCount is required/);
+
+    const model = await fetch(`${baseUrl}/capacity/model`);
+    const body = await model.json();
+    expect(model.status).toBe(200);
+    expect(body.resourceCoefficients.cpuMillicoresPerTagAtOneSecond).toBe(0.05);
+    expect(Object.keys(body.cloudRateCards).sort()).toEqual(['aws', 'azure', 'gcp']);
+  });
+
+  it('refuses to fabricate capacity trends without observations', async () => {
+    const response = await fetch(`${baseUrl}/capacity/trends`);
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/POST \/capacity\/forecast/);
+  });
+});

--- a/server/routes/capacity-readiness.ts
+++ b/server/routes/capacity-readiness.ts
@@ -1,0 +1,152 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { capacityPlanner, type CapacityWorkload } from '../services/capacity';
+
+const router = Router();
+
+const WorkloadSchema = z.object({
+  tagCount: z.number().int().min(1).max(100_000_000),
+  sampleIntervalSeconds: z.number().min(0.05).max(86_400).optional(),
+  retentionDays: z.number().int().min(1).max(3_650).optional(),
+  headroomPercent: z.number().min(0).max(300).optional(),
+  highAvailability: z.boolean().optional(),
+  historianCopies: z.number().int().min(1).max(5).optional(),
+  subscriberFanout: z.number().min(0).max(10_000).optional(),
+});
+
+const HistoryPointSchema = z.object({
+  timestamp: z.string().datetime({ offset: true }),
+  tagCount: z.number().int().min(0).max(100_000_000),
+});
+
+/**
+ * Accepts both the new explicit workload envelope and the original governance
+ * route's root/constraints shape. Unlike the old route, tag count is required:
+ * the server will not manufacture a capacity forecast from placeholder data.
+ */
+const CapacityPlanningSchema = z.object({
+  workload: WorkloadSchema.optional(),
+  tagCount: z.number().int().min(1).max(100_000_000).optional(),
+  sampleIntervalSeconds: z.number().min(0.05).max(86_400).optional(),
+  retentionDays: z.number().int().min(1).max(3_650).optional(),
+  headroomPercent: z.number().min(0).max(300).optional(),
+  highAvailability: z.boolean().optional(),
+  historianCopies: z.number().int().min(1).max(5).optional(),
+  subscriberFanout: z.number().min(0).max(10_000).optional(),
+  history: z.array(HistoryPointSchema).min(2).optional(),
+  historicalTagCounts: z.array(HistoryPointSchema).min(2).optional(),
+  horizonMonths: z.number().int().min(1).max(120).optional(),
+  providers: z.array(z.enum(['aws', 'azure', 'gcp'])).min(1).optional(),
+  // Legacy request fields:
+  timeHorizon: z.enum(['short', 'medium', 'long']).optional(),
+  scenario: z.enum(['current', 'growth', 'stress']).optional(),
+  metrics: z.array(z.string()).optional(),
+  constraints: z.record(z.unknown()).optional(),
+});
+
+function errorMessage(error: unknown): string {
+  if (error instanceof z.ZodError) {
+    return error.issues
+      .map(issue => `${issue.path.join('.') || 'request'}: ${issue.message}`)
+      .join('; ');
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function constraintNumber(
+  constraints: Readonly<Record<string, unknown>> | undefined,
+  field: string,
+): number | undefined {
+  const value = constraints?.[field];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function resolveCapacityWorkload(
+  request: z.infer<typeof CapacityPlanningSchema>,
+): CapacityWorkload {
+  if (request.workload !== undefined) return request.workload;
+  const tagCount = request.tagCount ?? constraintNumber(request.constraints, 'tagCount');
+  if (tagCount === undefined) {
+    throw new Error('tagCount is required in workload, at the request root, or in constraints');
+  }
+  return {
+    tagCount,
+    sampleIntervalSeconds: request.sampleIntervalSeconds
+      ?? constraintNumber(request.constraints, 'sampleIntervalSeconds'),
+    retentionDays: request.retentionDays
+      ?? constraintNumber(request.constraints, 'retentionDays'),
+    headroomPercent: request.headroomPercent
+      ?? constraintNumber(request.constraints, 'headroomPercent')
+      ?? (request.scenario === 'stress' ? 60 : undefined),
+    highAvailability: request.highAvailability,
+    historianCopies: request.historianCopies
+      ?? constraintNumber(request.constraints, 'historianCopies'),
+    subscriberFanout: request.subscriberFanout
+      ?? constraintNumber(request.constraints, 'subscriberFanout'),
+  };
+}
+
+router.post('/capacity/plan', (req, res) => {
+  try {
+    const request = CapacityPlanningSchema.parse(req.body);
+    const workload = resolveCapacityWorkload(request);
+    const history = request.history ?? request.historicalTagCounts;
+    const horizonMonths = request.horizonMonths
+      ?? (request.timeHorizon === 'short' ? 1 : request.timeHorizon === 'long' ? 12 : 6);
+    res.json(capacityPlanner.createPlan({
+      workload,
+      history,
+      horizonMonths,
+      providers: request.providers,
+    }));
+  } catch (error) {
+    res.status(400).json({ error: errorMessage(error) });
+  }
+});
+
+router.get('/capacity/model', (_req, res) => {
+  res.json({
+    resourceCoefficients: capacityPlanner.getCoefficients(),
+    cloudRateCards: capacityPlanner.getRateCards(),
+  });
+});
+
+router.get('/capacity/current', (req, res) => {
+  try {
+    const workload = WorkloadSchema.parse({
+      tagCount: z.coerce.number().parse(req.query.tagCount),
+      sampleIntervalSeconds: req.query.sampleIntervalSeconds === undefined
+        ? undefined
+        : z.coerce.number().parse(req.query.sampleIntervalSeconds),
+      retentionDays: req.query.retentionDays === undefined
+        ? undefined
+        : z.coerce.number().parse(req.query.retentionDays),
+    });
+    res.json(capacityPlanner.estimateResources(workload));
+  } catch (error) {
+    res.status(400).json({
+      error: `A valid tagCount query parameter is required: ${errorMessage(error)}`,
+    });
+  }
+});
+
+router.post('/capacity/forecast', (req, res) => {
+  try {
+    const request = z.object({
+      history: z.array(HistoryPointSchema).min(2),
+      horizonMonths: z.number().int().min(1).max(120).default(6),
+    }).parse(req.body);
+    res.json(capacityPlanner.forecastGrowth(request.history, request.horizonMonths));
+  } catch (error) {
+    res.status(400).json({ error: errorMessage(error) });
+  }
+});
+
+// Prevent the legacy placeholder handler from returning fabricated trend data.
+router.get('/capacity/trends', (_req, res) => {
+  res.status(400).json({
+    error: 'Historical observations are required; use POST /capacity/forecast',
+  });
+});
+
+export { router as capacityReadinessRoutes };

--- a/server/services/capacity/__tests__/capacity-planner.test.ts
+++ b/server/services/capacity/__tests__/capacity-planner.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CapacityPlanner,
+  DEFAULT_CLOUD_RATE_CARDS,
+  type TagCountObservation,
+} from '../index';
+
+const NOW = new Date('2026-07-28T12:00:00.000Z');
+const now = () => new Date(NOW);
+
+describe('CapacityPlanner resource estimation', () => {
+  it('calculates CPU, memory, storage, and bandwidth from transparent per-tag rates', () => {
+    const planner = new CapacityPlanner({ now });
+    const estimate = planner.estimateResources({
+      tagCount: 100_000,
+      sampleIntervalSeconds: 1,
+      retentionDays: 90,
+      headroomPercent: 30,
+      highAvailability: true,
+      subscriberFanout: 1,
+    });
+
+    expect(estimate.perTag).toEqual({
+      cpuMillicores: 0.05,
+      memoryKiB: 2,
+      storageKiBPerDay: 10,
+      ingressBytesPerSecond: 50,
+      egressBytesPerSecond: 50,
+    });
+    expect(estimate.totals.cpuCores).toBe(7.15);
+    expect(estimate.totals.memoryGiB).toBeCloseTo(1.548, 3);
+    expect(estimate.totals.storageGiB).toBeCloseTo(124.58, 3);
+    expect(estimate.totals.ingressMbps).toBe(52);
+    expect(estimate.topology).toEqual({
+      gatewayInstances: 3,
+      apiServerInstances: 2,
+      historianShards: 1,
+    });
+  });
+
+  it('scales sample-driven resources while keeping resident tag memory constant', () => {
+    const planner = new CapacityPlanner({ now });
+    const fast = planner.estimateResources({ tagCount: 10_000, sampleIntervalSeconds: 1 });
+    const slow = planner.estimateResources({ tagCount: 10_000, sampleIntervalSeconds: 10 });
+
+    expect(slow.perTag.cpuMillicores).toBe(fast.perTag.cpuMillicores / 10);
+    expect(slow.perTag.storageKiBPerDay).toBe(fast.perTag.storageKiBPerDay / 10);
+    expect(slow.totals.ingressMbps).toBe(fast.totals.ingressMbps / 10);
+    expect(slow.perTag.memoryKiB).toBe(fast.perTag.memoryKiB);
+  });
+
+  it('validates unsafe and non-finite inputs', () => {
+    const planner = new CapacityPlanner({ now });
+    expect(() => planner.estimateResources({ tagCount: 0 })).toThrow(/tagCount/);
+    expect(() => planner.estimateResources({
+      tagCount: 10,
+      sampleIntervalSeconds: Number.NaN,
+    })).toThrow(/sampleIntervalSeconds must be finite/);
+    expect(() => planner.estimateResources({
+      tagCount: 10,
+      historianCopies: 0,
+    })).toThrow(/historianCopies/);
+  });
+});
+
+describe('CapacityPlanner cloud cost projections', () => {
+  it('projects itemized monthly AWS, Azure, and GCP costs', () => {
+    const planner = new CapacityPlanner({ now });
+    const estimate = planner.estimateResources({ tagCount: 50_000, subscriberFanout: 0.2 });
+    const projections = planner.projectCloudCosts(estimate);
+
+    expect(projections.map(item => item.provider)).toEqual(['aws', 'azure', 'gcp']);
+    for (const projection of projections) {
+      expect(projection.pricingVersion).toBe('2026-07-reference');
+      expect(projection.computeNodes).toBeGreaterThanOrEqual(2);
+      expect(projection.monthly.total).toBeCloseTo(
+        projection.monthly.compute
+          + projection.monthly.storage
+          + projection.monthly.networkEgress
+          + projection.monthly.loadBalancer,
+        2,
+      );
+      expect(projection.annualTotal).toBeCloseTo(projection.monthly.total * 12, 1);
+      expect(projection.assumptions.join(' ')).toMatch(/not a provider quote/i);
+    }
+  });
+
+  it('uses replaceable contracted rate cards', () => {
+    const freeAws = structuredClone(DEFAULT_CLOUD_RATE_CARDS);
+    freeAws.aws.compute.hourlyPerNode = 0;
+    freeAws.aws.storagePerGiBMonth = 0;
+    freeAws.aws.egressPerGiB = 0;
+    freeAws.aws.monthlyLoadBalancer = 0;
+    const planner = new CapacityPlanner({ rateCards: freeAws, now });
+
+    const [projection] = planner.projectCloudCosts({ tagCount: 1_000 }, ['aws']);
+    expect(projection.monthly.total).toBe(0);
+
+    freeAws.aws.compute.hourlyPerNode = 10;
+    const [unchanged] = planner.projectCloudCosts({ tagCount: 1_000 }, ['aws']);
+    expect(unchanged.monthly.total).toBe(0);
+  });
+});
+
+describe('CapacityPlanner growth and scaling', () => {
+  const linearHistory: TagCountObservation[] = [
+    { timestamp: '2026-01-01T00:00:00.000Z', tagCount: 10_000 },
+    { timestamp: '2026-02-01T00:00:00.000Z', tagCount: 13_100 },
+    { timestamp: '2026-03-01T00:00:00.000Z', tagCount: 15_900 },
+    { timestamp: '2026-04-01T00:00:00.000Z', tagCount: 19_000 },
+    { timestamp: '2026-05-01T00:00:00.000Z', tagCount: 22_000 },
+    { timestamp: '2026-06-01T00:00:00.000Z', tagCount: 25_100 },
+  ];
+
+  it('forecasts tag growth with least-squares fit and reports confidence', () => {
+    const planner = new CapacityPlanner({ now });
+    const forecast = planner.forecastGrowth(linearHistory, 6);
+
+    expect(forecast.method).toBe('linear-least-squares');
+    expect(forecast.slopeTagsPerDay).toBeCloseTo(100, 0);
+    expect(forecast.projectedTagCount).toBeGreaterThan(43_000);
+    expect(forecast.absoluteGrowth).toBe(forecast.projectedTagCount - 25_100);
+    expect(forecast.rSquared).toBeGreaterThan(0.999);
+    expect(forecast.confidence).toBe('high');
+    expect(forecast.monthlyGrowthRate).toBeGreaterThan(0);
+  });
+
+  it('rejects inadequate or ambiguous history', () => {
+    const planner = new CapacityPlanner({ now });
+    expect(() => planner.forecastGrowth([linearHistory[0]])).toThrow(/At least two/);
+    expect(() => planner.forecastGrowth([
+      linearHistory[0],
+      { ...linearHistory[1], timestamp: linearHistory[0].timestamp },
+    ])).toThrow(/unique/);
+  });
+
+  it('returns explicit cost/performance options and safe scale triggers', () => {
+    const planner = new CapacityPlanner({ now });
+    const forecast = planner.forecastGrowth(linearHistory, 6);
+    const recommendation = planner.recommendScaling({ tagCount: 25_100 }, forecast);
+
+    expect(recommendation.options.map(item => item.strategy)).toEqual([
+      'cost-optimized',
+      'balanced',
+      'performance',
+    ]);
+    expect(recommendation.options[0].headroomPercent)
+      .toBeLessThan(recommendation.options[2].headroomPercent);
+    expect(recommendation.options.every(item =>
+      Object.keys(item.monthlyCostByProvider).sort().join(',') === 'aws,azure,gcp')).toBe(true);
+    expect(recommendation.scaleTriggers.storageUtilizationPercent).toBe(70);
+    expect(recommendation.planningTagCount).toBe(forecast.projectedTagCount);
+  });
+
+  it('produces one complete deterministic planning artifact', () => {
+    const planner = new CapacityPlanner({ now });
+    const plan = planner.createPlan({
+      workload: { tagCount: 25_100, retentionDays: 180 },
+      history: linearHistory,
+      horizonMonths: 12,
+      providers: ['aws', 'gcp'],
+    });
+
+    expect(plan.generatedAt).toBe(NOW.toISOString());
+    expect(plan.forecast?.horizonMonths).toBe(12);
+    expect(plan.planning.workload.tagCount).toBe(plan.forecast?.projectedTagCount);
+    expect(plan.cloudCosts.map(item => item.provider)).toEqual(['aws', 'gcp']);
+    expect(plan.scaling.options).toHaveLength(3);
+    expect(plan.scaling.options.every(option =>
+      Object.keys(option.monthlyCostByProvider).sort().join(',') === 'aws,gcp')).toBe(true);
+  });
+});

--- a/server/services/capacity/index.ts
+++ b/server/services/capacity/index.ts
@@ -1,0 +1,671 @@
+/**
+ * Capacity planning and cloud cost modeling (ADR-0014, issue #228).
+ *
+ * The planner uses explicit, versioned coefficients and prices.  It never
+ * represents its projections as a cloud-provider quote: callers can replace
+ * the reference rates with their contracted rates while retaining the same
+ * deterministic formulas.
+ */
+export type CloudProvider = 'aws' | 'azure' | 'gcp';
+export type ScalingStrategy = 'cost-optimized' | 'balanced' | 'performance';
+
+export interface ResourceCoefficients {
+  baseCpuCores: number;
+  baseMemoryGiB: number;
+  baseStorageGiB: number;
+  cpuMillicoresPerTagAtOneSecond: number;
+  memoryKiBPerTag: number;
+  storageKiBPerTagDayAtOneSecond: number;
+  bandwidthBytesPerSecondPerTagAtOneSecond: number;
+  tagsPerGateway: number;
+  tagsPerApiServer: number;
+  tagsPerHistorianShard: number;
+}
+
+export interface CapacityWorkload {
+  tagCount: number;
+  sampleIntervalSeconds?: number;
+  retentionDays?: number;
+  headroomPercent?: number;
+  highAvailability?: boolean;
+  historianCopies?: number;
+  /** Average delivered subscriber copies for each ingested update. */
+  subscriberFanout?: number;
+}
+
+export interface ResourceEstimate {
+  workload: Required<CapacityWorkload>;
+  perTag: {
+    cpuMillicores: number;
+    memoryKiB: number;
+    storageKiBPerDay: number;
+    ingressBytesPerSecond: number;
+    egressBytesPerSecond: number;
+  };
+  totals: {
+    cpuCores: number;
+    memoryGiB: number;
+    storageGiB: number;
+    ingressMbps: number;
+    egressMbps: number;
+    updatesPerSecond: number;
+  };
+  topology: {
+    gatewayInstances: number;
+    apiServerInstances: number;
+    historianShards: number;
+  };
+  assumptions: readonly string[];
+}
+
+export interface CloudRateCard {
+  provider: CloudProvider;
+  version: string;
+  region: string;
+  currency: 'USD';
+  compute: {
+    vCpuPerNode: number;
+    memoryGiBPerNode: number;
+    hourlyPerNode: number;
+    targetCpuUtilization: number;
+    targetMemoryUtilization: number;
+  };
+  storagePerGiBMonth: number;
+  egressPerGiB: number;
+  monthlyLoadBalancer: number;
+}
+
+export interface CloudCostProjection {
+  provider: CloudProvider;
+  currency: 'USD';
+  pricingVersion: string;
+  region: string;
+  computeNodes: number;
+  billableStorageGiB: number;
+  monthlyEgressGiB: number;
+  monthly: {
+    compute: number;
+    storage: number;
+    networkEgress: number;
+    loadBalancer: number;
+    total: number;
+  };
+  annualTotal: number;
+  assumptions: readonly string[];
+}
+
+export interface TagCountObservation {
+  timestamp: string | Date;
+  tagCount: number;
+}
+
+export interface GrowthForecast {
+  method: 'linear-least-squares';
+  historyStart: string;
+  historyEnd: string;
+  horizonMonths: number;
+  forecastDate: string;
+  currentTagCount: number;
+  projectedTagCount: number;
+  absoluteGrowth: number;
+  monthlyGrowthRate: number;
+  annualizedGrowthRate: number;
+  slopeTagsPerDay: number;
+  rSquared: number;
+  confidence: 'low' | 'medium' | 'high';
+  pointsUsed: number;
+}
+
+export interface ScalingOption {
+  strategy: ScalingStrategy;
+  headroomPercent: number;
+  resourceEstimate: ResourceEstimate;
+  monthlyCostByProvider: Readonly<Partial<Record<CloudProvider, number>>>;
+  cheapestProvider: CloudProvider;
+  performanceTradeoff: string;
+  costTradeoff: string;
+}
+
+export interface ScalingRecommendation {
+  currentTagCount: number;
+  planningTagCount: number;
+  forecast?: GrowthForecast;
+  recommendedStrategy: ScalingStrategy;
+  rationale: readonly string[];
+  options: readonly ScalingOption[];
+  scaleTriggers: {
+    gatewayTagUtilizationPercent: number;
+    cpuUtilizationPercent: number;
+    memoryUtilizationPercent: number;
+    storageUtilizationPercent: number;
+  };
+}
+
+export interface CapacityPlan {
+  generatedAt: string;
+  current: ResourceEstimate;
+  forecast?: GrowthForecast;
+  planning: ResourceEstimate;
+  cloudCosts: readonly CloudCostProjection[];
+  scaling: ScalingRecommendation;
+}
+
+export const DEFAULT_RESOURCE_COEFFICIENTS: Readonly<ResourceCoefficients> = Object.freeze({
+  baseCpuCores: 0.5,
+  baseMemoryGiB: 1,
+  baseStorageGiB: 10,
+  cpuMillicoresPerTagAtOneSecond: 0.05,
+  memoryKiBPerTag: 2,
+  storageKiBPerTagDayAtOneSecond: 10,
+  bandwidthBytesPerSecondPerTagAtOneSecond: 50,
+  tagsPerGateway: 50_000,
+  tagsPerApiServer: 100_000,
+  tagsPerHistorianShard: 250_000,
+});
+
+function frozenRateCard(card: CloudRateCard): CloudRateCard {
+  return Object.freeze({
+    ...card,
+    compute: Object.freeze({ ...card.compute }),
+  });
+}
+
+export const DEFAULT_CLOUD_RATE_CARDS: Readonly<Record<CloudProvider, CloudRateCard>> = Object.freeze({
+  aws: frozenRateCard({
+    provider: 'aws',
+    version: '2026-07-reference',
+    region: 'us-east-1',
+    currency: 'USD',
+    compute: {
+      vCpuPerNode: 4,
+      memoryGiBPerNode: 16,
+      hourlyPerNode: 0.192,
+      targetCpuUtilization: 0.7,
+      targetMemoryUtilization: 0.75,
+    },
+    storagePerGiBMonth: 0.08,
+    egressPerGiB: 0.09,
+    monthlyLoadBalancer: 18.25,
+  }),
+  azure: frozenRateCard({
+    provider: 'azure',
+    version: '2026-07-reference',
+    region: 'eastus',
+    currency: 'USD',
+    compute: {
+      vCpuPerNode: 4,
+      memoryGiBPerNode: 16,
+      hourlyPerNode: 0.2,
+      targetCpuUtilization: 0.7,
+      targetMemoryUtilization: 0.75,
+    },
+    storagePerGiBMonth: 0.09,
+    egressPerGiB: 0.087,
+    monthlyLoadBalancer: 18.25,
+  }),
+  gcp: frozenRateCard({
+    provider: 'gcp',
+    version: '2026-07-reference',
+    region: 'us-central1',
+    currency: 'USD',
+    compute: {
+      vCpuPerNode: 4,
+      memoryGiBPerNode: 16,
+      hourlyPerNode: 0.189,
+      targetCpuUtilization: 0.7,
+      targetMemoryUtilization: 0.75,
+    },
+    storagePerGiBMonth: 0.1,
+    egressPerGiB: 0.12,
+    monthlyLoadBalancer: 18,
+  }),
+});
+
+const HOURS_PER_MONTH = 730;
+const DAYS_PER_MONTH = 365.25 / 12;
+const SECONDS_PER_MONTH = DAYS_PER_MONTH * 24 * 60 * 60;
+
+function rounded(value: number, digits = 2): number {
+  const factor = 10 ** digits;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+function requireFinite(
+  value: number,
+  field: string,
+  options: { min?: number; max?: number; integer?: boolean } = {},
+): void {
+  if (!Number.isFinite(value)) throw new Error(`${field} must be finite`);
+  if (options.integer && !Number.isInteger(value)) throw new Error(`${field} must be an integer`);
+  if (options.min !== undefined && value < options.min) {
+    throw new Error(`${field} must be at least ${options.min}`);
+  }
+  if (options.max !== undefined && value > options.max) {
+    throw new Error(`${field} must be at most ${options.max}`);
+  }
+}
+
+function normalizeWorkload(workload: CapacityWorkload): Required<CapacityWorkload> {
+  const normalized: Required<CapacityWorkload> = {
+    tagCount: workload.tagCount,
+    sampleIntervalSeconds: workload.sampleIntervalSeconds ?? 1,
+    retentionDays: workload.retentionDays ?? 90,
+    headroomPercent: workload.headroomPercent ?? 30,
+    highAvailability: workload.highAvailability ?? true,
+    historianCopies: workload.historianCopies ?? 1,
+    subscriberFanout: workload.subscriberFanout ?? 1,
+  };
+  requireFinite(normalized.tagCount, 'tagCount', { min: 1, max: 100_000_000, integer: true });
+  requireFinite(normalized.sampleIntervalSeconds, 'sampleIntervalSeconds', { min: 0.05, max: 86_400 });
+  requireFinite(normalized.retentionDays, 'retentionDays', { min: 1, max: 3_650, integer: true });
+  requireFinite(normalized.headroomPercent, 'headroomPercent', { min: 0, max: 300 });
+  requireFinite(normalized.historianCopies, 'historianCopies', { min: 1, max: 5, integer: true });
+  requireFinite(normalized.subscriberFanout, 'subscriberFanout', { min: 0, max: 10_000 });
+  return normalized;
+}
+
+function validateCoefficients(coefficients: ResourceCoefficients): void {
+  for (const [field, value] of Object.entries(coefficients)) {
+    requireFinite(value, `coefficients.${field}`, { min: Number.EPSILON });
+  }
+}
+
+function validateRateCard(card: CloudRateCard): void {
+  if (!card.version.trim() || !card.region.trim()) {
+    throw new Error(`Rate card ${card.provider} requires a version and region`);
+  }
+  requireFinite(card.compute.vCpuPerNode, `${card.provider}.compute.vCpuPerNode`, { min: 1 });
+  requireFinite(card.compute.memoryGiBPerNode, `${card.provider}.compute.memoryGiBPerNode`, { min: 1 });
+  requireFinite(card.compute.hourlyPerNode, `${card.provider}.compute.hourlyPerNode`, { min: 0 });
+  requireFinite(card.compute.targetCpuUtilization, `${card.provider}.compute.targetCpuUtilization`, {
+    min: 0.01,
+    max: 1,
+  });
+  requireFinite(card.compute.targetMemoryUtilization, `${card.provider}.compute.targetMemoryUtilization`, {
+    min: 0.01,
+    max: 1,
+  });
+  requireFinite(card.storagePerGiBMonth, `${card.provider}.storagePerGiBMonth`, { min: 0 });
+  requireFinite(card.egressPerGiB, `${card.provider}.egressPerGiB`, { min: 0 });
+  requireFinite(card.monthlyLoadBalancer, `${card.provider}.monthlyLoadBalancer`, { min: 0 });
+}
+
+export class CapacityPlanner {
+  private readonly coefficients: Readonly<ResourceCoefficients>;
+  private readonly rateCards: Readonly<Record<CloudProvider, CloudRateCard>>;
+  private readonly now: () => Date;
+
+  constructor(options: {
+    coefficients?: ResourceCoefficients;
+    rateCards?: Record<CloudProvider, CloudRateCard>;
+    now?: () => Date;
+  } = {}) {
+    this.coefficients = Object.freeze({
+      ...DEFAULT_RESOURCE_COEFFICIENTS,
+      ...(options.coefficients ?? {}),
+    });
+    const rateCards = {
+      ...DEFAULT_CLOUD_RATE_CARDS,
+      ...(options.rateCards ?? {}),
+    };
+    // Never retain references to exported defaults or caller-owned nested
+    // objects; later mutation must not silently rewrite a live cost model.
+    this.rateCards = Object.freeze({
+      aws: structuredClone(rateCards.aws),
+      azure: structuredClone(rateCards.azure),
+      gcp: structuredClone(rateCards.gcp),
+    });
+    this.now = options.now ?? (() => new Date());
+    validateCoefficients(this.coefficients);
+    Object.values(this.rateCards).forEach(validateRateCard);
+  }
+
+  getCoefficients(): Readonly<ResourceCoefficients> {
+    return { ...this.coefficients };
+  }
+
+  getRateCards(): Readonly<Record<CloudProvider, CloudRateCard>> {
+    return {
+      aws: structuredClone(this.rateCards.aws),
+      azure: structuredClone(this.rateCards.azure),
+      gcp: structuredClone(this.rateCards.gcp),
+    };
+  }
+
+  estimateResources(workloadInput: CapacityWorkload): ResourceEstimate {
+    const workload = normalizeWorkload(workloadInput);
+    const intervalScale = 1 / workload.sampleIntervalSeconds;
+    const headroom = 1 + workload.headroomPercent / 100;
+    const perTag = {
+      cpuMillicores: rounded(this.coefficients.cpuMillicoresPerTagAtOneSecond * intervalScale, 6),
+      memoryKiB: this.coefficients.memoryKiBPerTag,
+      storageKiBPerDay: rounded(
+        this.coefficients.storageKiBPerTagDayAtOneSecond * intervalScale,
+        6,
+      ),
+      ingressBytesPerSecond: rounded(
+        this.coefficients.bandwidthBytesPerSecondPerTagAtOneSecond * intervalScale,
+        6,
+      ),
+      egressBytesPerSecond: rounded(
+        this.coefficients.bandwidthBytesPerSecondPerTagAtOneSecond
+          * intervalScale
+          * workload.subscriberFanout,
+        6,
+      ),
+    };
+    const cpuCores = (
+      this.coefficients.baseCpuCores
+      + workload.tagCount * perTag.cpuMillicores / 1_000
+    ) * headroom;
+    const memoryGiB = (
+      this.coefficients.baseMemoryGiB
+      + workload.tagCount * perTag.memoryKiB / 1_048_576
+    ) * headroom;
+    const storageGiB = (
+      this.coefficients.baseStorageGiB
+      + (
+        workload.tagCount
+        * perTag.storageKiBPerDay
+        * workload.retentionDays
+        * workload.historianCopies
+      ) / 1_048_576
+    ) * headroom;
+    const ingressMbps = workload.tagCount * perTag.ingressBytesPerSecond * 8 / 1_000_000;
+    const egressMbps = workload.tagCount * perTag.egressBytesPerSecond * 8 / 1_000_000;
+    const minimumInstances = workload.highAvailability ? 2 : 1;
+    return {
+      workload,
+      perTag,
+      totals: {
+        cpuCores: rounded(cpuCores, 3),
+        memoryGiB: rounded(memoryGiB, 3),
+        storageGiB: rounded(storageGiB, 3),
+        ingressMbps: rounded(ingressMbps * headroom, 3),
+        egressMbps: rounded(egressMbps * headroom, 3),
+        updatesPerSecond: rounded(workload.tagCount * intervalScale, 3),
+      },
+      topology: {
+        gatewayInstances: Math.max(
+          minimumInstances,
+          Math.ceil(workload.tagCount / this.coefficients.tagsPerGateway * headroom),
+        ),
+        apiServerInstances: Math.max(
+          minimumInstances,
+          Math.ceil(workload.tagCount / this.coefficients.tagsPerApiServer * headroom),
+        ),
+        historianShards: Math.max(
+          1,
+          Math.ceil(workload.tagCount / this.coefficients.tagsPerHistorianShard * headroom),
+        ),
+      },
+      assumptions: [
+        `Resource headroom is ${workload.headroomPercent}%.`,
+        `Per-tag rates are normalized to a ${workload.sampleIntervalSeconds}s sample interval.`,
+        `${workload.historianCopies} historian data ${
+          workload.historianCopies === 1 ? 'copy is' : 'copies are'
+        } retained for ${workload.retentionDays} days.`,
+        workload.highAvailability
+          ? 'Gateway and API topology has a minimum of two instances.'
+          : 'High availability is disabled; single-instance failure is possible.',
+      ],
+    };
+  }
+
+  projectCloudCosts(
+    estimateOrWorkload: ResourceEstimate | CapacityWorkload,
+    providers: readonly CloudProvider[] = ['aws', 'azure', 'gcp'],
+  ): readonly CloudCostProjection[] {
+    const estimate = 'totals' in estimateOrWorkload
+      ? estimateOrWorkload
+      : this.estimateResources(estimateOrWorkload);
+    const uniqueProviders = [...new Set(providers)];
+    if (uniqueProviders.length === 0) throw new Error('At least one cloud provider is required');
+    return uniqueProviders.map(provider => {
+      const card = this.rateCards[provider];
+      if (card === undefined) throw new Error(`Unsupported cloud provider: ${provider}`);
+      const resourceNodes = Math.max(
+        Math.ceil(
+          estimate.totals.cpuCores
+          / (card.compute.vCpuPerNode * card.compute.targetCpuUtilization),
+        ),
+        Math.ceil(
+          estimate.totals.memoryGiB
+          / (card.compute.memoryGiBPerNode * card.compute.targetMemoryUtilization),
+        ),
+      );
+      // This topology floor ensures that a cost projection does not silently
+      // co-locate every critical role on fewer nodes than the model recommends.
+      const topologyNodes = Math.max(
+        estimate.topology.gatewayInstances,
+        estimate.topology.apiServerInstances + estimate.topology.historianShards,
+      );
+      const computeNodes = Math.max(resourceNodes, topologyNodes);
+      const monthlyEgressGiB = estimate.totals.egressMbps
+        * 1_000_000
+        / 8
+        * SECONDS_PER_MONTH
+        / (1024 ** 3);
+      const compute = computeNodes * card.compute.hourlyPerNode * HOURS_PER_MONTH;
+      const storage = estimate.totals.storageGiB * card.storagePerGiBMonth;
+      const networkEgress = monthlyEgressGiB * card.egressPerGiB;
+      const loadBalancer = estimate.workload.highAvailability ? card.monthlyLoadBalancer : 0;
+      const monthly = {
+        compute: rounded(compute),
+        storage: rounded(storage),
+        networkEgress: rounded(networkEgress),
+        loadBalancer: rounded(loadBalancer),
+        total: 0,
+      };
+      monthly.total = rounded(
+        monthly.compute + monthly.storage + monthly.networkEgress + monthly.loadBalancer,
+      );
+      return {
+        provider,
+        currency: card.currency,
+        pricingVersion: card.version,
+        region: card.region,
+        computeNodes,
+        billableStorageGiB: rounded(estimate.totals.storageGiB, 3),
+        monthlyEgressGiB: rounded(monthlyEgressGiB, 3),
+        monthly,
+        annualTotal: rounded(monthly.total * 12),
+        assumptions: [
+          `Reference on-demand rates for ${card.region}, version ${card.version}.`,
+          `${HOURS_PER_MONTH} compute hours per month; taxes, support, discounts, and managed-service premiums excluded.`,
+          'Internet egress is modeled from subscriber fan-out; private inter-zone transfer is excluded.',
+          'This projection is a planning estimate, not a provider quote.',
+        ],
+      };
+    });
+  }
+
+  forecastGrowth(
+    historyInput: readonly TagCountObservation[],
+    horizonMonths = 6,
+  ): GrowthForecast {
+    requireFinite(horizonMonths, 'horizonMonths', { min: 1, max: 120, integer: true });
+    if (historyInput.length < 2) throw new Error('At least two historical tag-count observations are required');
+    const history = historyInput
+      .map(observation => {
+        const timestamp = observation.timestamp instanceof Date
+          ? observation.timestamp.getTime()
+          : Date.parse(observation.timestamp);
+        if (!Number.isFinite(timestamp)) throw new Error(`Invalid history timestamp: ${observation.timestamp}`);
+        requireFinite(observation.tagCount, 'history.tagCount', {
+          min: 0,
+          max: 100_000_000,
+          integer: true,
+        });
+        return { timestamp, tagCount: observation.tagCount };
+      })
+      .sort((a, b) => a.timestamp - b.timestamp);
+    for (let index = 1; index < history.length; index += 1) {
+      if (history[index].timestamp === history[index - 1].timestamp) {
+        throw new Error('Historical tag-count timestamps must be unique');
+      }
+    }
+    const firstTimestamp = history[0].timestamp;
+    const x = history.map(point => (point.timestamp - firstTimestamp) / (24 * 60 * 60 * 1000));
+    const y = history.map(point => point.tagCount);
+    const meanX = x.reduce((sum, value) => sum + value, 0) / x.length;
+    const meanY = y.reduce((sum, value) => sum + value, 0) / y.length;
+    const covariance = x.reduce(
+      (sum, value, index) => sum + (value - meanX) * (y[index] - meanY),
+      0,
+    );
+    const varianceX = x.reduce((sum, value) => sum + (value - meanX) ** 2, 0);
+    const slope = varianceX === 0 ? 0 : covariance / varianceX;
+    const intercept = meanY - slope * meanX;
+    const residual = y.reduce(
+      (sum, value, index) => sum + (value - (intercept + slope * x[index])) ** 2,
+      0,
+    );
+    const totalVariance = y.reduce((sum, value) => sum + (value - meanY) ** 2, 0);
+    const rSquared = totalVariance === 0 ? 1 : Math.max(0, Math.min(1, 1 - residual / totalVariance));
+    const last = history.at(-1)!;
+    const horizonDays = horizonMonths * DAYS_PER_MONTH;
+    const forecastTimestamp = last.timestamp + horizonDays * 24 * 60 * 60 * 1000;
+    const forecastX = (forecastTimestamp - firstTimestamp) / (24 * 60 * 60 * 1000);
+    const projectedTagCount = Math.max(0, Math.round(intercept + slope * forecastX));
+    const currentTagCount = last.tagCount;
+    const absoluteGrowth = projectedTagCount - currentTagCount;
+    const monthlyGrowthRate = currentTagCount === 0
+      ? 0
+      : ((projectedTagCount / currentTagCount) ** (1 / horizonMonths) - 1);
+    const annualizedGrowthRate = (1 + monthlyGrowthRate) ** 12 - 1;
+    const spanDays = (last.timestamp - firstTimestamp) / (24 * 60 * 60 * 1000);
+    const confidence: GrowthForecast['confidence'] = history.length >= 6
+      && spanDays >= 90
+      && rSquared >= 0.8
+      ? 'high'
+      : history.length >= 3 && spanDays >= 30 && rSquared >= 0.5
+        ? 'medium'
+        : 'low';
+    return {
+      method: 'linear-least-squares',
+      historyStart: new Date(firstTimestamp).toISOString(),
+      historyEnd: new Date(last.timestamp).toISOString(),
+      horizonMonths,
+      forecastDate: new Date(forecastTimestamp).toISOString(),
+      currentTagCount,
+      projectedTagCount,
+      absoluteGrowth,
+      monthlyGrowthRate: rounded(monthlyGrowthRate, 6),
+      annualizedGrowthRate: rounded(annualizedGrowthRate, 6),
+      slopeTagsPerDay: rounded(slope, 6),
+      rSquared: rounded(rSquared, 6),
+      confidence,
+      pointsUsed: history.length,
+    };
+  }
+
+  recommendScaling(
+    workloadInput: CapacityWorkload,
+    forecast?: GrowthForecast,
+    providers: readonly CloudProvider[] = ['aws', 'azure', 'gcp'],
+  ): ScalingRecommendation {
+    const current = normalizeWorkload(workloadInput);
+    const planningTagCount = Math.max(current.tagCount, forecast?.projectedTagCount ?? current.tagCount);
+    const strategyHeadroom: Readonly<Record<ScalingStrategy, number>> = {
+      'cost-optimized': 20,
+      balanced: 35,
+      performance: 60,
+    };
+    const options = (Object.entries(strategyHeadroom) as Array<[ScalingStrategy, number]>)
+      .map(([strategy, headroomPercent]): ScalingOption => {
+        const resourceEstimate = this.estimateResources({
+          ...current,
+          tagCount: planningTagCount,
+          headroomPercent,
+        });
+        const costs = this.projectCloudCosts(resourceEstimate, providers);
+        const monthlyCostByProvider = Object.fromEntries(
+          costs.map(cost => [cost.provider, cost.monthly.total]),
+        ) as Partial<Record<CloudProvider, number>>;
+        const cheapestProvider = costs.reduce((best, candidate) =>
+          candidate.monthly.total < best.monthly.total ? candidate : best).provider;
+        const tradeoffs: Record<ScalingStrategy, [string, string]> = {
+          'cost-optimized': [
+            'Higher target utilization; suitable for stable workloads with slower scale-out.',
+            'Lowest modeled spend, but the smallest burst and failover reserve.',
+          ],
+          balanced: [
+            'Moderate reserve for failover and forecast error without extensive over-provisioning.',
+            'Mid-range spend and the default choice for production OT workloads.',
+          ],
+          performance: [
+            'Largest burst reserve and lowest resource contention for rapidly growing workloads.',
+            'Highest modeled spend and greater idle capacity during steady demand.',
+          ],
+        };
+        return {
+          strategy,
+          headroomPercent,
+          resourceEstimate,
+          monthlyCostByProvider,
+          cheapestProvider,
+          performanceTradeoff: tradeoffs[strategy][0],
+          costTradeoff: tradeoffs[strategy][1],
+        };
+      });
+    const monthlyGrowth = forecast?.monthlyGrowthRate ?? 0;
+    const recommendedStrategy: ScalingStrategy = monthlyGrowth >= 0.05
+      || forecast?.confidence === 'low'
+      ? 'performance'
+      : monthlyGrowth <= 0.005 && forecast?.confidence === 'high'
+        ? 'cost-optimized'
+        : 'balanced';
+    const rationale = [
+      forecast === undefined
+        ? 'No historical forecast was supplied; the current tag count is used.'
+        : `Plan covers ${planningTagCount.toLocaleString('en-US')} tags at the ${forecast.forecastDate} horizon.`,
+      forecast?.confidence === 'low'
+        ? 'Forecast confidence is low, so additional performance reserve is recommended.'
+        : `Forecast confidence is ${forecast?.confidence ?? 'not available'}.`,
+      `The ${recommendedStrategy} option preserves high availability and explicit utilization triggers.`,
+    ];
+    return {
+      currentTagCount: current.tagCount,
+      planningTagCount,
+      forecast,
+      recommendedStrategy,
+      rationale,
+      options,
+      scaleTriggers: {
+        gatewayTagUtilizationPercent: 70,
+        cpuUtilizationPercent: 70,
+        memoryUtilizationPercent: 75,
+        storageUtilizationPercent: 70,
+      },
+    };
+  }
+
+  createPlan(input: {
+    workload: CapacityWorkload;
+    history?: readonly TagCountObservation[];
+    horizonMonths?: number;
+    providers?: readonly CloudProvider[];
+  }): CapacityPlan {
+    const current = this.estimateResources(input.workload);
+    const forecast = input.history === undefined
+      ? undefined
+      : this.forecastGrowth(input.history, input.horizonMonths ?? 6);
+    const planningTagCount = Math.max(input.workload.tagCount, forecast?.projectedTagCount ?? 0);
+    const planning = this.estimateResources({
+      ...input.workload,
+      tagCount: planningTagCount,
+      headroomPercent: input.workload.headroomPercent ?? 35,
+    });
+    return {
+      generatedAt: this.now().toISOString(),
+      current,
+      forecast,
+      planning,
+      cloudCosts: this.projectCloudCosts(planning, input.providers),
+      scaling: this.recommendScaling(input.workload, forecast, input.providers),
+    };
+  }
+}
+
+export const capacityPlanner = new CapacityPlanner();

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -33,6 +33,9 @@ export { getRedisClient, isRedisHealthy } from './cache';
 export * from './compliance';
 export { complianceService } from './compliance';
 
+// ── Capacity Planning Service (ADR-0014 [14.8], #228) ───────────────────────
+export * from './capacity';
+
 // ── Flux Service ─────────────────────────────────────────────────────────────
 export * from './flux';
 
@@ -259,6 +262,7 @@ export async function getServicesHealthStatus(): Promise<{
 export const serviceRegistry = {
   cache: () => import('./cache'),
   compliance: () => import('./compliance'),
+  capacity: () => import('./capacity'),
   flux: () => import('./flux'),
   geometry: () => import('./geometry'),
   ml: () => import('./ml'),


### PR DESCRIPTION
## Summary

- Adds a tag-count resource calculator for ingestion throughput, CPU, memory, storage, network, and high-availability headroom.
- Adds history-based growth forecasting, AWS/Azure/GCP reference cost projections, scaling thresholds, and three recommendation strategies with explicit trade-offs.
- Adds governance endpoints for complete plans, current estimates, model assumptions, and observation-backed forecasts, plus an updated operator guide.

Closes #228

## Safety and compatibility

- Planning fails closed when no tag count is supplied instead of manufacturing a placeholder forecast.
- Legacy root/constraint request shapes remain supported while the explicit workload envelope is preferred.
- Provider selections propagate consistently through current and projected costs; published rate cards are returned as immutable snapshots.
- The legacy trends route now directs callers to submit real history to the forecast endpoint.

## Attribution

City-Agent: Codex

## Verification

```text
npx vitest run server/services/capacity/__tests__/capacity-planner.test.ts server/routes/__tests__/capacity-readiness.test.ts
# 2 files passed; 12 tests passed

npm run typecheck
# passed

npm run build:server
# passed

git diff --cached --check
# passed before commit
```

## Gate self-check

- [x] Every commit is signed off (`git commit -s` → `Signed-off-by` line, DCO)
- [x] The `City-Agent:` line above is filled in
- [x] `npx tsc --noEmit` is clean
- [x] No new `any` types
- [x] Barrel export and dynamic service registry updated
- [x] Tests added/updated for every claim in the summary
- [x] PR is scoped to a single issue
