### PR TITLE
test(migrations): assert journal invariants instead of a literal tag list (#616)

### DIFF
--- a/server/blueprint/__tests__/production-safety.test.ts
+++ b/server/blueprint/__tests__/production-safety.test.ts
@@ -1,6 +1,38 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 
 import { describe, expect, it } from "vitest";
+
+const MIGRATIONS_DIR = new URL("../../../migrations/", import.meta.url);
+const SAFE_STATE_MIGRATION = "0009_blueprint_safe_state_log";
+const SQL_SUFFIX = ".sql";
+/** drizzle-kit tags: a 4-digit ordinal, an underscore, then a snake_case name. */
+const TAG_PATTERN = /^(\d{4})_[a-z0-9]+(?:_[a-z0-9]+)*$/;
+
+interface JournalEntry {
+  idx: number;
+  tag: string;
+  when: number;
+}
+
+/** Journal entries in declared file order (idx order is asserted separately). */
+function readJournalEntries(): JournalEntry[] {
+  const journal = JSON.parse(
+    readFileSync(new URL("meta/_journal.json", MIGRATIONS_DIR), "utf8"),
+  ) as { entries: JournalEntry[] };
+  return journal.entries;
+}
+
+/**
+ * Tags implied by the on-disk migrations, in the order migrations/migrate.ts
+ * applies them — it lists the directory and plain-`.sort()`s the `.sql` names,
+ * which for zero-padded drizzle-kit tags is numeric order.
+ */
+function readMigrationTagsFromDisk(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.endsWith(SQL_SUFFIX))
+    .map((file) => file.slice(0, -SQL_SUFFIX.length))
+    .sort();
+}
 
 describe("safe-state audit migration alignment", () => {
   it("creates every durable column and index declared by the Drizzle table", () => {
@@ -45,28 +77,89 @@ describe("safe-state audit migration alignment", () => {
     );
   });
 
-  it("appends the safe-state migration to the existing journal without renumbering", () => {
-    const journal = JSON.parse(
-      readFileSync(
-        new URL("../../../migrations/meta/_journal.json", import.meta.url),
-        "utf8",
-      ),
-    ) as { entries: Array<{ idx: number; tag: string; when: number }> };
+  it("is registered in the migration journal", () => {
+    expect(readJournalEntries().map((entry) => entry.tag)).toContain(
+      SAFE_STATE_MIGRATION,
+    );
+  });
+});
 
-    expect(journal.entries.map(({ idx, tag }) => ({ idx, tag }))).toEqual([
-      { idx: 0, tag: "0001_initial_schema" },
-      { idx: 1, tag: "0002_seed_rbac_defaults" },
-      { idx: 2, tag: "0003_blueprint_persistence" },
-      { idx: 3, tag: "0006_blueprint_instance_identity" },
-      { idx: 4, tag: "0007_validator_registry" },
-      { idx: 5, tag: "0008_modbus_register_map" },
-      { idx: 6, tag: "0009_blueprint_safe_state_log" },
-      { idx: 7, tag: "0010_pid_tuning_audit" },
-      { idx: 8, tag: "0011_agent_marketplace" },
-      { idx: 9, tag: "0012_validator_liveness_observations" },
-    ]);
+/**
+ * These guard the journal as a whole, not the safe-state migration specifically
+ * (#616). They deliberately assert invariants rather than a literal list of
+ * tags: the previous literal `toEqual` had to be hand-edited by every unrelated
+ * migration (#613, #614, #615), and it could not detect a `.sql` file that no
+ * journal entry referenced. Adding a migration correctly — file plus entry —
+ * leaves these green; adding half of one does not.
+ */
+describe("migration journal integrity", () => {
+  it("has exactly one journal entry per migrations/*.sql file, and no entry without a file", () => {
+    const fileTags = readMigrationTagsFromDisk();
+    const entryTags = readJournalEntries().map((entry) => entry.tag);
+
+    expect(fileTags.length).toBeGreaterThan(0);
+
+    const unjournalled = fileTags.filter((tag) => !entryTags.includes(tag));
+    expect(
+      unjournalled,
+      "migrations/*.sql files with no meta/_journal.json entry — drizzle-kit will never apply them",
+    ).toEqual([]);
+
+    const orphaned = entryTags.filter((tag) => !fileTags.includes(tag));
+    expect(
+      orphaned,
+      "journal entries with no matching migrations/<tag>.sql file",
+    ).toEqual([]);
+
+    const duplicated = entryTags.filter(
+      (tag, index) => entryTags.indexOf(tag) !== index,
+    );
+    expect(duplicated, "tags listed more than once in the journal").toEqual([]);
+  });
+
+  it("numbers entries contiguously from 0, in declared order, with no gaps or duplicates", () => {
+    const entries = readJournalEntries();
+
+    // Declared order, not sorted order: drizzle-kit tooling consumes
+    // `entries` as written, so a correct `idx` in the wrong array position
+    // still applies the DDL out of order.
+    expect(entries.map((entry) => entry.idx)).toEqual(
+      entries.map((_, position) => position),
+    );
+  });
+
+  it("orders entries by migration number, matching the order migrate.ts applies them", () => {
+    const entries = [...readJournalEntries()].sort((a, b) => a.idx - b.idx);
+
+    // idx order must equal the on-disk apply order, so a mis-numbered entry
+    // cannot silently reorder DDL relative to the runner.
+    expect(entries.map((entry) => entry.tag)).toEqual(readMigrationTagsFromDisk());
+
+    const ordinals = entries.map((entry) => {
+      const match = TAG_PATTERN.exec(entry.tag);
+      if (match === null) {
+        throw new Error(
+          `journal tag "${entry.tag}" is not a drizzle-kit tag (NNNN_snake_case)`,
+        );
+      }
+      return Number.parseInt(match[1], 10);
+    });
+    // Strictly increasing: no reused ordinal, and no renumbering that would
+    // change the meaning of an already-applied migration.
+    for (let i = 1; i < ordinals.length; i += 1) {
+      expect(
+        ordinals[i],
+        `migration ${entries[i].tag} does not come after ${entries[i - 1].tag}`,
+      ).toBeGreaterThan(ordinals[i - 1]);
+    }
+
     // `when` must stay monotonic so drizzle-kit orders the journal correctly.
-    const timestamps = journal.entries.map((e) => e.when);
-    expect([...timestamps].sort((a, b) => a - b)).toEqual(timestamps);
+    const timestamps = entries.map((entry) => entry.when);
+    for (let i = 1; i < timestamps.length; i += 1) {
+      expect(
+        timestamps[i],
+        `${entries[i].tag} has a "when" at or before ${entries[i - 1].tag}`,
+      ).toBeGreaterThan(timestamps[i - 1]);
+    }
   });
 });


### PR DESCRIPTION
Fixes #616.

`server/blueprint/__tests__/production-safety.test.ts` pinned the entire drizzle-kit journal with a literal `toEqual` over every `{idx, tag}`. The intent was right, but the execution meant every unrelated migration turned the blueprint safe-state suite red and forced a hand-edit (#613, #614, #615) — and each edit is an invitation to "fix" it by deleting the guard.

It also never checked the property it existed for: a `migrations/*.sql` file that no journal entry references passed happily, as long as the array matched.

## What changed

The literal list is replaced by invariants, split into a `migration journal integrity` describe block so an unrelated migration failure no longer reads as "I broke blueprint safe-state":

- **Bijection** — every `migrations/*.sql` has exactly one journal entry and every entry has a file, checked in both directions, with the offending tags named in the failure message. Plus a duplicate-tag check.
- **Contiguity** — `idx` values are exactly `0..n-1`, no gaps, no duplicates.
- **Ordering** — `idx` order equals the order `migrations/migrate.ts` actually applies files (it lists the dir and plain-`.sort()`s the `.sql` names); 4-digit ordinals strictly increase, so no reused ordinal and no renumbering of an already-applied migration; `when` strictly increases (tightened from the previous non-decreasing check).
- **Safe-state** — `0009_blueprint_safe_state_log` is asserted *present*, not pinned to a position, which is the only journal fact this file actually cares about.

Non-contiguous ordinals are deliberately allowed — the repo legitimately skips `0004`/`0005`.

## Verification (by mutation, not inspection)

**An unrelated migration stays green.** Added a temporary `migrations/0013_unrelated_widget.sql` plus its journal entry: `6 passed (6)`. With that same probe in place, the pre-change version of the file (checked out from `HEAD` and run alongside) failed on the literal array, `+ { idx: 10, tag: "0013_unrelated_widget" }`. That is exactly the edit-per-migration this issue is about, now gone.

**A broken journal still goes red.** Five separate mutations, each reverted afterwards:

| mutation | result |
|---|---|
| `.sql` on disk, journal entry removed | red — names `0013_unrelated_widget` as unjournalled |
| journal entry present, `.sql` removed | red — names it as orphaned (**old assertion could not detect this at all**) |
| duplicated `idx` leaving a gap (`…,6,6,8,9`) | red on contiguity |
| two `idx` swapped, contiguity intact (`…,5,7,6,8,9`) | red on ordering |
| `0009_blueprint_safe_state_log` dropped + renumbered | red on presence, bijection and ordering |

The journal was restored with `git checkout` and the probe `.sql` deleted; the diff touches one file.

## Checks

- `npx tsc --noEmit` — exit 0. (Note: the repo's `tsconfig.json` excludes `**/*.test.ts`, so this does not type-check the edited file itself.)
- Target file: 3 tests → 6 tests, all passing.
- Full `npx vitest run`: 3455 → 3458 tests (+3, exactly the new tests). Three suites (`blueprint-storage`, `scheduler-import-safety`, `anchor-pipeline-latency`) fail nondeterministically under parallel load **on the untouched baseline as well** and pass when run in isolation (14/14) — pre-existing flakes, untouched here.


🤖 Generated with [Claude Code](https://claude.com/claude-code)