### PR TITLE
test(blueprint): make the #458 import-safety guard order- and timing-independent (fixes #622)

### DIFF
--- a/docs/operations/preempt-rt.md
+++ b/docs/operations/preempt-rt.md
@@ -112,11 +112,21 @@ if (status.mode !== "realtime") log.warn(status.error);
 ```
 
 `BlueprintTickLoop` (`server/blueprint/tick-loop.ts`) accepts the same
-target as an option and forwards it at `start()`. Its `TickFn` seam is what the
-deterministic runtime from #457 plugs into:
+target as an option and forwards it at `start()`. It does **not** default to the
+process-wide scheduler: the instance is a required option, so a loop can never
+apply a scheduling decision to the shared singleton by accident (#622). Its
+`TickFn` seam is what the deterministic runtime from #457 plugs into:
 
 ```ts
-const loop = new BlueprintTickLoop({ blueprintId: bp.id, periodMs: 10 });
+import { BlueprintTickLoop, getScheduler } from "./server/blueprint";
+
+const loop = new BlueprintTickLoop({
+  blueprintId: bp.id,
+  periodMs: 10,
+  // Explicit: pass getScheduler() for the process-wide instance, or your own
+  // TickScheduler when the control process owns its configuration.
+  scheduler: getScheduler(),
+});
 loop.setTickFn(() => runtime.tickFast());
 loop.start();
 ```

--- a/server/blueprint/__tests__/scheduler-import-safety.test.ts
+++ b/server/blueprint/__tests__/scheduler-import-safety.test.ts
@@ -12,7 +12,7 @@
  * performed with real-time scheduling fully enabled in the environment.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
 
 const { spawnSyncMock } = vi.hoisted(() => ({
   spawnSyncMock: vi.fn(() => ({
@@ -49,6 +49,30 @@ afterEach(() => {
   vi.resetModules();
 });
 
+/**
+ * Cost of compiling `server/blueprint/index.ts` — the whole blueprint module
+ * graph — for the first time in a worker. Measured at ~18 s on a loaded Windows
+ * dev box (`vitest --reporter=verbose` on this file alone), against a 5 s
+ * default `testTimeout`, which is what actually made this file red in a full
+ * local run while it stayed green in CI (#622): every test here re-imports the
+ * barrel, so the very first one absorbed the entire cold transform.
+ *
+ * Paying it once in a hook with an explicit budget keeps the tests themselves on
+ * the strict default timeout — a test that becomes slow for a real reason still
+ * fails.
+ */
+const COLD_TRANSFORM_BUDGET_MS = 120_000;
+
+beforeAll(async () => {
+  // Warm the transform cache only. Every test below still does its own
+  // `vi.resetModules()` + `import()`, so the module graph each one observes is
+  // freshly evaluated under its own environment — this import asserts nothing
+  // and is deliberately not allowed to count towards the spawn assertions.
+  await import('../index');
+  spawnSyncMock.mockClear();
+  vi.resetModules();
+}, COLD_TRANSFORM_BUDGET_MS);
+
 describe('server/blueprint import safety (#458)', () => {
   it('importing the barrel with real-time ENABLED spawns no process', async () => {
     setEnv({
@@ -66,11 +90,40 @@ describe('server/blueprint import safety (#458)', () => {
     // an import-time apply() would fall back before reaching chrt and would slip
     // through. `status()` is the host-independent discriminator: it throws until
     // apply() has recorded a decision, so this fails on ANY host the moment an
-    // import-time apply() is reintroduced.
+    // import-time apply() is reintroduced. The `vi.resetModules()` above is what
+    // makes that read order-independent; the next test proves it.
     expect(() => mod.getScheduler().status()).toThrow(/before apply\(\)/);
     // …and the shared scheduler must still report the honest, unapplied state.
     expect(mod.getScheduler().healthSummary().schedulingMode).toBe('fallback');
     expect(mod.getScheduler().healthSummary().applied).toBe(false);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('the status() discriminator cannot be poisoned by an earlier apply() (#622)', async () => {
+    setEnv({ OXSCADA_RT_ENABLED: 'true', OXSCADA_RT_PRIORITY: '50' });
+    vi.resetModules();
+
+    const polluted = await import('../index');
+    const pollutedLogger = await import('../../logger');
+    const warnSpy = vi.spyOn(pollutedLogger, 'logWarn').mockImplementation(() => {});
+
+    // Pollute the shared singleton the way a composition root would. Applying to
+    // our own pid is refused, but the refusal is still a recorded decision — so
+    // `status()` stops throwing. This half proves the discriminator used by the
+    // test above is genuinely sensitive to a recorded apply(), i.e. it would go
+    // green for the wrong reason if the singleton arrived dirty.
+    polluted.applyScheduler({ kind: 'dedicated-control-process', pid: process.pid });
+    expect(() => polluted.getScheduler().status()).not.toThrow();
+    expect(polluted.getScheduler().status().applied).toBe(false);
+    warnSpy.mockRestore();
+
+    // The other half: resetting the module registry — which every test in this
+    // file does before importing — yields a genuinely pristine singleton, so no
+    // apply() recorded earlier in the process can flip the guard.
+    vi.resetModules();
+    const fresh = await import('../index');
+    expect(fresh.getScheduler()).not.toBe(polluted.getScheduler());
+    expect(() => fresh.getScheduler().status()).toThrow(/before apply\(\)/);
     expect(spawnSyncMock).not.toHaveBeenCalled();
   });
 

--- a/server/blueprint/__tests__/tick-loop.test.ts
+++ b/server/blueprint/__tests__/tick-loop.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BlueprintTickLoop } from '../tick-loop';
-import { TickScheduler, type HostProbe } from '../scheduler';
+import { TickScheduler, getScheduler, type HostProbe } from '../scheduler';
 import { resetBlueprintMetrics } from '../../metrics/blueprint';
 import * as logger from '../../logger';
 
@@ -223,6 +223,39 @@ describe('BlueprintTickLoop', () => {
           scheduler: optedInScheduler(stockProbe()),
         }),
     ).toThrow();
+  });
+
+  it('refuses to be constructed without an explicit scheduler (#622)', () => {
+    // `start()` records a decision on whatever scheduler it is handed. When the
+    // option defaulted to the process-wide `getScheduler()` singleton, merely
+    // starting a loop mutated shared state that other code — and other test
+    // files — observe. The option is now required at the type level; this
+    // covers the runtime guard for callers that are not type-checked.
+    const withoutScheduler = {
+      blueprintId: 'x',
+      periodMs: 10,
+    } as unknown as ConstructorParameters<typeof BlueprintTickLoop>[0];
+    expect(() => new BlueprintTickLoop(withoutScheduler)).toThrow(/scheduler is required/);
+  });
+
+  it('never touches the process-wide scheduler singleton (#622)', () => {
+    // The shared instance must still be un-applied after a loop has been fully
+    // constructed, started and stopped with an injected scheduler — i.e. the
+    // loop reaches for no global. `status()` throwing is the discriminator:
+    // it only stops throwing once `apply()` has recorded a decision.
+    const loop = new BlueprintTickLoop({
+      blueprintId: 'bp-no-global',
+      periodMs: 10,
+      scheduler: optedInScheduler(stockProbe()),
+      nowNs: scriptedClock([0, 1 * MS]),
+    });
+    loop.setTickFn(() => {});
+    loop.start();
+    loop.runOneTick();
+    loop.stop();
+
+    expect(() => getScheduler().status()).toThrow(/before apply\(\)/);
+    expect(getScheduler().healthSummary().applied).toBe(false);
   });
 
   it('requires a tick function before start', () => {

--- a/server/blueprint/tick-loop.ts
+++ b/server/blueprint/tick-loop.ts
@@ -16,14 +16,19 @@
  * the one-line {@link TickFn}:
  *
  * ```ts
- * const loop = new BlueprintTickLoop({ blueprintId: bp.id, periodMs: 10 });
+ * const loop = new BlueprintTickLoop({
+ *   blueprintId: bp.id,
+ *   periodMs: 10,
+ *   scheduler: getScheduler(), // explicit: see TickLoopOptions.scheduler
+ * });
  * loop.setTickFn(() => runtime.tickFast());
  * loop.start();
  * ```
  *
  * ## Scheduling
- * The loop does NOT elevate anything by itself. It asks the scheduler for a
- * decision at {@link BlueprintTickLoop.start} time, passing through whatever
+ * The loop does NOT elevate anything by itself, and it owns no scheduler: the
+ * composition root passes one in. It asks that scheduler for a decision at
+ * {@link BlueprintTickLoop.start} time, passing through whatever
  * {@link TickLoopOptions.schedulerTarget} the composition root supplied. When
  * the loop runs inside the API server process (the current deployment shape) no
  * target is available, the scheduler stays in `fallback`, and Express/WebSocket
@@ -34,7 +39,6 @@
 
 import {
   TickScheduler,
-  getScheduler,
   type DedicatedSchedulerTarget,
   type SchedulerHealthSummary,
   type SchedulerStatus,
@@ -64,12 +68,16 @@ export interface TickLoopOptions {
   /** Rolling window (tick count) over which WCET is computed. Default 1000. */
   wcetWindow?: number;
   /**
-   * Scheduler instance to consult. Defaults to the lazily-constructed
-   * process-wide singleton, which is off unless `OXSCADA_RT_ENABLED=true`.
-   * Injectable so tests (and a future dedicated control process) can supply
-   * their own configuration and host probe.
+   * Scheduler instance to consult. REQUIRED and never defaulted.
+   *
+   * `start()` calls `apply()` on whatever instance it is given, and `apply()`
+   * permanently records a decision on that instance. Defaulting to the
+   * process-wide singleton (`getScheduler()`) therefore made merely
+   * constructing and starting a loop mutate shared process state — the
+   * implicit coupling behind #622. A composition root that genuinely wants the
+   * process-wide scheduler must now say so: `scheduler: getScheduler()`.
    */
-  scheduler?: TickScheduler;
+  scheduler: TickScheduler;
   /**
    * Dedicated control-process target handed to the scheduler at `start()`.
    * Omitted by default — without it the scheduler stays in `fallback` and no
@@ -114,6 +122,14 @@ export class BlueprintTickLoop {
   constructor(options: TickLoopOptions) {
     if (!options.blueprintId) throw new Error('blueprintId is required');
     if (!(options.periodMs > 0)) throw new Error('periodMs must be > 0');
+    // Runtime guard as well as a type-level one: the whole point of dropping
+    // the `getScheduler()` default is that no caller can silently apply the
+    // process-wide scheduler, and a JS caller must not be able to opt back in.
+    if (!options.scheduler) {
+      throw new Error(
+        'scheduler is required; pass getScheduler() explicitly to use the process-wide instance',
+      );
+    }
 
     this.blueprintId = options.blueprintId;
     this.periodMs = options.periodMs;
@@ -121,9 +137,10 @@ export class BlueprintTickLoop {
     this.schedulerTarget = options.schedulerTarget;
     this.nowNs = options.nowNs ?? (() => process.hrtime.bigint());
 
-    // Constructing the loop must not probe the host or touch scheduling policy;
-    // `getScheduler()` is lazy and `apply()` only runs from `start()`.
-    this.scheduler = options.scheduler ?? getScheduler();
+    // Constructing the loop must not probe the host or touch scheduling policy:
+    // the instance is supplied by the caller and `apply()` only runs from
+    // `start()`.
+    this.scheduler = options.scheduler;
     this.accountant = new TickAccountant({
       targetPeriodNs: this.periodMs * MS_TO_NS,
       deadlineNs: this.deadlineMs * MS_TO_NS,


### PR DESCRIPTION
Fixes #622.

## What actually fails

I reproduced before changing anything. The literal failure is **not** the `status()` assertion:

```
FAIL server/blueprint/__tests__/scheduler-import-safety.test.ts >
     importing the barrel with real-time ENABLED spawns no process
Error: Test timed out in 5000ms.
```

Every test in that file does `vi.resetModules()` + `await import('../index')`, so the first one absorbs the cold Vite transform of the entire `server/blueprint` module graph. Measured on the file alone with `--reporter=verbose`:

| test | duration |
|---|---|
| importing the barrel with real-time ENABLED spawns no process | **18150 ms** |
| the spawn seam is genuinely observable | 55 ms |
| importing with a MALFORMED priority does not throw | 41 ms |
| a malformed priority also cannot crash the first getScheduler() call | 41 ms |

…against a 5000 ms default `testTimeout`. In a full run the whole file is starved and all four tests time out in 5 s slices (the fourth then fails with a cascading `expected "logWarn" to be called 1 times, but got 0 times`). On this host it also fails **in isolation**, which the issue reports as passing.

## The singleton diagnosis does not hold

On unmodified `main`, `npx vitest run --testTimeout=60000` is **172 passed | 2 skipped (174 files)**, **3450 passed | 5 skipped**, **zero failures**. The `status()` assertion passes in the full suite as soon as it is given time to execute. No `apply()` decision leaks between files here: vitest's `isolate` defaults to true (fresh module registry per file), and the test additionally calls `vi.resetModules()` before importing. Two independent barriers.

## Changes

**1. Pay the cold transform once, outside the per-test budget.** A `beforeAll` warms the transform cache under an explicit, documented budget (`COLD_TRANSFORM_BUDGET_MS`, justified by the measured ~18 s). The four tests keep the strict 5 s default, so a test that becomes slow for a real reason still fails. The warm-up asserts nothing and its `spawnSync` count is cleared, so it cannot make the spawn assertions vacuous; each test still evaluates a freshly reset graph under its own environment. No `test.sequential`, no sleep, no weakened assertion.

**2. Remove the implicit coupling the issue correctly identified** (its option 2 — "the most durable"), even though it is not what broke the test. `TickLoopOptions.scheduler` no longer defaults to `getScheduler()`. `start()` records a permanent decision on whatever scheduler it is handed, so the default meant that constructing and starting a loop mutated process-wide state. It is now required at the type level plus a runtime guard for untyped callers. There were no production call sites and every existing test already injected one.

I deliberately did **not** add a test-only `resetSchedulerForTests()` export (option 1): that would put unused API into a production module to defend against a leak that demonstrably does not occur.

**3. New regression coverage**
- `the status() discriminator cannot be poisoned by an earlier apply() (#622)` — proves both halves: `applyScheduler()` on the shared instance really does stop `status()` throwing (so the guard is non-vacuous and *would* be flipped by a dirty singleton), and `vi.resetModules()` really does hand back a pristine instance, so the guard is order-independent.
- `BlueprintTickLoop` refuses construction without a scheduler.
- a fully started/ticked/stopped loop leaves the process-wide singleton un-applied.

**4. Docs** — `docs/operations/preempt-rt.md` example updated to the explicit-scheduler form.

## Verification

`npx tsc --noEmit` → exit 0.

| scope | before | after |
|---|---|---|
| target file alone | 1 failed \| 3 passed (timeout) | **5 passed (5)**, slowest test 219 ms |
| `vitest run server/blueprint` | 218 passed | **221 passed** (+3 new) |
| full `vitest run` | 2 files failed \| 170 passed \| 2 skipped (174); **4 failed** \| 3440 passed \| 11 skipped (3455) — all 4 in this file | best of 3 runs: 1 file failed \| 171 passed \| 2 skipped (174); 1 failed \| **3452 passed** \| 5 skipped (3458) |

scheduler-import-safety was green in every post-fix run, alone and in the full suite.

## Known-unrelated residue

This box was running 5–6 sibling worktree suites concurrently. Remaining full-suite reds are all `Test timed out in 5000ms` / `Hook timed out in 10000ms` in files this PR does not touch (`blueprint-storage`, `marketplace-persistence`, `iec61850-goose/live-backend`, `cli/secure-storage`, `dnp3-outstation/server`, `anchor-pipeline-latency`). They vary run to run, `blueprint-storage` was already red in the baseline, and the two most frequent offenders pass in isolation (`2 passed (2)` / `11 passed (11)`, twice). Worth a separate issue; out of scope here.

⚠️ Measurement hygiene note for anyone reviewing these parallel branches: two of my early `npx vitest run` invocations printed `RUN v4.1.10 C:/Users/nmodha/scada-fix/wa461` / `wa460` rather than this worktree, and one capture contained two different runs' summaries. That is the shared `node_modules` junction plus concurrent sibling runs. Check the vitest banner path before trusting any local number — including the ones in the issue body.


🤖 Generated with [Claude Code](https://claude.com/claude-code)