### PR TITLE
ci: restore CodeQL scanning as a committed workflow (clears all 7 stale alerts)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,79 @@
+name: CodeQL
+
+# Static analysis for the TypeScript/JavaScript tree.
+#
+# WHY THIS FILE EXISTS. CodeQL used to run here through GitHub-managed *default
+# setup*, not a committed workflow — `git log --all -- '.github/workflows/*codeql*'`
+# is empty. That setup is now `not-configured`, so the last analysis on this repo
+# was 2026-02-17 against commit 55cdb8ed. Everything merged since then has been
+# unscanned, and the alerts left over from February are pinned to line numbers
+# that no longer mean anything (see the discussion on the PR that added this).
+#
+# Committing the workflow (CodeQL "advanced setup") makes scanning a reviewable
+# part of the repo rather than a console toggle that can be switched off without
+# leaving a trace in git.
+#
+# NOTE: advanced setup and default setup are mutually exclusive. If default setup
+# is ever re-enabled in Settings → Code security, this workflow's uploads will be
+# rejected — pick one. This file is the one under version control.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly floor so the tree is still scanned during quiet periods. Offset off
+    # the hour to avoid the load spike other repos schedule at :00.
+    - cron: "23 4 * * 1"
+  workflow_dispatch: {}
+
+# Least privilege: CodeQL needs to read the tree and write its findings back.
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # `javascript-typescript` is the current single language pack; the two
+        # historical analyses on this repo (`/language:javascript` and
+        # `/language:typescript`) were merged upstream into it.
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Pinned to the same Node major every other workflow uses (#598, #604), so
+      # a version skew here cannot produce findings the rest of CI never sees.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          # `security-and-quality` is deliberately NOT used: it adds
+          # maintainability rules that would bury the security findings this is
+          # here to surface. `security-extended` keeps the signal security-only
+          # while covering more than the default suite.
+          queries: security-extended
+
+      # No build step. This tree is interpreted TypeScript, so CodeQL's
+      # extractor works from source; running `npm ci` here would only add a
+      # multi-minute install for no additional coverage.
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
All 7 open code-scanning alerts are **stale**, not real. The fix is not a code change — it is restoring the scanner.

## The alerts describe February code

Every alert is pinned to commit `55cdb8ed`, and `code-scanning/analyses` shows the last run was **2026-02-17**. The line numbers no longer resolve to the code they describe — alert #14 points at `server/openapi/swagger-ui.ts:115`, which on current `main` is a closing brace.

I checked each one against `main` and diffed it against `55cdb8ed`. **All seven are already fixed:**

| Alert | File | At `55cdb8ed` | On current `main` |
|---|---|---|---|
| #24 high | `cli/src/lib/formatter.ts` | `.replace(/"/g, ...)` — no backslash escaping | `.replace(/\/g, "\\\\")` applied **first**, then quotes |
| #14 high | `server/openapi/swagger-ui.ts` | same defect at `:115` | same fix, now at `:190` |
| #27 med | `server/config/config-manager.ts` | `setNested()` had **no guard at all** | rejects `__proto__`/`constructor`/`prototype` on intermediate **and** final keys |
| #1 high | `server/routes/events.ts` | not rate-limited | `eventRoutes.use(eventRateLimit)` `:31` |
| #2 high | `server/static.ts` | not rate-limited | `app.use(staticRateLimit, ...)` `:14` |
| #3 high | `server/vite.ts` | not rate-limited | `app.use("*", spaRateLimit, ...)` `:30` |
| #15 high | `server/swagger.ts` | not rate-limited | `swaggerRouter.use(docsRateLimit)` `:19` |

## The actual defect: scanning has been dark since February

- `GET code-scanning/default-setup` → **`state: not-configured`**
- `git log --all -- ".github/workflows/*codeql*"` → **empty** — a CodeQL workflow was never committed

CodeQL ran through GitHub-managed *default setup*; that was turned off, and nothing in the repository recorded it. **Everything merged since February has gone unscanned** — which, given how much has landed in the last two days alone, is the finding that actually matters here.

## What this does

Commits the workflow (CodeQL "advanced setup") so scanning is a reviewable part of the repo rather than a console toggle that can be switched off without leaving a trace in git. Running it re-analyses HEAD and **closes the 7 stale alerts on their own** — which is the right way to clear them. Dismissing them by hand would have cleared the warnings while leaving the scanner off, hiding the real problem.

### Choices

- **`security-extended`, not `security-and-quality`** — the latter adds maintainability rules that would bury the security findings this exists to surface.
- **No build step** — the extractor works from source for interpreted TypeScript, so `npm ci` would add minutes for no extra coverage.
- **`setup-node` pinned to 22** — matches every other workflow (#598, #604), so a version skew here cannot produce findings the rest of CI never sees.
- **Weekly `schedule` floor** at `23 4 * * 1` so the tree is still scanned during quiet periods, offset off the hour.
- ⚠️ **Advanced and default setup are mutually exclusive.** If default setup is ever re-enabled in Settings → Code security, this workflow's uploads will be rejected. This file is the one under version control.

Scanning `actions` as a second language is a reasonable follow-up (the repo has substantial workflow code) but is deliberately out of scope here — this restores exactly the JS/TS coverage that was lost.

## Verification

- workflow parses under `js-yaml` `JSON_SCHEMA`; `permissions` is least-privilege (`contents: read`, `security-events: write`)
- the repo's own pin guard `test/ci/workflow-node-version.test.ts` (from #598/#635) passes **8/8** with this file present
- no source files touched — `1 file changed, 79 insertions(+)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)