### PR TITLE
fix(blueprints): null-prototype accumulators for header-keyed CSV parsing (CodeQL #149-#154, #28)

### DIFF
--- a/server/blueprints/__tests__/parser-prototype-pollution.test.ts
+++ b/server/blueprints/__tests__/parser-prototype-pollution.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression guard for the CodeQL `js/remote-property-injection` findings on the
+ * blueprint parsers (alerts #149-#154) and `js/prototype-pollution-utility` on
+ * `setNested` (#28).
+ *
+ * These parsers build objects keyed by the *header cells of an uploaded CSV*,
+ * i.e. by attacker-controlled strings:
+ *
+ *     const row = {};
+ *     headerRow.forEach((header, idx) => { row[header] = cells[idx]; });
+ *
+ * With a normal `{}` accumulator a header literally named `__proto__` writes
+ * through to `Object.prototype`, so one uploaded file could add a property to
+ * every object in the process. The accumulators now use `Object.create(null)`,
+ * which has no prototype chain to reach. `configuration` in
+ * `parseCMInstancesCSV` is the same story for non-standard column names.
+ *
+ * These tests assert the *property*, not the implementation: they parse a CSV
+ * whose header is `__proto__` and then check an unrelated, freshly-created
+ * object was not affected. That fails on the old code and passes on the new,
+ * and keeps passing under any future rewrite that is also safe.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseCMInstancesCSV } from "../csv-parser";
+
+/** A property name no legitimate code would define. */
+const CANARY = "__polluted_by_test__";
+
+function protoCanary(): unknown {
+  return ({} as Record<string, unknown>)[CANARY];
+}
+
+afterEach(() => {
+  // Never let a failure leak a polluted prototype into the rest of the suite.
+  delete (Object.prototype as Record<string, unknown>)[CANARY];
+});
+
+describe("blueprint CSV parsing uses null-prototype accumulators", () => {
+  it("Object.prototype is never reached, whatever the headers are", () => {
+    // Kept as a belt-and-braces assertion. Note it passes on the OLD code too:
+    // `row["__proto__"] = "a string"` is silently ignored, because the
+    // `__proto__` setter only accepts an object or null and CSV cells are
+    // always strings. That is exactly why the CodeQL finding is not an
+    // exploitable pollution — see the header comment.
+    const csv = [`Name,__proto__,constructor`, `pump-01,${CANARY},${CANARY}`].join("\n");
+
+    parseCMInstancesCSV(csv, "MotorCM");
+
+    expect(protoCanary()).toBeUndefined();
+    expect(CANARY in Object.prototype).toBe(false);
+  });
+
+  it("parsed configuration objects inherit nothing", () => {
+    // THIS is the assertion that binds the change: on the old `{}` accumulator
+    // the prototype is Object.prototype, so `configuration.toString` is an
+    // inherited function and a header named `toString` would shadow it for
+    // every downstream consumer. With Object.create(null) there is nothing to
+    // shadow and nothing to inherit.
+    const parsed = parseCMInstancesCSV(
+      [`Name,setpoint`, `pump-01,42`].join("\n"),
+      "MotorCM",
+    );
+
+    const config = parsed.instances[0].configuration as Record<string, unknown>;
+    expect(Object.getPrototypeOf(config)).toBeNull();
+    expect((config as any).toString).toBeUndefined();
+    expect((config as any).hasOwnProperty).toBeUndefined();
+  });
+
+  it("a header named toString cannot shadow an inherited member", () => {
+    // On a plain object this stores a string over the inherited function, so
+    // any downstream `String(config)` or `config.toString()` throws. With a
+    // null-prototype accumulator it is just an ordinary data key.
+    const parsed = parseCMInstancesCSV(
+      [`Name,toString`, `pump-01,hijacked`].join("\n"),
+      "MotorCM",
+    );
+
+    const config = parsed.instances[0].configuration as Record<string, unknown>;
+    expect(config.toString).toBe("hijacked");
+    // The prototype chain is empty, so nothing inherited was displaced.
+    expect(Object.getPrototypeOf(config)).toBeNull();
+  });
+
+  it("ordinary parsing still works", () => {
+    const parsed = parseCMInstancesCSV(
+      [`Name,Comment,setpoint`, `pump-01,north feed,42`].join("\n"),
+      "MotorCM",
+    );
+
+    expect(parsed.instances).toHaveLength(1);
+    expect(parsed.instances[0].name).toBe("pump-01");
+    // `setpoint` is not a standard column, so it lands in configuration —
+    // and numeric-looking values are coerced.
+    expect(parsed.instances[0].configuration.setpoint).toBe(42);
+  });
+});
+
+// NOTE on CodeQL #28 (`js/prototype-pollution-utility`, config-manager
+// `setNested`): deliberately not covered here. `setNested` is a private helper
+// called only with hardcoded config paths (config-manager.ts:316, :324, :364),
+// so its keys are never attacker-controlled and there is no reachable path to
+// test. It keeps a FORBIDDEN_KEYS denylist plus null-prototype intermediates as
+// defence-in-depth; writing a test that reaches past the public API to "prove"
+// an unreachable exploit would assert something the system does not actually do.

--- a/server/blueprints/batch-rung-generator.ts
+++ b/server/blueprints/batch-rung-generator.ts
@@ -149,7 +149,7 @@ export class BatchRungGenerator {
       const values = this.parseCSVLine(lines[i]);
       if (values.length === 0) continue;
 
-      const row: Record<string, string> = {};
+      const row: Record<string, string> = Object.create(null); // null-prototype: header cells are untrusted keys
       for (let j = 0; j < headers.length && j < values.length; j++) {
         const key = headers[j].trim();
         const value = values[j].trim();

--- a/server/blueprints/cm-type-parser.ts
+++ b/server/blueprints/cm-type-parser.ts
@@ -74,7 +74,7 @@ export function parseCMTypeMarkdown(content: string, sourceFile?: string): Parse
       }
       
       // Parse data row
-      const row: Record<string, string> = {};
+      const row: Record<string, string> = Object.create(null); // null-prototype: header cells are untrusted keys
       headerRow.forEach((header, idx) => {
         row[header] = cells[idx] || "";
       });

--- a/server/blueprints/csv-parser.ts
+++ b/server/blueprints/csv-parser.ts
@@ -17,7 +17,7 @@ function parseCSV(content: string): Array<Record<string, string>> {
   
   for (let i = 1; i < lines.length; i++) {
     const values = lines[i].split(",").map(v => v.trim());
-    const row: Record<string, string> = {};
+    const row: Record<string, string> = Object.create(null); // null-prototype: CSV headers are untrusted keys
     
     headers.forEach((header, idx) => {
       row[header] = values[idx] || "";
@@ -59,7 +59,7 @@ export function parseCMInstancesCSV(
     if (!name) continue;
     
     // Extract configuration (non-standard columns)
-    const configuration: Record<string, any> = {};
+    const configuration: Record<string, any> = Object.create(null); // null-prototype: column names are untrusted keys
     for (const [key, value] of Object.entries(row)) {
       if (!standardColumns.has(key) && value) {
         // Try to parse numeric values

--- a/server/blueprints/phase-type-parser.ts
+++ b/server/blueprints/phase-type-parser.ts
@@ -169,7 +169,7 @@ export function parsePhaseTypeMarkdown(content: string, sourceFile?: string): Pa
       }
       
       // Parse data row based on section
-      const row: Record<string, string> = {};
+      const row: Record<string, string> = Object.create(null); // null-prototype: header cells are untrusted keys
       headerRow.forEach((header, idx) => {
         row[header] = cells[idx] || "";
       });

--- a/server/blueprints/unit-type-parser.ts
+++ b/server/blueprints/unit-type-parser.ts
@@ -67,7 +67,7 @@ export function parseUnitTypeMarkdown(content: string, sourceFile?: string): Par
       }
       
       // Parse data row
-      const row: Record<string, string> = {};
+      const row: Record<string, string> = Object.create(null); // null-prototype: header cells are untrusted keys
       headerRow.forEach((header, idx) => {
         row[header] = cells[idx] || "";
       });

--- a/server/config/config-manager.ts
+++ b/server/config/config-manager.ts
@@ -185,7 +185,10 @@ function setNested(obj: Record<string, any>, path: string, value: unknown): void
     const key = parts[i];
     if (FORBIDDEN_KEYS.has(key)) return; // Guard against prototype pollution
     if (!Object.prototype.hasOwnProperty.call(current, key) || !current[key] || typeof current[key] !== 'object') {
-      current[key] = {};
+      // Null-prototype: the FORBIDDEN_KEYS denylist above already rejects
+      // __proto__/constructor/prototype, but an intermediate created here has no
+      // prototype chain to pollute even if that denylist is ever weakened.
+      current[key] = Object.create(null);
     }
     current = current[key];
   }


### PR DESCRIPTION
First slice of the code-scanning triage, after #639 restored CodeQL. Covers the `js/remote-property-injection` cluster and the `js/prototype-pollution-utility` finding.

## What this is — and what it is not

**It is not a fix for an exploitable prototype pollution.** I want that stated plainly, because the alert names imply otherwise.

Five parsers build a row object keyed by the header cells of an uploaded CSV, plus one that copies non-standard columns into `configuration`:

```ts
const row = {};
headerRow.forEach((header, idx) => { row[header] = cells[idx]; });
```

A header named `__proto__` looks alarming, but `row["__proto__"] = "some string"` is **silently ignored** — the `__proto__` setter only accepts an object or `null`, and CSV cells are always strings (or numbers in `configuration`). There is no path from an uploaded file to a polluted `Object.prototype` here.

I found this out the useful way: my first regression test asserted "Object.prototype is not polluted", and it **passed against the unfixed code**. A vacuous test. It is kept in the file, explicitly labelled as belt-and-braces, with a comment explaining why it cannot fail.

## What it does fix — real, but smaller

**Shadowing.** On a `{}` accumulator, a column named `toString`, `constructor` or `valueOf` writes a string over an inherited member. Any downstream `String(config)` or `config.toString()` then throws on data an operator uploaded. With `Object.create(null)` there is nothing to shadow and nothing to inherit.

That is what the two binding assertions check, and they fail when the accumulators are reverted to `{}`:

```
× parsed configuration objects inherit nothing
× a header named toString cannot shadow an inherited member
```

## Files

`csv-parser.ts` (×2), `cm-type-parser.ts`, `phase-type-parser.ts`, `unit-type-parser.ts`, `batch-rung-generator.ts`.

`server/config/config-manager.ts` also gets `Object.create(null)` for the intermediates `setNested` creates. **Deliberately untested**: `setNested` is private and every caller passes a hardcoded config path (`:316`, `:324`, `:364`), so its keys are never attacker-controlled and CodeQL **#28 is not reachable**. Reaching past the public API to "prove" an exploit would assert something the system does not do. The existing `FORBIDDEN_KEYS` denylist is correct; this is defence-in-depth.

## Also triaged, not changed

**#29 `js/unvalidated-dynamic-method-call`** (`marketplace/engine.ts:611`) is a **false positive**. `handler` comes from `this.implementations.get(pluginId)` — an internal registry of built-in implementations, not user input — and the call is capability-gated (#615) and `withTimeout`-bounded. Invoking a registered plugin handler is the engine's entire purpose. Recommend dismissing as "used in a safe way" rather than contorting the dispatch.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `vitest run` (full) | **3474 passed / 5 skipped / 0 failed** (174 files) |
| New assertions bind | revert accumulators to `{}` → **2 failed** |

## Still open from the triage

`js/log-injection` (17 — 11 of them in `examples/websocket-consumer.ts`, which is not shipped), `js/http-to-file-access` (5, CLI), `js/file-system-race` (2), `js/regex-injection` (1 — `geometry.ts` has a genuinely incomplete ReDoS denylist that misses `(a+)+` and `(a|a)*`), `js/file-access-to-http` (1). Next slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)