### PR TITLE
feat(predictive): persist thresholds and alert acknowledgement state across restart (#546)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,27 @@ PID_TUNING_PROPOSAL_TTL_MS=86400000
 # in development. Production uses DATABASE_URL and migration 0010.
 TUNING_AUDIT_SQLITE_PATH=
 
+# Predictive Maintenance durable state (ADR-0013 [13.1], Issues #212 / #546)
+# Operator thresholds and alert acknowledgement state live in the database
+# (migration 0013), not in process memory, so they survive a restart and are
+# shared between replicas. There is no in-memory fallback: while the store is
+# unreachable, threshold writes, alert generation and acknowledgements are all
+# refused (HTTP 503) and /api/predictive/status reports the reason.
+#
+# Optional override for the SQLite file backing that state in development.
+# Production uses DATABASE_URL and migration 0013.
+PREDICTIVE_SQLITE_PATH=
+# Retention for DURABLE ALERT state. This is deliberately independent of the
+# raw prediction history, which is an in-process sliding window bounded by
+# sample count (1000 points across at most 500 tags) and is never persisted.
+# Acknowledged alerts are pruned once they are older than this (default 90d).
+PREDICTIVE_ALERT_RETENTION_MS=7776000000
+# Absolute cut-off: any alert older than this is pruned whether or not it was
+# ever acknowledged (default 365d), so an abandoned alert cannot pin the table
+# open forever. Clamped to at least PREDICTIVE_ALERT_RETENTION_MS. Every
+# eviction is emitted as an `alerts-pruned` event rather than done silently.
+PREDICTIVE_ALERT_MAX_AGE_MS=31536000000
+
 # Flux State Engine Integration (ADR-0015, Issue #260)
 # Set FLUX_URL to enable. Leave blank to disable.
 FLUX_URL=

--- a/migrations/0013_predictive_durable_state.sql
+++ b/migrations/0013_predictive_durable_state.sql
@@ -1,0 +1,129 @@
+-- Migration: 0013_predictive_durable_state
+-- Issue: #546 — [QE] persist predictive thresholds and alert acknowledgement
+--         state across restart (ADR-0013 [13.1], features #212 / PR #493)
+--
+-- ─── WHY ─────────────────────────────────────────────────────────────────────
+--
+-- The predictive-maintenance engine kept operator thresholds, generated alerts
+-- and acknowledgement state in process-local Maps. A restart or a replica
+-- change therefore reverted every configured tag to the built-in defaults and
+-- erased the record of who had taken ownership of which alert. That fails the
+-- "Durable approvals/state" row of ADR-0026: an acknowledgement that does not
+-- survive process replacement is not an audit record, and a threshold that does
+-- not survive it is not a configuration.
+--
+-- ─── WHAT IS DURABLE HERE, AND WHAT IS DELIBERATELY NOT ──────────────────────
+--
+-- Durable (this migration): operator configuration and alert lifecycle/audit.
+--
+-- NOT durable, by design: the raw prediction history (the per-tag time-series
+-- window the detectors run over). It is a recomputable sliding window fed
+-- continuously by the live tag stream, it is bounded in-process
+-- (PredictiveMaintenanceEngine.maxHistorySize / maxTrackedTags), and the
+-- historian — not this feature — is the system of record for sampled process
+-- data. Persisting every ingested point here would put a per-sample write on
+-- the ingest path and duplicate the historian. Its retention is therefore
+-- defined separately and independently from the retention of the two tables
+-- below; see server/services/predictive/engine.ts.
+--
+-- ─── RETENTION ───────────────────────────────────────────────────────────────
+--
+-- predictive_tag_thresholds: none. Operator configuration is kept until an
+--   operator changes it. Rows are only ever replaced, never aged out.
+--
+-- predictive_alerts: applied by server/services/predictive/index.ts, which runs
+--   a retention sweep on an interval.
+--     * acknowledged alerts older than PREDICTIVE_ALERT_RETENTION_MS
+--       (default 90 days) are deleted — the operator has closed them out;
+--     * ANY alert older than PREDICTIVE_ALERT_MAX_AGE_MS (default 365 days) is
+--       deleted, acknowledged or not, so an abandoned alert cannot pin the
+--       table open forever;
+--     * a row cap (PredictiveMaintenanceEngine.maxAlerts) bounds the table if
+--       alerts arrive faster than they age out. Acknowledged rows are evicted
+--       before unacknowledged ones and every eviction is emitted as an
+--       `alerts-pruned` event, so nothing is discarded silently.
+--
+-- ─── MULTI-REPLICA ───────────────────────────────────────────────────────────
+--
+-- Unlike migration 0012, this table has no single-writer assumption. Alert
+-- `id` is content-derived (tag + severity + cooldown window) rather than a
+-- per-process counter, so two replicas observing the same anomaly compute the
+-- same primary key; the engine inserts with ON CONFLICT DO NOTHING, which makes
+-- this table — not a process-local Map — the alert-suppression authority.
+-- Acknowledgement is a conditional UPDATE guarded on `acknowledged = FALSE`, so
+-- the first acknowledgement wins and a concurrent second one is reported back
+-- as already-acknowledged instead of overwriting the original attribution.
+--
+-- Date: 2026-07-28
+
+CREATE TABLE IF NOT EXISTS predictive_tag_thresholds (
+  -- Tag identifier as supplied on the ingest/threshold routes (bounded to 256
+  -- characters there by the Zod schema).
+  tag_id VARCHAR(256) PRIMARY KEY,
+  min_samples INTEGER NOT NULL,
+  z_score_threshold DOUBLE PRECISION NOT NULL,
+  ewma_alpha DOUBLE PRECISION NOT NULL,
+  ewma_l DOUBLE PRECISION NOT NULL,
+  iqr_multiplier DOUBLE PRECISION NOT NULL,
+  -- Detector name -> weight. Validated against the registered detector set on
+  -- the write path before it reaches this table.
+  ensemble_weights JSONB NOT NULL,
+  -- { warning, critical, emergency }, validated warning <= critical <= emergency.
+  severity_thresholds JSONB NOT NULL,
+  -- { low?, high? } engineering limits for time-to-limit estimation. NULL when
+  -- the operator has not configured any.
+  failure_limits JSONB,
+  -- Control-plane principal name (API key record name) that last wrote this
+  -- configuration. Never client-supplied.
+  updated_by VARCHAR(128) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_predictive_thresholds_updated_at
+  ON predictive_tag_thresholds(updated_at);
+
+CREATE TABLE IF NOT EXISTS predictive_alerts (
+  -- Content-derived identity: PMA-<sha256(tag | severity | cooldown window)>.
+  -- Restart-stable and replica-stable on purpose — see the note above.
+  id VARCHAR(64) PRIMARY KEY,
+  tag_id VARCHAR(256) NOT NULL,
+  severity VARCHAR(16) NOT NULL,
+  score DOUBLE PRECISION NOT NULL,
+  message TEXT NOT NULL,
+  -- Names of the detectors that actually fired, as a JSON array of strings.
+  detectors JSONB NOT NULL,
+  recommendation TEXT NOT NULL,
+  -- Data-clock timestamp of the observation that triggered the alert. This can
+  -- lag or lead wall clock (replayed history, clock-skewed field devices), so
+  -- it is deliberately NOT the retention key.
+  observed_at TIMESTAMPTZ NOT NULL,
+  -- Wall-clock time the row was written. Retention and ordering key.
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  acknowledged BOOLEAN NOT NULL DEFAULT FALSE,
+  -- Control-plane principal name. Never taken from a request body.
+  acknowledged_by VARCHAR(128),
+  acknowledged_at TIMESTAMPTZ,
+  CONSTRAINT predictive_alerts_severity_check
+    CHECK (severity IN ('info', 'warning', 'critical', 'emergency')),
+  -- Acknowledgement is all-or-nothing: an acknowledged alert always carries
+  -- both an attributed principal and a time, and an unacknowledged one carries
+  -- neither. This is what stops an "acknowledged" row from existing with no
+  -- record of who acknowledged it.
+  CONSTRAINT predictive_alerts_ack_attribution_check
+    CHECK (
+      (acknowledged = FALSE AND acknowledged_by IS NULL AND acknowledged_at IS NULL)
+      OR (acknowledged = TRUE AND acknowledged_by IS NOT NULL AND acknowledged_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_predictive_alerts_tag
+  ON predictive_alerts(tag_id);
+CREATE INDEX IF NOT EXISTS idx_predictive_alerts_severity
+  ON predictive_alerts(severity);
+-- The operator's work queue (`GET /api/predictive/alerts?acknowledged=false`)
+-- and the retention sweep both filter on this column.
+CREATE INDEX IF NOT EXISTS idx_predictive_alerts_acknowledged
+  ON predictive_alerts(acknowledged);
+CREATE INDEX IF NOT EXISTS idx_predictive_alerts_created_at
+  ON predictive_alerts(created_at);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -75,6 +75,13 @@
     {
       "idx": 10,
       "version": "7",
+      "when": 1784780410000,
+      "tag": "0013_predictive_durable_state",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
       "when": 1784780411000,
       "tag": "0014_twin_persistence",
       "breakpoints": true

--- a/server/__tests__/predictive-auth-http.test.ts
+++ b/server/__tests__/predictive-auth-http.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import express from "express";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createServer, type Server } from "node:http";
 
 import { _resetControlPlaneAuthCache } from "../middleware/control-plane-auth";
@@ -8,6 +11,7 @@ import {
   type ApiKeyRecord,
 } from "../middleware/api-gateway";
 import { predictiveRoutes } from "../routes/predictive";
+import { predictiveStore } from "../services/predictive/store";
 
 interface TestServer {
   server: Server;
@@ -25,6 +29,7 @@ interface RouteCase {
 
 const readRoutes: RouteCase[] = [
   { method: "GET", path: "/tags", authorizedStatus: 200 },
+  { method: "GET", path: "/configured-tags", authorizedStatus: 200 },
   { method: "GET", path: "/thresholds/unknown-tag", authorizedStatus: 200 },
   { method: "GET", path: "/alerts", authorizedStatus: 200 },
   { method: "GET", path: "/status", authorizedStatus: 200 },
@@ -156,8 +161,13 @@ function request(
 describe("predictive HTTP authorization", () => {
   const originalApiKeys = process.env.API_KEYS;
   let testServer: TestServer;
+  let temporaryDirectory: string;
 
   beforeAll(async () => {
+    // #546: the routes now read and write a real durable store. Point it at a
+    // throwaway file so authorization tests cannot touch a developer database.
+    temporaryDirectory = mkdtempSync(join(tmpdir(), "predictive-auth-"));
+    process.env.PREDICTIVE_SQLITE_PATH = join(temporaryDirectory, "predictive.sqlite");
     process.env.API_KEYS = [
       "read-key:predictive-reader:predictive.read",
       "recommend-key:predictive-recommender:predictive.recommend",
@@ -174,7 +184,11 @@ describe("predictive HTTP authorization", () => {
     await closeServer(testServer.server);
     if (originalApiKeys === undefined) delete process.env.API_KEYS;
     else process.env.API_KEYS = originalApiKeys;
+    delete process.env.PREDICTIVE_SQLITE_PATH;
     _resetControlPlaneAuthCache();
+    // Release the durable-store handle before removing the file it holds open.
+    await predictiveStore.close();
+    rmSync(temporaryDirectory, { recursive: true, force: true });
   });
 
   it.each([...readRoutes, ...recommendationRoutes, ...mutationRoutes])(

--- a/server/routes/__tests__/predictive-contract.test.ts
+++ b/server/routes/__tests__/predictive-contract.test.ts
@@ -11,17 +11,26 @@
  *
  * Harness pattern copied from twin-auth.test.ts (port-0 express, API_KEYS env,
  * x-api-key header). No new dependencies, no production code changes.
+ *
+ * Since #546 the engine's thresholds and alerts are durable, so the suite
+ * points the store at a throwaway SQLite file: the routes talk to a real
+ * database, and nothing here can touch a developer's `dev-database.sqlite`.
  */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import express from "express";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createServer, type Server } from "node:http";
 
 import { _resetControlPlaneAuthCache } from "../../middleware/control-plane-auth";
 import { predictiveRoutes } from "../predictive";
+import { predictiveStore } from "../../services/predictive/store";
 
 const KEY = "contract-key";
 let server: Server;
 let base: string;
+let temporaryDirectory: string;
 let tagSeq = 0;
 const nextTag = () => `contract-tag-${tagSeq++}`;
 
@@ -60,14 +69,20 @@ beforeAll(async () => {
   // scope enforcement itself is covered elsewhere. Contract tests focus on the
   // request/response contract, not authorization.
   process.env.API_KEYS = `${KEY}:contract-tester:*`;
+  temporaryDirectory = mkdtempSync(join(tmpdir(), "predictive-contract-"));
+  process.env.PREDICTIVE_SQLITE_PATH = join(temporaryDirectory, "predictive.sqlite");
   _resetControlPlaneAuthCache();
   ({ server, base } = await startServer());
 });
 
 afterAll(async () => {
   delete process.env.API_KEYS;
+  delete process.env.PREDICTIVE_SQLITE_PATH;
   _resetControlPlaneAuthCache();
   await new Promise<void>((resolve) => server.close(() => resolve()));
+  // Release the durable-store handle before removing the file it holds open.
+  await predictiveStore.close();
+  rmSync(temporaryDirectory, { recursive: true, force: true });
 });
 
 function series(count: number, at = Date.now()): Array<{ timestamp: number; value: number }> {
@@ -206,6 +221,74 @@ describe("POST /api/predictive/alerts/:alertId/acknowledge", () => {
     expect(status).toBe(404);
     expect(typeof json.error).toBe("string");
   });
+
+  it("attributes the acknowledgement to the authenticated principal (#546)", async () => {
+    const tag = nextTag();
+    await api("POST", "/ingest", { tagId: tag, points: spikeSeries() });
+    const alerts = (await api("GET", `/alerts?tagId=${tag}`)).json.alerts;
+    expect(alerts.length).toBeGreaterThan(0);
+
+    const { status, json } = await api("POST", `/alerts/${alerts[0].id}/acknowledge`);
+    expect(status).toBe(200);
+    expect(json.acknowledged).toBe(true);
+    // "contract-tester" is the NAME on the server-owned API key record, not
+    // anything the caller sent.
+    expect(json.acknowledgedBy).toBe("contract-tester");
+    expect(typeof json.acknowledgedAt).toBe("number");
+
+    const reread = (await api("GET", `/alerts?tagId=${tag}`)).json.alerts[0];
+    expect(reread.acknowledged).toBe(true);
+    expect(reread.acknowledgedBy).toBe("contract-tester");
+  });
+
+  it("returns 409 and preserves the original attribution on a second acknowledgement", async () => {
+    const tag = nextTag();
+    await api("POST", "/ingest", { tagId: tag, points: spikeSeries() });
+    const alertId = (await api("GET", `/alerts?tagId=${tag}`)).json.alerts[0].id;
+    expect((await api("POST", `/alerts/${alertId}/acknowledge`)).status).toBe(200);
+
+    const { status, json } = await api("POST", `/alerts/${alertId}/acknowledge`);
+    expect(status).toBe(409);
+    expect(json.acknowledgedBy).toBe("contract-tester");
+  });
+
+  it("rejects a caller-supplied acknowledging identity with 400 (#546)", async () => {
+    const tag = nextTag();
+    await api("POST", "/ingest", { tagId: tag, points: spikeSeries() });
+    const alertId = (await api("GET", `/alerts?tagId=${tag}`)).json.alerts[0].id;
+
+    const { status, json } = await api("POST", `/alerts/${alertId}/acknowledge`, {
+      acknowledgedBy: "somebody-else",
+    });
+    // Spoofed attribution fails loudly rather than being silently ignored.
+    expect(status).toBe(400);
+    expect(json.error).toContain("authenticated principal");
+
+    const alert = (await api("GET", `/alerts?tagId=${tag}`)).json.alerts[0];
+    expect(alert.acknowledged).toBe(false);
+    expect(alert.acknowledgedBy).toBeNull();
+  });
+});
+
+describe("PUT /api/predictive/thresholds/:tagId attribution (#546)", () => {
+  it("rejects a caller-supplied updatedBy with 400", async () => {
+    const tag = nextTag();
+    const { status } = await api("PUT", `/thresholds/${tag}`, {
+      minSamples: 5,
+      updatedBy: "somebody-else",
+    });
+    expect(status).toBe(400);
+  });
+
+  it("records the authenticated principal on GET /configured-tags", async () => {
+    const tag = nextTag();
+    expect((await api("PUT", `/thresholds/${tag}`, { minSamples: 5 })).status).toBe(200);
+    const { status, json } = await api("GET", "/configured-tags");
+    expect(status).toBe(200);
+    const entry = json.tags.find((t: { tagId: string }) => t.tagId === tag);
+    expect(entry.updatedBy).toBe("contract-tester");
+    expect(typeof entry.updatedAt).toBe("string");
+  });
 });
 
 describe("GET /api/predictive/status", () => {
@@ -215,5 +298,14 @@ describe("GET /api/predictive/status", () => {
     expect(typeof json.trackedTags).toBe("number");
     expect(typeof json.totalAlerts).toBe("number");
     expect(Array.isArray(json.detectors)).toBe(true);
+  });
+
+  it("reports the durable backend and hydration state (#546)", async () => {
+    const { json } = await api("GET", "/status");
+    expect(json.durable).toBe(true);
+    expect(json.storeBackend).toBe("sqlite");
+    expect(json.lastStoreError).toBeNull();
+    expect(typeof json.configuredTags).toBe("number");
+    expect(typeof json.activeAlerts).toBe("number");
   });
 });

--- a/server/routes/__tests__/predictive-rate-limit.test.ts
+++ b/server/routes/__tests__/predictive-rate-limit.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression coverage for the authenticated predictive-state rate limit.
+ *
+ * The four routes below read or mutate durable state. Their limiter must run
+ * after control-plane authentication and use the trusted API-key identity, so
+ * operators behind one proxy do not share a source-IP bucket and anonymous
+ * traffic cannot consume an authenticated operator's allowance.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { _resetControlPlaneAuthCache } from "../../middleware/control-plane-auth";
+import { predictiveStore } from "../../services/predictive/store";
+import { predictiveRoutes } from "../predictive";
+
+const ALPHA_KEY = "predictive-rate-alpha";
+const BETA_KEY = "predictive-rate-beta";
+const LIMIT = 60;
+
+let server: Server;
+let baseUrl: string;
+let temporaryDirectory: string;
+const originalApiKeys = process.env.API_KEYS;
+const originalSqlitePath = process.env.PREDICTIVE_SQLITE_PATH;
+
+function request(
+  path: string,
+  options: {
+    method?: "GET" | "PUT";
+    apiKey?: string;
+    body?: unknown;
+  } = {},
+): Promise<Response> {
+  const method = options.method ?? "GET";
+  const headers: Record<string, string> = {};
+  if (options.apiKey !== undefined) headers["x-api-key"] = options.apiKey;
+  if (options.body !== undefined) headers["content-type"] = "application/json";
+  return fetch(`${baseUrl}/api/predictive${path}`, {
+    method,
+    headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+}
+
+beforeAll(async () => {
+  process.env.API_KEYS = [
+    `${ALPHA_KEY}:predictive-alpha:*`,
+    `${BETA_KEY}:predictive-beta:*`,
+  ].join(",");
+  temporaryDirectory = mkdtempSync(join(tmpdir(), "predictive-rate-limit-"));
+  process.env.PREDICTIVE_SQLITE_PATH = join(temporaryDirectory, "predictive.sqlite");
+  _resetControlPlaneAuthCache();
+
+  const app = express();
+  app.use(express.json());
+  app.use("/api/predictive", predictiveRoutes);
+  await new Promise<void>((resolve) => {
+    server = createServer(app);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (typeof address !== "object" || address === null) {
+    throw new Error("Predictive rate-limit test server did not bind");
+  }
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await predictiveStore.close();
+  rmSync(temporaryDirectory, { recursive: true, force: true });
+
+  if (originalApiKeys === undefined) delete process.env.API_KEYS;
+  else process.env.API_KEYS = originalApiKeys;
+  if (originalSqlitePath === undefined) delete process.env.PREDICTIVE_SQLITE_PATH;
+  else process.env.PREDICTIVE_SQLITE_PATH = originalSqlitePath;
+  _resetControlPlaneAuthCache();
+});
+
+describe("predictive durable-state rate limiting", () => {
+  it("returns 429 on every protected route after an operator exhausts the shared budget", async () => {
+    // Invalid threshold data exits before a store mutation, making this a cheap
+    // way to consume the route-local budget without polluting durable fixtures.
+    for (let attempt = 0; attempt < LIMIT; attempt += 1) {
+      const response = await request("/thresholds/rate-limit-target", {
+        method: "PUT",
+        apiKey: ALPHA_KEY,
+        body: { minSamples: 1 },
+      });
+      expect(response.status).toBe(400);
+    }
+
+    const protectedRoutes = [
+      request("/configured-tags", { apiKey: ALPHA_KEY }),
+      request("/thresholds/rate-limit-target", { apiKey: ALPHA_KEY }),
+      request("/thresholds/rate-limit-target", {
+        method: "PUT",
+        apiKey: ALPHA_KEY,
+        body: { minSamples: 1 },
+      }),
+      request("/alerts", { apiKey: ALPHA_KEY }),
+    ];
+    const responses = await Promise.all(protectedRoutes);
+    expect(responses.map((response) => response.status)).toEqual([429, 429, 429, 429]);
+    for (const response of responses) {
+      expect(response.headers.get("x-ratelimit-limit")).toBe(String(LIMIT));
+      expect((await response.json()).error).toBe("Too Many Requests");
+    }
+  });
+
+  it("isolates buckets by authenticated API-key identity, not shared source IP", async () => {
+    const responses = await Promise.all([
+      request("/configured-tags", { apiKey: BETA_KEY }),
+      request("/thresholds/rate-limit-target", { apiKey: BETA_KEY }),
+      request("/thresholds/rate-limit-target", {
+        method: "PUT",
+        apiKey: BETA_KEY,
+        body: { minSamples: 1 },
+      }),
+      request("/alerts", { apiKey: BETA_KEY }),
+    ]);
+
+    expect(responses.map((response) => response.status)).toEqual([200, 200, 400, 200]);
+  });
+
+  it("authenticates before consulting the limiter", async () => {
+    const response = await request("/configured-tags");
+    expect(response.status).toBe(401);
+    expect(response.headers.has("x-ratelimit-limit")).toBe(false);
+  });
+});

--- a/server/routes/predictive.ts
+++ b/server/routes/predictive.ts
@@ -28,6 +28,7 @@ import { Router } from "express";
 import type { Request, Response, RequestHandler } from "express";
 import { z } from "zod";
 import { fromZodError } from "zod-validation-error";
+import { rateLimitMiddleware } from "../middleware/api-gateway";
 import {
   controlPlanePrincipal,
   requireControlPlaneAccess,
@@ -52,6 +53,20 @@ const requirePredictiveConfigure = requireControlPlaneAccess({
 });
 const requirePredictiveAcknowledge = requireControlPlaneAccess({
   scopes: ["predictive.acknowledge"],
+});
+
+/**
+ * Durable predictive-state reads and writes can amplify storage work. Key the
+ * local budget by the server-authenticated API-key name, never by a caller
+ * header or the shared source IP. Every route below places its auth guard
+ * before this middleware, so an unauthenticated request cannot consume an
+ * operator's bucket and a future ordering regression fails closed when the
+ * principal is unavailable.
+ */
+const predictiveStateRateLimit = rateLimitMiddleware({
+  windowMs: 60_000,
+  maxRequests: 60,
+  keyExtractor: (req) => `operator:${controlPlanePrincipal(req).name}`,
 });
 
 /**
@@ -224,6 +239,7 @@ router.get("/tags", requirePredictiveRead, (_req, res) => {
 router.get(
   "/configured-tags",
   requirePredictiveRead,
+  predictiveStateRateLimit,
   asyncHandler(async (_req, res) => {
     const configured = await engine.listConfiguredTags();
     res.json({
@@ -240,6 +256,7 @@ router.get(
 router.get(
   "/thresholds/:tagId",
   requirePredictiveRead,
+  predictiveStateRateLimit,
   asyncHandler(async (req, res) => {
     res.json(await engine.getThresholds(req.params.tagId));
   })
@@ -248,6 +265,7 @@ router.get(
 router.put(
   "/thresholds/:tagId",
   requirePredictiveConfigure,
+  predictiveStateRateLimit,
   asyncHandler(async (req, res) => {
     // The tag id is a caller-controlled path segment that becomes a durable
     // primary key. It must be bounded HERE, at the same 256 characters the
@@ -320,6 +338,7 @@ router.put(
 router.get(
   "/alerts",
   requirePredictiveRead,
+  predictiveStateRateLimit,
   asyncHandler(async (req, res) => {
     const parsed = AlertQuerySchema.safeParse(req.query);
     if (!parsed.success) {

--- a/server/routes/predictive.ts
+++ b/server/routes/predictive.ts
@@ -1,18 +1,39 @@
 /**
  * Predictive Maintenance API
- * ADR-0013 [13.1] — Issue #212
+ * ADR-0013 [13.1] — Issue #212, made durable by #546
  *
  * REST surface for the predictive maintenance engine: tag ingestion,
  * on-demand analysis, per-tag threshold configuration, alerts, and
  * trend-based failure prediction.
+ *
+ * ─── IDENTITY (#546, composed with the control-plane auth of #576) ──────────
+ *
+ * Every route that writes durable state attributes the write to
+ * `controlPlanePrincipal(req).name` — the name on the server-owned API key
+ * record bound by `requireControlPlaneAccess`. That helper throws if the guard
+ * did not run, so an unauthenticated write cannot reach the store even if a
+ * future refactor drops a guard. The request bodies below are `.strict()`, so
+ * a caller that tries to supply its own `updatedBy` / `acknowledgedBy` is
+ * rejected with 400 rather than having the field quietly ignored: spoofed
+ * attribution fails loudly instead of looking accepted.
+ *
+ * ─── FAIL-CLOSED (#546) ────────────────────────────────────────────────────
+ *
+ * Durable state has no in-memory fallback. If the store cannot be read or
+ * written, every handler here answers 503 and nothing is mutated — a threshold
+ * or acknowledgement that is only in RAM is the defect this feature removed.
  */
 
 import { Router } from "express";
 import type { Request, Response, RequestHandler } from "express";
 import { z } from "zod";
 import { fromZodError } from "zod-validation-error";
-import { requireControlPlaneAccess } from "../middleware/control-plane-auth";
+import {
+  controlPlanePrincipal,
+  requireControlPlaneAccess,
+} from "../middleware/control-plane-auth";
 import { predictiveMaintenanceService } from "../services/predictive";
+import { PredictiveStoreUnavailableError } from "../services/predictive/store";
 import type { SeverityLevel } from "@shared/types/predictive";
 
 const router = Router();
@@ -33,14 +54,26 @@ const requirePredictiveAcknowledge = requireControlPlaneAccess({
   scopes: ["predictive.acknowledge"],
 });
 
-/** Express 4 does not catch async rejections — wrap every async handler */
+/**
+ * Express 4 does not catch async rejections — wrap every async handler.
+ * A durable-store failure is answered 503 (fail closed and retryable) rather
+ * than 500, so a caller can tell "your request was refused because state could
+ * not be recorded" from "the server is broken".
+ */
 function asyncHandler(
   fn: (req: Request, res: Response) => Promise<unknown>
 ): RequestHandler {
   return (req, res) => {
     fn(req, res).catch((error) => {
       if (!res.headersSent) {
-        res.status(500).json({ error: "Internal error" });
+        if (error instanceof PredictiveStoreUnavailableError) {
+          res.status(503).json({
+            error: "Durable predictive state unavailable",
+            message: error.message,
+          });
+        } else {
+          res.status(500).json({ error: "Internal error" });
+        }
       }
       console.error("[predictive] handler error:", error);
     });
@@ -71,6 +104,8 @@ const IngestSchema = z.object({
 
 const SeveritySchema = z.enum(["info", "warning", "critical", "emergency"]);
 
+// `.strict()`: a body carrying `updatedBy` (or any other unknown key) is
+// rejected. Attribution comes from the authenticated principal only.
 const ThresholdsSchema = z
   .object({
     minSamples: z.number().int().min(3).max(MAX_WINDOW),
@@ -91,14 +126,27 @@ const ThresholdsSchema = z
       high: z.number().optional(),
     }),
   })
-  .partial();
+  .partial()
+  .strict();
+
+/**
+ * Acknowledgement takes no body at all. Declaring it `.strict()` and empty is
+ * what makes `{"acknowledgedBy":"someone-else"}` a 400 instead of a silently
+ * dropped field.
+ */
+const AcknowledgeBodySchema = z.object({}).strict();
+
+/** Same bound as IngestSchema.tagId and the durable `varchar(256)` column. */
+const TagIdParamSchema = z.string().min(1).max(256);
 
 const AlertQuerySchema = z.object({
   severity: SeveritySchema.optional(),
+  tagId: z.string().min(1).max(256).optional(),
   acknowledged: z
     .enum(["true", "false"])
     .transform((v) => v === "true")
     .optional(),
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
 });
 
 // ── Ingestion & analysis ───────────────────────────────────────────────────
@@ -123,6 +171,9 @@ router.post(
     const cutoff = Date.now() + MAX_FUTURE_SKEW_MS;
     const usable = points.filter((p) => p.timestamp <= cutoff);
     engine.ingestSeries(tagId, usable);
+    // analyze() persists any alert it raises before emitting it, so a store
+    // outage surfaces here as a 503 rather than as an alert nobody can
+    // acknowledge later.
     const assessment = await engine.analyze(tagId);
     res.json({
       ingested: usable.length,
@@ -140,9 +191,10 @@ router.get(
   asyncHandler(async (req, res) => {
     const assessment = await engine.analyze(req.params.tagId, { generateAlerts: false });
     if (!assessment) {
+      const thresholds = await engine.getThresholds(req.params.tagId);
       return res.status(404).json({
         error: "Insufficient data for analysis",
-        required: engine.getThresholds(req.params.tagId).minSamples,
+        required: thresholds.minSamples,
         available: engine.getHistory(req.params.tagId).length,
       });
     }
@@ -168,84 +220,158 @@ router.get("/tags", requirePredictiveRead, (_req, res) => {
   res.json({ tags: engine.getTrackedTags() });
 });
 
-router.get("/thresholds/:tagId", requirePredictiveRead, (req, res) => {
-  res.json(engine.getThresholds(req.params.tagId));
-});
-
-router.put("/thresholds/:tagId", requirePredictiveConfigure, (req, res) => {
-  const parsed = ThresholdsSchema.safeParse(req.body);
-  if (!parsed.success) {
-    return res.status(400).json({ error: fromZodError(parsed.error as any).message });
-  }
-  const overrides = parsed.data;
-
-  // Cross-field checks run against the merged result so partial updates
-  // can't sneak an inconsistent final configuration past validation.
-  const current = engine.getThresholds(req.params.tagId);
-  const merged = {
-    ...current,
-    ...overrides,
-    severityThresholds: { ...current.severityThresholds, ...overrides.severityThresholds },
-    failureLimits: overrides.failureLimits ?? current.failureLimits,
-  };
-  const { warning, critical, emergency } = merged.severityThresholds;
-  if (!(warning <= critical && critical <= emergency)) {
-    return res.status(400).json({
-      error: "severityThresholds must satisfy warning <= critical <= emergency",
+/** Durably configured tags, with the principal that last wrote each one. */
+router.get(
+  "/configured-tags",
+  requirePredictiveRead,
+  asyncHandler(async (_req, res) => {
+    const configured = await engine.listConfiguredTags();
+    res.json({
+      tags: configured.map(({ tagId, thresholds, updatedBy, updatedAt }) => ({
+        tagId,
+        thresholds,
+        updatedBy,
+        updatedAt: updatedAt.toISOString(),
+      })),
     });
-  }
-  if (
-    merged.failureLimits?.low !== undefined &&
-    merged.failureLimits?.high !== undefined &&
-    merged.failureLimits.low >= merged.failureLimits.high
-  ) {
-    return res.status(400).json({ error: "failureLimits.low must be below failureLimits.high" });
-  }
-  if (overrides.ensembleWeights) {
-    const known = new Set(engine.getDetectors().map((d) => d.name));
-    const unknown = Object.keys(overrides.ensembleWeights).filter((k) => !known.has(k));
-    if (unknown.length > 0) {
+  })
+);
+
+router.get(
+  "/thresholds/:tagId",
+  requirePredictiveRead,
+  asyncHandler(async (req, res) => {
+    res.json(await engine.getThresholds(req.params.tagId));
+  })
+);
+
+router.put(
+  "/thresholds/:tagId",
+  requirePredictiveConfigure,
+  asyncHandler(async (req, res) => {
+    // The tag id is a caller-controlled path segment that becomes a durable
+    // primary key. It must be bounded HERE, at the same 256 characters the
+    // ingest schema and the `varchar(256)` column use: without this an
+    // over-long id is accepted on SQLite and, on PostgreSQL, is rejected by
+    // the driver and surfaces as a 503 "durable state unavailable" plus a
+    // `store-error` event — a caller-forged store-outage signal for what is
+    // really a bad request.
+    const tagIdCheck = TagIdParamSchema.safeParse(req.params.tagId);
+    if (!tagIdCheck.success) {
+      return res.status(400).json({ error: fromZodError(tagIdCheck.error as any).message });
+    }
+    const tagId = tagIdCheck.data;
+
+    const parsed = ThresholdsSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({ error: fromZodError(parsed.error as any).message });
+    }
+    const overrides = parsed.data;
+
+    // Cross-field checks run against the merged result so partial updates
+    // can't sneak an inconsistent final configuration past validation.
+    const current = await engine.getThresholds(tagId);
+    const merged = {
+      ...current,
+      ...overrides,
+      severityThresholds: { ...current.severityThresholds, ...overrides.severityThresholds },
+      failureLimits: overrides.failureLimits ?? current.failureLimits,
+    };
+    const { warning, critical, emergency } = merged.severityThresholds;
+    if (!(warning <= critical && critical <= emergency)) {
       return res.status(400).json({
-        error: `Unknown detectors in ensembleWeights: ${unknown.join(", ")}`,
+        error: "severityThresholds must satisfy warning <= critical <= emergency",
       });
     }
-    const mergedWeights = { ...current.ensembleWeights, ...overrides.ensembleWeights };
-    if (!Object.values(mergedWeights).some((w) => w > 0)) {
-      return res.status(400).json({ error: "ensembleWeights must include a positive weight" });
+    if (
+      merged.failureLimits?.low !== undefined &&
+      merged.failureLimits?.high !== undefined &&
+      merged.failureLimits.low >= merged.failureLimits.high
+    ) {
+      return res.status(400).json({ error: "failureLimits.low must be below failureLimits.high" });
     }
-  }
-  if (merged.minSamples > MAX_WINDOW) {
-    return res.status(400).json({
-      error: `minSamples cannot exceed the ${MAX_WINDOW}-point history window`,
-    });
-  }
+    if (overrides.ensembleWeights) {
+      const known = new Set(engine.getDetectors().map((d) => d.name));
+      const unknown = Object.keys(overrides.ensembleWeights).filter((k) => !known.has(k));
+      if (unknown.length > 0) {
+        return res.status(400).json({
+          error: `Unknown detectors in ensembleWeights: ${unknown.join(", ")}`,
+        });
+      }
+      const mergedWeights = { ...current.ensembleWeights, ...overrides.ensembleWeights };
+      if (!Object.values(mergedWeights).some((w) => w > 0)) {
+        return res.status(400).json({ error: "ensembleWeights must include a positive weight" });
+      }
+    }
+    if (merged.minSamples > MAX_WINDOW) {
+      return res.status(400).json({
+        error: `minSamples cannot exceed the ${MAX_WINDOW}-point history window`,
+      });
+    }
 
-  res.json(engine.setThresholds(req.params.tagId, overrides));
-});
+    // Attribution is the authenticated principal, never the request body.
+    const principal = controlPlanePrincipal(req);
+    res.json(await engine.setThresholds(tagId, overrides, principal.name));
+  })
+);
 
 // ── Alerts ─────────────────────────────────────────────────────────────────
 
-router.get("/alerts", requirePredictiveRead, (req, res) => {
-  const parsed = AlertQuerySchema.safeParse(req.query);
-  if (!parsed.success) {
-    return res.status(400).json({ error: fromZodError(parsed.error as any).message });
-  }
-  const { severity, acknowledged } = parsed.data;
-  res.json({
-    alerts: engine.getAlerts({ severity: severity as SeverityLevel | undefined, acknowledged }),
-  });
-});
+router.get(
+  "/alerts",
+  requirePredictiveRead,
+  asyncHandler(async (req, res) => {
+    const parsed = AlertQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(400).json({ error: fromZodError(parsed.error as any).message });
+    }
+    const { severity, acknowledged, tagId, limit } = parsed.data;
+    res.json({
+      alerts: await engine.listAlerts({
+        severity: severity as SeverityLevel | undefined,
+        acknowledged,
+        tagId,
+        limit,
+      }),
+    });
+  })
+);
 
 router.post(
   "/alerts/:alertId/acknowledge",
   requirePredictiveAcknowledge,
-  (req, res) => {
-    const ok = engine.acknowledgeAlert(req.params.alertId);
-    if (!ok) {
+  asyncHandler(async (req, res) => {
+    const parsed = AcknowledgeBodySchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({
+        error:
+          "Acknowledgement takes no body; the acknowledging identity is the "
+          + "authenticated principal and cannot be supplied by the caller.",
+        detail: fromZodError(parsed.error as any).message,
+      });
+    }
+
+    const principal = controlPlanePrincipal(req);
+    const outcome = await engine.acknowledgeAlert(req.params.alertId, principal.name);
+    if (outcome.status === "not-found") {
       return res.status(404).json({ error: `Alert ${req.params.alertId} not found` });
     }
-    res.json({ acknowledged: true });
-  }
+    if (outcome.status === "already-acknowledged") {
+      // Conflict rather than success: the caller did not acknowledge this
+      // alert, and the original attribution is what stays on the record.
+      return res.status(409).json({
+        error: "Alert already acknowledged",
+        acknowledgedBy: outcome.alert?.acknowledgedBy ?? null,
+        acknowledgedAt: outcome.alert?.acknowledgedAt ?? null,
+      });
+    }
+    res.json({
+      acknowledged: true,
+      alertId: req.params.alertId,
+      acknowledgedBy: outcome.alert?.acknowledgedBy ?? principal.name,
+      acknowledgedAt: outcome.alert?.acknowledgedAt ?? null,
+    });
+  })
 );
 
 // ── Status ─────────────────────────────────────────────────────────────────
@@ -255,7 +381,34 @@ router.get(
   requirePredictiveRead,
   asyncHandler(async (_req, res) => {
     const health = await predictiveMaintenanceService.healthCheck();
-    res.json({ ...engine.getStatus(), ...health });
+    const hydration = predictiveMaintenanceService.getHydration();
+    const inMemory = engine.getStatus();
+    // Durable counts are reported best-effort: /status must still answer when
+    // the store is down, because that is exactly when an operator needs to
+    // see WHY their writes are being refused.
+    let durable: {
+      backend: string;
+      configuredTags: number;
+      activeAlerts: number;
+      totalAlerts: number;
+    } | null = null;
+    try {
+      durable = await engine.getDurableStatus();
+    } catch {
+      durable = null;
+    }
+    res.json({
+      ...inMemory,
+      ...health,
+      durable: durable !== null,
+      storeBackend: engine.storeBackend(),
+      lastStoreError: engine.getLastStoreError(),
+      hydrated: hydration !== null,
+      hydration,
+      configuredTags: durable?.configuredTags ?? null,
+      activeAlerts: durable?.activeAlerts ?? null,
+      totalAlerts: durable?.totalAlerts ?? null,
+    });
   })
 );
 

--- a/server/services/predictive/__tests__/predictive-maintenance.test.ts
+++ b/server/services/predictive/__tests__/predictive-maintenance.test.ts
@@ -1,9 +1,14 @@
 /**
  * Predictive Maintenance Engine tests
  * ADR-0013 [13.1] — Issue #212
+ *
+ * Since #546 the engine's thresholds and alerts are durable, so these run
+ * against a real private in-memory SQLite database per engine through the real
+ * Drizzle store — no stub, no fake. Restart behaviour needs a file rather than
+ * a private connection and is covered in `predictive-persistence.test.ts`.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, afterAll } from 'vitest';
 import type { AnomalyDetector, TimeSeriesPoint } from '@shared/types/predictive';
 import {
   quantile,
@@ -16,12 +21,41 @@ import {
   estimateTrend,
   estimateHoursToLimit,
 } from '../detectors';
-import { PredictiveMaintenanceEngine } from '../engine';
+import { PredictiveMaintenanceEngine, type EngineOptions } from '../engine';
 import { PredictiveMaintenanceService } from '../index';
+import { DrizzlePredictiveStore } from '../store';
 
 function series(values: number[], intervalMs = 1000): TimeSeriesPoint[] {
   return values.map((value, i) => ({ timestamp: i * intervalMs, value }));
 }
+
+/** Principal name every write in this file is attributed to. */
+const OPERATOR = 'unit-test-operator';
+
+const openStores: DrizzlePredictiveStore[] = [];
+
+/**
+ * A real SQLite database, private to this connection. `:memory:` is a genuine
+ * database engine executing the same SQL as production — it just cannot be
+ * reopened, which is why the restart suite uses a file instead.
+ */
+function newStore(): DrizzlePredictiveStore {
+  const store = new DrizzlePredictiveStore({ sqlitePath: ':memory:' });
+  openStores.push(store);
+  return store;
+}
+
+function newEngine(options: Omit<EngineOptions, 'store'> = {}): PredictiveMaintenanceEngine {
+  return new PredictiveMaintenanceEngine({ ...options, store: newStore() });
+}
+
+function newService(sweepIntervalMs = 30_000): PredictiveMaintenanceService {
+  return new PredictiveMaintenanceService(sweepIntervalMs, { store: newStore() });
+}
+
+afterAll(async () => {
+  await Promise.all(openStores.map((store) => store.close()));
+});
 
 // ── Statistics primitives ─────────────────────────────────────────────────
 
@@ -197,13 +231,13 @@ describe('estimateHoursToLimit', () => {
 
 describe('PredictiveMaintenanceEngine', () => {
   it('returns null for insufficient data', async () => {
-    const engine = new PredictiveMaintenanceEngine();
+    const engine = newEngine();
     engine.ingestPoint('x', 0, 10);
     expect(await engine.analyze('x')).toBeNull();
   });
 
   it('detects a spike, classifies severity, and emits an alert', async () => {
-    const engine = new PredictiveMaintenanceEngine();
+    const engine = newEngine();
     const onAlert = vi.fn();
     engine.on('alert', onAlert);
 
@@ -216,50 +250,71 @@ describe('PredictiveMaintenanceEngine', () => {
     expect(result!.detectorResults.length).toBe(3);
     expect(onAlert).toHaveBeenCalledTimes(1);
 
-    const alerts = engine.getAlerts();
+    const alerts = await engine.listAlerts();
     expect(alerts.length).toBe(1);
     expect(alerts[0].detectors.length).toBeGreaterThan(0);
     expect(alerts[0].recommendation).toBeTruthy();
+    // A freshly generated alert carries no attribution until someone
+    // acknowledges it.
+    expect(alerts[0].acknowledged).toBe(false);
+    expect(alerts[0].acknowledgedBy).toBeNull();
+    expect(alerts[0].acknowledgedAt).toBeNull();
   });
 
   it('suppresses duplicate alerts within the cooldown window', async () => {
-    const engine = new PredictiveMaintenanceEngine({ alertCooldownMs: 60_000 });
+    const engine = newEngine({ alertCooldownMs: 60_000 });
     for (let i = 0; i < 50; i++) engine.ingestPoint('t', i * 1000, 10);
     engine.ingestPoint('t', 50_000, 500);
 
     await engine.analyze('t');
     await engine.analyze('t');
-    expect(engine.getAlerts().length).toBe(1);
+    expect(await engine.listAlerts()).toHaveLength(1);
   });
 
-  it('acknowledges alerts and filters by acknowledged state', async () => {
-    const engine = new PredictiveMaintenanceEngine();
+  it('acknowledges alerts, attributes them, and filters by acknowledged state', async () => {
+    const engine = newEngine();
     for (let i = 0; i < 50; i++) engine.ingestPoint('t', i * 1000, 10);
     engine.ingestPoint('t', 50_000, 500);
     await engine.analyze('t');
 
-    const [alert] = engine.getAlerts();
-    expect(engine.acknowledgeAlert(alert.id)).toBe(true);
-    expect(engine.getAlerts({ acknowledged: false })).toHaveLength(0);
-    expect(engine.getAlerts({ acknowledged: true })).toHaveLength(1);
-    expect(engine.acknowledgeAlert('nope')).toBe(false);
+    const [alert] = await engine.listAlerts();
+    const outcome = await engine.acknowledgeAlert(alert.id, OPERATOR);
+    expect(outcome.status).toBe('acknowledged');
+    expect(outcome.alert?.acknowledgedBy).toBe(OPERATOR);
+    expect(outcome.alert?.acknowledgedAt).toEqual(expect.any(Number));
+
+    expect(await engine.listAlerts({ acknowledged: false })).toHaveLength(0);
+    expect(await engine.listAlerts({ acknowledged: true })).toHaveLength(1);
+    expect((await engine.acknowledgeAlert('nope', OPERATOR)).status).toBe('not-found');
   });
 
-  it('merges per-tag threshold overrides onto defaults', () => {
-    const engine = new PredictiveMaintenanceEngine();
-    const updated = engine.setThresholds('tag-a', {
+  it('refuses an acknowledgement with no principal', async () => {
+    const engine = newEngine();
+    await expect(engine.acknowledgeAlert('any-id', '  ')).rejects.toThrow(
+      /authenticated principal/,
+    );
+  });
+
+  it('merges per-tag threshold overrides onto defaults', async () => {
+    const engine = newEngine();
+    const updated = await engine.setThresholds('tag-a', {
       zScoreThreshold: 4,
       severityThresholds: { warning: 0.5, critical: 0.8, emergency: 0.95 },
-    });
+    }, OPERATOR);
     expect(updated.zScoreThreshold).toBe(4);
     expect(updated.iqrMultiplier).toBe(1.5); // default preserved
-    expect(engine.getThresholds('tag-a').severityThresholds.warning).toBe(0.5);
+    expect((await engine.getThresholds('tag-a')).severityThresholds.warning).toBe(0.5);
     // unconfigured tags fall back to defaults
-    expect(engine.getThresholds('tag-b').zScoreThreshold).toBe(3);
+    expect((await engine.getThresholds('tag-b')).zScoreThreshold).toBe(3);
+    // and the write is attributed to the principal that made it
+    const configured = await engine.listConfiguredTags();
+    expect(configured).toEqual([
+      expect.objectContaining({ tagId: 'tag-a', updatedBy: OPERATOR }),
+    ]);
   });
 
   it('runs registered ML detectors alongside statistical ones', async () => {
-    const engine = new PredictiveMaintenanceEngine();
+    const engine = newEngine();
     const mlDetector: AnomalyDetector = {
       name: 'custom-ml',
       kind: 'ml',
@@ -281,7 +336,7 @@ describe('PredictiveMaintenanceEngine', () => {
   });
 
   it('surfaces detector failures without breaking analysis', async () => {
-    const engine = new PredictiveMaintenanceEngine();
+    const engine = newEngine();
     const onError = vi.fn();
     engine.on('detector-error', onError);
     engine.registerDetector({
@@ -302,7 +357,7 @@ describe('PredictiveMaintenanceEngine', () => {
   });
 
   it('bounds history to the sliding window', () => {
-    const engine = new PredictiveMaintenanceEngine({ maxHistorySize: 100 });
+    const engine = newEngine({ maxHistorySize: 100 });
     for (let i = 0; i < 250; i++) engine.ingestPoint('t', i * 1000, i);
     const history = engine.getHistory('t');
     expect(history.length).toBe(100);
@@ -310,7 +365,7 @@ describe('PredictiveMaintenanceEngine', () => {
   });
 
   it('ignores non-finite inputs', () => {
-    const engine = new PredictiveMaintenanceEngine();
+    const engine = newEngine();
     engine.ingestPoint('t', 0, NaN);
     engine.ingestPoint('t', NaN, 5);
     engine.ingestPoint('t', 0, Infinity);
@@ -318,8 +373,8 @@ describe('PredictiveMaintenanceEngine', () => {
   });
 
   it('predicts hours until a failure limit on a rising trend', async () => {
-    const engine = new PredictiveMaintenanceEngine();
-    engine.setThresholds('bearing-temp', { failureLimits: { high: 189 } });
+    const engine = newEngine();
+    await engine.setThresholds('bearing-temp', { failureLimits: { high: 189 } }, OPERATOR);
     // 1 unit/minute ramp: 100 → 129 over 30 minutes, limit 60 units away
     for (let i = 0; i < 30; i++) engine.ingestPoint('bearing-temp', i * 60_000, 100 + i);
 
@@ -331,11 +386,11 @@ describe('PredictiveMaintenanceEngine', () => {
     expect(prediction!.confidence).toBeCloseTo(1);
     expect(prediction!.failureProbability).toBeGreaterThan(0.9);
     // prediction must not generate alerts as a side effect
-    expect(engine.getAlerts()).toHaveLength(0);
+    expect(await engine.listAlerts()).toHaveLength(0);
   });
 
   it('reports tracked tags and status', () => {
-    const engine = new PredictiveMaintenanceEngine();
+    const engine = newEngine();
     for (let i = 0; i < 5; i++) engine.ingestPoint('a', i, i);
     engine.ingestPoint('b', 0, 1);
 
@@ -357,7 +412,7 @@ describe('PredictiveMaintenanceEngine', () => {
 
 describe('PredictiveMaintenanceService', () => {
   it('ingests numeric tag updates and skips non-numeric values', () => {
-    const service = new PredictiveMaintenanceService();
+    const service = newService();
     service.ingestTagUpdate({ tagName: 'pump.flow', value: 42.5, timestamp: 1000 });
     service.ingestTagUpdate({ tagName: 'pump.flow', value: '43.1', timestamp: '1970-01-01T00:00:02.000Z' });
     service.ingestTagUpdate({ tagName: 'pump.flow', value: 'running', timestamp: 3000 });
@@ -371,7 +426,7 @@ describe('PredictiveMaintenanceService', () => {
   });
 
   it('re-emits engine alerts', async () => {
-    const service = new PredictiveMaintenanceService();
+    const service = newService();
     const onAlert = vi.fn();
     service.on('alert', onAlert);
 
@@ -384,7 +439,7 @@ describe('PredictiveMaintenanceService', () => {
   });
 
   it('reports health based on initialization', async () => {
-    const service = new PredictiveMaintenanceService();
+    const service = newService();
     expect((await service.healthCheck()).healthy).toBe(false);
     await service.initialize();
     expect((await service.healthCheck()).healthy).toBe(true);
@@ -405,19 +460,19 @@ describe('constant decimal series (float rounding residue)', () => {
         expect(zScoreDetector(flat, 3).score, `z score v=${value} n=${n}`).toBe(0);
       }
     }
-    const engine = new PredictiveMaintenanceEngine();
+    const engine = newEngine();
     for (let i = 0; i < 40; i++) engine.ingestPoint('flat', i * 1000, 0.4);
     const result = await engine.analyze('flat');
     expect(result!.severity).toBe('info');
-    expect(engine.getAlerts()).toHaveLength(0);
+    expect(await engine.listAlerts()).toHaveLength(0);
   });
 });
 
 describe('ensemble abstention', () => {
   it('renormalizes over detectors that actually ran', async () => {
     // 4 samples: IQR abstains (insufficient); z-score + EWMA both saturate.
-    const engine = new PredictiveMaintenanceEngine();
-    engine.setThresholds('fast', { minSamples: 4 });
+    const engine = newEngine();
+    await engine.setThresholds('fast', { minSamples: 4 }, OPERATOR);
     engine.ingestSeries('fast', series([100, 100, 100, 180]));
     const result = await engine.analyze('fast');
     expect(result!.ensembleScore).toBeCloseTo(1);
@@ -460,12 +515,12 @@ describe('EWMA statistic formulation (drift detection)', () => {
 
 describe('per-tag threshold overrides drive analysis outcomes', () => {
   it('a desensitized tag stays info while a default tag alarms on the same data', async () => {
-    const engine = new PredictiveMaintenanceEngine();
-    engine.setThresholds('desensitized', {
+    const engine = newEngine();
+    await engine.setThresholds('desensitized', {
       zScoreThreshold: 100_000,
       ewmaL: 100_000,
       iqrMultiplier: 100_000,
-    });
+    }, OPERATOR);
     const data = [...Array.from({ length: 30 }, (_, i) => 10 + Math.sin(i)), 500];
     engine.ingestSeries('desensitized', series(data));
     engine.ingestSeries('default', series(data));
@@ -474,7 +529,7 @@ describe('per-tag threshold overrides drive analysis outcomes', () => {
     const standard = await engine.analyze('default');
     expect(standard!.severity).not.toBe('info');
     expect(desensitized!.severity).toBe('info');
-    expect(engine.getAlerts().every((a) => a.tagId === 'default')).toBe(true);
+    expect((await engine.listAlerts()).every((a) => a.tagId === 'default')).toBe(true);
   });
 });
 
@@ -484,8 +539,12 @@ describe('alert cooldown (wall clock)', () => {
   });
 
   it('re-alerts after the window and is immune to future-dated data', async () => {
+    // Fake timers move Date.now(), which is what the cooldown window (and
+    // therefore the alert id) is derived from. sqlite3 dispatches its
+    // callbacks off the libuv work queue rather than off a timer, so the real
+    // database still answers under fake time.
     vi.useFakeTimers();
-    const engine = new PredictiveMaintenanceEngine({ alertCooldownMs: 60_000 });
+    const engine = newEngine({ alertCooldownMs: 60_000 });
     // Future-dated spike data must not permanently mute the tag
     const farFuture = Date.now() + 365 * 24 * 3600 * 1000;
     for (let i = 0; i < 30; i++) engine.ingestPoint('t', farFuture + i * 1000, 10);
@@ -493,33 +552,80 @@ describe('alert cooldown (wall clock)', () => {
 
     await engine.analyze('t');
     await engine.analyze('t');
-    expect(engine.getAlerts()).toHaveLength(1); // within cooldown
+    expect(await engine.listAlerts()).toHaveLength(1); // within cooldown
 
     vi.advanceTimersByTime(61_000);
     await engine.analyze('t');
-    expect(engine.getAlerts()).toHaveLength(2); // wall-clock window elapsed
+    expect(await engine.listAlerts()).toHaveLength(2); // wall-clock window elapsed
   });
 });
 
 describe('bounded state', () => {
-  it('caps retained alerts at maxAlerts', async () => {
-    vi.useFakeTimers();
-    try {
-      const engine = new PredictiveMaintenanceEngine({ maxAlerts: 3, alertCooldownMs: 0 });
-      for (let i = 0; i < 30; i++) engine.ingestPoint('t', i * 1000, 10);
-      for (let k = 0; k < 6; k++) {
-        engine.ingestPoint('t', 31_000 + k, 500 + k);
-        await engine.analyze('t');
-        vi.advanceTimersByTime(1);
-      }
-      expect(engine.getAlerts().length).toBeLessThanOrEqual(3);
-    } finally {
-      vi.useRealTimers();
+  it('holds the durable alert table to maxAlerts, and says what it evicted', async () => {
+    // Cooldown off, so every analysis raises a distinct alert.
+    const engine = newEngine({ maxAlerts: 3, alertCooldownMs: 0 });
+    const pruned: Array<{ overflow: number; unacknowledgedEvicted: string[] }> = [];
+    engine.on('alerts-pruned', (result) => pruned.push(result));
+
+    for (let i = 0; i < 30; i++) engine.ingestPoint('t', i * 1000, 10);
+    for (let k = 0; k < 6; k++) {
+      engine.ingestPoint('t', 31_000 + k, 500 + k);
+      await engine.analyze('t');
     }
+    expect(await engine.listAlerts()).toHaveLength(6);
+
+    await engine.pruneAlerts();
+    expect(await engine.listAlerts()).toHaveLength(3);
+    // Bounding the table is allowed to drop rows; doing it silently is not.
+    expect(pruned).toHaveLength(1);
+    expect(pruned[0].overflow).toBe(3);
+    expect(pruned[0].unacknowledgedEvicted).toHaveLength(3);
+  });
+
+  it('evicts acknowledged alerts before unacknowledged ones', async () => {
+    const engine = newEngine({ maxAlerts: 1, alertCooldownMs: 0 });
+    for (let i = 0; i < 30; i++) engine.ingestPoint('t', i * 1000, 10);
+    for (let k = 0; k < 2; k++) {
+      engine.ingestPoint('t', 31_000 + k, 500 + k);
+      await engine.analyze('t');
+    }
+    const [first, second] = await engine.listAlerts();
+    await engine.acknowledgeAlert(first.id, OPERATOR);
+
+    const result = await engine.pruneAlerts();
+    expect(result.unacknowledgedEvicted).toEqual([]);
+    const remaining = await engine.listAlerts();
+    expect(remaining.map((a) => a.id)).toEqual([second.id]);
+  });
+
+  it('retires acknowledged alerts on the retention window but keeps open ones', async () => {
+    const engine = newEngine({
+      alertCooldownMs: 0,
+      alertRetentionMs: 60_000,
+      alertMaxAgeMs: 10 * 60_000,
+    });
+    for (let i = 0; i < 30; i++) engine.ingestPoint('t', i * 1000, 10);
+    for (let k = 0; k < 2; k++) {
+      engine.ingestPoint('t', 31_000 + k, 500 + k);
+      await engine.analyze('t');
+    }
+    const [acked, open] = await engine.listAlerts();
+    await engine.acknowledgeAlert(acked.id, OPERATOR);
+
+    // Two minutes on: past the acknowledged-alert window, inside the absolute one.
+    const result = await engine.pruneAlerts(new Date(Date.now() + 2 * 60_000));
+    expect(result.retired).toBe(1);
+    expect(result.expired).toBe(0);
+    expect((await engine.listAlerts()).map((a) => a.id)).toEqual([open.id]);
+
+    // Eleven minutes on: past the absolute cut-off, so the open one goes too.
+    const later = await engine.pruneAlerts(new Date(Date.now() + 11 * 60_000));
+    expect(later.expired).toBe(1);
+    expect(await engine.listAlerts()).toHaveLength(0);
   });
 
   it('evicts the least-recently-updated tag beyond maxTrackedTags', () => {
-    const engine = new PredictiveMaintenanceEngine({ maxTrackedTags: 3 });
+    const engine = newEngine({ maxTrackedTags: 3 });
     for (const tag of ['a', 'b', 'c']) engine.ingestPoint(tag, 0, 1);
     engine.ingestPoint('a', 1000, 2); // refresh a — b is now oldest
     engine.ingestPoint('d', 2000, 1);
@@ -532,7 +638,7 @@ describe('bounded state', () => {
 
 describe('resilient sweeps', () => {
   it('keeps analyzing other tags when an alert listener throws', async () => {
-    const engine = new PredictiveMaintenanceEngine();
+    const engine = newEngine();
     engine.on('alert', () => {
       throw new Error('listener boom');
     });
@@ -551,7 +657,7 @@ describe('resilient sweeps', () => {
 
 describe('ingestion quality guards', () => {
   it('skips non-good quality readings and empty-string values', () => {
-    const service = new PredictiveMaintenanceService();
+    const service = newService();
     service.ingestTagUpdate({ tagName: 'q', value: 10, timestamp: 1000, quality: 'bad' });
     service.ingestTagUpdate({ tagName: 'q', value: 11, timestamp: 2000, quality: 'uncertain' });
     service.ingestTagUpdate({ tagName: 'q', value: '', timestamp: 3000 });

--- a/server/services/predictive/__tests__/predictive-migration.test.ts
+++ b/server/services/predictive/__tests__/predictive-migration.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Migration 0013 tests — Issue #546
+ *
+ * Two things have to be true of a schema change in this repository:
+ *
+ *   1. it works on a FRESH database — nothing exists, the tables appear, and
+ *      durable predictive state can immediately be written and read;
+ *   2. it works as an UPGRADE from current main — a database that already
+ *      carries main's tables and rows gains the new tables without disturbing
+ *      anything that was already there.
+ *
+ * Both are executed here, not asserted about — but read the next paragraph for
+ * exactly WHAT is executed, because it is not the same artefact on both
+ * dialects.
+ *
+ * `migrations/0013_predictive_durable_state.sql` is PostgreSQL DDL (JSONB,
+ * TIMESTAMPTZ, DEFAULT NOW()) and CANNOT be executed by SQLite. It is run
+ * verbatim against a real PostgreSQL server — fresh schema and upgrade — only
+ * when DATABASE_URL is configured; without one that suite is skipped rather
+ * than faked, and the file is instead checked statically for alignment with
+ * the Drizzle table definitions.
+ *
+ * The SQLite suites below therefore exercise the equivalent SQLite DDL that
+ * `server/services/predictive/store.ts` applies for the development back-end,
+ * NOT the 0013 file. They prove the dev-fallback schema is created, is
+ * idempotent, and leaves a populated database intact; they do not and cannot
+ * prove anything about the Postgres migration text.
+ */
+
+import { readFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getTableColumns } from 'drizzle-orm';
+import { Client } from 'pg';
+import { Database } from 'sqlite3';
+import { predictiveAlerts, predictiveTagThresholds } from '@shared/schema';
+import { DrizzlePredictiveStore } from '../store';
+
+const MIGRATION_SQL = readFileSync(
+  new URL('../../../../migrations/0013_predictive_durable_state.sql', import.meta.url),
+  'utf8',
+);
+
+const OPERATOR = 'migration-test-operator';
+
+function run(client: Database, sqlText: string, params: unknown[] = []): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client.run(sqlText, params, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function all(client: Database, sqlText: string): Promise<Array<Record<string, unknown>>> {
+  return new Promise((resolve, reject) => {
+    client.all(sqlText, (error, rows) =>
+      error ? reject(error) : resolve(rows as Array<Record<string, unknown>>));
+  });
+}
+
+function close(client: Database): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+let directory: string;
+const open: DrizzlePredictiveStore[] = [];
+
+beforeEach(async () => {
+  directory = await mkdtemp(path.join(tmpdir(), 'predictive-migration-'));
+});
+
+afterEach(async () => {
+  await Promise.all(open.splice(0).map((store) => store.close()));
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe('SQLite dev-fallback schema (store DDL, not the 0013 file) — fresh database', () => {
+  it('creates both tables and round-trips durable state', async () => {
+    const file = path.join(directory, 'fresh.sqlite');
+    const store = new DrizzlePredictiveStore({ sqlitePath: file });
+    open.push(store);
+    await store.ready();
+
+    const client = new Database(file);
+    try {
+      const tables = await all(
+        client,
+        "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
+      );
+      expect(tables.map((row) => row.name)).toEqual([
+        'predictive_alerts',
+        'predictive_tag_thresholds',
+      ]);
+      const indexes = await all(
+        client,
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_%' ORDER BY name",
+      );
+      expect(indexes.map((row) => row.name)).toEqual([
+        'idx_predictive_alerts_acknowledged',
+        'idx_predictive_alerts_created_at',
+        'idx_predictive_alerts_severity',
+        'idx_predictive_alerts_tag',
+        'idx_predictive_thresholds_updated_at',
+      ]);
+    } finally {
+      await close(client);
+    }
+
+    const written = await store.upsertThresholds({
+      thresholds: {
+        tagId: 'fresh-tag',
+        minSamples: 10,
+        zScoreThreshold: 3,
+        ewmaAlpha: 0.3,
+        ewmaL: 3,
+        iqrMultiplier: 1.5,
+        ensembleWeights: { 'z-score': 1 },
+        severityThresholds: { warning: 0.4, critical: 0.7, emergency: 0.9 },
+      },
+      updatedBy: OPERATOR,
+      at: new Date(),
+    });
+    expect(written.updatedBy).toBe(OPERATOR);
+    expect(await store.countThresholds()).toBe(1);
+  });
+
+  it('is idempotent — opening an already-migrated database changes nothing', async () => {
+    const file = path.join(directory, 'twice.sqlite');
+    const first = new DrizzlePredictiveStore({ sqlitePath: file });
+    open.push(first);
+    await first.upsertThresholds({
+      thresholds: {
+        tagId: 'kept',
+        minSamples: 11,
+        zScoreThreshold: 3,
+        ewmaAlpha: 0.3,
+        ewmaL: 3,
+        iqrMultiplier: 1.5,
+        ensembleWeights: { 'z-score': 1 },
+        severityThresholds: { warning: 0.4, critical: 0.7, emergency: 0.9 },
+      },
+      updatedBy: OPERATOR,
+      at: new Date(),
+    });
+    await first.close();
+
+    // Re-running the DDL must not drop the row that is already there.
+    const second = new DrizzlePredictiveStore({ sqlitePath: file });
+    open.push(second);
+    await second.ready();
+    expect(await second.countThresholds()).toBe(1);
+    expect((await second.getThresholds('kept'))?.thresholds.minSamples).toBe(11);
+  });
+});
+
+describe('SQLite dev-fallback schema (store DDL, not the 0013 file) — upgrade', () => {
+  it('adds the tables to a populated pre-0013 database without touching it', async () => {
+    const file = path.join(directory, 'upgrade.sqlite');
+
+    // A stand-in for a database that already carries an earlier migration's
+    // table and rows. This is a reduced `pid_tuning_audit` (migration 0010),
+    // NOT that table's full 15-column shape from shared/schema-sqlite.ts — it
+    // is here to prove the new DDL leaves a pre-existing populated table
+    // alone, not to reproduce main's schema.
+    const legacy = new Database(file);
+    await run(legacy, `
+      CREATE TABLE pid_tuning_audit (
+        id TEXT PRIMARY KEY,
+        proposal_id TEXT NOT NULL,
+        controller_id TEXT NOT NULL,
+        recorded_at INTEGER NOT NULL
+      )
+    `);
+    await run(
+      legacy,
+      'INSERT INTO pid_tuning_audit(id, proposal_id, controller_id, recorded_at) VALUES (?,?,?,?)',
+      ['audit-1', 'TUNE-1', 'FIC-101', 1_700_000_000_000],
+    );
+    await close(legacy);
+
+    // Upgrade.
+    const store = new DrizzlePredictiveStore({ sqlitePath: file });
+    open.push(store);
+    await store.ready();
+
+    const client = new Database(file);
+    try {
+      const tables = await all(
+        client,
+        "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
+      );
+      expect(tables.map((row) => row.name)).toEqual([
+        'pid_tuning_audit',
+        'predictive_alerts',
+        'predictive_tag_thresholds',
+      ]);
+      // The pre-existing data is untouched — an upgrade that silently drops
+      // rows is exactly the failure mode this test exists for.
+      const preserved = await all(client, 'SELECT id, proposal_id FROM pid_tuning_audit');
+      expect(preserved).toEqual([{ id: 'audit-1', proposal_id: 'TUNE-1' }]);
+    } finally {
+      await close(client);
+    }
+
+    // And the upgraded database is immediately usable.
+    await store.insertAlert({
+      id: 'PMA-upgrade-check',
+      tagId: 'upgraded-tag',
+      severity: 'critical',
+      score: 0.8,
+      message: 'upgraded',
+      timestamp: 1_700_000_000_000,
+      detectors: ['z-score'],
+      acknowledged: false,
+      recommendation: 'inspect',
+      createdAt: 1_700_000_000_000,
+      acknowledgedBy: null,
+      acknowledgedAt: null,
+    });
+    expect(await store.countAlerts()).toEqual({ total: 1, unacknowledged: 1 });
+  });
+});
+
+describe('migration 0013 SQL matches the Drizzle tables', () => {
+  it('creates every column the Postgres schema declares', () => {
+    for (const table of [predictiveTagThresholds, predictiveAlerts]) {
+      for (const column of Object.values(getTableColumns(table))) {
+        expect(MIGRATION_SQL, `column ${column.name}`).toMatch(
+          new RegExp(`^\\s*${column.name}\\s`, 'm'),
+        );
+      }
+    }
+  });
+
+  it('creates every index the Postgres schema declares, and the attribution guard', () => {
+    for (const index of [
+      'idx_predictive_thresholds_updated_at',
+      'idx_predictive_alerts_tag',
+      'idx_predictive_alerts_severity',
+      'idx_predictive_alerts_acknowledged',
+      'idx_predictive_alerts_created_at',
+    ]) {
+      expect(MIGRATION_SQL).toContain(index);
+    }
+    expect(MIGRATION_SQL).toContain('predictive_alerts_ack_attribution_check');
+    expect(MIGRATION_SQL).toContain('predictive_alerts_severity_check');
+  });
+
+  it('is re-runnable against an already-upgraded database', () => {
+    // `migrations/migrate.ts` tracks applied files, but an operator running the
+    // file by hand must not be punished for it.
+    const creates = MIGRATION_SQL.match(/CREATE (TABLE|INDEX)/g) ?? [];
+    const guarded = MIGRATION_SQL.match(/CREATE (TABLE|INDEX) IF NOT EXISTS/g) ?? [];
+    expect(creates.length).toBeGreaterThan(0);
+    expect(guarded.length).toBe(creates.length);
+  });
+});
+
+/**
+ * The production dialect. Runs the real migration file against a real
+ * PostgreSQL server when one is configured, on both a fresh schema and a
+ * schema that already contains a table from an earlier migration. Skipped —
+ * not stubbed — when DATABASE_URL is absent.
+ */
+const postgresUrl = process.env.DATABASE_URL;
+describe.skipIf(!postgresUrl)('migration 0013 on PostgreSQL', () => {
+  let client: Client;
+  let schema: string;
+
+  beforeEach(async () => {
+    schema = `predictive_migration_${Date.now().toString(36)}`;
+    client = new Client({ connectionString: postgresUrl });
+    await client.connect();
+    await client.query(`CREATE SCHEMA "${schema}"`);
+    await client.query(`SET search_path TO "${schema}"`);
+  });
+
+  afterEach(async () => {
+    await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await client.end();
+  });
+
+  async function columnsOf(table: string): Promise<string[]> {
+    const result = await client.query<{ column_name: string }>(
+      'SELECT column_name FROM information_schema.columns '
+      + 'WHERE table_schema = $1 AND table_name = $2 ORDER BY column_name',
+      [schema, table],
+    );
+    return result.rows.map((row) => row.column_name);
+  }
+
+  it('applies to a fresh schema and enforces the attribution constraint', async () => {
+    await client.query(MIGRATION_SQL);
+
+    expect(await columnsOf('predictive_tag_thresholds')).toEqual(
+      Object.values(getTableColumns(predictiveTagThresholds)).map((c) => c.name).sort(),
+    );
+    expect(await columnsOf('predictive_alerts')).toEqual(
+      Object.values(getTableColumns(predictiveAlerts)).map((c) => c.name).sort(),
+    );
+
+    await client.query(
+      'INSERT INTO predictive_alerts '
+      + '(id, tag_id, severity, score, message, detectors, recommendation, observed_at) '
+      + "VALUES ('PMA-pg', 't', 'critical', 0.8, 'm', '[\"z-score\"]'::jsonb, 'r', NOW())",
+    );
+    await expect(
+      client.query("UPDATE predictive_alerts SET acknowledged = TRUE WHERE id = 'PMA-pg'"),
+    ).rejects.toThrow(/predictive_alerts_ack_attribution_check/);
+  });
+
+  it('upgrades a schema that already holds an earlier migration table', async () => {
+    await client.query(
+      'CREATE TABLE pid_tuning_audit (id UUID PRIMARY KEY, proposal_id VARCHAR(128) NOT NULL)',
+    );
+    await client.query(
+      "INSERT INTO pid_tuning_audit (id, proposal_id) VALUES (gen_random_uuid(), 'TUNE-1')",
+    );
+
+    await client.query(MIGRATION_SQL);
+    // Re-running must be safe, which is what an operator re-applying a
+    // partially-failed migration actually does.
+    await client.query(MIGRATION_SQL);
+
+    const preserved = await client.query('SELECT proposal_id FROM pid_tuning_audit');
+    expect(preserved.rows).toEqual([{ proposal_id: 'TUNE-1' }]);
+    expect((await columnsOf('predictive_alerts')).length).toBeGreaterThan(0);
+  });
+});

--- a/server/services/predictive/__tests__/predictive-persistence.test.ts
+++ b/server/services/predictive/__tests__/predictive-persistence.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Predictive-maintenance durability tests
+ * ADR-0013 [13.1] / ADR-0026 "Durable approvals" row — Issue #546
+ *
+ * These run against a REAL file-backed SQLite database through the REAL
+ * Drizzle store. Nothing is mocked and nothing is in-memory: the store is
+ * closed and reopened between assertions, which is what "survives a restart"
+ * actually means. A threshold that reset on restart would not be a
+ * configuration, and an acknowledgement that reset on restart would not be an
+ * audit record, so both are re-read on the far side of the reopen.
+ *
+ * Postgres gets the same two tables from
+ * `migrations/0013_predictive_durable_state.sql`; the migration itself is
+ * exercised in `predictive-migration.test.ts`.
+ */
+
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Database } from 'sqlite3';
+import {
+  DEFAULT_ALERT_MAX_AGE_MS,
+  DEFAULT_ALERT_RETENTION_MS,
+  PredictiveMaintenanceEngine,
+  type EngineOptions,
+} from '../engine';
+import { PredictiveMaintenanceService, resolveAlertRetention } from '../index';
+import { DrizzlePredictiveStore, PredictiveStoreUnavailableError } from '../store';
+
+const OPERATOR = 'control-room-lead';
+const OTHER_OPERATOR = 'night-shift-lead';
+
+let directory: string;
+let file: string;
+let open: DrizzlePredictiveStore[] = [];
+
+function store(): DrizzlePredictiveStore {
+  const created = new DrizzlePredictiveStore({ sqlitePath: file });
+  open.push(created);
+  return created;
+}
+
+/**
+ * A brand new engine on a brand new connection to the same database file.
+ * This is the restart: no state is carried across in JavaScript, so anything
+ * the new engine can see came out of the database.
+ */
+function restartedEngine(options: Omit<EngineOptions, 'store'> = {}): PredictiveMaintenanceEngine {
+  return new PredictiveMaintenanceEngine({ ...options, store: store() });
+}
+
+/**
+ * A spike big enough that the ensemble rates it non-`info`.
+ *
+ * The baseline deliberately has variance: a perfectly constant baseline gives
+ * an infinite z-score, which saturates every detector no matter how the
+ * thresholds are configured, and would make the desensitisation test below
+ * pass for the wrong reason.
+ */
+function loadSpike(engine: PredictiveMaintenanceEngine, tagId: string): void {
+  for (let i = 0; i < 40; i++) engine.ingestPoint(tagId, i * 1000, 10 + Math.sin(i));
+  engine.ingestPoint(tagId, 41_000, 500);
+}
+
+beforeEach(async () => {
+  directory = await mkdtemp(path.join(tmpdir(), 'predictive-durable-'));
+  file = path.join(directory, 'predictive.sqlite');
+  open = [];
+});
+
+afterEach(async () => {
+  await Promise.all(open.map((instance) => instance.close()));
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe('configured thresholds survive process replacement (#546)', () => {
+  it('restores every field, including failure limits and attribution', async () => {
+    const before = restartedEngine();
+    await before.setThresholds('bearing-temp', {
+      minSamples: 7,
+      zScoreThreshold: 4.5,
+      ewmaAlpha: 0.15,
+      ewmaL: 2.5,
+      iqrMultiplier: 2,
+      ensembleWeights: { 'z-score': 0.6, ewma: 0.3, iqr: 0.1 },
+      severityThresholds: { warning: 0.5, critical: 0.8, emergency: 0.95 },
+      failureLimits: { low: 5, high: 189 },
+    }, OPERATOR);
+
+    const after = restartedEngine();
+    const restored = await after.getThresholds('bearing-temp');
+    expect(restored).toEqual({
+      tagId: 'bearing-temp',
+      minSamples: 7,
+      zScoreThreshold: 4.5,
+      ewmaAlpha: 0.15,
+      ewmaL: 2.5,
+      iqrMultiplier: 2,
+      ensembleWeights: { 'z-score': 0.6, ewma: 0.3, iqr: 0.1 },
+      severityThresholds: { warning: 0.5, critical: 0.8, emergency: 0.95 },
+      failureLimits: { low: 5, high: 189 },
+    });
+
+    const [configured] = await after.listConfiguredTags();
+    expect(configured.tagId).toBe('bearing-temp');
+    expect(configured.updatedBy).toBe(OPERATOR);
+    expect(configured.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('keeps a desensitised tag desensitised after a restart', async () => {
+    // The behavioural version of the claim above: before #546 a restart
+    // reverted this tag to the built-in defaults and it started alarming again.
+    const before = restartedEngine();
+    await before.setThresholds('quiet-tag', {
+      zScoreThreshold: 100_000,
+      ewmaL: 100_000,
+      iqrMultiplier: 100_000,
+    }, OPERATOR);
+
+    const after = restartedEngine();
+    loadSpike(after, 'quiet-tag');
+    const assessment = await after.analyze('quiet-tag');
+    expect(assessment?.severity).toBe('info');
+    expect(await after.listAlerts()).toHaveLength(0);
+  });
+
+  it('does not duplicate or lose a tag when the same threshold is written twice', async () => {
+    const first = restartedEngine();
+    await first.setThresholds('t', { minSamples: 5 }, OPERATOR);
+    const second = restartedEngine();
+    await second.setThresholds('t', { zScoreThreshold: 9 }, OTHER_OPERATOR);
+
+    const third = restartedEngine();
+    const configured = await third.listConfiguredTags();
+    expect(configured).toHaveLength(1);
+    // Merged, not replaced: the second write kept the first write's minSamples.
+    expect(configured[0].thresholds.minSamples).toBe(5);
+    expect(configured[0].thresholds.zScoreThreshold).toBe(9);
+    expect(configured[0].updatedBy).toBe(OTHER_OPERATOR);
+  });
+});
+
+describe('alert identity and acknowledgement survive process replacement (#546)', () => {
+  it('restores the alert and its acknowledgement attribution', async () => {
+    const before = restartedEngine();
+    loadSpike(before, 'pump-vibration');
+    await before.analyze('pump-vibration');
+    const [raised] = await before.listAlerts();
+    expect(raised).toBeDefined();
+    const acknowledgement = await before.acknowledgeAlert(raised.id, OPERATOR);
+    expect(acknowledgement.status).toBe('acknowledged');
+
+    const after = restartedEngine();
+    const [restored] = await after.listAlerts();
+    expect(restored.id).toBe(raised.id);
+    expect(restored.tagId).toBe('pump-vibration');
+    expect(restored.severity).toBe(raised.severity);
+    expect(restored.score).toBeCloseTo(raised.score, 10);
+    expect(restored.message).toBe(raised.message);
+    expect(restored.detectors).toEqual(raised.detectors);
+    expect(restored.recommendation).toBe(raised.recommendation);
+    expect(restored.timestamp).toBe(raised.timestamp);
+    expect(restored.acknowledged).toBe(true);
+    expect(restored.acknowledgedBy).toBe(OPERATOR);
+    expect(restored.acknowledgedAt).toBe(acknowledgement.alert?.acknowledgedAt);
+  });
+
+  it('does not re-raise an alert the operator already acknowledged', async () => {
+    // The duplication half of the acceptance criteria. The alert id is derived
+    // from tag + severity + cooldown window rather than from a per-process
+    // counter, so the restarted process recognises the anomaly it already
+    // reported instead of opening a second one.
+    const before = restartedEngine({ alertCooldownMs: 60 * 60 * 1000 });
+    loadSpike(before, 'fan-current');
+    await before.analyze('fan-current');
+    const [raised] = await before.listAlerts();
+    await before.acknowledgeAlert(raised.id, OPERATOR);
+
+    const after = restartedEngine({ alertCooldownMs: 60 * 60 * 1000 });
+    const emitted: string[] = [];
+    after.on('alert', (alert: { id: string }) => emitted.push(alert.id));
+    loadSpike(after, 'fan-current');
+    await after.analyze('fan-current');
+
+    const alerts = await after.listAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].id).toBe(raised.id);
+    // Still acknowledged: the restart neither reopened it nor lost the record.
+    expect(alerts[0].acknowledged).toBe(true);
+    expect(alerts[0].acknowledgedBy).toBe(OPERATOR);
+    // And no operator-facing alarm was re-emitted for the suppressed alert.
+    expect(emitted).toEqual([]);
+  });
+
+  it('keeps the first acknowledger when a second process acknowledges the same alert', async () => {
+    // Two engines on two connections to one database is the multi-replica
+    // case: whoever gets there first owns the record.
+    const replicaA = restartedEngine();
+    const replicaB = restartedEngine();
+    loadSpike(replicaA, 'valve-position');
+    await replicaA.analyze('valve-position');
+    const [alert] = await replicaA.listAlerts();
+
+    const first = await replicaA.acknowledgeAlert(alert.id, OPERATOR);
+    const second = await replicaB.acknowledgeAlert(alert.id, OTHER_OPERATOR);
+
+    expect(first.status).toBe('acknowledged');
+    expect(second.status).toBe('already-acknowledged');
+    expect(second.alert?.acknowledgedBy).toBe(OPERATOR);
+
+    const after = restartedEngine();
+    const [persisted] = await after.listAlerts();
+    expect(persisted.acknowledgedBy).toBe(OPERATOR);
+  });
+
+  it('lets a second replica see the first replica\'s alerts and configuration', async () => {
+    const replicaA = restartedEngine();
+    await replicaA.setThresholds('shared-tag', { minSamples: 12 }, OPERATOR);
+    loadSpike(replicaA, 'shared-tag');
+    await replicaA.analyze('shared-tag');
+
+    // Never ingested anything, never configured anything — it reads the store.
+    const replicaB = restartedEngine();
+    expect((await replicaB.getThresholds('shared-tag')).minSamples).toBe(12);
+    expect(await replicaB.listAlerts({ tagId: 'shared-tag' })).toHaveLength(1);
+    const status = await replicaB.getDurableStatus();
+    expect(status).toMatchObject({
+      backend: 'sqlite',
+      configuredTags: 1,
+      activeAlerts: 1,
+      totalAlerts: 1,
+    });
+  });
+});
+
+describe('startup hydration is deterministic (#546)', () => {
+  it('reports the durable state it found, and reports it identically twice', async () => {
+    const seed = restartedEngine();
+    await seed.setThresholds('a', { minSamples: 5 }, OPERATOR);
+    await seed.setThresholds('b', { minSamples: 6 }, OPERATOR);
+    loadSpike(seed, 'a');
+    await seed.analyze('a');
+
+    const restarted = restartedEngine();
+    const first = await restarted.hydrate();
+    expect(first).toEqual({
+      backend: 'sqlite',
+      configuredTags: 2,
+      totalAlerts: 1,
+      unacknowledgedAlerts: 1,
+    });
+
+    // Re-hydrating must be a no-op: no row is dropped and none is created.
+    const again = await restarted.hydrate();
+    expect(again).toEqual(first);
+    expect(await restarted.listAlerts()).toHaveLength(1);
+    expect(await restarted.listConfiguredTags()).toHaveLength(2);
+  });
+
+  it('surfaces the hydrated summary through the service and its health check', async () => {
+    const seed = restartedEngine();
+    await seed.setThresholds('a', { minSamples: 5 }, OPERATOR);
+
+    const service = new PredictiveMaintenanceService(30_000, { store: store() });
+    try {
+      expect(service.getHydration()).toBeNull();
+      await service.initialize();
+      expect(service.getHydration()).toMatchObject({ configuredTags: 1, totalAlerts: 0 });
+      const health = await service.healthCheck();
+      expect(health.healthy).toBe(true);
+      expect(health.message).toContain('1 configured tag(s)');
+    } finally {
+      await service.shutdown();
+    }
+  });
+});
+
+describe('durable-state failures are observable and fail closed (#546)', () => {
+  /** A store pointed at a path that cannot be opened as a database. */
+  function brokenEngine(): PredictiveMaintenanceEngine {
+    const broken = new DrizzlePredictiveStore({ sqlitePath: directory });
+    open.push(broken);
+    return new PredictiveMaintenanceEngine({ store: broken });
+  }
+
+  it('refuses a threshold write rather than keeping it in memory', async () => {
+    const engine = brokenEngine();
+    const errors: Array<{ error: string }> = [];
+    engine.on('store-error', (event: { error: string }) => errors.push(event));
+
+    await expect(engine.setThresholds('t', { minSamples: 5 }, OPERATOR))
+      .rejects.toBeInstanceOf(PredictiveStoreUnavailableError);
+    // Observable: the failure is emitted and retained for /status.
+    expect(errors.length).toBeGreaterThan(0);
+    expect(engine.getLastStoreError()).toEqual(expect.any(String));
+    // Fail closed: the value was NOT retained anywhere.
+    await expect(engine.getThresholds('t'))
+      .rejects.toBeInstanceOf(PredictiveStoreUnavailableError);
+  });
+
+  it('refuses an acknowledgement and an alert generation', async () => {
+    const engine = brokenEngine();
+    await expect(engine.acknowledgeAlert('PMA-anything', OPERATOR))
+      .rejects.toBeInstanceOf(PredictiveStoreUnavailableError);
+
+    const emitted: unknown[] = [];
+    engine.on('alert', (alert) => emitted.push(alert));
+    loadSpike(engine, 't');
+    await expect(engine.analyze('t')).rejects.toBeInstanceOf(PredictiveStoreUnavailableError);
+    // No alarm is raised for an alert that was never recorded — an operator
+    // must never see an alarm they cannot then acknowledge.
+    expect(emitted).toEqual([]);
+  });
+
+  it('reports the service as unhealthy while the store is unreachable', async () => {
+    const broken = new DrizzlePredictiveStore({ sqlitePath: directory });
+    open.push(broken);
+    const service = new PredictiveMaintenanceService(30_000, { store: broken });
+    try {
+      await service.initialize();
+      expect(service.getHydration()).toBeNull();
+      const health = await service.healthCheck();
+      expect(health.healthy).toBe(false);
+      expect(health.message).toContain('durable store unavailable');
+    } finally {
+      await service.shutdown();
+    }
+  });
+
+  it('recovers once the store becomes reachable again', async () => {
+    // The refusal must be a state of the store, not a latch: the same engine
+    // that just failed has to work again once the database can be opened.
+    const missing = path.join(directory, 'not-created-yet');
+    const recovering = new DrizzlePredictiveStore({
+      sqlitePath: path.join(missing, 'predictive.sqlite'),
+    });
+    open.push(recovering);
+    const engine = new PredictiveMaintenanceEngine({ store: recovering });
+
+    await expect(engine.setThresholds('t', { minSamples: 5 }, OPERATOR))
+      .rejects.toBeInstanceOf(PredictiveStoreUnavailableError);
+    expect(engine.getLastStoreError()).toEqual(expect.any(String));
+
+    await mkdir(missing, { recursive: true });
+    await engine.setThresholds('t', { minSamples: 5 }, OPERATOR);
+    expect(engine.getLastStoreError()).toBeNull();
+    expect((await engine.getThresholds('t')).minSamples).toBe(5);
+  });
+});
+
+describe('alert retention is configured independently of the history window (#546)', () => {
+  it('defaults to 90 days for acknowledged alerts and 365 days absolute', () => {
+    expect(resolveAlertRetention({} as NodeJS.ProcessEnv)).toEqual({
+      alertRetentionMs: DEFAULT_ALERT_RETENTION_MS,
+      alertMaxAgeMs: DEFAULT_ALERT_MAX_AGE_MS,
+    });
+  });
+
+  it('reads both windows from the environment', () => {
+    expect(resolveAlertRetention({
+      PREDICTIVE_ALERT_RETENTION_MS: '1000',
+      PREDICTIVE_ALERT_MAX_AGE_MS: '5000',
+    } as NodeJS.ProcessEnv)).toEqual({ alertRetentionMs: 1000, alertMaxAgeMs: 5000 });
+  });
+
+  it('never lets the absolute cut-off fall below the acknowledged window', () => {
+    // Otherwise an acknowledged alert would outlive an unacknowledged one.
+    expect(resolveAlertRetention({
+      PREDICTIVE_ALERT_RETENTION_MS: '5000',
+      PREDICTIVE_ALERT_MAX_AGE_MS: '1000',
+    } as NodeJS.ProcessEnv)).toEqual({ alertRetentionMs: 5000, alertMaxAgeMs: 5000 });
+  });
+
+  it('ignores unusable values rather than disabling retention', () => {
+    expect(resolveAlertRetention({
+      PREDICTIVE_ALERT_RETENTION_MS: '0',
+      PREDICTIVE_ALERT_MAX_AGE_MS: 'not-a-number',
+    } as NodeJS.ProcessEnv)).toEqual({
+      alertRetentionMs: DEFAULT_ALERT_RETENTION_MS,
+      alertMaxAgeMs: DEFAULT_ALERT_MAX_AGE_MS,
+    });
+  });
+
+  it('does not persist raw prediction history', async () => {
+    // The scope split the issue asks for: sampled data stays in the bounded
+    // in-process window, only operator config and alert/audit state go durable.
+    const engine = restartedEngine();
+    loadSpike(engine, 'history-tag');
+    await engine.analyze('history-tag');
+    expect(engine.getHistory('history-tag').length).toBe(41);
+
+    const after = restartedEngine();
+    expect(after.getHistory('history-tag')).toEqual([]);
+    expect(after.getTrackedTags()).toEqual([]);
+    // ...but the alert the history produced did survive.
+    expect(await after.listAlerts({ tagId: 'history-tag' })).toHaveLength(1);
+  });
+});
+
+describe('the store releases its handle (#546)', () => {
+  it('closes the connection even when close() races an in-flight connect()', async () => {
+    // `connect()` publishes `this.connection` from a `.then()` callback. A
+    // close() that lands in that gap used to clear a still-undefined field and
+    // then have the pending open write a live handle back, leaking the
+    // descriptor (and, on Postgres, the server-side session) with no reference
+    // left to close it. Closing must therefore wait for the open to settle.
+    const racing = new DrizzlePredictiveStore({ sqlitePath: file });
+    const opening = racing.ready();
+    await racing.close();
+    await opening.catch(() => undefined);
+
+    expect(racing.backend()).toBe('unopened');
+    // Proof the OS handle really went: on Windows an open SQLite file cannot
+    // be unlinked, so this throws EBUSY if the descriptor was leaked.
+    await rm(file, { force: true });
+  });
+});
+
+describe('the durable tables really are on disk (#546)', () => {
+  it('writes rows a plain SQLite client can read back', async () => {
+    const engine = restartedEngine();
+    await engine.setThresholds('disk-tag', { minSamples: 5 }, OPERATOR);
+    loadSpike(engine, 'disk-tag');
+    await engine.analyze('disk-tag');
+    const [alert] = await engine.listAlerts();
+    await engine.acknowledgeAlert(alert.id, OPERATOR);
+    await Promise.all(open.map((instance) => instance.close()));
+    open = [];
+
+    const raw = new Database(file);
+    try {
+      const rows = await new Promise<Array<Record<string, unknown>>>((resolve, reject) => {
+        raw.all(
+          'SELECT tag_id, updated_by FROM predictive_tag_thresholds',
+          (error, result) => (error ? reject(error) : resolve(result as Array<Record<string, unknown>>)),
+        );
+      });
+      expect(rows).toEqual([{ tag_id: 'disk-tag', updated_by: OPERATOR }]);
+
+      const alerts = await new Promise<Array<Record<string, unknown>>>((resolve, reject) => {
+        raw.all(
+          'SELECT id, acknowledged, acknowledged_by FROM predictive_alerts',
+          (error, result) => (error ? reject(error) : resolve(result as Array<Record<string, unknown>>)),
+        );
+      });
+      expect(alerts).toEqual([
+        { id: alert.id, acknowledged: 1, acknowledged_by: OPERATOR },
+      ]);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        raw.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it('rejects an acknowledged row with no acknowledger at the database level', async () => {
+    // The CHECK constraint is the last line of defence for attribution: even a
+    // direct SQL writer cannot record an anonymous acknowledgement.
+    const engine = restartedEngine();
+    loadSpike(engine, 'constraint-tag');
+    await engine.analyze('constraint-tag');
+    const [alert] = await engine.listAlerts();
+    await Promise.all(open.map((instance) => instance.close()));
+    open = [];
+
+    const raw = new Database(file);
+    try {
+      await expect(new Promise<void>((resolve, reject) => {
+        raw.run(
+          'UPDATE predictive_alerts SET acknowledged = 1 WHERE id = ?',
+          [alert.id],
+          (error) => (error ? reject(error) : resolve()),
+        );
+      })).rejects.toThrow(/constraint/i);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        raw.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/server/services/predictive/engine.ts
+++ b/server/services/predictive/engine.ts
@@ -1,26 +1,56 @@
 /**
  * Predictive Maintenance Engine
- * ADR-0013 [13.1] — Issue #212
+ * ADR-0013 [13.1] — Issue #212, made durable by #546
  *
  * Ingests tag time-series, runs an ensemble of anomaly detectors
  * (z-score, EWMA, IQR by default — ML models pluggable via the
  * AnomalyDetector contract), classifies severity against per-tag
  * thresholds, and generates alerts before failures using trend-based
  * time-to-limit estimation.
+ *
+ * ─── WHAT LIVES WHERE (#546) ────────────────────────────────────────────────
+ *
+ * Durable, in the shared store (`./store.ts`):
+ *   - per-tag operator thresholds
+ *   - generated alerts, their identity, and acknowledgement attribution
+ *
+ * In process, deliberately:
+ *   - the detector registry (that is code, not state)
+ *   - the raw prediction history: a bounded per-tag sliding window
+ *     (`maxHistorySize` points over at most `maxTrackedTags` tags) fed by the
+ *     live tag stream. It is recomputable, the historian is the system of
+ *     record for sampled process data, and persisting it would put a write on
+ *     every ingested sample. Its retention is therefore defined here and
+ *     independently of the durable retention applied to alerts.
+ *
+ * There is no process-local ownership of durable state: alert suppression is
+ * an idempotent insert against a content-derived primary key rather than a
+ * local `lastAlertAt` map, so a restarted process — or a second replica —
+ * neither loses nor duplicates an alert.
  */
 
+import { createHash, randomUUID } from 'node:crypto';
 import { EventEmitter } from 'events';
 import type {
+  AcknowledgeOutcome,
   AnomalyAssessment,
   AnomalyDetector,
   DetectorResult,
   MaintenancePrediction,
   PredictiveAlert,
+  PredictiveHydrationSummary,
   SeverityLevel,
   SeverityThresholds,
   TagThresholds,
   TimeSeriesPoint,
 } from '@shared/types/predictive';
+import {
+  predictiveStore,
+  PredictiveStoreUnavailableError,
+  type AlertFilter,
+  type PredictiveStore,
+  type PruneResult,
+} from './store';
 
 /** Threshold overrides — nested objects may be partial; they merge over the base */
 export type ThresholdOverrides = Partial<
@@ -46,15 +76,28 @@ export const DEFAULT_THRESHOLDS: Omit<TagThresholds, 'tagId'> = {
   severityThresholds: { warning: 0.4, critical: 0.7, emergency: 0.9 },
 };
 
+/** Acknowledged alerts are pruned after this long. */
+export const DEFAULT_ALERT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+/** Any alert is pruned after this long, acknowledged or not. */
+export const DEFAULT_ALERT_MAX_AGE_MS = 365 * 24 * 60 * 60 * 1000;
+/** Durable row cap for `predictive_alerts`. */
+export const DEFAULT_MAX_ALERTS = 5_000;
+
 export interface EngineOptions {
-  /** Points retained per tag (sliding window) */
+  /** Points retained per tag, in process (sliding window) */
   maxHistorySize?: number;
-  /** Alerts retained before the oldest are dropped */
+  /** Durable alert rows retained before the oldest are evicted */
   maxAlerts?: number;
   /** Suppress repeat alerts for the same tag+severity within this window */
   alertCooldownMs?: number;
-  /** Tags tracked before the least-recently-updated is evicted */
+  /** Tags tracked in process before the least-recently-updated is evicted */
   maxTrackedTags?: number;
+  /** Acknowledged alerts older than this are pruned */
+  alertRetentionMs?: number;
+  /** Any alert older than this is pruned, acknowledged or not */
+  alertMaxAgeMs?: number;
+  /** Durable state boundary. Defaults to the process-wide store. */
+  store?: PredictiveStore;
 }
 
 export class PredictiveMaintenanceEngine extends EventEmitter {
@@ -62,27 +105,66 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
   private readonly maxAlerts: number;
   private readonly alertCooldownMs: number;
   private readonly maxTrackedTags: number;
-  /** Distinguishes alert ids across process restarts */
+  private readonly alertRetentionMs: number;
+  private readonly alertMaxAgeMs: number;
+  private readonly store: PredictiveStore;
+  /** Only used to keep ids unique when alert suppression is switched off */
   private readonly bootId: string;
 
   private detectors: Map<string, AnomalyDetector> = new Map();
-  private thresholds: Map<string, TagThresholds> = new Map();
   /** Insertion order doubles as recency order — refreshed on every ingest */
   private history: Map<string, TimeSeriesPoint[]> = new Map();
-  private alerts: PredictiveAlert[] = [];
-  private lastAlertAt: Map<string, number> = new Map(); // key: tagId:severity
-  private alertCounter = 0;
+  private alertNonce = 0;
+  private lastStoreError: string | null = null;
 
   constructor(options: EngineOptions = {}) {
     super();
     this.maxHistorySize = options.maxHistorySize ?? 1000;
-    this.maxAlerts = options.maxAlerts ?? 500;
+    this.maxAlerts = options.maxAlerts ?? DEFAULT_MAX_ALERTS;
     this.alertCooldownMs = options.alertCooldownMs ?? 5 * 60 * 1000;
     this.maxTrackedTags = options.maxTrackedTags ?? 500;
-    this.bootId = Date.now().toString(36);
+    this.alertRetentionMs = options.alertRetentionMs ?? DEFAULT_ALERT_RETENTION_MS;
+    this.alertMaxAgeMs = options.alertMaxAgeMs ?? DEFAULT_ALERT_MAX_AGE_MS;
+    this.store = options.store ?? predictiveStore;
+    this.bootId = randomUUID();
     for (const d of builtinDetectors) {
       this.detectors.set(d.name, d);
     }
+  }
+
+  // ── Startup hydration ────────────────────────────────────────────────
+
+  /**
+   * Open the durable store and report what is already there.
+   *
+   * There is nothing to copy into memory: thresholds and alerts are read from
+   * the store on demand, which is what lets a second replica see the first
+   * one's configuration and acknowledgements. Hydration is therefore
+   * deterministic and idempotent by construction — running it twice, or after
+   * a restart, can neither drop a row nor create one. The returned summary is
+   * the observable proof that state was found rather than silently reset.
+   */
+  async hydrate(): Promise<PredictiveHydrationSummary> {
+    await this.runDurable(() => this.store.ready());
+    const [configuredTags, counts] = await Promise.all([
+      this.runDurable(() => this.store.countThresholds()),
+      this.runDurable(() => this.store.countAlerts()),
+    ]);
+    return {
+      backend: this.store.backend(),
+      configuredTags,
+      totalAlerts: counts.total,
+      unacknowledgedAlerts: counts.unacknowledged,
+    };
+  }
+
+  /** Last durable-store failure seen, for `/status`. Null once one succeeds. */
+  getLastStoreError(): string | null {
+    return this.lastStoreError;
+  }
+
+  storeBackend(): 'postgres' | 'sqlite' | 'unopened' {
+    return this.store.backend();
   }
 
   // ── Detector registry (ML integration point) ─────────────────────────
@@ -99,10 +181,25 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
     return Array.from(this.detectors.values()).map(({ name, kind }) => ({ name, kind }));
   }
 
-  // ── Per-tag threshold configuration ──────────────────────────────────
+  // ── Per-tag threshold configuration (durable) ────────────────────────
 
-  setThresholds(tagId: string, overrides: ThresholdOverrides): TagThresholds {
-    const base = this.thresholds.get(tagId) ?? { ...DEFAULT_THRESHOLDS, tagId };
+  /**
+   * Merge `overrides` over the stored configuration and persist the result.
+   *
+   * Store-first: the merged value is only returned once the row is written, so
+   * a caller can never be told a threshold was configured when it was not.
+   * `updatedBy` is the authenticated control-plane principal supplied by the
+   * route — it is never read from a request body.
+   */
+  async setThresholds(
+    tagId: string,
+    overrides: ThresholdOverrides,
+    updatedBy: string,
+  ): Promise<TagThresholds> {
+    if (updatedBy.trim() === '') {
+      throw new Error('setThresholds requires an authenticated principal name');
+    }
+    const base = await this.getThresholds(tagId);
     const merged: TagThresholds = {
       ...base,
       ...overrides,
@@ -110,12 +207,28 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
       severityThresholds: { ...base.severityThresholds, ...overrides.severityThresholds },
       tagId,
     };
-    this.thresholds.set(tagId, merged);
-    return merged;
+    const stored = await this.runDurable(() =>
+      this.store.upsertThresholds({ thresholds: merged, updatedBy, at: new Date() }));
+    return stored.thresholds;
   }
 
-  getThresholds(tagId: string): TagThresholds {
-    return this.thresholds.get(tagId) ?? { ...DEFAULT_THRESHOLDS, tagId };
+  /** Stored thresholds for a tag, or the built-in defaults if none are set. */
+  async getThresholds(tagId: string): Promise<TagThresholds> {
+    const stored = await this.runDurable(() => this.store.getThresholds(tagId));
+    return stored?.thresholds ?? { ...DEFAULT_THRESHOLDS, tagId };
+  }
+
+  /** Every tag an operator has explicitly configured, with attribution. */
+  async listConfiguredTags(): Promise<
+    Array<{ tagId: string; thresholds: TagThresholds; updatedBy: string; updatedAt: Date }>
+  > {
+    const rows = await this.runDurable(() => this.store.listThresholds());
+    return rows.map(({ tagId, thresholds, updatedBy, updatedAt }) => ({
+      tagId,
+      thresholds,
+      updatedBy,
+      updatedAt,
+    }));
   }
 
   // ── Ingestion ────────────────────────────────────────────────────────
@@ -148,7 +261,9 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
     options: { generateAlerts?: boolean } = {}
   ): Promise<AnomalyAssessment | null> {
     const live = this.history.get(tagId);
-    const cfg = this.getThresholds(tagId);
+    // Thresholds come from the shared store, so a configuration change made on
+    // another replica takes effect here without a restart.
+    const cfg = await this.getThresholds(tagId);
     if (!live || live.length < cfg.minSamples) return null;
     // Snapshot before any await — the live series mutates while async
     // detectors run, and every detector (and the alert) must describe the
@@ -184,7 +299,7 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
     };
 
     if (severity !== 'info' && options.generateAlerts !== false) {
-      this.generateAlert(assessment);
+      await this.generateAlert(assessment);
     }
 
     return assessment;
@@ -197,8 +312,8 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
         const result = await this.analyze(tagId);
         if (result) results.push(result);
       } catch (error) {
-        // One tag's failure (including a throwing 'alert' listener) must
-        // not starve the remaining tags of analysis.
+        // One tag's failure (including a throwing 'alert' listener or an
+        // unreachable store) must not starve the remaining tags of analysis.
         this.emit('analyze-error', {
           tagId,
           error: error instanceof Error ? error.message : String(error),
@@ -212,7 +327,7 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
 
   async predictFailure(tagId: string): Promise<MaintenancePrediction | null> {
     const series = this.history.get(tagId);
-    const cfg = this.getThresholds(tagId);
+    const cfg = await this.getThresholds(tagId);
     if (!series || series.length < cfg.minSamples) return null;
 
     const trend = estimateTrend(series);
@@ -246,25 +361,60 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
     };
   }
 
-  // ── Alerts ───────────────────────────────────────────────────────────
+  // ── Alerts (durable) ─────────────────────────────────────────────────
 
-  getAlerts(filter?: { severity?: SeverityLevel; acknowledged?: boolean }): PredictiveAlert[] {
-    let alerts = [...this.alerts];
-    if (filter?.severity) alerts = alerts.filter((a) => a.severity === filter.severity);
-    if (filter?.acknowledged !== undefined) {
-      alerts = alerts.filter((a) => a.acknowledged === filter.acknowledged);
+  /** Read alerts from the shared store, oldest first. */
+  listAlerts(filter?: AlertFilter): Promise<PredictiveAlert[]> {
+    return this.runDurable(() => this.store.listAlerts(filter));
+  }
+
+  getAlert(alertId: string): Promise<PredictiveAlert | null> {
+    return this.runDurable(() => this.store.getAlert(alertId));
+  }
+
+  /**
+   * Record an acknowledgement against the durable alert row.
+   *
+   * `acknowledgedBy` must be an authenticated control-plane principal name.
+   * The update is conditional on the alert still being unacknowledged, so a
+   * second acknowledgement — from this process or another replica — reports
+   * `already-acknowledged` and leaves the original attribution intact.
+   */
+  acknowledgeAlert(alertId: string, acknowledgedBy: string): Promise<AcknowledgeOutcome> {
+    if (acknowledgedBy.trim() === '') {
+      // An unattributed acknowledgement is not an audit record. Refusing here
+      // means no code path can write one even if a caller passes an empty
+      // principal name.
+      return Promise.reject(
+        new Error('acknowledgeAlert requires an authenticated principal name'),
+      );
     }
-    return alerts;
+    return this.runDurable(() =>
+      this.store.acknowledgeAlert(alertId, acknowledgedBy, new Date()));
   }
 
-  acknowledgeAlert(alertId: string): boolean {
-    const alert = this.alerts.find((a) => a.id === alertId);
-    if (!alert) return false;
-    alert.acknowledged = true;
-    return true;
+  /**
+   * Apply the alert retention policy. Deliberately separate from the raw
+   * history window above: operator/audit state ages out on a calendar
+   * schedule, sampled data ages out by sample count.
+   */
+  async pruneAlerts(now: Date = new Date()): Promise<PruneResult> {
+    const result = await this.runDurable(() =>
+      this.store.prune({
+        acknowledgedBefore: new Date(now.getTime() - this.alertRetentionMs),
+        anyBefore: new Date(now.getTime() - this.alertMaxAgeMs),
+        maxRows: this.maxAlerts,
+      }));
+    if (result.retired + result.expired + result.overflow > 0) {
+      // Retention is allowed to remove state; it is not allowed to remove it
+      // quietly. Unacknowledged evictions are called out separately because
+      // those are the ones no operator ever closed out.
+      this.emit('alerts-pruned', result);
+    }
+    return result;
   }
 
-  // ── History access ───────────────────────────────────────────────────
+  // ── History access (in process, ephemeral) ───────────────────────────
 
   getHistory(tagId: string): TimeSeriesPoint[] {
     return this.history.get(tagId) ?? [];
@@ -278,11 +428,13 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
     }));
   }
 
+  /**
+   * Drop a tag's in-process sample window. This is a history operation only —
+   * it deliberately does not touch the tag's durable thresholds or its alert
+   * history, which belong to the operator, not to the sampling window.
+   */
   clearHistory(tagId: string): void {
     this.history.delete(tagId);
-    for (const severity of ['warning', 'critical', 'emergency'] as const) {
-      this.lastAlertAt.delete(`${tagId}:${severity}`);
-    }
   }
 
   /** Evict least-recently-updated tags beyond the tracked-tag cap */
@@ -295,12 +447,11 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
     }
   }
 
+  /** In-process status. Durable counts come from `getDurableStatus()`. */
   getStatus(): {
     trackedTags: number;
     totalSamples: number;
     detectors: Array<Pick<AnomalyDetector, 'name' | 'kind'>>;
-    activeAlerts: number;
-    totalAlerts: number;
   } {
     let totalSamples = 0;
     for (const series of this.history.values()) totalSamples += series.length;
@@ -308,27 +459,74 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
       trackedTags: this.history.size,
       totalSamples,
       detectors: this.getDetectors(),
-      activeAlerts: this.alerts.filter((a) => !a.acknowledged).length,
-      totalAlerts: this.alerts.length,
+    };
+  }
+
+  /** Durable state summary, read from the shared store. */
+  async getDurableStatus(): Promise<{
+    backend: 'postgres' | 'sqlite' | 'unopened';
+    configuredTags: number;
+    activeAlerts: number;
+    totalAlerts: number;
+  }> {
+    const [configuredTags, counts] = await Promise.all([
+      this.runDurable(() => this.store.countThresholds()),
+      this.runDurable(() => this.store.countAlerts()),
+    ]);
+    return {
+      backend: this.store.backend(),
+      configuredTags,
+      activeAlerts: counts.unacknowledged,
+      totalAlerts: counts.total,
     };
   }
 
   // ── Private ──────────────────────────────────────────────────────────
 
-  private generateAlert(assessment: AnomalyAssessment): void {
-    // Cooldown is an operator-facing rate limit, so it runs on wall clock —
-    // keying it on data timestamps would let one future-dated point mute a
-    // tag+severity permanently.
-    const cooldownKey = `${assessment.tagId}:${assessment.severity}`;
-    const now = Date.now();
-    const last = this.lastAlertAt.get(cooldownKey);
-    if (last !== undefined && now - last < this.alertCooldownMs) {
-      return;
-    }
-    this.lastAlertAt.set(cooldownKey, now);
+  /**
+   * Content-derived alert identity.
+   *
+   * The tuple is (tag, severity, cooldown window). Two consequences, both
+   * intentional:
+   *   - a restarted process that re-detects the same anomaly inside the same
+   *     window writes the same primary key, so the alert is not duplicated and
+   *     an acknowledgement made before the restart still applies to it;
+   *   - two replicas that both see the anomaly converge on one row, which is
+   *     what replaces the old process-local `lastAlertAt` suppression map.
+   *
+   * The window is aligned on absolute time (`floor(now / cooldown)`) rather
+   * than measured from the previous alert, because a sliding window needs a
+   * shared "previous alert" value and that is precisely the process-local
+   * state this issue removes. When suppression is disabled (`cooldown <= 0`)
+   * every alert must stay distinct, so the tuple gets a per-process nonce.
+   */
+  private alertId(tagId: string, severity: SeverityLevel, now: number): string {
+    const window = this.alertCooldownMs > 0
+      ? String(Math.floor(now / this.alertCooldownMs))
+      : `${this.bootId}:${now}:${++this.alertNonce}`;
+    const digest = createHash('sha256')
+      .update(`${tagId} ${severity} ${window}`)
+      .digest('hex');
+    return `PMA-${digest.slice(0, 32)}`;
+  }
 
+  /**
+   * Persist first, emit second.
+   *
+   * The `alert` event drives the operator-facing alarm fan-out, so it is only
+   * raised once the row exists: an alarm the operator cannot then acknowledge
+   * — because the alert was never recorded — would be worse than no alarm.
+   * If the store is unreachable this throws, which fails the ingest request
+   * closed and surfaces on `/api/predictive/status`; the next analysis of a
+   * still-anomalous tag retries the same id.
+   */
+  private async generateAlert(assessment: AnomalyAssessment): Promise<void> {
+    // Suppression runs on wall clock, not on data timestamps: keying it on
+    // data time would let one future-dated point mute a tag+severity
+    // permanently.
+    const now = Date.now();
     const alert: PredictiveAlert = {
-      id: `PMA-${this.bootId}-${++this.alertCounter}`,
+      id: this.alertId(assessment.tagId, assessment.severity, now),
       tagId: assessment.tagId,
       severity: assessment.severity,
       score: assessment.ensembleScore,
@@ -337,12 +535,17 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
       detectors: assessment.detectorResults.filter((d) => d.anomalous).map((d) => d.detector),
       acknowledged: false,
       recommendation: this.getRecommendation(assessment.severity),
+      createdAt: now,
+      acknowledgedBy: null,
+      acknowledgedAt: null,
     };
 
-    this.alerts.push(alert);
-    if (this.alerts.length > this.maxAlerts) {
-      this.alerts.splice(0, this.alerts.length - this.maxAlerts);
-    }
+    const inserted = await this.runDurable(() => this.store.insertAlert(alert));
+    // Already present: this tag+severity already alerted in this window, on
+    // this process or another one. Suppressed, exactly as before — only now
+    // the suppression survives a restart.
+    if (!inserted) return;
+
     try {
       this.emit('alert', alert);
     } catch (error) {
@@ -351,6 +554,25 @@ export class PredictiveMaintenanceEngine extends EventEmitter {
         tagId: alert.tagId,
         error: error instanceof Error ? error.message : String(error),
       });
+    }
+  }
+
+  /**
+   * Run a durable-store operation, recording the outcome so failures are
+   * observable rather than silent. The error is re-thrown: every caller either
+   * fails a mutation closed or is caught by `analyzeAll`'s per-tag handler.
+   */
+  private async runDurable<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      const value = await operation();
+      this.lastStoreError = null;
+      return value;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.lastStoreError = message;
+      this.emit('store-error', { error: message });
+      if (error instanceof PredictiveStoreUnavailableError) throw error;
+      throw new PredictiveStoreUnavailableError(message, error);
     }
   }
 

--- a/server/services/predictive/index.ts
+++ b/server/services/predictive/index.ts
@@ -1,19 +1,26 @@
 /**
  * Predictive Maintenance Service
- * ADR-0013 [13.1] — Issue #212
+ * ADR-0013 [13.1] — Issue #212, made durable by #546
  *
- * Wraps the PredictiveMaintenanceEngine as a singleton service: consumes
- * live tag updates (numeric values only), runs a periodic analysis sweep,
- * and re-emits engine alerts for downstream consumers (WebSocket, alarms).
+ * Wraps the PredictiveMaintenanceEngine as a singleton service: hydrates
+ * durable state at startup, consumes live tag updates (numeric values only),
+ * runs a periodic analysis sweep, applies the alert retention policy, and
+ * re-emits engine alerts for downstream consumers (WebSocket, alarms).
  */
 
 import { EventEmitter } from 'events';
 
 export * from './detectors';
 export * from './engine';
+export * from './store';
 
-import { PredictiveMaintenanceEngine } from './engine';
-import type { PredictiveAlert } from '@shared/types/predictive';
+import {
+  DEFAULT_ALERT_MAX_AGE_MS,
+  DEFAULT_ALERT_RETENTION_MS,
+  PredictiveMaintenanceEngine,
+  type EngineOptions,
+} from './engine';
+import type { PredictiveAlert, PredictiveHydrationSummary } from '@shared/types/predictive';
 
 export interface TagUpdateInput {
   tagName: string;
@@ -23,29 +30,101 @@ export interface TagUpdateInput {
   quality?: 'good' | 'bad' | 'uncertain';
 }
 
+/**
+ * Retention for durable alert state, read from the environment.
+ *
+ * This is deliberately separate from the raw-history window
+ * (`EngineOptions.maxHistorySize` / `maxTrackedTags`), which bounds sampled
+ * data by sample count rather than by calendar age: operator/audit state and
+ * process data have different reasons to be kept and different reasons to go.
+ */
+export function resolveAlertRetention(
+  env: NodeJS.ProcessEnv = process.env,
+): { alertRetentionMs: number; alertMaxAgeMs: number } {
+  const retention = positiveMs(env.PREDICTIVE_ALERT_RETENTION_MS, DEFAULT_ALERT_RETENTION_MS);
+  const maxAge = positiveMs(env.PREDICTIVE_ALERT_MAX_AGE_MS, DEFAULT_ALERT_MAX_AGE_MS);
+  // The absolute cut-off must not be shorter than the acknowledged-alert
+  // window, or an acknowledged alert would outlive an unacknowledged one.
+  return { alertRetentionMs: retention, alertMaxAgeMs: Math.max(retention, maxAge) };
+}
+
+function positiveMs(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+export interface PredictiveServiceOptions extends EngineOptions {
+  sweepIntervalMs?: number;
+  /** How often the alert retention policy is applied. */
+  retentionIntervalMs?: number;
+}
+
 export class PredictiveMaintenanceService extends EventEmitter {
-  readonly engine = new PredictiveMaintenanceEngine();
+  readonly engine: PredictiveMaintenanceEngine;
 
   private initialized = false;
+  private hydration: PredictiveHydrationSummary | null = null;
   private sweepTimer: NodeJS.Timeout | null = null;
+  private retentionTimer: NodeJS.Timeout | null = null;
   private sweepIntervalMs: number;
+  private retentionIntervalMs: number;
 
-  constructor(sweepIntervalMs = 30_000) {
+  constructor(sweepIntervalMs = 30_000, options: PredictiveServiceOptions = {}) {
     super();
-    this.sweepIntervalMs = sweepIntervalMs;
+    this.sweepIntervalMs = options.sweepIntervalMs ?? sweepIntervalMs;
+    this.retentionIntervalMs = options.retentionIntervalMs ?? 60 * 60 * 1000;
+    const { alertRetentionMs, alertMaxAgeMs } = resolveAlertRetention();
+    this.engine = new PredictiveMaintenanceEngine({
+      alertRetentionMs,
+      alertMaxAgeMs,
+      ...options,
+    });
     this.engine.on('alert', (alert: PredictiveAlert) => this.emit('alert', alert));
     this.engine.on('detector-error', (err) => this.emit('detector-error', err));
+    this.engine.on('store-error', (err) => this.emit('store-error', err));
+    this.engine.on('alerts-pruned', (result) => this.emit('alerts-pruned', result));
   }
 
+  /**
+   * Hydrate durable state, then start the sweeps.
+   *
+   * Hydration failure does NOT silently degrade into the old process-local
+   * behaviour: it is logged, reported by `healthCheck()`, and retried on every
+   * sweep. Until it succeeds every durable mutation (threshold write, alert
+   * generation, acknowledgement) fails closed on its own, because each one
+   * goes through the store rather than through a local cache.
+   */
   async initialize(): Promise<void> {
     if (this.initialized) return;
     this.initialized = true;
+    await this.hydrateOnce();
+
     this.sweepTimer = setInterval(() => {
-      void this.engine.analyzeAll().catch(() => {
-        /* per-detector errors already surface via 'detector-error' */
-      });
+      void (async () => {
+        if (!this.hydration) await this.hydrateOnce();
+        await this.engine.analyzeAll().catch(() => {
+          /* per-tag errors already surface via 'analyze-error' */
+        });
+      })();
     }, this.sweepIntervalMs);
     this.sweepTimer.unref?.();
+
+    this.retentionTimer = setInterval(() => {
+      void this.engine.pruneAlerts().catch((error: unknown) => {
+        console.error(
+          '[predictive] alert retention sweep failed:',
+          error instanceof Error ? error.message : error,
+        );
+      });
+    }, this.retentionIntervalMs);
+    this.retentionTimer.unref?.();
+  }
+
+  /** What startup hydration found, or null if it has not succeeded yet. */
+  getHydration(): PredictiveHydrationSummary | null {
+    return this.hydration;
   }
 
   /**
@@ -72,17 +151,58 @@ export class PredictiveMaintenanceService extends EventEmitter {
       clearInterval(this.sweepTimer);
       this.sweepTimer = null;
     }
+    if (this.retentionTimer) {
+      clearInterval(this.retentionTimer);
+      this.retentionTimer = null;
+    }
     this.initialized = false;
+    this.hydration = null;
   }
 
   async healthCheck(): Promise<{ healthy: boolean; message: string }> {
     const status = this.engine.getStatus();
-    return {
-      healthy: this.initialized,
-      message: this.initialized
-        ? `Predictive maintenance running: ${status.trackedTags} tags, ${status.activeAlerts} active alerts`
-        : 'Predictive maintenance service not initialized',
-    };
+    if (!this.initialized) {
+      return { healthy: false, message: 'Predictive maintenance service not initialized' };
+    }
+    try {
+      const durable = await this.engine.getDurableStatus();
+      return {
+        healthy: true,
+        message:
+          `Predictive maintenance running: ${status.trackedTags} tags in window, `
+          + `${durable.configuredTags} configured tag(s), `
+          + `${durable.activeAlerts} unacknowledged of ${durable.totalAlerts} durable alert(s), `
+          + `store backend ${durable.backend}`,
+      };
+    } catch (error) {
+      // A reachable process with an unreachable store is NOT healthy: every
+      // threshold write and acknowledgement is failing closed right now.
+      return {
+        healthy: false,
+        message:
+          'Predictive maintenance durable store unavailable: '
+          + (error instanceof Error ? error.message : String(error)),
+      };
+    }
+  }
+
+  private async hydrateOnce(): Promise<void> {
+    try {
+      this.hydration = await this.engine.hydrate();
+      console.log(
+        `[predictive] hydrated durable state from ${this.hydration.backend}: `
+        + `${this.hydration.configuredTags} configured tag(s), `
+        + `${this.hydration.unacknowledgedAlerts} unacknowledged of `
+        + `${this.hydration.totalAlerts} alert(s)`,
+      );
+    } catch (error) {
+      this.hydration = null;
+      console.error(
+        '[predictive] durable state unavailable — threshold writes, alert generation and '
+        + 'acknowledgements will be refused until it is reachable:',
+        error instanceof Error ? error.message : error,
+      );
+    }
   }
 }
 

--- a/server/services/predictive/store.ts
+++ b/server/services/predictive/store.ts
@@ -1,0 +1,812 @@
+/**
+ * Durable predictive-maintenance state store
+ * ADR-0013 [13.1] — Issues #212 / #493, made durable by #546
+ *
+ * The persistence boundary for the two kinds of predictive state that must
+ * outlive a process:
+ *
+ *   1. operator-configured per-tag thresholds (`predictive_tag_thresholds`)
+ *   2. generated alerts and their acknowledgement audit
+ *      (`predictive_alerts`)
+ *
+ * Raw prediction history is deliberately NOT in this boundary. It is a
+ * recomputable in-process sliding window with its own, separate retention
+ * (`PredictiveMaintenanceEngine.maxHistorySize` / `maxTrackedTags`); see the
+ * rationale in `migrations/0013_predictive_durable_state.sql`.
+ *
+ * Everything here is real Drizzle against real tables — there is no in-memory
+ * fallback. If the store cannot be reached, callers get a
+ * `PredictiveStoreUnavailableError` and the mutation is refused, because a
+ * threshold change or an acknowledgement that is only in RAM is exactly the
+ * defect this module exists to remove.
+ *
+ * Two backends, matching how `server/storage.ts` and
+ * `server/services/tuning/audit-store.ts` choose theirs:
+ *   - PostgreSQL (production) via drizzle-orm/node-postgres, tables from
+ *     migration 0013
+ *   - SQLite (development/test fallback) via drizzle-orm/sqlite-proxy over the
+ *     repo's `sqlite3` driver, tables from the DDL below
+ *
+ * The store owns its own connection rather than borrowing the shared handle in
+ * `server/storage.ts`, which serialises every caller behind one physical
+ * connection and one application-level transaction mutex. An acknowledgement
+ * must not queue behind a blueprint import.
+ *
+ * MULTI-REPLICA. Nothing here assumes a single writer:
+ *   - alert inserts are idempotent (`ON CONFLICT DO NOTHING`) against a
+ *     content-derived primary key, so two replicas that observe the same
+ *     anomaly converge on one row instead of writing two;
+ *   - acknowledgement is a conditional UPDATE guarded on `acknowledged =
+ *     false`, so the first acknowledgement wins and a concurrent second one is
+ *     reported as `already-acknowledged` rather than silently overwriting the
+ *     original attribution.
+ */
+
+import path from "node:path";
+import { and, asc, desc, eq, inArray, lt, sql } from "drizzle-orm";
+import { drizzle as drizzlePostgres, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import {
+  drizzle as drizzleSqliteProxy,
+  type SqliteRemoteDatabase,
+} from "drizzle-orm/sqlite-proxy";
+import { Client } from "pg";
+import { Database } from "sqlite3";
+import {
+  predictiveAlerts as pgAlerts,
+  predictiveTagThresholds as pgThresholds,
+} from "@shared/schema";
+import {
+  predictiveAlerts as sqliteAlerts,
+  predictiveTagThresholds as sqliteThresholds,
+} from "@shared/schema-sqlite";
+import type {
+  AcknowledgeStatus,
+  FailureLimits,
+  PredictiveAlert,
+  SeverityLevel,
+  SeverityThresholds,
+  TagThresholds,
+} from "@shared/types/predictive";
+
+/**
+ * Raised whenever durable state could not be read or written. Every caller
+ * treats this as fail-closed: the route returns 503 and no in-memory state is
+ * mutated, so the process never reports success for something that was not
+ * recorded.
+ */
+export class PredictiveStoreUnavailableError extends Error {
+  override readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "PredictiveStoreUnavailableError";
+    this.cause = cause;
+  }
+}
+
+export interface StoredThresholds {
+  tagId: string;
+  thresholds: TagThresholds;
+  updatedBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface AlertFilter {
+  severity?: SeverityLevel;
+  acknowledged?: boolean;
+  tagId?: string;
+  limit?: number;
+}
+
+export interface AlertCounts {
+  total: number;
+  unacknowledged: number;
+}
+
+export interface PruneRequest {
+  /** Acknowledged alerts created before this instant are removed. */
+  acknowledgedBefore: Date;
+  /** Any alert created before this instant is removed, acknowledged or not. */
+  anyBefore: Date;
+  /** Hard row cap; excess rows are evicted acknowledged-first, oldest-first. */
+  maxRows: number;
+}
+
+export interface PruneResult {
+  /** Acknowledged rows removed by the retention window. */
+  retired: number;
+  /** Rows removed by the absolute max-age cut-off, regardless of state. */
+  expired: number;
+  /** Rows removed to hold the row cap. */
+  overflow: number;
+  /** Ids removed by the row cap that had never been acknowledged. */
+  unacknowledgedEvicted: string[];
+}
+
+export interface PredictiveStore {
+  /** Open the connection and ensure the schema exists. Safe to call repeatedly. */
+  ready(): Promise<void>;
+  /** Backend actually in use, for /status reporting. */
+  backend(): "postgres" | "sqlite" | "unopened";
+  getThresholds(tagId: string): Promise<StoredThresholds | null>;
+  listThresholds(): Promise<StoredThresholds[]>;
+  upsertThresholds(input: {
+    thresholds: TagThresholds;
+    updatedBy: string;
+    at: Date;
+  }): Promise<StoredThresholds>;
+  countThresholds(): Promise<number>;
+  /**
+   * Insert an alert. Returns false when the content-derived id already exists,
+   * which is how alert suppression works across restarts and replicas.
+   */
+  insertAlert(alert: PredictiveAlert): Promise<boolean>;
+  getAlert(alertId: string): Promise<PredictiveAlert | null>;
+  listAlerts(filter?: AlertFilter): Promise<PredictiveAlert[]>;
+  countAlerts(): Promise<AlertCounts>;
+  /** Conditional, first-writer-wins acknowledgement. */
+  acknowledgeAlert(
+    alertId: string,
+    acknowledgedBy: string,
+    at: Date,
+  ): Promise<{ status: AcknowledgeStatus; alert: PredictiveAlert | null }>;
+  prune(request: PruneRequest): Promise<PruneResult>;
+  close(): Promise<void>;
+}
+
+const DEFAULT_LIST_LIMIT = 200;
+const MAX_LIST_LIMIT = 1000;
+
+/**
+ * SQLite DDL. `migrations/0013_predictive_durable_state.sql` is the Postgres
+ * source of truth; this mirrors it for the dev/test fallback, including the
+ * acknowledgement-attribution CHECK, so "acknowledged with no acknowledger" is
+ * impossible on both backends.
+ *
+ * Column order matches both Drizzle declarations — drizzle's sqlite-proxy
+ * driver maps result columns positionally.
+ *
+ * `busy_timeout` is set because `server/storage.ts` and
+ * `server/services/tuning/audit-store.ts` open their own handles onto the same
+ * development file; a concurrent writer should block briefly rather than fail
+ * a threshold write with SQLITE_BUSY.
+ */
+const SQLITE_DDL = `
+PRAGMA busy_timeout = 5000;
+CREATE TABLE IF NOT EXISTS predictive_tag_thresholds (
+  tag_id TEXT PRIMARY KEY,
+  min_samples INTEGER NOT NULL,
+  z_score_threshold REAL NOT NULL,
+  ewma_alpha REAL NOT NULL,
+  ewma_l REAL NOT NULL,
+  iqr_multiplier REAL NOT NULL,
+  ensemble_weights TEXT NOT NULL,
+  severity_thresholds TEXT NOT NULL,
+  failure_limits TEXT,
+  updated_by TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_predictive_thresholds_updated_at
+  ON predictive_tag_thresholds(updated_at);
+CREATE TABLE IF NOT EXISTS predictive_alerts (
+  id TEXT PRIMARY KEY,
+  tag_id TEXT NOT NULL,
+  severity TEXT NOT NULL,
+  score REAL NOT NULL,
+  message TEXT NOT NULL,
+  detectors TEXT NOT NULL,
+  recommendation TEXT NOT NULL,
+  observed_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  acknowledged INTEGER NOT NULL DEFAULT 0,
+  acknowledged_by TEXT,
+  acknowledged_at INTEGER,
+  CONSTRAINT predictive_alerts_severity_check
+    CHECK (severity IN ('info', 'warning', 'critical', 'emergency')),
+  CONSTRAINT predictive_alerts_ack_attribution_check
+    CHECK (
+      (acknowledged = 0 AND acknowledged_by IS NULL AND acknowledged_at IS NULL)
+      OR (acknowledged = 1 AND acknowledged_by IS NOT NULL AND acknowledged_at IS NOT NULL)
+    )
+);
+CREATE INDEX IF NOT EXISTS idx_predictive_alerts_tag
+  ON predictive_alerts(tag_id);
+CREATE INDEX IF NOT EXISTS idx_predictive_alerts_severity
+  ON predictive_alerts(severity);
+CREATE INDEX IF NOT EXISTS idx_predictive_alerts_acknowledged
+  ON predictive_alerts(acknowledged);
+CREATE INDEX IF NOT EXISTS idx_predictive_alerts_created_at
+  ON predictive_alerts(created_at);
+`;
+
+type SqliteDrizzle = SqliteRemoteDatabase<Record<string, never>>;
+type PostgresDrizzle = NodePgDatabase<Record<string, never>>;
+
+interface PostgresConnection {
+  kind: "postgres";
+  client: Client;
+  db: PostgresDrizzle;
+}
+
+interface SqliteConnection {
+  kind: "sqlite";
+  client: Database;
+  db: SqliteDrizzle;
+}
+
+type Connection = PostgresConnection | SqliteConnection;
+
+export interface PredictiveStoreOptions {
+  /** Explicit PostgreSQL URL; defaults to the DATABASE_URL selection below. */
+  postgresUrl?: string;
+  /** Explicit SQLite file; defaults to PREDICTIVE_SQLITE_PATH/SQLITE_DATABASE_PATH. */
+  sqlitePath?: string;
+}
+
+/**
+ * Mirrors `server/storage.ts`: Postgres only when a URL is configured, the
+ * Postgres override is not disabled, and the process is not in development
+ * mode. Everything else falls back to the file-backed SQLite database.
+ */
+function resolvePostgresUrl(options: PredictiveStoreOptions): string | undefined {
+  if (options.postgresUrl) return options.postgresUrl;
+  // An explicit SQLite path is an explicit backend choice and must not be
+  // overridden by an ambient DATABASE_URL — otherwise a test (or a tool) that
+  // names its own database file would silently write to production.
+  if (options.sqlitePath) return undefined;
+  const url = process.env.DATABASE_URL;
+  if (!url) return undefined;
+  if (process.env.FORCE_POSTGRES === "false") return undefined;
+  if (process.env.NODE_ENV === "development") return undefined;
+  return url;
+}
+
+function resolveSqlitePath(options: PredictiveStoreOptions): string {
+  return options.sqlitePath
+    ?? process.env.PREDICTIVE_SQLITE_PATH
+    ?? process.env.SQLITE_DATABASE_PATH
+    ?? path.join(process.cwd(), "dev-database.sqlite");
+}
+
+function sqliteExec(client: Database, sqlText: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client.exec(sqlText, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function sqliteRun(client: Database, sqlText: string, params: unknown[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client.run(sqlText, params, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function sqliteAll(
+  client: Database,
+  sqlText: string,
+  params: unknown[],
+): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve, reject) => {
+    client.all(sqlText, params, (error, rows) =>
+      error ? reject(error) : resolve(rows as Record<string, unknown>[]));
+  });
+}
+
+/**
+ * drizzle-orm's SQLite proxy driver maps result columns positionally, while
+ * node-sqlite3 hands back objects. node-sqlite3 materialises those objects in
+ * result-column order and every column of both tables has a distinct
+ * snake_case name, so ordered values reconstruct the positional row exactly.
+ */
+function positionalRow(row: Record<string, unknown>): unknown[] {
+  return Object.values(row);
+}
+
+/** Shape shared by the Postgres and SQLite threshold rows. */
+interface ThresholdRowShape {
+  tagId: string;
+  minSamples: number;
+  zScoreThreshold: number;
+  ewmaAlpha: number;
+  ewmaL: number;
+  iqrMultiplier: number;
+  ensembleWeights: Record<string, number>;
+  severityThresholds: SeverityThresholds;
+  failureLimits: FailureLimits | null;
+  updatedBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Shape shared by the Postgres and SQLite alert rows. */
+interface AlertRowShape {
+  id: string;
+  tagId: string;
+  severity: string;
+  score: number;
+  message: string;
+  detectors: string[];
+  recommendation: string;
+  observedAt: Date;
+  createdAt: Date;
+  acknowledged: boolean;
+  acknowledgedBy: string | null;
+  acknowledgedAt: Date | null;
+}
+
+function toStoredThresholds(row: ThresholdRowShape): StoredThresholds {
+  const thresholds: TagThresholds = {
+    tagId: row.tagId,
+    minSamples: row.minSamples,
+    zScoreThreshold: row.zScoreThreshold,
+    ewmaAlpha: row.ewmaAlpha,
+    ewmaL: row.ewmaL,
+    iqrMultiplier: row.iqrMultiplier,
+    ensembleWeights: row.ensembleWeights,
+    severityThresholds: row.severityThresholds,
+  };
+  // A stored NULL means "no engineering limits configured"; keep the key
+  // absent so it round-trips to exactly the shape the engine produces.
+  if (row.failureLimits) thresholds.failureLimits = row.failureLimits;
+  return {
+    tagId: row.tagId,
+    thresholds,
+    updatedBy: row.updatedBy,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function toAlert(row: AlertRowShape): PredictiveAlert {
+  return {
+    id: row.id,
+    tagId: row.tagId,
+    severity: row.severity as SeverityLevel,
+    score: row.score,
+    message: row.message,
+    timestamp: row.observedAt.getTime(),
+    detectors: row.detectors,
+    acknowledged: row.acknowledged,
+    recommendation: row.recommendation,
+    createdAt: row.createdAt.getTime(),
+    acknowledgedBy: row.acknowledgedBy,
+    acknowledgedAt: row.acknowledgedAt ? row.acknowledgedAt.getTime() : null,
+  };
+}
+
+function boundedLimit(limit: number | undefined): number {
+  return Math.min(Math.max(limit ?? DEFAULT_LIST_LIMIT, 1), MAX_LIST_LIMIT);
+}
+
+export class DrizzlePredictiveStore implements PredictiveStore {
+  private connection: Connection | undefined;
+  private opening: Promise<Connection> | undefined;
+
+  constructor(private readonly options: PredictiveStoreOptions = {}) {}
+
+  backend(): "postgres" | "sqlite" | "unopened" {
+    return this.connection?.kind ?? "unopened";
+  }
+
+  async ready(): Promise<void> {
+    await this.connect();
+  }
+
+  async getThresholds(tagId: string): Promise<StoredThresholds | null> {
+    const connection = await this.connect();
+    const rows = await this.guard("read thresholds", async () =>
+      connection.kind === "postgres"
+        ? connection.db.select().from(pgThresholds).where(eq(pgThresholds.tagId, tagId)).limit(1)
+        : connection.db
+          .select()
+          .from(sqliteThresholds)
+          .where(eq(sqliteThresholds.tagId, tagId))
+          .limit(1));
+    const [row] = rows as ThresholdRowShape[];
+    return row ? toStoredThresholds(row) : null;
+  }
+
+  async listThresholds(): Promise<StoredThresholds[]> {
+    const connection = await this.connect();
+    const rows = await this.guard("list thresholds", async () =>
+      connection.kind === "postgres"
+        ? connection.db.select().from(pgThresholds).orderBy(asc(pgThresholds.tagId))
+        : connection.db.select().from(sqliteThresholds).orderBy(asc(sqliteThresholds.tagId)));
+    return (rows as ThresholdRowShape[]).map(toStoredThresholds);
+  }
+
+  async upsertThresholds(input: {
+    thresholds: TagThresholds;
+    updatedBy: string;
+    at: Date;
+  }): Promise<StoredThresholds> {
+    const connection = await this.connect();
+    const { thresholds, updatedBy, at } = input;
+    const values = {
+      tagId: thresholds.tagId,
+      minSamples: thresholds.minSamples,
+      zScoreThreshold: thresholds.zScoreThreshold,
+      ewmaAlpha: thresholds.ewmaAlpha,
+      ewmaL: thresholds.ewmaL,
+      iqrMultiplier: thresholds.iqrMultiplier,
+      ensembleWeights: thresholds.ensembleWeights,
+      severityThresholds: thresholds.severityThresholds,
+      failureLimits: thresholds.failureLimits ?? null,
+      updatedBy,
+      createdAt: at,
+      updatedAt: at,
+    };
+    // `created_at` is intentionally excluded from the update set: it records
+    // when the tag was first configured and must not be rewritten by an edit.
+    const updateSet = {
+      minSamples: values.minSamples,
+      zScoreThreshold: values.zScoreThreshold,
+      ewmaAlpha: values.ewmaAlpha,
+      ewmaL: values.ewmaL,
+      iqrMultiplier: values.iqrMultiplier,
+      ensembleWeights: values.ensembleWeights,
+      severityThresholds: values.severityThresholds,
+      failureLimits: values.failureLimits,
+      updatedBy,
+      updatedAt: at,
+    };
+
+    await this.guard("persist thresholds", async () => {
+      if (connection.kind === "postgres") {
+        await connection.db
+          .insert(pgThresholds)
+          .values(values)
+          .onConflictDoUpdate({ target: pgThresholds.tagId, set: updateSet });
+        return;
+      }
+      await connection.db
+        .insert(sqliteThresholds)
+        .values(values)
+        .onConflictDoUpdate({ target: sqliteThresholds.tagId, set: updateSet });
+    });
+
+    const stored = await this.getThresholds(thresholds.tagId);
+    if (!stored) {
+      // The row was written and immediately not readable — treat it as a store
+      // failure rather than returning a value the caller cannot re-read.
+      throw new PredictiveStoreUnavailableError(
+        `Thresholds for "${thresholds.tagId}" were written but could not be read back`,
+      );
+    }
+    return stored;
+  }
+
+  async countThresholds(): Promise<number> {
+    const connection = await this.connect();
+    const rows = await this.guard("count thresholds", async () =>
+      connection.kind === "postgres"
+        ? connection.db.select({ value: sql<number>`count(*)` }).from(pgThresholds)
+        : connection.db.select({ value: sql<number>`count(*)` }).from(sqliteThresholds));
+    return Number((rows as Array<{ value: number | string }>)[0]?.value ?? 0);
+  }
+
+  async insertAlert(alert: PredictiveAlert): Promise<boolean> {
+    const connection = await this.connect();
+    const values = {
+      id: alert.id,
+      tagId: alert.tagId,
+      severity: alert.severity,
+      score: alert.score,
+      message: alert.message,
+      detectors: alert.detectors,
+      recommendation: alert.recommendation,
+      observedAt: new Date(alert.timestamp),
+      createdAt: new Date(alert.createdAt),
+      acknowledged: alert.acknowledged,
+      acknowledgedBy: alert.acknowledgedBy,
+      acknowledgedAt: alert.acknowledgedAt ? new Date(alert.acknowledgedAt) : null,
+    };
+    const inserted = await this.guard("persist alert", async () =>
+      connection.kind === "postgres"
+        ? connection.db
+          .insert(pgAlerts)
+          .values(values)
+          .onConflictDoNothing()
+          .returning({ id: pgAlerts.id })
+        : connection.db
+          .insert(sqliteAlerts)
+          .values(values)
+          .onConflictDoNothing()
+          .returning({ id: sqliteAlerts.id }));
+    return (inserted as Array<{ id: string }>).length > 0;
+  }
+
+  async getAlert(alertId: string): Promise<PredictiveAlert | null> {
+    const connection = await this.connect();
+    const rows = await this.guard("read alert", async () =>
+      connection.kind === "postgres"
+        ? connection.db.select().from(pgAlerts).where(eq(pgAlerts.id, alertId)).limit(1)
+        : connection.db.select().from(sqliteAlerts).where(eq(sqliteAlerts.id, alertId)).limit(1));
+    const [row] = rows as AlertRowShape[];
+    return row ? toAlert(row) : null;
+  }
+
+  /**
+   * Alerts matching `filter`, returned oldest-first.
+   *
+   * The LIMIT is applied to the NEWEST rows (descending select, re-ordered
+   * ascending before returning). Truncating from the old end is a safety
+   * requirement, not a preference: this is an alarm list, and an ascending
+   * `LIMIT` would return the oldest N rows, so once a backlog of N alerts
+   * exists a freshly raised emergency would be absent from the default
+   * response and from `?acknowledged=false`. The caller still sees a stable
+   * oldest-first ordering within the window it was given.
+   */
+  async listAlerts(filter: AlertFilter = {}): Promise<PredictiveAlert[]> {
+    const connection = await this.connect();
+    const limit = boundedLimit(filter.limit);
+    const rows = await this.guard("list alerts", async () => {
+      if (connection.kind === "postgres") {
+        const conditions = [
+          filter.severity ? eq(pgAlerts.severity, filter.severity) : undefined,
+          filter.tagId ? eq(pgAlerts.tagId, filter.tagId) : undefined,
+          filter.acknowledged !== undefined
+            ? eq(pgAlerts.acknowledged, filter.acknowledged)
+            : undefined,
+        ].filter((condition) => condition !== undefined);
+        return connection.db
+          .select()
+          .from(pgAlerts)
+          .where(conditions.length > 0 ? and(...conditions) : undefined)
+          .orderBy(desc(pgAlerts.createdAt), desc(pgAlerts.id))
+          .limit(limit);
+      }
+      const conditions = [
+        filter.severity ? eq(sqliteAlerts.severity, filter.severity) : undefined,
+        filter.tagId ? eq(sqliteAlerts.tagId, filter.tagId) : undefined,
+        filter.acknowledged !== undefined
+          ? eq(sqliteAlerts.acknowledged, filter.acknowledged)
+          : undefined,
+      ].filter((condition) => condition !== undefined);
+      return connection.db
+        .select()
+        .from(sqliteAlerts)
+        .where(conditions.length > 0 ? and(...conditions) : undefined)
+        .orderBy(desc(sqliteAlerts.createdAt), desc(sqliteAlerts.id))
+        .limit(limit);
+    });
+    return (rows as AlertRowShape[]).map(toAlert).reverse();
+  }
+
+  async countAlerts(): Promise<AlertCounts> {
+    const connection = await this.connect();
+    const rows = await this.guard("count alerts", async () =>
+      connection.kind === "postgres"
+        ? connection.db
+          .select({
+            total: sql<number>`count(*)`,
+            unacknowledged: sql<number>`count(*) filter (where ${pgAlerts.acknowledged} = false)`,
+          })
+          .from(pgAlerts)
+        : connection.db
+          .select({
+            total: sql<number>`count(*)`,
+            unacknowledged: sql<number>`sum(case when ${sqliteAlerts.acknowledged} = 0 then 1 else 0 end)`,
+          })
+          .from(sqliteAlerts));
+    const [row] = rows as Array<{ total: number | string; unacknowledged: number | string | null }>;
+    return {
+      total: Number(row?.total ?? 0),
+      unacknowledged: Number(row?.unacknowledged ?? 0),
+    };
+  }
+
+  async acknowledgeAlert(
+    alertId: string,
+    acknowledgedBy: string,
+    at: Date,
+  ): Promise<{ status: AcknowledgeStatus; alert: PredictiveAlert | null }> {
+    const connection = await this.connect();
+    // Conditional update: the `acknowledged = false` predicate is what makes
+    // this first-writer-wins across replicas. A second acknowledgement matches
+    // no rows, so the original attribution is preserved rather than clobbered.
+    const updated = await this.guard("acknowledge alert", async () =>
+      connection.kind === "postgres"
+        ? connection.db
+          .update(pgAlerts)
+          .set({ acknowledged: true, acknowledgedBy, acknowledgedAt: at })
+          .where(and(eq(pgAlerts.id, alertId), eq(pgAlerts.acknowledged, false)))
+          .returning({ id: pgAlerts.id })
+        : connection.db
+          .update(sqliteAlerts)
+          .set({ acknowledged: true, acknowledgedBy, acknowledgedAt: at })
+          .where(and(eq(sqliteAlerts.id, alertId), eq(sqliteAlerts.acknowledged, false)))
+          .returning({ id: sqliteAlerts.id }));
+
+    const alert = await this.getAlert(alertId);
+    if (!alert) return { status: "not-found", alert: null };
+    return {
+      status: (updated as Array<{ id: string }>).length > 0
+        ? "acknowledged"
+        : "already-acknowledged",
+      alert,
+    };
+  }
+
+  async prune(request: PruneRequest): Promise<PruneResult> {
+    const connection = await this.connect();
+    const retired = await this.deleteAlerts({
+      acknowledgedBefore: request.acknowledgedBefore,
+    });
+    const expired = await this.deleteAlerts({ anyBefore: request.anyBefore });
+
+    // Row cap: evict acknowledged rows before unacknowledged ones, oldest
+    // first inside each group, so an operator's outstanding work queue is the
+    // last thing to go.
+    const total = (await this.countAlerts()).total;
+    const overflow = Math.max(0, total - Math.max(1, request.maxRows));
+    let unacknowledgedEvicted: string[] = [];
+    if (overflow > 0) {
+      const victims = await this.guard("select overflow alerts", async () =>
+        connection.kind === "postgres"
+          ? connection.db
+            .select({ id: pgAlerts.id, acknowledged: pgAlerts.acknowledged })
+            .from(pgAlerts)
+            .orderBy(desc(pgAlerts.acknowledged), asc(pgAlerts.createdAt), asc(pgAlerts.id))
+            .limit(overflow)
+          : connection.db
+            .select({ id: sqliteAlerts.id, acknowledged: sqliteAlerts.acknowledged })
+            .from(sqliteAlerts)
+            .orderBy(
+              desc(sqliteAlerts.acknowledged),
+              asc(sqliteAlerts.createdAt),
+              asc(sqliteAlerts.id),
+            )
+            .limit(overflow));
+      const rows = victims as Array<{ id: string; acknowledged: boolean }>;
+      unacknowledgedEvicted = rows.filter((row) => !row.acknowledged).map((row) => row.id);
+      if (rows.length > 0) {
+        const ids = rows.map((row) => row.id);
+        await this.guard("evict overflow alerts", async () => {
+          if (connection.kind === "postgres") {
+            await connection.db.delete(pgAlerts).where(inArray(pgAlerts.id, ids));
+            return;
+          }
+          await connection.db.delete(sqliteAlerts).where(inArray(sqliteAlerts.id, ids));
+        });
+      }
+    }
+
+    return { retired, expired, overflow, unacknowledgedEvicted };
+  }
+
+  async close(): Promise<void> {
+    // Settle any in-flight connect() FIRST. `connect()` assigns `this.connection`
+    // from a `.then()` callback, so a close() that raced an open would clear an
+    // still-undefined field and then have the pending open write a live handle
+    // straight back — leaving the file descriptor (and, on Postgres, the
+    // server-side session) open forever with no reference left to close it.
+    if (this.opening) await this.opening.catch(() => undefined);
+    const connection = this.connection;
+    this.connection = undefined;
+    this.opening = undefined;
+    if (!connection) return;
+    if (connection.kind === "postgres") {
+      await connection.client.end();
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      connection.client.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+
+  /**
+   * Delete alerts matching one retention rule and report how many went. The
+   * ids are selected first so the caller can report exactly what was removed
+   * — a retention pass that cannot say what it deleted is not observable.
+   */
+  private async deleteAlerts(
+    rule: { acknowledgedBefore?: Date; anyBefore?: Date },
+  ): Promise<number> {
+    const connection = await this.connect();
+    const rows = await this.guard("select expired alerts", async () => {
+      if (connection.kind === "postgres") {
+        const where = rule.acknowledgedBefore
+          ? and(
+            eq(pgAlerts.acknowledged, true),
+            lt(pgAlerts.createdAt, rule.acknowledgedBefore),
+          )
+          : lt(pgAlerts.createdAt, rule.anyBefore as Date);
+        return connection.db.select({ id: pgAlerts.id }).from(pgAlerts).where(where);
+      }
+      const where = rule.acknowledgedBefore
+        ? and(
+          eq(sqliteAlerts.acknowledged, true),
+          lt(sqliteAlerts.createdAt, rule.acknowledgedBefore),
+        )
+        : lt(sqliteAlerts.createdAt, rule.anyBefore as Date);
+      return connection.db.select({ id: sqliteAlerts.id }).from(sqliteAlerts).where(where);
+    });
+    const ids = (rows as Array<{ id: string }>).map((row) => row.id);
+    if (ids.length === 0) return 0;
+    await this.guard("delete expired alerts", async () => {
+      if (connection.kind === "postgres") {
+        await connection.db.delete(pgAlerts).where(inArray(pgAlerts.id, ids));
+        return;
+      }
+      await connection.db.delete(sqliteAlerts).where(inArray(sqliteAlerts.id, ids));
+    });
+    return ids.length;
+  }
+
+  /**
+   * Translate any driver-level failure into the fail-closed error type. The
+   * original error is attached as `cause` so the operator sees the real reason
+   * in logs and in `/api/predictive/status`.
+   */
+  private async guard<T>(operation: string, run: () => Promise<T>): Promise<T> {
+    try {
+      return await run();
+    } catch (error) {
+      if (error instanceof PredictiveStoreUnavailableError) throw error;
+      throw new PredictiveStoreUnavailableError(
+        `Predictive store failed to ${operation}: `
+        + (error instanceof Error ? error.message : String(error)),
+        error,
+      );
+    }
+  }
+
+  private connect(): Promise<Connection> {
+    if (this.connection) return Promise.resolve(this.connection);
+    if (this.opening) return this.opening;
+
+    this.opening = this.openConnection()
+      .then((connection) => {
+        this.connection = connection;
+        return connection;
+      })
+      .catch((error: unknown) => {
+        // Let the next caller retry rather than caching a failed connection.
+        this.opening = undefined;
+        throw new PredictiveStoreUnavailableError(
+          "Predictive store is unreachable: "
+          + (error instanceof Error ? error.message : String(error)),
+          error,
+        );
+      });
+    return this.opening;
+  }
+
+  private async openConnection(): Promise<Connection> {
+    const postgresUrl = resolvePostgresUrl(this.options);
+    if (postgresUrl) {
+      const client = new Client({ connectionString: postgresUrl });
+      await client.connect();
+      return { kind: "postgres", client, db: drizzlePostgres(client) };
+    }
+
+    const filePath = resolveSqlitePath(this.options);
+    const client = await new Promise<Database>((resolve, reject) => {
+      const opened: Database = new Database(filePath, (error) =>
+        error ? reject(error) : resolve(opened));
+    });
+    await sqliteExec(client, SQLITE_DDL);
+
+    const db = drizzleSqliteProxy(async (sqlText, params, method) => {
+      if (method === "run") {
+        await sqliteRun(client, sqlText, params);
+        return { rows: [] };
+      }
+      const rows = await sqliteAll(client, sqlText, params);
+      if (method === "get") {
+        return { rows: rows.length > 0 ? positionalRow(rows[0]) : [] };
+      }
+      return { rows: rows.map(positionalRow) };
+    });
+
+    return { kind: "sqlite", client, db };
+  }
+}
+
+/**
+ * Process-wide predictive store. Connects lazily on first use so importing the
+ * predictive service never opens a database handle.
+ */
+export const predictiveStore: PredictiveStore = new DrizzlePredictiveStore();

--- a/shared/__tests__/schema-parity.test.ts
+++ b/shared/__tests__/schema-parity.test.ts
@@ -12,6 +12,8 @@ import {
   pidTuningAudit as pgPidTuningAudit,
   twinModels as pgTwinModels,
   twinCheckpoints as pgTwinCheckpoints,
+  predictiveTagThresholds as pgPredictiveTagThresholds,
+  predictiveAlerts as pgPredictiveAlerts,
 } from '../schema';
 import {
   alarms as sqliteAlarms,
@@ -24,6 +26,8 @@ import {
   pidTuningAudit as sqlitePidTuningAudit,
   twinModels as sqliteTwinModels,
   twinCheckpoints as sqliteTwinCheckpoints,
+  predictiveTagThresholds as sqlitePredictiveTagThresholds,
+  predictiveAlerts as sqlitePredictiveAlerts,
 } from '../schema-sqlite';
 
 /**
@@ -86,6 +90,16 @@ const cases = [
   // one that refuses to come back at all.
   { name: 'twin_models', pg: pgTwinModels, sqlite: sqliteTwinModels },
   { name: 'twin_checkpoints', pg: pgTwinCheckpoints, sqlite: sqliteTwinCheckpoints },
+  // #546: predictive thresholds and alert acknowledgement state. A column
+  // present on only one dialect would mean an operator's configuration — or
+  // the record of who acknowledged an alert — silently vanishing on the other,
+  // which is the exact defect this table was added to fix.
+  {
+    name: 'predictive_tag_thresholds',
+    pg: pgPredictiveTagThresholds,
+    sqlite: sqlitePredictiveTagThresholds,
+  },
+  { name: 'predictive_alerts', pg: pgPredictiveAlerts, sqlite: sqlitePredictiveAlerts },
 ] as const;
 
 describe('schema parity (Postgres vs SQLite dev fallback)', () => {

--- a/shared/schema-sqlite.ts
+++ b/shared/schema-sqlite.ts
@@ -435,6 +435,44 @@ export const twinModels = sqliteTable("twin_models", {
     .$defaultFn(() => new Date()),
 });
 
+// ─── Predictive Maintenance Durable State (#212/#493, #546) ──────────────────
+// Dev-mode parity with `shared/schema.ts`. jsonb → text(mode json), timestamptz
+// → integer timestamp_ms, double precision → real, varchar → text. The DDL that
+// creates these tables for SQLite lives in
+// `server/services/predictive/store.ts`; `migrations/0013_predictive_durable_state.sql`
+// is the Postgres source of truth. Kept in sync by
+// `shared/__tests__/schema-parity.test.ts`.
+//
+// Column ORDER matters here: `server/services/predictive/store.ts` reads rows
+// back through drizzle's sqlite-proxy driver, which maps result columns
+// positionally, so the DDL, this declaration and the Postgres table must all
+// list columns in the same order.
+export const predictiveTagThresholds = sqliteTable("predictive_tag_thresholds", {
+  tagId: text("tag_id").primaryKey(),
+  minSamples: integer("min_samples").notNull(),
+  zScoreThreshold: real("z_score_threshold").notNull(),
+  ewmaAlpha: real("ewma_alpha").notNull(),
+  ewmaL: real("ewma_l").notNull(),
+  iqrMultiplier: real("iqr_multiplier").notNull(),
+  ensembleWeights: text("ensemble_weights", { mode: "json" })
+    .$type<Record<string, number>>()
+    .notNull(),
+  severityThresholds: text("severity_thresholds", { mode: "json" })
+    .$type<{ warning: number; critical: number; emergency: number }>()
+    .notNull(),
+  failureLimits: text("failure_limits", { mode: "json" }).$type<{
+    low?: number;
+    high?: number;
+  }>(),
+  updatedBy: text("updated_by").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
 // No `status` column, matching Postgres: a restored simulation is always idle.
 export const twinCheckpoints = sqliteTable("twin_checkpoints", {
   modelId: text("model_id")
@@ -450,6 +488,23 @@ export const twinCheckpoints = sqliteTable("twin_checkpoints", {
   committedAt: integer("committed_at", { mode: "timestamp_ms" })
     .notNull()
     .$defaultFn(() => new Date()),
+});
+
+export const predictiveAlerts = sqliteTable("predictive_alerts", {
+  id: text("id").primaryKey(),
+  tagId: text("tag_id").notNull(),
+  severity: text("severity").notNull(),
+  score: real("score").notNull(),
+  message: text("message").notNull(),
+  detectors: text("detectors", { mode: "json" }).$type<string[]>().notNull(),
+  recommendation: text("recommendation").notNull(),
+  observedAt: integer("observed_at", { mode: "timestamp_ms" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  acknowledged: integer("acknowledged", { mode: "boolean" }).notNull().default(false),
+  acknowledgedBy: text("acknowledged_by"),
+  acknowledgedAt: integer("acknowledged_at", { mode: "timestamp_ms" }),
 });
 
 // Basic exports for compatibility

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -813,6 +813,86 @@ export const pidTuningAudit = pgTable("pid_tuning_audit", {
   recordedAtIdx: index("idx_pid_tuning_audit_recorded_at").on(table.recordedAt),
 }));
 
+// ─── Predictive Maintenance Durable State (ADR-0013 [13.1], #212/#493, #546) ─
+
+/**
+ * Operator-configured per-tag detection thresholds.
+ *
+ * This is durable *configuration*, not sampled data: it changes only when an
+ * operator calls `PUT /api/predictive/thresholds/:tagId`, and it is what the
+ * detectors are graded against. Holding it in a process-local Map meant a
+ * restart silently reverted every tag to the built-in defaults — a tag that had
+ * been deliberately desensitised would start alarming again, and a tag that had
+ * been made more sensitive would stop. `updated_by` is the authenticated
+ * control-plane principal (API key record name), never a request body field.
+ *
+ * Retention: none. Operator configuration is kept until the operator changes
+ * it. Raw prediction history has a completely separate policy — it is an
+ * in-process sliding window that is never written here (see
+ * `server/services/predictive/engine.ts`).
+ */
+export const predictiveTagThresholds = pgTable("predictive_tag_thresholds", {
+  tagId: varchar("tag_id", { length: 256 }).primaryKey(),
+  minSamples: integer("min_samples").notNull(),
+  zScoreThreshold: doublePrecision("z_score_threshold").notNull(),
+  ewmaAlpha: doublePrecision("ewma_alpha").notNull(),
+  ewmaL: doublePrecision("ewma_l").notNull(),
+  iqrMultiplier: doublePrecision("iqr_multiplier").notNull(),
+  ensembleWeights: jsonb("ensemble_weights").$type<Record<string, number>>().notNull(),
+  severityThresholds: jsonb("severity_thresholds")
+    .$type<{ warning: number; critical: number; emergency: number }>()
+    .notNull(),
+  failureLimits: jsonb("failure_limits").$type<{ low?: number; high?: number }>(),
+  updatedBy: varchar("updated_by", { length: 128 }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  updatedAtIdx: index("idx_predictive_thresholds_updated_at").on(table.updatedAt),
+}));
+
+/**
+ * Generated predictive alerts and their acknowledgement state.
+ *
+ * `id` is content-derived (tag + severity + cooldown window), not a process
+ * counter, so a restarted process or a second replica that observes the same
+ * anomaly writes the same row instead of a duplicate. Inserts use
+ * ON CONFLICT DO NOTHING, which makes the shared table — rather than a
+ * process-local `lastAlertAt` Map — the alert-suppression authority.
+ *
+ * `acknowledged_by` / `acknowledged_at` are the audit half of the row: who
+ * took ownership of the alert and when. Acknowledgement is a conditional
+ * UPDATE (`WHERE acknowledged = false`), so the first acknowledgement wins
+ * across replicas and a later one is reported as `already-acknowledged`
+ * instead of overwriting the original attribution.
+ *
+ * Retention (distinct from operator configuration above, and applied by
+ * `server/services/predictive/index.ts`):
+ *   - acknowledged alerts are pruned after PREDICTIVE_ALERT_RETENTION_MS
+ *   - any alert is pruned after PREDICTIVE_ALERT_MAX_AGE_MS
+ *   - a row cap bounds the table; evictions are emitted, never silent
+ */
+export const predictiveAlerts = pgTable("predictive_alerts", {
+  id: varchar("id", { length: 64 }).primaryKey(),
+  tagId: varchar("tag_id", { length: 256 }).notNull(),
+  severity: varchar("severity", { length: 16 }).notNull(),
+  score: doublePrecision("score").notNull(),
+  message: text("message").notNull(),
+  detectors: jsonb("detectors").$type<string[]>().notNull(),
+  recommendation: text("recommendation").notNull(),
+  /** Data-clock timestamp of the observation that triggered the alert. */
+  observedAt: timestamp("observed_at", { withTimezone: true }).notNull(),
+  /** Wall-clock time the row was written. Retention and ordering key. */
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  acknowledged: boolean("acknowledged").default(false).notNull(),
+  acknowledgedBy: varchar("acknowledged_by", { length: 128 }),
+  acknowledgedAt: timestamp("acknowledged_at", { withTimezone: true }),
+}, (table) => ({
+  tagIdx: index("idx_predictive_alerts_tag").on(table.tagId),
+  severityIdx: index("idx_predictive_alerts_severity").on(table.severity),
+  acknowledgedIdx: index("idx_predictive_alerts_acknowledged").on(table.acknowledged),
+  createdAtIdx: index("idx_predictive_alerts_created_at").on(table.createdAt),
+}));
+
 // ─── Agent Marketplace (ADR-0013 [13.6], #217) ───────────────────────────────
 
 /**
@@ -984,6 +1064,10 @@ export type ModbusRegisterMapRow = typeof modbusRegisterMap.$inferSelect;
 export type InsertModbusRegisterMapRow = typeof modbusRegisterMap.$inferInsert;
 export type PidTuningAuditRow = typeof pidTuningAudit.$inferSelect;
 export type InsertPidTuningAuditRow = typeof pidTuningAudit.$inferInsert;
+export type PredictiveTagThresholdRow = typeof predictiveTagThresholds.$inferSelect;
+export type InsertPredictiveTagThresholdRow = typeof predictiveTagThresholds.$inferInsert;
+export type PredictiveAlertRow = typeof predictiveAlerts.$inferSelect;
+export type InsertPredictiveAlertRow = typeof predictiveAlerts.$inferInsert;
 export type PluginRegistryRow = typeof pluginRegistry.$inferSelect;
 export type InsertPluginRegistryRow = typeof pluginRegistry.$inferInsert;
 export type PluginInstallationRow = typeof pluginInstallations.$inferSelect;

--- a/shared/types/predictive.ts
+++ b/shared/types/predictive.ts
@@ -91,14 +91,45 @@ export interface MaintenancePrediction {
 }
 
 export interface PredictiveAlert {
+  /**
+   * Content-derived, restart-stable identity (#546). Derived from
+   * tag + severity + the cooldown window the alert was raised in, so the same
+   * anomaly seen by a restarted process — or by a second replica — resolves to
+   * the same durable row instead of a new one.
+   */
   id: string;
   tagId: string;
   severity: SeverityLevel;
   score: number;
   message: string;
+  /** Timestamp of the observation that triggered the alert (data clock) */
   timestamp: number;
   detectors: string[];
   acknowledged: boolean;
   recommendation: string;
   prediction?: MaintenancePrediction | null;
+  /** Wall-clock time the alert was durably recorded. Retention/order key. */
+  createdAt: number;
+  /**
+   * Authenticated control-plane principal that acknowledged the alert.
+   * Never taken from a request body — see `server/routes/predictive.ts`.
+   */
+  acknowledgedBy: string | null;
+  acknowledgedAt: number | null;
+}
+
+/** What `hydrate()` actually loaded from the durable store at startup (#546). */
+export interface PredictiveHydrationSummary {
+  backend: 'postgres' | 'sqlite' | 'unopened';
+  configuredTags: number;
+  totalAlerts: number;
+  unacknowledgedAlerts: number;
+}
+
+/** Outcome of a durable acknowledgement attempt (#546). */
+export type AcknowledgeStatus = 'acknowledged' | 'already-acknowledged' | 'not-found';
+
+export interface AcknowledgeOutcome {
+  status: AcknowledgeStatus;
+  alert: PredictiveAlert | null;
 }


### PR DESCRIPTION
Closes #546.

## Problem

The predictive-maintenance implementation (#212 / #493) kept operator thresholds, generated alerts and acknowledgement state in process-local `Map`s. A restart reverted every configured tag to the built-in defaults — a tag that had been deliberately desensitised would start alarming again — and erased the record of who had taken ownership of which alert. A second replica saw none of it. That fails the **Durable approvals/state** row of ADR-0026: an acknowledgement that does not survive process replacement is not an audit record, and a threshold that does not survive it is not a configuration.

## Persistence boundary

`server/services/predictive/store.ts` is the new boundary: real Drizzle against two real tables, PostgreSQL in production (migration **0013**) and the repository's SQLite development fallback otherwise, following the same pattern as `server/services/tuning/audit-store.ts`. There is deliberately **no in-memory fallback** — if the store cannot be reached, the mutation is refused.

The engine no longer owns durable state at all. Thresholds and alerts are read from the store on demand rather than from a local cache, which is what lets a second replica see the first one's configuration and acknowledgements. Startup hydration is therefore idempotent by construction; `hydrate()` returns `{backend, configuredTags, totalAlerts, unacknowledgedAlerts}` so "state was restored" is observable rather than assumed.

## Authenticated identity

Threshold writes and acknowledgements are attributed to `controlPlanePrincipal(req).name` — the name on the server-owned API key record bound by `requireControlPlaneAccess` (#576), which throws if the guard did not run. Both request bodies are Zod `.strict()`, so a caller supplying `updatedBy` / `acknowledgedBy` gets a **400** instead of having the field silently ignored: spoofed attribution fails loudly rather than looking accepted. `acknowledgeAlert` additionally refuses an empty principal, and a database `CHECK` constraint on both dialects rejects an acknowledged row that carries no acknowledger.

## Alert identity

Alert ids were `PMA-<bootId>-<counter>`, which changed on every restart. They are now content-derived from `(tag, severity, cooldown window)` and inserted with `ON CONFLICT DO NOTHING`. Consequences, both intended:

- a restarted process that re-detects the same anomaly writes the same primary key instead of opening a second alert, and an acknowledgement made before the restart still applies to it;
- the shared table — not a process-local `lastAlertAt` map — is now the alert-suppression authority.

Acknowledgement is a conditional `UPDATE ... WHERE acknowledged = false`, so the first acknowledgement wins across replicas and a second one returns **409** with the original attribution intact rather than overwriting it.

## Fail closed

Store failures surface as `PredictiveStoreUnavailableError`: answered **503** by every route, emitted as a `store-error` event, retained for `GET /api/predictive/status`, and reported unhealthy by `healthCheck()`. Alerts are persisted *before* the `alert` event is emitted, so an operator is never shown an alarm for an alert that was never recorded and therefore cannot be acknowledged.

## Retention (defined separately, as the issue asks)

Raw prediction history is explicitly **not** persisted: it is a recomputable sliding window bounded by sample count (1000 points over at most 500 tags), the historian is the system of record for sampled process data, and persisting it would put a write on every ingested sample. The reasoning is written into the migration and the engine header rather than left implicit.

Durable alert state has its own, independent calendar-based policy:

| knob | default | effect |
|---|---|---|
| `PREDICTIVE_ALERT_RETENTION_MS` | 90d | acknowledged alerts are pruned past this age |
| `PREDICTIVE_ALERT_MAX_AGE_MS` | 365d | *any* alert is pruned past this age (clamped ≥ the above) |
| `maxAlerts` | 5000 | row cap; acknowledged rows evicted before unacknowledged ones |

Every eviction is emitted as an `alerts-pruned` event carrying the ids of any unacknowledged rows removed — nothing is discarded silently. Documented in `.env.example`.

## Schema

Migration 0013 adds `predictive_tag_thresholds` and `predictive_alerts`. Both are declared in `shared/schema.ts` **and** `shared/schema-sqlite.ts` and added to `shared/__tests__/schema-parity.test.ts`; `migrations/meta/_journal.json` gains a contiguous `idx: 10` entry and the journal assertion in `production-safety.test.ts` was extended.

## Tests

- **restart recovery** against a real file-backed SQLite database — the store is closed and a new engine on a new connection re-reads thresholds, alert identity and acknowledgement attribution; a desensitised tag stays desensitised
- **non-duplication** — a restarted engine recognises the alert it already raised, does not re-emit it, and keeps it acknowledged
- **multi-replica** — two engines on one database; first-acknowledger wins, the loser gets `already-acknowledged` with the original attribution
- **migration 0013** executed on SQLite for both a fresh database and an upgrade from a populated pre-0013 one (pre-existing rows asserted intact), plus column-by-column alignment of the Postgres migration file with the Drizzle tables and a re-runnability check. The Postgres migration itself is executed against a throwaway schema when `DATABASE_URL` is configured, and **skipped — not faked** — otherwise.
- **fail-closed** — threshold write, acknowledgement and alert generation all reject against an unreachable store, nothing is retained in memory, the failure is observable, and the store recovers once reachable
- **identity** — HTTP-level tests that a caller-supplied `acknowledgedBy` / `updatedBy` is a 400 and that the recorded principal is the API key record name
- **retention** — both windows, row-cap eviction ordering, and that raw history is not durable while the alert it produced is

Engine unit tests were converted from `new PredictiveMaintenanceEngine()` to a real per-test in-memory SQLite database through the same Drizzle store, so nothing in the suite exercises a fake persistence layer.

## Verification

- `npx tsc --noEmit` — exits 0
- `npx vitest run` — 3487 passed (baseline on `origin/main` measured locally: 3430 passed). The 4 failing files are the same pre-existing timing/child-process flakes present on main (`blueprint-storage`, `scheduler-import-safety`, `live-backend`, `anchor-pipeline-latency`); none touch predictive code, and `anchor-pipeline-latency` / `live-backend` were confirmed failing on a pristine checkout.


🤖 Generated with [Claude Code](https://claude.com/claude-code)