### PR TITLE
feat(twin): persist digital-twin models and simulation checkpoints across restart (#550)

### DIFF
--- a/docs/api/twin-persistence.md
+++ b/docs/api/twin-persistence.md
@@ -1,0 +1,125 @@
+# Digital-twin persistence
+
+Issue #550 — ADR-0013 [13.3]
+
+The digital-twin runtime used to keep registered `ProcessModel` definitions and
+simulation state in process memory only, so a restart lost the model registry
+and every checkpoint. Both are now durable.
+
+## What is stored
+
+| Table | Contents |
+| --- | --- |
+| `twin_models` | One row per registered model: the authored `ProcessModel` definition, keyed by the model id, plus the schema version it was written under. |
+| `twin_checkpoints` | The **last committed** simulation state per model: tick, simulated clock, per-component parameter values, and the last live-sync timestamp. |
+
+Physical DDL: `migrations/0014_twin_persistence.sql` (PostgreSQL) and the
+`SQLITE_DDL` in `server/services/twin/persistence.ts` (development fallback).
+The two Drizzle definitions in `shared/schema.ts` and `shared/schema-sqlite.ts`
+are held in sync by `shared/__tests__/schema-parity.test.ts`.
+
+Neither table has a `status` or `running` column, and that is deliberate — see
+below.
+
+## A restart never resumes a simulation
+
+A restored simulation always comes back **idle**, whatever it was doing when
+its checkpoint was committed. The stored schema cannot express "resume on
+boot": run status is not persisted at all. Restoring does not start a timer,
+does not step, and does not assimilate live tag data. An authorized caller must
+explicitly `POST /api/twin/models/:modelId/start` or `.../step` before the
+model does anything.
+
+The twin remains advisory and read-only toward the plant (ADR-0009); nothing in
+this feature introduces a plant-output or control-write path.
+
+## Checkpoints are explicit
+
+```
+POST /api/twin/models/:modelId/checkpoint      scope: twin.operate
+```
+
+Commits the model's simulation state **at the instant of the call** as its
+durable checkpoint and returns it. The runtime keeps advancing afterwards;
+those later ticks are not durable until the next commit. A restart restores the
+last committed checkpoint, not the last tick that happened to run.
+
+An initial checkpoint is written when the model is registered, in the same
+transaction as the definition, so a registered model always has one.
+
+No other route writes a checkpoint. `start`, `stop`, `step`, `reset` and `sync`
+change only in-memory state, so **a restart after a `reset` restores the
+pre-reset checkpoint**, not the reset state — the restored simulation can be
+older than what the twin last showed. Commit a checkpoint after any state
+change you need to survive a restart.
+
+## Atomicity
+
+`POST /api/twin/models` and `DELETE /api/twin/models/:modelId` mutate storage
+and the in-memory registry inside one database transaction:
+
+* the runtime rejects the model → nothing is written and nothing changes;
+* the durable write or the commit fails → the transaction rolls back **and**
+  the in-memory registry is restored from the snapshot taken before the
+  mutation, including the replaced model's simulation state and live actuals.
+
+A storage failure on these routes answers `503`, not `400`: the request was
+well-formed, and the twin refuses to hold state it cannot durably store.
+
+The startup restore holds the store exclusively while it reads the stored rows
+**and** while it applies them to the runtime, so a registration or delete
+arriving mid-restore is ordered against it rather than silently overwritten in
+memory by rows the restore had already read. Such a request waits for the
+restore to finish and then applies on top of it.
+
+## Corrupt or unreadable rows fail closed, one model at a time
+
+At startup each stored model is decoded, version-checked and re-validated by
+the runtime, and its checkpoint is validated against the model's components. A
+row that fails any of those checks is **refused for that model only** — every
+other valid model still loads. Refused rows are reported, never repaired:
+
+* a definition that is not readable JSON, or not a valid process model;
+* a `schema_version` this build does not know;
+* a checkpoint whose component states do not match the model, or that contains
+  a non-finite value;
+* a model row with no checkpoint row, which can only be a torn write. It is
+  refused rather than re-seeded from authored initial conditions, because
+  substituting authored state for real state would be indistinguishable from
+  inventing it.
+
+Refusals are visible on:
+
+```
+GET /api/twin/status                            scope: twin.read
+```
+
+under `persistence.lastRestore.failed`, each entry naming the model, whether
+the definition or the checkpoint was rejected, and why. `persistence.error` is
+set instead when storage could not be read at all — in that case the runtime
+starts empty and later writes still fail loudly rather than silently running
+without durability.
+
+### Clearing a refused model
+
+The stored rows are left untouched, so an operator can either
+
+* re-register the model with `POST /api/twin/models`, which replaces the
+  definition and checkpoint atomically, or
+* remove it with `DELETE /api/twin/models/:modelId`, which reaches models that
+  the last restore refused as well as loaded ones.
+
+## Limits
+
+A stored model definition or checkpoint payload is capped at 16 MiB
+(`MAX_PERSISTED_PAYLOAD_BYTES`). The cap sits above what the runtime's own
+structural limits can produce. An oversized payload is refused outright; a
+checkpoint is never truncated.
+
+## Configuration
+
+The store follows the same backend selection as `server/storage.ts`: PostgreSQL
+when `DATABASE_URL` is set, `FORCE_POSTGRES` is not `false`, and `NODE_ENV` is
+not `development`; otherwise a SQLite file resolved from
+`TWIN_STATE_SQLITE_PATH`, then `SQLITE_DATABASE_PATH`, then
+`./dev-database.sqlite`. The connection opens lazily on first use.

--- a/migrations/0014_twin_persistence.sql
+++ b/migrations/0014_twin_persistence.sql
@@ -1,0 +1,77 @@
+-- Migration: 0014_twin_persistence
+-- Issue: #550 — [QE] persist digital-twin models and simulation checkpoints
+--                across restart
+-- Description: Durable storage for the digital-twin model registry and one
+--   explicitly committed simulation checkpoint per model. Before this, both
+--   lived only in process memory (server/services/twin/engine.ts), so a
+--   restart lost the registry and every checkpoint.
+--
+-- ─── WHAT THESE TABLES DO AND DO NOT CONTAIN ────────────────────────────────
+--
+-- `twin_models` holds the authored `ProcessModel` definition exactly as it was
+-- registered. `twin_checkpoints` holds the LAST COMMITTED simulation state for
+-- that model: the tick counter, the simulated clock, and the per-component
+-- parameter values. Nothing here is derived, estimated or back-filled — a row
+-- exists only because a caller registered a model or committed a checkpoint.
+--
+-- There is deliberately NO `status` / `running` column. The runtime status is
+-- not persisted, because a restored simulation always comes back IDLE: a
+-- restart must never resume stepping, live-data assimilation or any other
+-- activity that an authorized caller did not ask for. Stopped is the safe
+-- state for an advisory twin (ADR-0009 — the twin is the sandbox, never the
+-- actuator), and this schema cannot express "resume running on boot".
+--
+-- The twin is read-only toward the plant, so nothing in these tables is or can
+-- become a control write.
+--
+-- ─── VERSIONING ─────────────────────────────────────────────────────────────
+--
+-- `schema_version` on both tables records the payload version the row was
+-- written under (TWIN_MODEL_SCHEMA_VERSION / TWIN_CHECKPOINT_SCHEMA_VERSION in
+-- shared/types/digital-twin.ts; both are 1 today). The loader refuses a row
+-- whose version it does not know rather than decoding it under current
+-- assumptions. Refusal is per model: one unreadable row never blocks the rest
+-- of the registry from loading.
+--
+-- ─── ATOMICITY ──────────────────────────────────────────────────────────────
+--
+-- A model and its checkpoint are always written in one transaction, so a model
+-- row without a checkpoint row is a torn write. The loader treats that as
+-- corrupt and refuses the model rather than silently seeding it from authored
+-- initial conditions, which would substitute invented state for real state.
+-- The foreign key with ON DELETE CASCADE keeps deletion atomic even if a
+-- future caller removes a model row directly.
+-- Date: 2026-07-28
+
+CREATE TABLE IF NOT EXISTS twin_models (
+  -- The model id itself, which is also the in-memory registry key, so storage
+  -- and runtime cannot disagree about which model a row describes.
+  id VARCHAR(128) PRIMARY KEY,
+  schema_version INTEGER NOT NULL,
+  definition JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS twin_checkpoints (
+  -- At most one committed checkpoint per model.
+  model_id VARCHAR(128) PRIMARY KEY
+    REFERENCES twin_models(id) ON DELETE CASCADE,
+  schema_version INTEGER NOT NULL,
+  tick BIGINT NOT NULL,
+  -- Simulated clock in milliseconds. Double precision rather than bigint: the
+  -- runtime carries it as a JS number and only requires it to stay finite.
+  time_ms DOUBLE PRECISION NOT NULL,
+  -- Record<componentId, Record<parameter, number>>, re-validated against the
+  -- model's components before it is admitted back into the runtime.
+  component_states JSONB NOT NULL,
+  -- Epoch ms of the last live-tag assimilation folded into this checkpoint.
+  last_sync_at BIGINT,
+  committed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT twin_checkpoints_tick_check CHECK (tick >= 0)
+);
+
+-- Operators list checkpoints by recency when deciding what a restart would
+-- restore.
+CREATE INDEX IF NOT EXISTS idx_twin_checkpoints_committed_at
+  ON twin_checkpoints(committed_at);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1784780409000,
       "tag": "0012_validator_liveness_observations",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1784780411000,
+      "tag": "0014_twin_persistence",
+      "breakpoints": true
     }
   ]
 }

--- a/server/routes/__tests__/twin-auth.test.ts
+++ b/server/routes/__tests__/twin-auth.test.ts
@@ -79,6 +79,8 @@ const operateRoutes = routeCases("operate-key", "configure-key", [
   ["POST", "/models/missing/reset", 400],
   ["POST", "/models/missing/step", 400],
   ["POST", "/models/missing/sync", 400],
+  // #550: committing a durable checkpoint is an operate-scope action.
+  ["POST", "/models/missing/checkpoint", 400],
 ]);
 
 const simulationRoutes = routeCases("simulate-key", "operate-key", [

--- a/server/routes/__tests__/twin-persistence-routes.test.ts
+++ b/server/routes/__tests__/twin-persistence-routes.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Digital-twin API ↔ durable storage
+ * ADR-0013 [13.3] — Issue #550
+ *
+ * The unit suite in server/services/twin/__tests__ proves the store and the
+ * transactional registry behave. This suite proves the HTTP surface is
+ * actually wired to them: a model registered through POST /api/twin/models is
+ * in the database, a checkpoint committed through the API is what a restart
+ * restores, that restart comes back idle, and DELETE removes both rows.
+ *
+ * It drives the real router against a real SQLite file — no mocks.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import { createServer, type Server } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { _resetControlPlaneAuthCache } from "../../middleware/control-plane-auth";
+import {
+  DigitalTwinService,
+  DrizzleTwinStore,
+  digitalTwinService,
+} from "../../services/twin";
+import type { ProcessModel } from "@shared/types/digital-twin";
+import { twinRoutes } from "../twin";
+
+const MODEL: ProcessModel = {
+  id: "route-tank",
+  name: "Route tank",
+  components: [
+    {
+      id: "valve-1",
+      type: "valve",
+      name: "Feed valve",
+      config: { maxFlow: 10 },
+      initialState: { position: 50 },
+      connections: ["tank-1"],
+    },
+    {
+      id: "tank-1",
+      type: "tank",
+      name: "Buffer tank",
+      config: { capacity: 100, outflow: 2 },
+      initialState: { level: 20 },
+      connections: [],
+    },
+  ],
+  tagBindings: [{ tagId: "TK-1.LEVEL", componentId: "tank-1", parameter: "level" }],
+  stepFunction: "basic-flow",
+  timeStepMs: 1000,
+};
+
+interface EnvBackup {
+  apiKeys: string | undefined;
+  sqlitePath: string | undefined;
+  forcePostgres: string | undefined;
+}
+
+describe("digital-twin API persistence", () => {
+  let server: Server;
+  let baseUrl: string;
+  let directory: string;
+  let file: string;
+  let env: EnvBackup;
+
+  function api(
+    method: "GET" | "POST" | "DELETE",
+    routePath: string,
+    apiKey: string,
+    body?: unknown,
+  ): Promise<Response> {
+    const headers: Record<string, string> = { "x-api-key": apiKey };
+    if (body !== undefined) headers["content-type"] = "application/json";
+    return fetch(`${baseUrl}/api/twin${routePath}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  }
+
+  /** A fresh process reading the same database file. */
+  async function restartAndRestore(): Promise<DigitalTwinService> {
+    const service = new DigitalTwinService(
+      3_600_000,
+      new DrizzleTwinStore({ sqlitePath: file }),
+    );
+    await service.initialize();
+    return service;
+  }
+
+  beforeAll(async () => {
+    directory = await mkdtemp(path.join(tmpdir(), "twin-routes-"));
+    file = path.join(directory, "twin.sqlite");
+    env = {
+      apiKeys: process.env.API_KEYS,
+      sqlitePath: process.env.TWIN_STATE_SQLITE_PATH,
+      forcePostgres: process.env.FORCE_POSTGRES,
+    };
+    process.env.API_KEYS = [
+      "read-key:twin-reader:twin.read",
+      "configure-key:twin-configurer:twin.configure",
+      "operate-key:twin-operator:twin.operate",
+    ].join(",");
+    // The singleton store resolves its path lazily, on first use.
+    process.env.TWIN_STATE_SQLITE_PATH = file;
+    process.env.FORCE_POSTGRES = "false";
+    _resetControlPlaneAuthCache();
+
+    const app = express();
+    app.use(express.json());
+    app.use("/api/twin", twinRoutes);
+    await new Promise<void>((resolve) => {
+      server = createServer(app);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    baseUrl = `http://127.0.0.1:${typeof address === "object" && address ? address.port : 0}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await digitalTwinService.shutdown();
+    await rm(directory, { recursive: true, force: true });
+    if (env.apiKeys === undefined) delete process.env.API_KEYS;
+    else process.env.API_KEYS = env.apiKeys;
+    if (env.sqlitePath === undefined) delete process.env.TWIN_STATE_SQLITE_PATH;
+    else process.env.TWIN_STATE_SQLITE_PATH = env.sqlitePath;
+    if (env.forcePostgres === undefined) delete process.env.FORCE_POSTGRES;
+    else process.env.FORCE_POSTGRES = env.forcePostgres;
+    _resetControlPlaneAuthCache();
+  });
+
+  it("registers, checkpoints, restores idle, and deletes through the API", async () => {
+    const created = await api("POST", "/models", "configure-key", MODEL);
+    expect(created.status).toBe(201);
+
+    // A model is durable from the moment it is registered, before any
+    // checkpoint is explicitly committed.
+    const beforeAnyStep = await restartAndRestore();
+    try {
+      expect(beforeAnyStep.persistenceStatus().lastRestore?.restored).toEqual(["route-tank"]);
+      expect(beforeAnyStep.runtime.getState("route-tank")!.tick).toBe(0);
+    } finally {
+      await beforeAnyStep.shutdown();
+    }
+
+    const stepped = await api("POST", "/models/route-tank/step", "operate-key", { ticks: 3 });
+    expect(stepped.status).toBe(200);
+    expect(((await stepped.json()) as { tick: number }).tick).toBe(3);
+
+    const started = await api("POST", "/models/route-tank/start", "operate-key");
+    expect(started.status).toBe(200);
+
+    const checkpoint = await api("POST", "/models/route-tank/checkpoint", "operate-key");
+    expect(checkpoint.status).toBe(200);
+    const committed = (await checkpoint.json()) as {
+      checkpoint: { tick: number; schemaVersion: number; committedAt: number };
+    };
+    expect(committed.checkpoint.tick).toBe(3);
+    expect(committed.checkpoint.schemaVersion).toBe(1);
+    expect(committed.checkpoint.committedAt).toBeGreaterThan(0);
+
+    const status = await api("GET", "/status", "read-key");
+    expect(status.status).toBe(200);
+    const reported = (await status.json()) as {
+      persistence: { configured: boolean; backend: string };
+    };
+    expect(reported.persistence.configured).toBe(true);
+    expect(reported.persistence.backend).toBe("sqlite");
+
+    // Restart: the checkpoint comes back, and the simulation that was running
+    // when it was committed comes back STOPPED.
+    const restarted = await restartAndRestore();
+    try {
+      const restored = restarted.runtime.getState("route-tank")!;
+      expect(restored.tick).toBe(3);
+      expect(restored.status).toBe("idle");
+      expect(restarted.runtime.getStatus().running).toBe(0);
+      restarted.runtime.stepRunning(Date.now() + 3_600_000);
+      expect(restarted.runtime.getState("route-tank")!.tick).toBe(3);
+    } finally {
+      await restarted.shutdown();
+    }
+
+    const removed = await api("DELETE", "/models/route-tank", "configure-key");
+    expect(removed.status).toBe(200);
+
+    const afterDelete = await restartAndRestore();
+    try {
+      expect(afterDelete.persistenceStatus().lastRestore).toEqual({
+        scanned: 0,
+        restored: [],
+        failed: [],
+      });
+      expect(afterDelete.runtime.getModel("route-tank")).toBeUndefined();
+    } finally {
+      await afterDelete.shutdown();
+    }
+  });
+});

--- a/server/routes/twin.ts
+++ b/server/routes/twin.ts
@@ -6,6 +6,12 @@
  * control, live-state sync/compare, what-if scenarios, and rollback
  * simulation. Deliberately mounted at /api/twin — the mock
  * /api/intelligence/digitaltwin endpoints are a separate legacy surface.
+ *
+ * #550: the model registry and committed checkpoints are durable. Model
+ * create/delete and checkpoint commits go through the twin service, which
+ * keeps storage and the in-memory registry in one transaction; the simulation
+ * control routes below stay purely in-memory and only become durable when a
+ * caller commits a checkpoint. See docs/api/twin-persistence.md.
  */
 
 import { Router } from "express";
@@ -13,7 +19,11 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { fromZodError } from "zod-validation-error/v3";
 import { requireControlPlaneAccess } from "../middleware/control-plane-auth";
-import { digitalTwinService, listStepFunctions } from "../services/twin";
+import {
+  digitalTwinService,
+  listStepFunctions,
+  TwinPersistenceError,
+} from "../services/twin";
 import type { ProcessModel, WhatIfScenario } from "@shared/types/digital-twin";
 
 const router = Router();
@@ -42,6 +52,23 @@ function handle(fn: (req: Request, res: Response) => void) {
         res.status(400).json({ error: error instanceof Error ? error.message : "Invalid request" });
       }
     }
+  };
+}
+
+/**
+ * Same, for handlers that touch durable storage (#550). A storage failure is a
+ * 503 rather than a 400: the request was well-formed, the twin simply refused
+ * to hold state it could not durably store, so the caller should retry rather
+ * than rewrite the request.
+ */
+function handleAsync(fn: (req: Request, res: Response) => Promise<void>) {
+  return (req: Request, res: Response) => {
+    fn(req, res).catch((error: unknown) => {
+      if (res.headersSent) return;
+      const message = error instanceof Error ? error.message : "Invalid request";
+      const status = error instanceof TwinPersistenceError ? 503 : 400;
+      res.status(status).json({ error: message });
+    });
   };
 }
 
@@ -115,12 +142,16 @@ const StepSchema = z.object({
 
 // ── Model registry ─────────────────────────────────────────────────────────
 
-router.post("/models", requireTwinConfigure, handle((req, res) => {
+// Registration is durable (#550): the definition and its initial checkpoint
+// are committed in the same transaction as the in-memory registration, so a
+// storage failure leaves neither behind.
+router.post("/models", requireTwinConfigure, handleAsync(async (req, res) => {
   const parsed = ModelSchema.safeParse(req.body);
   if (!parsed.success) {
-    return res.status(400).json({ error: fromZodError(parsed.error).message });
+    res.status(400).json({ error: fromZodError(parsed.error).message });
+    return;
   }
-  const state = runtime.registerModel(parsed.data as ProcessModel);
+  const state = await digitalTwinService.registerModel(parsed.data as ProcessModel);
   res.status(201).json({ model: parsed.data, state });
 }));
 
@@ -134,12 +165,13 @@ router.get("/models/:modelId", requireTwinRead, (req, res) => {
   res.json({ model, state: runtime.getState(req.params.modelId) });
 });
 
-router.delete("/models/:modelId", requireTwinConfigure, (req, res) => {
-  if (!runtime.removeModel(req.params.modelId)) {
-    return res.status(404).json({ error: `Model ${req.params.modelId} not found` });
+router.delete("/models/:modelId", requireTwinConfigure, handleAsync(async (req, res) => {
+  if (!(await digitalTwinService.removeModel(req.params.modelId))) {
+    res.status(404).json({ error: `Model ${req.params.modelId} not found` });
+    return;
   }
   res.json({ removed: true });
-});
+}));
 
 // ── Simulation control ─────────────────────────────────────────────────────
 
@@ -168,6 +200,16 @@ router.get("/models/:modelId/state", requireTwinRead, (req, res) => {
   if (!state) return res.status(404).json({ error: `Model ${req.params.modelId} not found` });
   res.json(state);
 });
+
+/**
+ * Commit the model's current simulation state as its durable checkpoint (#550)
+ * — the state a restart would restore. The restored simulation always comes
+ * back idle, whatever it was doing when the checkpoint was taken; only an
+ * explicit start or step resumes it.
+ */
+router.post("/models/:modelId/checkpoint", requireTwinOperate, handleAsync(async (req, res) => {
+  res.json({ checkpoint: await digitalTwinService.commitCheckpoint(req.params.modelId) });
+}));
 
 // ── Live sync & comparison ─────────────────────────────────────────────────
 
@@ -211,7 +253,14 @@ router.get("/step-functions", requireTwinRead, (_req, res) => {
 
 router.get("/status", requireTwinRead, async (_req, res) => {
   const health = await digitalTwinService.healthCheck();
-  res.json({ ...runtime.getStatus(), ...health });
+  // `persistence.lastRestore.failed` lists stored models this build refused to
+  // load. They are still in storage, untouched, and can be cleared with
+  // DELETE /models/:modelId or replaced by re-registering the model.
+  res.json({
+    ...runtime.getStatus(),
+    ...health,
+    persistence: digitalTwinService.persistenceStatus(),
+  });
 });
 
 export { router as twinRoutes };

--- a/server/services/twin/__tests__/twin-persistence.test.ts
+++ b/server/services/twin/__tests__/twin-persistence.test.ts
@@ -1,0 +1,812 @@
+/**
+ * Durable digital-twin registry and checkpoint tests
+ * ADR-0013 [13.3] — Issue #550
+ *
+ * These run against a real SQLite file through the real Drizzle store — no
+ * in-memory stand-in — so the claims that matter are actually observed:
+ * a model and its committed checkpoint survive a restart, the restored
+ * simulation is idle, corrupt rows fail closed for their own model only, and
+ * a failed write leaves neither storage nor the in-memory registry changed.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Database } from "sqlite3";
+import type { ProcessModel } from "@shared/types/digital-twin";
+import { TwinRuntime } from "../engine";
+import {
+  DrizzleTwinStore,
+  MAX_PERSISTED_PAYLOAD_BYTES,
+  TwinPersistenceError,
+  type TwinLoadResult,
+  type TwinPersistence,
+  type TwinStoreTransaction,
+} from "../persistence";
+import { PersistentTwinRegistry } from "../registry";
+
+/** Valve (maxFlow 10, position 50 → flow 5) feeding a tank draining at 2 */
+function valveTankModel(overrides: Partial<ProcessModel> = {}): ProcessModel {
+  return {
+    id: "m1",
+    name: "valve-tank",
+    components: [
+      {
+        id: "valve-1",
+        type: "valve",
+        name: "Feed valve",
+        config: { maxFlow: 10 },
+        initialState: { position: 50 },
+        connections: ["tank-1"],
+      },
+      {
+        id: "tank-1",
+        type: "tank",
+        name: "Buffer tank",
+        config: { capacity: 100, outflow: 2 },
+        initialState: { level: 20 },
+        connections: [],
+      },
+    ],
+    tagBindings: [{ tagId: "TK-1.LEVEL", componentId: "tank-1", parameter: "level" }],
+    stepFunction: "basic-flow",
+    timeStepMs: 1000,
+    ...overrides,
+  };
+}
+
+function rawSqlite(file: string): Database {
+  return new Database(file);
+}
+
+function rawRun(client: Database, sql: string, params: unknown[] = []): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client.run(sql, params, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function rawAll(
+  client: Database,
+  sql: string,
+  params: unknown[] = [],
+): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve, reject) => {
+    client.all(sql, params, (error, rows) =>
+      error ? reject(error) : resolve(rows as Record<string, unknown>[]));
+  });
+}
+
+function rawClose(client: Database): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+/** A promise together with its resolver, for driving an exact interleaving. */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * Wait for `settling`, giving up after `ms`.
+ *
+ * Used to give a concurrent registration its chance to commit. The bound only
+ * decides whether an *unsynchronised* store is caught in the act; a store that
+ * serialises the restore against mutations cannot commit that registration
+ * early however long the wait, so the assertions that follow never depend on
+ * which way this went.
+ */
+async function settleWithin(settling: Promise<unknown>, ms: number): Promise<void> {
+  let timer: NodeJS.Timeout | undefined;
+  await Promise.race([
+    settling.then(() => undefined, () => undefined),
+    new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, ms);
+    }),
+  ]);
+  if (timer) clearTimeout(timer);
+}
+
+/**
+ * The real store with the window between "the stored rows have been read" and
+ * "the read resolves to its caller" held open on demand. Everything else — the
+ * read itself, the transactions, the lock — is the production implementation.
+ */
+class GatedLoadStore extends DrizzleTwinStore {
+  private readonly read = deferred();
+  private readonly gate = deferred();
+  /** Resolves once a `load()` has read the database and is holding its result. */
+  readonly loadHasRead = this.read.promise;
+
+  override async load(): Promise<TwinLoadResult> {
+    const loaded = await super.load();
+    this.read.resolve();
+    await this.gate.promise;
+    return loaded;
+  }
+
+  /** Let the in-flight read — and every later one — resolve. */
+  releaseLoad(): void {
+    this.gate.resolve();
+  }
+}
+
+describe("durable twin registry (SQLite backend)", () => {
+  let directory: string;
+  let file: string;
+  let store: DrizzleTwinStore;
+  let runtime: TwinRuntime;
+  let registry: PersistentTwinRegistry;
+  const openStores: DrizzleTwinStore[] = [];
+  let databaseCounter = 0;
+
+  /** A fresh process: new store handle, new runtime, nothing in memory. */
+  function restart(): { runtime: TwinRuntime; registry: PersistentTwinRegistry } {
+    const reopened = new DrizzleTwinStore({ sqlitePath: file });
+    openStores.push(reopened);
+    const freshRuntime = new TwinRuntime();
+    return {
+      runtime: freshRuntime,
+      registry: new PersistentTwinRegistry(freshRuntime, reopened),
+    };
+  }
+
+  beforeAll(async () => {
+    directory = await mkdtemp(path.join(tmpdir(), "twin-persistence-"));
+  });
+
+  afterAll(async () => {
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    // A database file per test, in one shared temp directory: each test still
+    // starts from an empty store, without paying for a directory create and
+    // recursive delete per case.
+    file = path.join(directory, `twin-${databaseCounter++}.sqlite`);
+    store = new DrizzleTwinStore({ sqlitePath: file });
+    openStores.length = 0;
+    openStores.push(store);
+    runtime = new TwinRuntime();
+    registry = new PersistentTwinRegistry(runtime, store);
+  });
+
+  afterEach(async () => {
+    for (const open of openStores) await open.close();
+  });
+
+  // ── Restart recovery ─────────────────────────────────────────────────────
+
+  it("restores a registered model and its last committed checkpoint", async () => {
+    await registry.registerModel(valveTankModel({ description: "feed loop" }));
+    runtime.step("m1", 4);
+    const committed = await registry.commitCheckpoint("m1");
+    expect(committed.tick).toBe(4);
+    expect(committed.componentStates["tank-1"].level).toBe(32);
+    await store.close();
+
+    const after = restart();
+    const report = await after.registry.restore();
+
+    expect(report.scanned).toBe(1);
+    expect(report.restored).toEqual(["m1"]);
+    expect(report.failed).toEqual([]);
+    expect(after.runtime.getModel("m1")).toEqual(valveTankModel({ description: "feed loop" }));
+    const state = after.runtime.getState("m1")!;
+    expect(state.tick).toBe(4);
+    expect(state.timeMs).toBe(4000);
+    // Including the solver's derived state, so the restored simulation
+    // continues from exactly where it stopped rather than re-deriving it.
+    expect(state.componentStates).toEqual({
+      "valve-1": { position: 50, currentFlow: 5 },
+      "tank-1": { level: 32, inflow: 5, fillPercent: 32 },
+    });
+  });
+
+  it("restores ticks the caller committed, not ticks run after the commit", async () => {
+    await registry.registerModel(valveTankModel());
+    runtime.step("m1", 2);
+    await registry.commitCheckpoint("m1");
+    runtime.step("m1", 5);
+    expect(runtime.getState("m1")!.tick).toBe(7);
+    await store.close();
+
+    const after = restart();
+    await after.registry.restore();
+    expect(after.runtime.getState("m1")!.tick).toBe(2);
+  });
+
+  it("carries the last live-sync timestamp into the restored checkpoint", async () => {
+    await registry.registerModel(valveTankModel());
+    runtime.ingestActual("TK-1.LEVEL", 61.5, 1_000);
+    runtime.syncFromLive("m1", 9_000);
+    await registry.commitCheckpoint("m1");
+    await store.close();
+
+    const after = restart();
+    await after.registry.restore();
+    const state = after.runtime.getState("m1")!;
+    expect(state.lastSyncAt).toBe(9_000);
+    expect(state.componentStates["tank-1"].level).toBe(61.5);
+  });
+
+  // ── Safety: a restart never resumes anything ─────────────────────────────
+
+  it("restores a running simulation in a stopped state and does not resume it", async () => {
+    await registry.registerModel(valveTankModel());
+    runtime.setRunning("m1", true, 0);
+    runtime.stepRunning(3_000);
+    expect(runtime.getState("m1")!.status).toBe("running");
+    expect(runtime.getState("m1")!.tick).toBe(3);
+    await registry.commitCheckpoint("m1");
+    await store.close();
+
+    const after = restart();
+    await after.registry.restore();
+
+    const restored = after.runtime.getState("m1")!;
+    expect(restored.status).toBe("idle");
+    expect(restored.tick).toBe(3);
+
+    // The service's step driver must find nothing to do, however much
+    // wall-clock time has passed since the checkpoint.
+    after.runtime.syncRunningFromLive(1_000_000);
+    after.runtime.stepRunning(1_000_000);
+    expect(after.runtime.getState("m1")!.tick).toBe(3);
+    expect(after.runtime.getStatus().running).toBe(0);
+
+    // ...until an authorized caller explicitly steps it.
+    expect(after.runtime.step("m1", 1).tick).toBe(4);
+  });
+
+  it("restores a simulation that failed with a solver error as idle, not error", async () => {
+    await registry.registerModel(valveTankModel());
+    runtime.step("m1", 1);
+    await registry.commitCheckpoint("m1");
+    // Force the runtime into the error state after the commit.
+    const errored = runtime.exportEntry("m1")!;
+    errored.state.status = "error";
+    errored.state.error = "solver blew up";
+    runtime.restoreEntry("m1", errored);
+    expect(runtime.getState("m1")!.status).toBe("error");
+    await store.close();
+
+    const after = restart();
+    await after.registry.restore();
+    const restored = after.runtime.getState("m1")!;
+    expect(restored.status).toBe("idle");
+    expect(restored.error).toBeUndefined();
+  });
+
+  // ── Corruption and partial writes fail closed, per model ─────────────────
+
+  it("refuses a model whose stored definition is not valid JSON and loads the rest", async () => {
+    await registry.registerModel(valveTankModel({ id: "broken" }));
+    await registry.registerModel(valveTankModel({ id: "healthy" }));
+    await store.close();
+
+    const raw = rawSqlite(file);
+    await rawRun(raw, "UPDATE twin_models SET definition = ? WHERE id = ?", [
+      "{not json at all",
+      "broken",
+    ]);
+    await rawClose(raw);
+
+    const after = restart();
+    const report = await after.registry.restore();
+
+    expect(report.restored).toEqual(["healthy"]);
+    expect(report.failed).toHaveLength(1);
+    expect(report.failed[0].modelId).toBe("broken");
+    expect(report.failed[0].stage).toBe("model");
+    expect(after.runtime.getModel("broken")).toBeUndefined();
+    expect(after.runtime.getModel("healthy")).toBeDefined();
+  });
+
+  it("refuses a model row written under an unknown schema version", async () => {
+    await registry.registerModel(valveTankModel({ id: "future" }));
+    await registry.registerModel(valveTankModel({ id: "healthy" }));
+    await store.close();
+
+    const raw = rawSqlite(file);
+    await rawRun(raw, "UPDATE twin_models SET schema_version = 99 WHERE id = ?", ["future"]);
+    await rawClose(raw);
+
+    const after = restart();
+    const report = await after.registry.restore();
+
+    expect(report.restored).toEqual(["healthy"]);
+    expect(report.failed).toEqual([
+      {
+        modelId: "future",
+        stage: "model",
+        reason: expect.stringContaining("unsupported model schema version 99"),
+      },
+    ]);
+  });
+
+  it("refuses a checkpoint written under an unknown schema version", async () => {
+    await registry.registerModel(valveTankModel({ id: "future-cp" }));
+    await registry.registerModel(valveTankModel({ id: "healthy" }));
+    await store.close();
+
+    const raw = rawSqlite(file);
+    await rawRun(raw, "UPDATE twin_checkpoints SET schema_version = 7 WHERE model_id = ?", [
+      "future-cp",
+    ]);
+    await rawClose(raw);
+
+    const after = restart();
+    const report = await after.registry.restore();
+
+    expect(report.restored).toEqual(["healthy"]);
+    expect(report.failed[0].stage).toBe("checkpoint");
+    expect(report.failed[0].reason).toContain("unsupported checkpoint schema version 7");
+    expect(after.runtime.getModel("future-cp")).toBeUndefined();
+  });
+
+  it("refuses a checkpoint whose component states do not match the model", async () => {
+    await registry.registerModel(valveTankModel({ id: "mismatched" }));
+    await registry.registerModel(valveTankModel({ id: "healthy" }));
+    await store.close();
+
+    const raw = rawSqlite(file);
+    // A state record for a component the model does not contain: the stored
+    // pair disagrees, so neither half can be trusted.
+    await rawRun(raw, "UPDATE twin_checkpoints SET component_states = ? WHERE model_id = ?", [
+      JSON.stringify({ "valve-1": { position: 50 }, "ghost-tank": { level: 1 } }),
+      "mismatched",
+    ]);
+    await rawClose(raw);
+
+    const after = restart();
+    const report = await after.registry.restore();
+
+    expect(report.restored).toEqual(["healthy"]);
+    expect(report.failed[0]).toMatchObject({ modelId: "mismatched", stage: "checkpoint" });
+    expect(after.runtime.getModel("mismatched")).toBeUndefined();
+  });
+
+  it("refuses a checkpoint carrying a non-finite value rather than admitting it", async () => {
+    await registry.registerModel(valveTankModel({ id: "nan-state" }));
+    await store.close();
+
+    const raw = rawSqlite(file);
+    await rawRun(raw, "UPDATE twin_checkpoints SET component_states = ? WHERE model_id = ?", [
+      '{"valve-1":{"position":50},"tank-1":{"level":null}}',
+      "nan-state",
+    ]);
+    await rawClose(raw);
+
+    const after = restart();
+    const report = await after.registry.restore();
+    expect(report.restored).toEqual([]);
+    expect(report.failed[0].stage).toBe("checkpoint");
+  });
+
+  it("treats a model row with no checkpoint row as a torn write", async () => {
+    await registry.registerModel(valveTankModel({ id: "torn" }));
+    await registry.registerModel(valveTankModel({ id: "healthy" }));
+    await store.close();
+
+    const raw = rawSqlite(file);
+    await rawRun(raw, "DELETE FROM twin_checkpoints WHERE model_id = ?", ["torn"]);
+    await rawClose(raw);
+
+    const after = restart();
+    const report = await after.registry.restore();
+
+    expect(report.scanned).toBe(2);
+    expect(report.restored).toEqual(["healthy"]);
+    expect(report.failed).toEqual([
+      { modelId: "torn", stage: "checkpoint", reason: expect.stringContaining("torn write") },
+    ]);
+    // The unreadable row is reported, not repaired: it is still in storage.
+    const check = rawSqlite(file);
+    const rows = await rawAll(check, "SELECT id FROM twin_models WHERE id = ?", ["torn"]);
+    await rawClose(check);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("refuses a definition whose id does not match the row it was stored under", async () => {
+    await registry.registerModel(valveTankModel({ id: "renamed" }));
+    await store.close();
+
+    const raw = rawSqlite(file);
+    await rawRun(raw, "UPDATE twin_models SET definition = ? WHERE id = ?", [
+      JSON.stringify(valveTankModel({ id: "somethingelse" })),
+      "renamed",
+    ]);
+    await rawClose(raw);
+
+    const after = restart();
+    const report = await after.registry.restore();
+    expect(report.restored).toEqual([]);
+    expect(report.failed[0]).toMatchObject({ modelId: "renamed", stage: "model" });
+  });
+
+  it("refuses a model whose step function this build does not know", async () => {
+    await registry.registerModel(valveTankModel({ id: "exotic" }));
+    await store.close();
+
+    const raw = rawSqlite(file);
+    await rawRun(raw, "UPDATE twin_models SET definition = ? WHERE id = ?", [
+      JSON.stringify(valveTankModel({ id: "exotic", stepFunction: "quantum-flow" })),
+      "exotic",
+    ]);
+    await rawClose(raw);
+
+    const after = restart();
+    const report = await after.registry.restore();
+    expect(report.failed[0]).toMatchObject({ modelId: "exotic", stage: "model" });
+    expect(report.failed[0].reason).toContain("quantum-flow");
+  });
+
+  // ── Transactional storage ────────────────────────────────────────────────
+
+  it("rolls the stored model and checkpoint back together when the transaction throws", async () => {
+    const model = valveTankModel({ id: "half-written" });
+    await expect(
+      store.transaction(async (tx: TwinStoreTransaction) => {
+        await tx.putModel(model, { tick: 0, timeMs: 0, componentStates: { "valve-1": {} } }, 1);
+        throw new Error("interrupted before commit");
+      }),
+    ).rejects.toThrow("interrupted before commit");
+
+    const loaded: TwinLoadResult = await store.load();
+    expect(loaded.scanned).toBe(0);
+    expect(loaded.records).toEqual([]);
+    expect(loaded.failures).toEqual([]);
+  });
+
+  it("deletes a model and its checkpoint together", async () => {
+    await registry.registerModel(valveTankModel({ id: "doomed" }));
+    await registry.registerModel(valveTankModel({ id: "kept" }));
+
+    expect(await registry.removeModel("doomed")).toBe(true);
+    expect(runtime.getModel("doomed")).toBeUndefined();
+
+    const loaded = await store.load();
+    expect(loaded.records.map((record) => record.model.id)).toEqual(["kept"]);
+
+    const raw = rawSqlite(file);
+    const orphans = await rawAll(raw, "SELECT model_id FROM twin_checkpoints WHERE model_id = ?", [
+      "doomed",
+    ]);
+    await rawClose(raw);
+    expect(orphans).toEqual([]);
+  });
+
+  it("reports an unknown model as not removed without touching storage", async () => {
+    await registry.registerModel(valveTankModel({ id: "kept" }));
+    expect(await registry.removeModel("never-existed")).toBe(false);
+    expect((await store.load()).records).toHaveLength(1);
+  });
+
+  it("re-registering replaces the stored definition and its checkpoint", async () => {
+    await registry.registerModel(valveTankModel());
+    runtime.step("m1", 3);
+    await registry.commitCheckpoint("m1");
+
+    const revised = valveTankModel({ name: "valve-tank rev B" });
+    revised.components[1].config.outflow = 4;
+    await registry.registerModel(revised);
+    await store.close();
+
+    const after = restart();
+    await after.registry.restore();
+    expect(after.runtime.getModel("m1")!.name).toBe("valve-tank rev B");
+    // Re-registration reseeds the simulation, and the checkpoint written in
+    // the same transaction says so.
+    expect(after.runtime.getState("m1")!.tick).toBe(0);
+    expect(after.runtime.getState("m1")!.componentStates["tank-1"].level).toBe(20);
+  });
+
+  it("lets an operator clear a stored model this build refused to load", async () => {
+    await registry.registerModel(valveTankModel({ id: "unloadable" }));
+    await store.close();
+
+    const raw = rawSqlite(file);
+    await rawRun(raw, "UPDATE twin_models SET schema_version = 42 WHERE id = ?", ["unloadable"]);
+    await rawClose(raw);
+
+    const after = restart();
+    const report = await after.registry.restore();
+    expect(report.failed).toHaveLength(1);
+
+    expect(await after.registry.removeModel("unloadable")).toBe(true);
+    expect((await after.registry.restore()).scanned).toBe(0);
+  });
+
+  it("refuses a checkpoint payload over the persistence cap instead of truncating it", async () => {
+    await registry.registerModel(valveTankModel({ id: "huge" }));
+    runtime.step("huge", 2);
+    await registry.commitCheckpoint("huge");
+
+    const parameter = "p".repeat(60);
+    const oversized: Record<string, number> = {};
+    for (let i = 0; oversized[`${parameter}${i}`] === undefined; i++) {
+      oversized[`${parameter}${i}`] = 1.2345678901234;
+      if (i * 82 > MAX_PERSISTED_PAYLOAD_BYTES) break;
+    }
+    await expect(
+      store.transaction((tx) => tx.putCheckpoint(
+        "huge",
+        { tick: 9, timeMs: 9000, componentStates: { "tank-1": oversized } },
+        Date.now(),
+      )),
+    ).rejects.toThrow(/persistence limit/);
+
+    // The previously committed checkpoint is untouched.
+    const loaded = await store.load();
+    expect(loaded.records[0].checkpoint.tick).toBe(2);
+  });
+
+  it("serialises concurrent transactions on its single connection", async () => {
+    await Promise.all([
+      registry.registerModel(valveTankModel({ id: "a" })),
+      registry.registerModel(valveTankModel({ id: "b" })),
+      registry.registerModel(valveTankModel({ id: "c" })),
+    ]);
+    const loaded = await store.load();
+    expect(loaded.records.map((record) => record.model.id).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not apply a restore over a registration that committed during it", async () => {
+    await registry.registerModel(valveTankModel({ description: "v1" }));
+    runtime.step("m1", 5);
+    await registry.commitCheckpoint("m1");
+    await store.close();
+
+    const gated = new GatedLoadStore({ sqlitePath: file });
+    openStores.push(gated);
+    const freshRuntime = new TwinRuntime();
+    const freshRegistry = new PersistentTwinRegistry(freshRuntime, gated);
+
+    // The restore has read "v1" at tick 5 out of storage but has not applied
+    // it to the runtime yet.
+    const restoring = freshRegistry.restore();
+    await gated.loadHasRead;
+
+    // A registration arriving in exactly that window replaces the stored model
+    // with "v2" at tick 0. It must not be able to commit while the restore is
+    // still deciding what the runtime should contain.
+    const registering = freshRegistry.registerModel(valveTankModel({ description: "v2" }));
+    await settleWithin(registering, 250);
+    gated.releaseLoad();
+    await restoring;
+    await registering;
+
+    const stored = (await gated.load()).records;
+    expect(stored).toHaveLength(1);
+    // Whichever of the two ran last, storage and the runtime must describe the
+    // same model: the restore's rows are stale the moment a mutation commits.
+    expect(freshRuntime.getModel("m1")!.description).toBe(stored[0].model.description);
+    expect(freshRuntime.getState("m1")!.tick).toBe(stored[0].checkpoint.tick);
+  });
+
+  it("reports a checkpoint for a concurrently deleted model as unknown, not as an outage", async () => {
+    await registry.registerModel(valveTankModel());
+    runtime.step("m1", 2);
+
+    // The delete is requested first, so it takes the store first; the
+    // checkpoint runs against a model that is gone by the time it does.
+    const removing = registry.removeModel("m1");
+    const committing = registry.commitCheckpoint("m1");
+
+    expect(await removing).toBe(true);
+    // Reading the state before the transaction let this reach the database and
+    // fail on the checkpoint's foreign key — a storage error for a request
+    // that is simply naming a model that no longer exists.
+    await expect(committing).rejects.toThrow('Unknown model "m1"');
+    await expect(committing).rejects.not.toBeInstanceOf(TwinPersistenceError);
+    expect((await store.load()).records).toEqual([]);
+  });
+
+  it("closes the connection an open still in flight is about to produce", async () => {
+    const raced = new DrizzleTwinStore({ sqlitePath: path.join(directory, "raced.sqlite") });
+    const opening = raced.ready();
+    // close() races the very first connect(): the handle the open resolves is
+    // the store's to release, so it must not be left owned by nobody.
+    await raced.close();
+    await opening;
+    expect(raced.backend()).toBe("unopened");
+  });
+
+  it("reports a store that cannot be opened as a persistence failure", async () => {
+    const unopenable = new DrizzleTwinStore({
+      sqlitePath: path.join(directory, "no-such-directory", "twin.sqlite"),
+    });
+    await expect(unopenable.ready()).rejects.toBeInstanceOf(TwinPersistenceError);
+  });
+});
+
+// ── CRUD atomicity against a store that fails on demand ────────────────────
+
+type StoreFailure = "putModel" | "putCheckpoint" | "deleteModel" | "commit";
+
+/**
+ * A `TwinPersistence` with real transactional semantics — staged writes are
+ * applied only on commit — that can be told to fail at a chosen point. Used to
+ * observe what the in-memory registry looks like after a durable write fails;
+ * the SQLite suite above covers the storage half.
+ */
+class FailingStore implements TwinPersistence {
+  readonly models = new Map<string, ProcessModel>();
+  readonly checkpoints = new Map<string, { tick: number }>();
+  failAt: StoreFailure | null = null;
+  /** Fail the Nth `putModel` of this store's lifetime (1-based). */
+  failPutModelOnCall: number | null = null;
+  private putModelCalls = 0;
+  private tail: Promise<unknown> = Promise.resolve();
+
+  async ready(): Promise<void> {}
+
+  async load(): Promise<TwinLoadResult> {
+    return { scanned: this.models.size, records: [], failures: [] };
+  }
+
+  transaction<T>(work: (tx: TwinStoreTransaction) => Promise<T>): Promise<T> {
+    // Serialised like the real store, so concurrent callers see one another's
+    // committed writes instead of interleaving on a stale staging snapshot.
+    return this.serialise(() => this.runTransaction(work));
+  }
+
+  /** The same queue, held without opening a transaction — as the real store. */
+  exclusive<T>(operation: () => Promise<T>): Promise<T> {
+    return this.serialise(operation);
+  }
+
+  private serialise<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.tail.catch(() => undefined).then(operation);
+    this.tail = run.catch(() => undefined);
+    return run;
+  }
+
+  private async runTransaction<T>(work: (tx: TwinStoreTransaction) => Promise<T>): Promise<T> {
+    const stagedModels = new Map(this.models);
+    const stagedCheckpoints = new Map(this.checkpoints);
+    const tx: TwinStoreTransaction = {
+      putModel: async (model, checkpoint) => {
+        this.putModelCalls += 1;
+        if (this.failAt === "putModel" || this.putModelCalls === this.failPutModelOnCall) {
+          throw new TwinPersistenceError("disk on fire");
+        }
+        stagedModels.set(model.id, model);
+        stagedCheckpoints.set(model.id, { tick: checkpoint.tick });
+      },
+      putCheckpoint: async (modelId, checkpoint) => {
+        if (this.failAt === "putCheckpoint") throw new TwinPersistenceError("disk on fire");
+        stagedCheckpoints.set(modelId, { tick: checkpoint.tick });
+      },
+      deleteModel: async (modelId) => {
+        if (this.failAt === "deleteModel") throw new TwinPersistenceError("disk on fire");
+        const existed = stagedModels.delete(modelId);
+        stagedCheckpoints.delete(modelId);
+        return existed;
+      },
+    };
+    const result = await work(tx);
+    if (this.failAt === "commit") throw new TwinPersistenceError("commit rejected");
+    this.models.clear();
+    for (const [id, model] of stagedModels) this.models.set(id, model);
+    this.checkpoints.clear();
+    for (const [id, checkpoint] of stagedCheckpoints) this.checkpoints.set(id, checkpoint);
+    return result;
+  }
+
+  backend(): "postgres" | "sqlite" | "unopened" {
+    return "unopened";
+  }
+
+  async close(): Promise<void> {}
+}
+
+describe("twin registry CRUD atomicity", () => {
+  let store: FailingStore;
+  let runtime: TwinRuntime;
+  let registry: PersistentTwinRegistry;
+
+  beforeEach(() => {
+    store = new FailingStore();
+    runtime = new TwinRuntime();
+    registry = new PersistentTwinRegistry(runtime, store);
+  });
+
+  it("does not register a model whose durable write fails", async () => {
+    store.failAt = "putModel";
+    await expect(registry.registerModel(valveTankModel())).rejects.toThrow("disk on fire");
+    expect(runtime.getModel("m1")).toBeUndefined();
+    expect(runtime.getStatus().models).toBe(0);
+    expect(store.models.size).toBe(0);
+  });
+
+  it("does not register a model whose commit fails", async () => {
+    store.failAt = "commit";
+    await expect(registry.registerModel(valveTankModel())).rejects.toThrow("commit rejected");
+    expect(runtime.getModel("m1")).toBeUndefined();
+    expect(store.models.size).toBe(0);
+  });
+
+  it("keeps the previous model, state and live actuals when a replacement fails", async () => {
+    await registry.registerModel(valveTankModel({ description: "rev A" }));
+    runtime.step("m1", 3);
+    runtime.ingestActual("TK-1.LEVEL", 47, 5_000);
+    runtime.setRunning("m1", true, 1_000);
+
+    store.failAt = "putModel";
+    const replacement = valveTankModel({ description: "rev B" });
+    await expect(registry.registerModel(replacement)).rejects.toThrow("disk on fire");
+
+    expect(runtime.getModel("m1")!.description).toBe("rev A");
+    const state = runtime.getState("m1")!;
+    expect(state.tick).toBe(3);
+    expect(state.status).toBe("running");
+    expect(runtime.compare("m1")[0].actual).toBe(47);
+    expect(store.models.get("m1")!.description).toBe("rev A");
+  });
+
+  it("keeps the model registered when its delete fails", async () => {
+    await registry.registerModel(valveTankModel());
+    runtime.step("m1", 2);
+
+    store.failAt = "deleteModel";
+    await expect(registry.removeModel("m1")).rejects.toThrow("disk on fire");
+
+    expect(runtime.getModel("m1")).toBeDefined();
+    expect(runtime.getState("m1")!.tick).toBe(2);
+    expect(store.models.has("m1")).toBe(true);
+  });
+
+  it("keeps the model registered when the delete commit fails", async () => {
+    await registry.registerModel(valveTankModel());
+    store.failAt = "commit";
+    await expect(registry.removeModel("m1")).rejects.toThrow("commit rejected");
+    expect(runtime.getModel("m1")).toBeDefined();
+    expect(store.models.has("m1")).toBe(true);
+  });
+
+  it("leaves the runtime untouched when a checkpoint commit fails", async () => {
+    await registry.registerModel(valveTankModel());
+    runtime.step("m1", 4);
+
+    store.failAt = "putCheckpoint";
+    await expect(registry.commitCheckpoint("m1")).rejects.toThrow("disk on fire");
+
+    expect(runtime.getState("m1")!.tick).toBe(4);
+    expect(store.checkpoints.get("m1")!.tick).toBe(0);
+  });
+
+  it("writes nothing when the runtime rejects the model", async () => {
+    const invalid = valveTankModel();
+    invalid.components[1].config.capacity = -5;
+    await expect(registry.registerModel(invalid)).rejects.toThrow(/capacity must be positive/);
+    expect(store.models.size).toBe(0);
+    expect(runtime.getStatus().models).toBe(0);
+  });
+
+  it("does not roll a concurrently committed registration out of the registry", async () => {
+    // Both requests arrive before either transaction runs; the second one's
+    // durable write fails. Its rollback must not undo the first one's commit,
+    // or storage would hold a model the runtime has forgotten.
+    store.failPutModelOnCall = 2;
+    const first = registry.registerModel(valveTankModel({ description: "rev A" }));
+    const second = registry.registerModel(valveTankModel({ description: "rev B" }));
+
+    await expect(first).resolves.toBeTruthy();
+    await expect(second).rejects.toThrow("disk on fire");
+
+    expect(store.models.get("m1")!.description).toBe("rev A");
+    expect(runtime.getModel("m1")?.description).toBe("rev A");
+  });
+
+  it("refuses to checkpoint a model that is not registered", async () => {
+    await expect(registry.commitCheckpoint("ghost")).rejects.toThrow('Unknown model "ghost"');
+    expect(store.checkpoints.size).toBe(0);
+  });
+});

--- a/server/services/twin/engine.ts
+++ b/server/services/twin/engine.ts
@@ -48,6 +48,35 @@ interface ModelEntry {
   nextStepAt?: number;
 }
 
+/**
+ * The durable part of a simulation: everything a checkpoint restores.
+ *
+ * `status` is absent on purpose — a restored simulation is always idle
+ * (#550). Live actuals are absent too: they are readings of the real plant
+ * that a restarted process must re-observe, not replay from disk.
+ */
+export interface TwinCheckpointState {
+  tick: number;
+  timeMs: number;
+  componentStates: Record<string, Record<string, number>>;
+  lastSyncAt?: number;
+}
+
+/**
+ * Deep-cloned snapshot of one registered model's complete runtime entry.
+ *
+ * Used only to roll the in-memory registry back when the durable write that
+ * accompanies a registry mutation fails, so storage and runtime cannot end up
+ * describing different models (#550).
+ */
+export interface TwinEntrySnapshot {
+  model: ProcessModel;
+  state: SimulationState;
+  actuals: Array<[string, { value: number; timestamp: number }]>;
+  appliedActualTimestamps: Array<[string, number]>;
+  nextStepAt?: number;
+}
+
 export class TwinRuntime extends EventEmitter {
   private readonly maxModels: number;
   private readonly maxStepWorkUnits: number;
@@ -88,6 +117,100 @@ export class TwinRuntime extends EventEmitter {
       appliedActualTimestamps: new Map(),
     });
     return structuredClone(state);
+  }
+
+  /**
+   * Throw if `model` is not a model this runtime would accept, without
+   * touching the registry. Lets a restore report say whether a stored row was
+   * refused for its definition or for its checkpoint (#550).
+   */
+  validateModelDefinition(model: ProcessModel): void {
+    this.validateModel(structuredClone(model));
+  }
+
+  /**
+   * Register a model together with a checkpoint restored from storage (#550).
+   *
+   * The checkpoint is validated against the model exactly as a solver result
+   * would be — an unknown component, a missing bound parameter, a non-finite
+   * value or a non-integer tick throws, so a corrupt or torn checkpoint is
+   * refused rather than admitted into the runtime.
+   *
+   * The restored simulation is ALWAYS idle. Nothing here starts a timer or
+   * schedules a tick: an authorized caller must explicitly start or step it.
+   */
+  restoreModel(model: ProcessModel, checkpoint: TwinCheckpointState): SimulationState {
+    const storedModel = structuredClone(model);
+    this.validateModel(storedModel);
+    if (!this.entries.has(storedModel.id) && this.entries.size >= this.maxModels) {
+      throw new Error(`Model limit (${this.maxModels}) reached`);
+    }
+    if (!Number.isSafeInteger(checkpoint.tick) || checkpoint.tick < 0) {
+      throw new Error('checkpoint tick must be a non-negative safe integer');
+    }
+    if (!Number.isFinite(checkpoint.timeMs) || checkpoint.timeMs < 0) {
+      throw new Error('checkpoint timeMs must be a non-negative finite number');
+    }
+    if (checkpoint.lastSyncAt !== undefined && !Number.isFinite(checkpoint.lastSyncAt)) {
+      throw new Error('checkpoint lastSyncAt must be finite when present');
+    }
+    const componentStates = structuredClone(checkpoint.componentStates);
+    this.assertValidStates(storedModel, componentStates);
+
+    const state: SimulationState = {
+      modelId: storedModel.id,
+      tick: checkpoint.tick,
+      timeMs: checkpoint.timeMs,
+      componentStates,
+      // Stopped is the safe state: a restart never resumes stepping.
+      status: 'idle',
+      ...(checkpoint.lastSyncAt !== undefined ? { lastSyncAt: checkpoint.lastSyncAt } : {}),
+    };
+    this.entries.set(storedModel.id, {
+      model: storedModel,
+      state,
+      actuals: new Map(),
+      appliedActualTimestamps: new Map(),
+    });
+    return structuredClone(state);
+  }
+
+  /**
+   * Deep-cloned snapshot of one entry, or undefined when the model is not
+   * registered. Paired with `restoreEntry` to undo a registry mutation whose
+   * durable write failed (#550).
+   */
+  exportEntry(modelId: string): TwinEntrySnapshot | undefined {
+    const entry = this.entries.get(modelId);
+    if (!entry) return undefined;
+    return {
+      model: structuredClone(entry.model),
+      state: structuredClone(entry.state),
+      actuals: structuredClone([...entry.actuals.entries()]),
+      appliedActualTimestamps: [...entry.appliedActualTimestamps.entries()],
+      nextStepAt: entry.nextStepAt,
+    };
+  }
+
+  /**
+   * Put the registry back exactly as `exportEntry` found it. An undefined
+   * snapshot means the model was not registered at snapshot time, so it is
+   * removed. Restores the entry verbatim, including a `running` status the
+   * caller had already set — this reverses a failed mutation, it does not
+   * start anything that was not already started.
+   */
+  restoreEntry(modelId: string, snapshot: TwinEntrySnapshot | undefined): void {
+    if (!snapshot) {
+      this.entries.delete(modelId);
+      return;
+    }
+    this.entries.set(modelId, {
+      model: structuredClone(snapshot.model),
+      state: structuredClone(snapshot.state),
+      actuals: new Map(structuredClone(snapshot.actuals)),
+      appliedActualTimestamps: new Map(snapshot.appliedActualTimestamps),
+      nextStepAt: snapshot.nextStepAt,
+    });
   }
 
   getModel(modelId: string): ProcessModel | undefined {

--- a/server/services/twin/index.ts
+++ b/server/services/twin/index.ts
@@ -6,14 +6,30 @@
  * tag updates into the runtime (numeric, good-quality readings only), and
  * exposes health. Read-only toward the plant — predictions never become
  * control writes here.
+ *
+ * #550: the model registry and one committed checkpoint per model are durable.
+ * `initialize()` reloads them, always in a stopped/idle state — a restart never
+ * resumes stepping or live-data assimilation on its own. Registry mutations go
+ * through `PersistentTwinRegistry`, which keeps storage and the in-memory
+ * registry inside the same transaction.
  */
 
 import { EventEmitter } from 'events';
 
 export * from './solver';
 export * from './engine';
+export * from './persistence';
+export * from './registry';
 
+import type {
+  ProcessModel,
+  SimulationState,
+  TwinCheckpoint,
+  TwinRestoreReport,
+} from '@shared/types/digital-twin';
 import { TwinRuntime } from './engine';
+import { twinStore, type TwinPersistence, type TwinStoreBackend } from './persistence';
+import { PersistentTwinRegistry } from './registry';
 
 export interface TwinTagUpdateInput {
   tagName: string;
@@ -22,16 +38,41 @@ export interface TwinTagUpdateInput {
   quality?: 'good' | 'bad' | 'uncertain';
 }
 
+/**
+ * What the twin can say about its durable state, for `/api/twin/status`.
+ *
+ * `configured: false` means this instance was constructed without a store and
+ * keeps nothing across a restart. It is reported rather than implied, because
+ * a twin that silently forgets its models is the defect #550 removed.
+ */
+export interface TwinPersistenceStatus {
+  configured: boolean;
+  backend: TwinStoreBackend;
+  /** Set when the last restore attempt could not read storage at all. */
+  error?: string;
+  lastRestore?: TwinRestoreReport;
+}
+
 export class DigitalTwinService extends EventEmitter {
   readonly runtime = new TwinRuntime();
+  private readonly registry: PersistentTwinRegistry | null;
 
   private initialized = false;
   private stepTimer: NodeJS.Timeout | null = null;
   private readonly stepIntervalMs: number;
+  private restoreError: string | undefined;
 
-  constructor(stepIntervalMs = 100) {
+  /**
+   * @param persistence durable store, or null for an ephemeral runtime — the
+   *   default, so constructing a service never opens a database handle.
+   */
+  constructor(
+    stepIntervalMs = 100,
+    private readonly persistence: TwinPersistence | null = null,
+  ) {
     super();
     this.stepIntervalMs = stepIntervalMs;
+    this.registry = persistence ? new PersistentTwinRegistry(this.runtime, persistence) : null;
     this.runtime.on('model-error', (e) => this.emit('model-error', e));
     this.runtime.on('model-warnings', (e) => this.emit('model-warnings', e));
   }
@@ -39,6 +80,21 @@ export class DigitalTwinService extends EventEmitter {
   async initialize(): Promise<void> {
     if (this.initialized) return;
     this.initialized = true;
+    if (this.registry) {
+      try {
+        const report = await this.registry.restore();
+        this.restoreError = undefined;
+        if (report.failed.length > 0) {
+          this.emit('restore-failures', { failures: report.failed });
+        }
+      } catch (error) {
+        // Reads degrade visibly rather than silently: the runtime starts
+        // empty, and every later registry mutation still goes through the
+        // store, so it fails loudly instead of pretending to persist.
+        this.restoreError = error instanceof Error ? error.message : String(error);
+        this.emit('restore-error', { error: this.restoreError });
+      }
+    }
     this.stepTimer = setInterval(() => {
       try {
         const now = Date.now();
@@ -57,6 +113,44 @@ export class DigitalTwinService extends EventEmitter {
       this.stepTimer = null;
     }
     this.initialized = false;
+    if (this.persistence) await this.persistence.close();
+  }
+
+  /**
+   * Register a model. With a store configured, the definition and its initial
+   * checkpoint are committed in the same transaction as the in-memory
+   * registration, so a failure leaves neither behind.
+   */
+  async registerModel(model: ProcessModel): Promise<SimulationState> {
+    if (!this.registry) return this.runtime.registerModel(model);
+    return this.registry.registerModel(model);
+  }
+
+  /** Remove a model from the runtime and storage atomically. */
+  async removeModel(modelId: string): Promise<boolean> {
+    if (!this.registry) return this.runtime.removeModel(modelId);
+    return this.registry.removeModel(modelId);
+  }
+
+  /**
+   * Commit the model's current simulation state as its durable checkpoint —
+   * the state a restart would restore, always brought back idle.
+   */
+  async commitCheckpoint(modelId: string): Promise<TwinCheckpoint> {
+    if (!this.registry) {
+      throw new Error('Digital twin persistence is not configured; cannot commit a checkpoint');
+    }
+    return this.registry.commitCheckpoint(modelId);
+  }
+
+  persistenceStatus(): TwinPersistenceStatus {
+    const lastRestore = this.registry?.lastRestore();
+    return {
+      configured: this.registry !== null,
+      backend: this.persistence?.backend() ?? 'unopened',
+      ...(this.restoreError !== undefined ? { error: this.restoreError } : {}),
+      ...(lastRestore !== undefined ? { lastRestore } : {}),
+    };
   }
 
   /** Feed a live tag update — non-numeric or non-good readings are ignored */
@@ -85,4 +179,4 @@ export class DigitalTwinService extends EventEmitter {
   }
 }
 
-export const digitalTwinService = new DigitalTwinService();
+export const digitalTwinService = new DigitalTwinService(100, twinStore);

--- a/server/services/twin/persistence.ts
+++ b/server/services/twin/persistence.ts
@@ -1,0 +1,830 @@
+/**
+ * Durable digital-twin model registry and simulation checkpoints
+ * ADR-0013 [13.3] — Issue #550
+ *
+ * The twin runtime (`./engine.ts`) keeps its model registry and simulation
+ * state in process memory. This module is the durable half: it stores the
+ * registered `ProcessModel` definitions and, per model, the LAST EXPLICITLY
+ * COMMITTED simulation checkpoint, so both survive a restart.
+ *
+ * What is deliberately NOT stored is the run status. A restored simulation
+ * always comes back idle; nothing here can express "resume stepping on boot"
+ * (see `TwinRuntime.restoreModel`). The twin stays advisory and read-only
+ * toward the plant (ADR-0009), so no row here is or can become a control
+ * write.
+ *
+ * Two backends, matching `server/services/tuning/audit-store.ts`:
+ *   - PostgreSQL (production) via drizzle-orm/node-postgres
+ *   - SQLite (development/test fallback) via drizzle-orm/sqlite-proxy over the
+ *     repo's `sqlite3` driver
+ *
+ * The store owns its own connection rather than borrowing the shared handle in
+ * `server/storage.ts`, which serialises every caller behind one connection and
+ * one application-level transaction mutex: a twin registry write must not be
+ * rolled back by an unrelated storage transaction.
+ *
+ * Every registry mutation runs inside a real database transaction, and the
+ * caller mutates the in-memory registry inside that same transaction (see
+ * `./registry.ts`), so storage and runtime cannot diverge.
+ */
+
+import path from "node:path";
+import { eq, sql } from "drizzle-orm";
+import { drizzle as drizzlePostgres, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import {
+  drizzle as drizzleSqliteProxy,
+  type SqliteRemoteDatabase,
+} from "drizzle-orm/sqlite-proxy";
+import { Client } from "pg";
+import { Database } from "sqlite3";
+import { z } from "zod";
+import {
+  twinCheckpoints as pgCheckpoints,
+  twinModels as pgModels,
+} from "@shared/schema";
+import {
+  twinCheckpoints as sqliteCheckpoints,
+  twinModels as sqliteModels,
+} from "@shared/schema-sqlite";
+import {
+  TWIN_CHECKPOINT_SCHEMA_VERSION,
+  TWIN_MODEL_SCHEMA_VERSION,
+  type ProcessModel,
+  type TwinRestoreFailure,
+} from "@shared/types/digital-twin";
+import type { TwinCheckpointState } from "./engine";
+
+export type TwinStoreBackend = "postgres" | "sqlite" | "unopened";
+
+/**
+ * Raised when the database itself refused or failed a twin operation, as
+ * opposed to the runtime refusing the model or the payload exceeding the
+ * persistence cap. Callers use it to tell "this request is wrong" from "the
+ * twin could not durably hold this, try again" — a distinction that matters
+ * because the twin refuses to register anything it cannot store.
+ */
+export class TwinPersistenceError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "TwinPersistenceError";
+  }
+}
+
+async function asStoreFailure<T>(label: string, work: () => Promise<T>): Promise<T> {
+  try {
+    return await work();
+  } catch (error) {
+    if (error instanceof TwinPersistenceError) throw error;
+    throw new TwinPersistenceError(`${label}: ${describe(error)}`, { cause: error });
+  }
+}
+
+/** One stored model together with the checkpoint written alongside it. */
+export interface TwinStoredRecord {
+  model: ProcessModel;
+  checkpoint: TwinCheckpointState;
+}
+
+/**
+ * Outcome of reading the whole store. Rows that could not be decoded are
+ * reported, never repaired: they stay in storage untouched for an operator to
+ * inspect, and they never stop the remaining rows from loading.
+ */
+export interface TwinLoadResult {
+  /** Model rows examined */
+  scanned: number;
+  records: TwinStoredRecord[];
+  failures: TwinRestoreFailure[];
+}
+
+/** Mutations available inside one store transaction. */
+export interface TwinStoreTransaction {
+  /** Upsert a model and its checkpoint together — never one without the other. */
+  putModel(
+    model: ProcessModel,
+    checkpoint: TwinCheckpointState,
+    committedAt: number,
+  ): Promise<void>;
+  /** Replace the committed checkpoint of an already-stored model. */
+  putCheckpoint(
+    modelId: string,
+    checkpoint: TwinCheckpointState,
+    committedAt: number,
+  ): Promise<void>;
+  /** Remove a model and its checkpoint. Resolves false when no row existed. */
+  deleteModel(modelId: string): Promise<boolean>;
+}
+
+export interface TwinPersistence {
+  /** Open the connection and ensure the tables exist. Safe to call repeatedly. */
+  ready(): Promise<void>;
+  /**
+   * Read every stored model and checkpoint.
+   *
+   * NOT serialised against mutations on its own: the rows it returns are a
+   * snapshot of the moment the read ran, and a transaction can commit while
+   * that result is still in flight. A caller that then ACTS on those rows —
+   * the restore pass rebuilding the in-memory registry — must run the read and
+   * whatever it does with the result inside `exclusive()`. Otherwise it can
+   * apply a stale snapshot over a newer committed write and leave storage and
+   * the runtime describing different models (#550).
+   */
+  load(): Promise<TwinLoadResult>;
+  /**
+   * Run `work` inside one database transaction. Everything `work` does is
+   * committed together or rolled back together; a throw from `work` rolls the
+   * transaction back and propagates.
+   */
+  transaction<T>(work: (tx: TwinStoreTransaction) => Promise<T>): Promise<T>;
+  /**
+   * Run `operation` with exclusive access to the store: no `transaction()`
+   * begins while it is in flight, and it begins only once every transaction
+   * queued ahead of it has finished.
+   *
+   * Unlike `transaction()` it opens no database transaction — it is the mutual
+   * exclusion alone, for a caller that must read the store and then act on
+   * what it read without a mutation slipping into the gap.
+   *
+   * Not reentrant: `operation` must not call `exclusive()` or `transaction()`
+   * on the same store, which would wait on a lock it already holds. `load()`
+   * takes no lock and is safe to call inside it.
+   */
+  exclusive<T>(operation: () => Promise<T>): Promise<T>;
+  backend(): TwinStoreBackend;
+  close(): Promise<void>;
+}
+
+/**
+ * Byte cap for one stored JSON payload.
+ *
+ * Chosen to sit above what the runtime's own structural limits can produce, so
+ * a model the runtime accepts is a model the store can hold: 500 components ×
+ * (128 config + 128 initial-state fields) × ~72 bytes for a maximum-length
+ * (64-char) parameter name and value is roughly 9 MB, plus component names,
+ * connections and tag bindings. Anything larger is refused outright — a
+ * checkpoint is never truncated, because a silently shortened state record is
+ * indistinguishable from a fabricated one.
+ */
+export const MAX_PERSISTED_PAYLOAD_BYTES = 16 * 1024 * 1024;
+
+// ── Stored-payload decoders ────────────────────────────────────────────────
+//
+// These check the JS shape of a decoded row: that it is an object of the right
+// kind with the right primitive types, that `type` is a component type this
+// build knows, and that the string fields are bounded. Domain validation
+// (connection targets, solver support, parameter counts, finiteness of every
+// state value, the checkpoint matching the model's components) is the
+// runtime's job and runs afterwards in `TwinRuntime.restoreModel`, which is
+// the same validation a freshly registered model goes through. A row that
+// fails either layer is refused; neither layer repairs it.
+
+const parameterRecordSchema = z.record(z.string(), z.number());
+
+const componentSchema = z.object({
+  id: z.string().min(1).max(128),
+  type: z.enum(["tank", "pipe", "valve", "pump", "controller", "sensor", "heater", "mixer"]),
+  name: z.string().min(1).max(256),
+  config: parameterRecordSchema,
+  initialState: parameterRecordSchema,
+  connections: z.array(z.string().min(1)),
+  pvSource: z.string().min(1).optional(),
+});
+
+const storedModelSchema = z.object({
+  id: z.string().min(1).max(128),
+  name: z.string().min(1).max(256),
+  description: z.string().max(2000).optional(),
+  components: z.array(componentSchema).min(1),
+  tagBindings: z.array(
+    z.object({
+      tagId: z.string().min(1).max(256),
+      componentId: z.string().min(1),
+      parameter: z.string().min(1).max(64),
+    }),
+  ),
+  stepFunction: z.string().min(1),
+  timeStepMs: z.number(),
+});
+
+const storedComponentStatesSchema = z.record(z.string(), parameterRecordSchema);
+
+function describe(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length > 500 ? `${message.slice(0, 500)}…` : message;
+}
+
+function assertWithinPayloadCap(label: string, payload: unknown): string {
+  const serialized = JSON.stringify(payload);
+  if (serialized === undefined) {
+    throw new Error(`${label} is not JSON-serialisable`);
+  }
+  const bytes = Buffer.byteLength(serialized, "utf8");
+  if (bytes > MAX_PERSISTED_PAYLOAD_BYTES) {
+    throw new Error(
+      `${label} is ${bytes} bytes, over the ${MAX_PERSISTED_PAYLOAD_BYTES}-byte persistence limit`,
+    );
+  }
+  return serialized;
+}
+
+/**
+ * JSON columns come back already parsed on Postgres (jsonb) and as text on
+ * SQLite, so both are normalised here. Invalid JSON is a per-row failure, not
+ * a failure of the whole load.
+ */
+function decodeJsonColumn(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  return JSON.parse(value) as unknown;
+}
+
+// ── Connection plumbing ────────────────────────────────────────────────────
+
+/**
+ * SQLite DDL. `migrations/0014_twin_persistence.sql` is the Postgres source of
+ * truth; this mirrors it for the dev/test fallback, including the cascade from
+ * model to checkpoint, so deletion is atomic on both backends.
+ */
+const SQLITE_DDL = `
+CREATE TABLE IF NOT EXISTS twin_models (
+  id TEXT PRIMARY KEY,
+  schema_version INTEGER NOT NULL,
+  definition TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS twin_checkpoints (
+  model_id TEXT PRIMARY KEY REFERENCES twin_models(id) ON DELETE CASCADE,
+  schema_version INTEGER NOT NULL,
+  tick INTEGER NOT NULL CHECK (tick >= 0),
+  time_ms REAL NOT NULL,
+  component_states TEXT NOT NULL,
+  last_sync_at INTEGER,
+  committed_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_twin_checkpoints_committed_at
+  ON twin_checkpoints(committed_at);
+`;
+
+type SqliteDrizzle = SqliteRemoteDatabase<Record<string, never>>;
+type PostgresDrizzle = NodePgDatabase<Record<string, never>>;
+
+interface PostgresConnection {
+  kind: "postgres";
+  client: Client;
+  db: PostgresDrizzle;
+}
+
+interface SqliteConnection {
+  kind: "sqlite";
+  client: Database;
+  db: SqliteDrizzle;
+}
+
+type Connection = PostgresConnection | SqliteConnection;
+
+export interface TwinStoreOptions {
+  /** Explicit PostgreSQL URL; defaults to the DATABASE_URL selection below. */
+  postgresUrl?: string;
+  /** Explicit SQLite file; defaults to TWIN_STATE_SQLITE_PATH/SQLITE_DATABASE_PATH. */
+  sqlitePath?: string;
+}
+
+/**
+ * Mirrors `server/storage.ts` and the tuning audit store: Postgres only when a
+ * URL is configured, the Postgres override is not disabled, and the process is
+ * not in development mode. Everything else falls back to the file-backed
+ * SQLite database.
+ */
+function resolvePostgresUrl(options: TwinStoreOptions): string | undefined {
+  if (options.postgresUrl) return options.postgresUrl;
+  const url = process.env.DATABASE_URL;
+  if (!url) return undefined;
+  if (process.env.FORCE_POSTGRES === "false") return undefined;
+  if (process.env.NODE_ENV === "development") return undefined;
+  return url;
+}
+
+function resolveSqlitePath(options: TwinStoreOptions): string {
+  return options.sqlitePath
+    ?? process.env.TWIN_STATE_SQLITE_PATH
+    ?? process.env.SQLITE_DATABASE_PATH
+    ?? path.join(process.cwd(), "dev-database.sqlite");
+}
+
+function sqliteExec(client: Database, sqlText: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client.exec(sqlText, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function sqliteRun(client: Database, sqlText: string, params: unknown[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client.run(sqlText, params, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function sqliteAll(
+  client: Database,
+  sqlText: string,
+  params: unknown[],
+): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve, reject) => {
+    client.all(sqlText, params, (error, rows) =>
+      error ? reject(error) : resolve(rows as Record<string, unknown>[]));
+  });
+}
+
+/**
+ * drizzle-orm's SQLite proxy driver maps result columns positionally, while
+ * node-sqlite3 hands back objects in result-column order. Every selection this
+ * module issues names distinct columns, so ordered values reconstruct the
+ * positional row exactly.
+ */
+function positionalRow(row: Record<string, unknown>): unknown[] {
+  return Object.values(row);
+}
+
+interface RawModelRow {
+  id: unknown;
+  schemaVersion: unknown;
+  definition: unknown;
+}
+
+interface RawCheckpointRow {
+  modelId: unknown;
+  schemaVersion: unknown;
+  tick: unknown;
+  timeMs: unknown;
+  componentStates: unknown;
+  lastSyncAt: unknown;
+}
+
+export class DrizzleTwinStore implements TwinPersistence {
+  private connection: Connection | undefined;
+  private opening: Promise<Connection> | undefined;
+  /**
+   * The store owns a single physical connection, so transactions must not
+   * interleave on it: without this, a concurrent caller's statements could be
+   * committed or rolled back by someone else's transaction.
+   */
+  private lockTail: Promise<void> = Promise.resolve();
+
+  constructor(private readonly options: TwinStoreOptions = {}) {}
+
+  backend(): TwinStoreBackend {
+    return this.connection?.kind ?? "unopened";
+  }
+
+  async ready(): Promise<void> {
+    await this.connect();
+  }
+
+  async load(): Promise<TwinLoadResult> {
+    const connection = await this.connect();
+    const modelRows = await asStoreFailure(
+      "reading stored twin models",
+      () => this.selectModelRows(connection),
+    );
+    const checkpointRows = await asStoreFailure(
+      "reading stored twin checkpoints",
+      () => this.selectCheckpointRows(connection),
+    );
+
+    const checkpointsByModel = new Map<string, RawCheckpointRow>();
+    for (const row of checkpointRows) {
+      if (typeof row.modelId === "string") checkpointsByModel.set(row.modelId, row);
+    }
+
+    const records: TwinStoredRecord[] = [];
+    const failures: TwinRestoreFailure[] = [];
+
+    for (const modelRow of modelRows) {
+      const modelId = typeof modelRow.id === "string" ? modelRow.id : "(unreadable id)";
+      let model: ProcessModel;
+      try {
+        model = this.decodeModel(modelRow);
+      } catch (error) {
+        failures.push({ modelId, stage: "model", reason: describe(error) });
+        continue;
+      }
+      if (model.id !== modelId) {
+        failures.push({
+          modelId,
+          stage: "model",
+          reason: `stored definition declares id "${model.id}", row key is "${modelId}"`,
+        });
+        continue;
+      }
+
+      const checkpointRow = checkpointsByModel.get(modelId);
+      if (!checkpointRow) {
+        // Models and checkpoints are always written in one transaction, so a
+        // model without a checkpoint is a torn write. Seeding it from authored
+        // initial conditions would substitute invented state for real state.
+        failures.push({
+          modelId,
+          stage: "checkpoint",
+          reason: "no committed checkpoint stored for this model (torn write)",
+        });
+        continue;
+      }
+      try {
+        records.push({ model, checkpoint: this.decodeCheckpoint(checkpointRow) });
+      } catch (error) {
+        failures.push({ modelId, stage: "checkpoint", reason: describe(error) });
+      }
+    }
+
+    return { scanned: modelRows.length, records, failures };
+  }
+
+  async transaction<T>(work: (tx: TwinStoreTransaction) => Promise<T>): Promise<T> {
+    const connection = await this.connect();
+    return this.withLock(async () => {
+      await asStoreFailure("opening a twin store transaction", () => this.begin(connection));
+      let result: T;
+      try {
+        result = await work(this.transactionApi(connection));
+      } catch (error) {
+        await this.rollbackQuietly(connection);
+        throw error;
+      }
+      try {
+        await asStoreFailure(
+          "committing a twin store transaction",
+          () => this.exec(connection, "COMMIT"),
+        );
+      } catch (error) {
+        await this.rollbackQuietly(connection);
+        throw error;
+      }
+      return result;
+    });
+  }
+
+  /**
+   * The transaction mutex without a transaction. `load()` takes no lock, so a
+   * caller may read inside `operation` without deadlocking this non-reentrant
+   * lock; opening a nested transaction or a nested `exclusive` would deadlock.
+   */
+  exclusive<T>(operation: () => Promise<T>): Promise<T> {
+    return this.withLock(operation);
+  }
+
+  async close(): Promise<void> {
+    const opening = this.opening;
+    const connection = this.connection;
+    // Cleared before any await, so a second close() cannot reach the same
+    // handle and close it twice.
+    this.connection = undefined;
+    this.opening = undefined;
+    if (connection) {
+      await this.closeConnection(connection);
+      return;
+    }
+    if (!opening) return;
+    // close() raced the first connect(): returning now would leave the handle
+    // that open is about to produce owned by nobody and never released. Wait
+    // for it and close that instead. A failed open has no handle to release,
+    // and its error belongs to the caller that asked for the connection.
+    const opened = await opening.catch(() => undefined);
+    // `connect()` publishes the connection as it resolves, so undo that too.
+    if (this.connection === opened) this.connection = undefined;
+    if (opened) await this.closeConnection(opened);
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────────
+
+  private async closeConnection(connection: Connection): Promise<void> {
+    if (connection.kind === "postgres") {
+      await connection.client.end();
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      connection.client.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+
+  private transactionApi(connection: Connection): TwinStoreTransaction {
+    return {
+      putModel: async (model, checkpoint, committedAt) => {
+        // Cap breaches are the caller's problem, not the database's, so they
+        // stay plain errors and are raised before anything is written.
+        assertWithinPayloadCap(`model "${model.id}" definition`, model);
+        assertWithinPayloadCap(`checkpoint for model "${model.id}"`, checkpoint.componentStates);
+        const now = new Date(committedAt);
+        await asStoreFailure(`storing twin model "${model.id}"`, async () => {
+          if (connection.kind === "postgres") {
+            await connection.db
+              .insert(pgModels)
+              .values({
+                id: model.id,
+                schemaVersion: TWIN_MODEL_SCHEMA_VERSION,
+                definition: model,
+                createdAt: now,
+                updatedAt: now,
+              })
+              .onConflictDoUpdate({
+                target: pgModels.id,
+                // created_at deliberately untouched: it records first registration.
+                set: {
+                  schemaVersion: TWIN_MODEL_SCHEMA_VERSION,
+                  definition: model,
+                  updatedAt: now,
+                },
+              });
+          } else {
+            await connection.db
+              .insert(sqliteModels)
+              .values({
+                id: model.id,
+                schemaVersion: TWIN_MODEL_SCHEMA_VERSION,
+                definition: model,
+                createdAt: now,
+                updatedAt: now,
+              })
+              .onConflictDoUpdate({
+                target: sqliteModels.id,
+                set: {
+                  schemaVersion: TWIN_MODEL_SCHEMA_VERSION,
+                  definition: model,
+                  updatedAt: now,
+                },
+              });
+          }
+        });
+        await this.writeCheckpoint(connection, model.id, checkpoint, committedAt);
+      },
+
+      putCheckpoint: async (modelId, checkpoint, committedAt) => {
+        assertWithinPayloadCap(`checkpoint for model "${modelId}"`, checkpoint.componentStates);
+        await this.writeCheckpoint(connection, modelId, checkpoint, committedAt);
+      },
+
+      deleteModel: (modelId) => asStoreFailure(
+        `deleting twin model "${modelId}"`,
+        async () => {
+          if (connection.kind === "postgres") {
+            const existing = await connection.db
+              .select({ id: pgModels.id })
+              .from(pgModels)
+              .where(eq(pgModels.id, modelId));
+            if (existing.length === 0) return false;
+            await connection.db.delete(pgCheckpoints).where(eq(pgCheckpoints.modelId, modelId));
+            await connection.db.delete(pgModels).where(eq(pgModels.id, modelId));
+            return true;
+          }
+          const existing = await connection.db
+            .select({ id: sqliteModels.id })
+            .from(sqliteModels)
+            .where(eq(sqliteModels.id, modelId));
+          if (existing.length === 0) return false;
+          await connection.db
+            .delete(sqliteCheckpoints)
+            .where(eq(sqliteCheckpoints.modelId, modelId));
+          await connection.db.delete(sqliteModels).where(eq(sqliteModels.id, modelId));
+          return true;
+        },
+      ),
+    };
+  }
+
+  private async writeCheckpoint(
+    connection: Connection,
+    modelId: string,
+    checkpoint: TwinCheckpointState,
+    committedAt: number,
+  ): Promise<void> {
+    if (!Number.isSafeInteger(checkpoint.tick) || checkpoint.tick < 0) {
+      throw new Error(`checkpoint for model "${modelId}" has a non-integer tick`);
+    }
+    if (!Number.isFinite(checkpoint.timeMs)) {
+      throw new Error(`checkpoint for model "${modelId}" has a non-finite clock`);
+    }
+    const values = {
+      modelId,
+      schemaVersion: TWIN_CHECKPOINT_SCHEMA_VERSION,
+      tick: checkpoint.tick,
+      timeMs: checkpoint.timeMs,
+      componentStates: checkpoint.componentStates,
+      lastSyncAt: checkpoint.lastSyncAt ?? null,
+      committedAt: new Date(committedAt),
+    };
+    const set = {
+      schemaVersion: values.schemaVersion,
+      tick: values.tick,
+      timeMs: values.timeMs,
+      componentStates: values.componentStates,
+      lastSyncAt: values.lastSyncAt,
+      committedAt: values.committedAt,
+    };
+    await asStoreFailure(`storing checkpoint for twin model "${modelId}"`, async () => {
+      if (connection.kind === "postgres") {
+        await connection.db
+          .insert(pgCheckpoints)
+          .values(values)
+          .onConflictDoUpdate({ target: pgCheckpoints.modelId, set });
+      } else {
+        await connection.db
+          .insert(sqliteCheckpoints)
+          .values(values)
+          .onConflictDoUpdate({ target: sqliteCheckpoints.modelId, set });
+      }
+    });
+  }
+
+  private decodeModel(row: RawModelRow): ProcessModel {
+    if (row.schemaVersion !== TWIN_MODEL_SCHEMA_VERSION) {
+      throw new Error(
+        `unsupported model schema version ${String(row.schemaVersion)} `
+        + `(this build stores version ${TWIN_MODEL_SCHEMA_VERSION})`,
+      );
+    }
+    const decoded = storedModelSchema.safeParse(decodeJsonColumn(row.definition));
+    if (!decoded.success) {
+      throw new Error(`stored definition is not a process model: ${decoded.error.issues
+        .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+        .join("; ")}`);
+    }
+    return decoded.data as ProcessModel;
+  }
+
+  private decodeCheckpoint(row: RawCheckpointRow): TwinCheckpointState {
+    if (row.schemaVersion !== TWIN_CHECKPOINT_SCHEMA_VERSION) {
+      throw new Error(
+        `unsupported checkpoint schema version ${String(row.schemaVersion)} `
+        + `(this build stores version ${TWIN_CHECKPOINT_SCHEMA_VERSION})`,
+      );
+    }
+    if (typeof row.tick !== "number" || !Number.isSafeInteger(row.tick) || row.tick < 0) {
+      throw new Error(`stored tick ${String(row.tick)} is not a non-negative integer`);
+    }
+    if (typeof row.timeMs !== "number" || !Number.isFinite(row.timeMs)) {
+      throw new Error(`stored clock ${String(row.timeMs)} is not finite`);
+    }
+    if (
+      row.lastSyncAt !== null
+      && row.lastSyncAt !== undefined
+      && (typeof row.lastSyncAt !== "number" || !Number.isFinite(row.lastSyncAt))
+    ) {
+      throw new Error(`stored lastSyncAt ${String(row.lastSyncAt)} is not finite`);
+    }
+    const decoded = storedComponentStatesSchema.safeParse(
+      decodeJsonColumn(row.componentStates),
+    );
+    if (!decoded.success) {
+      throw new Error(`stored component states are malformed: ${decoded.error.issues
+        .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+        .join("; ")}`);
+    }
+    return {
+      tick: row.tick,
+      timeMs: row.timeMs,
+      componentStates: decoded.data,
+      ...(typeof row.lastSyncAt === "number" ? { lastSyncAt: row.lastSyncAt } : {}),
+    };
+  }
+
+  private async selectModelRows(connection: Connection): Promise<RawModelRow[]> {
+    if (connection.kind === "postgres") {
+      return connection.db
+        .select({
+          id: pgModels.id,
+          schemaVersion: pgModels.schemaVersion,
+          // Read the payload as text on both dialects so a row whose JSON is
+          // unreadable fails on its own instead of aborting the whole load.
+          definition: sql<string>`${pgModels.definition}::text`,
+        })
+        .from(pgModels);
+    }
+    return connection.db
+      .select({
+        id: sqliteModels.id,
+        schemaVersion: sqliteModels.schemaVersion,
+        definition: sql<string>`${sqliteModels.definition}`,
+      })
+      .from(sqliteModels);
+  }
+
+  private async selectCheckpointRows(connection: Connection): Promise<RawCheckpointRow[]> {
+    if (connection.kind === "postgres") {
+      return connection.db
+        .select({
+          modelId: pgCheckpoints.modelId,
+          schemaVersion: pgCheckpoints.schemaVersion,
+          tick: pgCheckpoints.tick,
+          timeMs: pgCheckpoints.timeMs,
+          componentStates: sql<string>`${pgCheckpoints.componentStates}::text`,
+          lastSyncAt: pgCheckpoints.lastSyncAt,
+        })
+        .from(pgCheckpoints);
+    }
+    return connection.db
+      .select({
+        modelId: sqliteCheckpoints.modelId,
+        schemaVersion: sqliteCheckpoints.schemaVersion,
+        tick: sqliteCheckpoints.tick,
+        timeMs: sqliteCheckpoints.timeMs,
+        componentStates: sql<string>`${sqliteCheckpoints.componentStates}`,
+        lastSyncAt: sqliteCheckpoints.lastSyncAt,
+      })
+      .from(sqliteCheckpoints);
+  }
+
+  private async withLock<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.lockTail.catch(() => undefined);
+    let release!: () => void;
+    this.lockTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private begin(connection: Connection): Promise<void> {
+    // BEGIN IMMEDIATE takes the SQLite write lock up front, so a concurrent
+    // writer fails at BEGIN rather than half-way through the transaction.
+    return this.exec(connection, connection.kind === "sqlite" ? "BEGIN IMMEDIATE" : "BEGIN");
+  }
+
+  private async exec(connection: Connection, statement: string): Promise<void> {
+    if (connection.kind === "postgres") {
+      await connection.client.query(statement);
+      return;
+    }
+    await sqliteRun(connection.client, statement, []);
+  }
+
+  private async rollbackQuietly(connection: Connection): Promise<void> {
+    try {
+      await this.exec(connection, "ROLLBACK");
+    } catch {
+      // A ROLLBACK that itself fails leaves the connection unusable rather
+      // than the data half-written; the original error is the one that
+      // matters and is rethrown by the caller.
+    }
+  }
+
+  private connect(): Promise<Connection> {
+    if (this.connection) return Promise.resolve(this.connection);
+    if (this.opening) return this.opening;
+
+    this.opening = this.openConnection()
+      .then((connection) => {
+        this.connection = connection;
+        return connection;
+      })
+      .catch((error: unknown) => {
+        // Let the next caller retry rather than caching a failed connection.
+        this.opening = undefined;
+        throw new TwinPersistenceError(
+          `opening the twin store: ${describe(error)}`,
+          { cause: error },
+        );
+      });
+    return this.opening;
+  }
+
+  private async openConnection(): Promise<Connection> {
+    const postgresUrl = resolvePostgresUrl(this.options);
+    if (postgresUrl) {
+      const client = new Client({ connectionString: postgresUrl });
+      await client.connect();
+      return { kind: "postgres", client, db: drizzlePostgres(client) };
+    }
+
+    const filePath = resolveSqlitePath(this.options);
+    const client = await new Promise<Database>((resolve, reject) => {
+      const opened: Database = new Database(filePath, (error) =>
+        error ? reject(error) : resolve(opened));
+    });
+    // Per-connection, and must be set outside a transaction: without it SQLite
+    // parses the model→checkpoint foreign key but does not enforce it.
+    await sqliteExec(client, "PRAGMA foreign_keys = ON;");
+    await sqliteExec(client, SQLITE_DDL);
+
+    const db = drizzleSqliteProxy(async (sqlText, params, method) => {
+      if (method === "run") {
+        await sqliteRun(client, sqlText, params);
+        return { rows: [] };
+      }
+      const rows = await sqliteAll(client, sqlText, params);
+      if (method === "get") {
+        return { rows: rows.length > 0 ? positionalRow(rows[0]) : [] };
+      }
+      return { rows: rows.map(positionalRow) };
+    });
+
+    return { kind: "sqlite", client, db };
+  }
+}
+
+/**
+ * Process-wide twin store. Connects lazily on first use so importing the twin
+ * service never opens a database handle.
+ */
+export const twinStore: TwinPersistence = new DrizzleTwinStore();

--- a/server/services/twin/registry.ts
+++ b/server/services/twin/registry.ts
@@ -1,0 +1,218 @@
+/**
+ * Transactional digital-twin registry
+ * ADR-0013 [13.3] — Issue #550
+ *
+ * Binds the in-memory `TwinRuntime` to durable storage so the two cannot
+ * diverge. Every mutation runs inside one database transaction, and the
+ * in-memory mutation happens *inside* that transaction:
+ *
+ *   - the runtime rejects the model  → nothing was written, nothing changed
+ *   - the durable write fails        → the transaction rolls back AND the
+ *                                      registry is restored from the snapshot
+ *                                      taken before the mutation
+ *   - the COMMIT fails               → same rollback, same restore
+ *
+ * so a caller never observes a model that is registered but not stored, or
+ * stored but not registered.
+ *
+ * Restore is deliberately conservative: models come back IDLE, and a stored
+ * row this build cannot decode is refused for that model alone and left in
+ * storage untouched. Nothing is repaired, re-seeded or invented on its behalf.
+ * It holds the store exclusively while it reads AND while it applies what it
+ * read, so a mutation arriving mid-restore is ordered against it instead of
+ * being overwritten in memory by rows the restore had already taken.
+ */
+
+import type {
+  ProcessModel,
+  SimulationState,
+  TwinCheckpoint,
+  TwinRestoreFailure,
+  TwinRestoreReport,
+} from "@shared/types/digital-twin";
+import { TWIN_CHECKPOINT_SCHEMA_VERSION } from "@shared/types/digital-twin";
+import type { TwinCheckpointState, TwinEntrySnapshot, TwinRuntime } from "./engine";
+import type { TwinPersistence } from "./persistence";
+
+function describe(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length > 500 ? `${message.slice(0, 500)}…` : message;
+}
+
+/** The durable projection of a live simulation state (status excluded). */
+function checkpointStateOf(state: SimulationState): TwinCheckpointState {
+  return {
+    tick: state.tick,
+    timeMs: state.timeMs,
+    componentStates: state.componentStates,
+    ...(state.lastSyncAt !== undefined ? { lastSyncAt: state.lastSyncAt } : {}),
+  };
+}
+
+export class PersistentTwinRegistry {
+  private restoreReport: TwinRestoreReport | undefined;
+  /**
+   * Ids whose stored rows the last restore refused. They are not in the
+   * runtime, but they are still in storage, so a delete must be able to reach
+   * them — otherwise an undecodable row would be unremovable.
+   */
+  private readonly refusedModelIds = new Set<string>();
+
+  constructor(
+    private readonly runtime: TwinRuntime,
+    private readonly store: TwinPersistence,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  /** The last restore pass, or undefined if none has run in this process. */
+  lastRestore(): TwinRestoreReport | undefined {
+    return this.restoreReport
+      ? {
+        scanned: this.restoreReport.scanned,
+        restored: [...this.restoreReport.restored],
+        failed: this.restoreReport.failed.map((failure) => ({ ...failure })),
+      }
+      : undefined;
+  }
+
+  /**
+   * Load every stored model and its committed checkpoint into the runtime.
+   *
+   * Restored simulations are idle: this never starts a timer, never steps and
+   * never assimilates live data. An authorized caller must explicitly start or
+   * step a model before it does anything.
+   *
+   * The read and the apply loop run under one exclusive hold on the store. A
+   * mutation that committed in between would otherwise be overwritten in
+   * memory by the stale rows this pass is still carrying, leaving storage with
+   * the new definition and the runtime with the old one — the divergence this
+   * class exists to prevent. `load()` takes no store lock of its own, so
+   * calling it inside the hold does not deadlock.
+   */
+  restore(): Promise<TwinRestoreReport> {
+    return this.store.exclusive(async () => {
+      const loaded = await this.store.load();
+      const restored: string[] = [];
+      const failed: TwinRestoreFailure[] = [...loaded.failures];
+
+      for (const record of loaded.records) {
+        // Validate the definition first so the reported stage is accurate: a
+        // model the runtime refuses is a model problem, and anything that
+        // fails only once the checkpoint is applied is a checkpoint problem.
+        try {
+          this.runtime.validateModelDefinition(record.model);
+        } catch (error) {
+          failed.push({ modelId: record.model.id, stage: "model", reason: describe(error) });
+          continue;
+        }
+        try {
+          this.runtime.restoreModel(record.model, record.checkpoint);
+          restored.push(record.model.id);
+        } catch (error) {
+          failed.push({ modelId: record.model.id, stage: "checkpoint", reason: describe(error) });
+        }
+      }
+
+      this.refusedModelIds.clear();
+      for (const failure of failed) this.refusedModelIds.add(failure.modelId);
+      this.restoreReport = { scanned: loaded.scanned, restored, failed };
+      return this.lastRestore()!;
+    });
+  }
+
+  /**
+   * Register (or replace) a model and commit its current state as the first
+   * checkpoint, atomically. A replaced model's previous entry — including its
+   * live actuals — is restored verbatim if the durable write fails.
+   */
+  async registerModel(model: ProcessModel): Promise<SimulationState> {
+    const committedAt = this.now();
+    // Snapshotted inside the transaction, never before it: the store
+    // serialises transactions, so a snapshot taken at request entry can be
+    // stale by the time this body runs, and rolling back to it would undo a
+    // concurrent mutation that did commit — leaving storage and the registry
+    // describing different things, which is exactly what this class prevents.
+    let snapshot: TwinEntrySnapshot | undefined;
+    let mutated = false;
+    try {
+      return await this.store.transaction(async (tx) => {
+        snapshot = this.runtime.exportEntry(model.id);
+        mutated = true;
+        const state = this.runtime.registerModel(model);
+        // Persist the model exactly as the runtime stored it, so the row and
+        // the registry entry can never describe different models.
+        const stored = this.runtime.getModel(model.id);
+        if (!stored) throw new Error(`Model "${model.id}" vanished during registration`);
+        await tx.putModel(stored, checkpointStateOf(state), committedAt);
+        this.refusedModelIds.delete(model.id);
+        return state;
+      });
+    } catch (error) {
+      // Nothing was touched if the transaction never reached this body.
+      if (mutated) this.runtime.restoreEntry(model.id, snapshot);
+      throw error;
+    }
+  }
+
+  /**
+   * Remove a model from storage and the runtime atomically. Also removes a
+   * model whose stored rows the last restore refused, which is the operator's
+   * way to clear an undecodable row.
+   */
+  async removeModel(modelId: string): Promise<boolean> {
+    if (this.runtime.getModel(modelId) === undefined && !this.refusedModelIds.has(modelId)) {
+      return false;
+    }
+    // As in registerModel: the snapshot must be taken inside the transaction,
+    // so a rollback restores what was actually there when this body ran.
+    let snapshot: TwinEntrySnapshot | undefined;
+    let mutated = false;
+    try {
+      return await this.store.transaction(async (tx) => {
+        snapshot = this.runtime.exportEntry(modelId);
+        mutated = true;
+        const removedFromStorage = await tx.deleteModel(modelId);
+        this.runtime.removeModel(modelId);
+        this.refusedModelIds.delete(modelId);
+        return removedFromStorage || snapshot !== undefined;
+      });
+    } catch (error) {
+      if (mutated) this.runtime.restoreEntry(modelId, snapshot);
+      throw error;
+    }
+  }
+
+  /**
+   * Commit the model's state as its checkpoint.
+   *
+   * This is the state a restart would restore — the runtime keeps advancing
+   * afterwards, and those later ticks are not durable until the next commit.
+   * Nothing in the runtime changes here, so there is nothing to roll back if
+   * the write fails; the caller is simply told the commit did not happen.
+   *
+   * The state is read inside the transaction, as in `registerModel`: the store
+   * serialises transactions, so a concurrent delete either lands before this
+   * read — and the model is reported unknown, exactly as if it had never been
+   * registered — or after the commit. Reading beforehand let a delete land in
+   * between, and the checkpoint write then failed on the model's foreign key,
+   * reporting a storage outage for what is really an unknown model.
+   */
+  commitCheckpoint(modelId: string): Promise<TwinCheckpoint> {
+    return this.store.transaction(async (tx) => {
+      const state = this.runtime.getState(modelId);
+      if (!state) throw new Error(`Unknown model "${modelId}"`);
+      const checkpoint = checkpointStateOf(state);
+      const committedAt = this.now();
+      await tx.putCheckpoint(modelId, checkpoint, committedAt);
+      return {
+        modelId,
+        schemaVersion: TWIN_CHECKPOINT_SCHEMA_VERSION,
+        tick: checkpoint.tick,
+        timeMs: checkpoint.timeMs,
+        componentStates: checkpoint.componentStates,
+        ...(checkpoint.lastSyncAt !== undefined ? { lastSyncAt: checkpoint.lastSyncAt } : {}),
+        committedAt,
+      };
+    });
+  }
+}

--- a/shared/__tests__/schema-parity.test.ts
+++ b/shared/__tests__/schema-parity.test.ts
@@ -10,6 +10,8 @@ import {
   validatorLivenessObservations as pgValidatorLivenessObservations,
   blueprintSafeStateLog as pgBlueprintSafeStateLog,
   pidTuningAudit as pgPidTuningAudit,
+  twinModels as pgTwinModels,
+  twinCheckpoints as pgTwinCheckpoints,
 } from '../schema';
 import {
   alarms as sqliteAlarms,
@@ -20,6 +22,8 @@ import {
   validatorLivenessObservations as sqliteValidatorLivenessObservations,
   blueprintSafeStateLog as sqliteBlueprintSafeStateLog,
   pidTuningAudit as sqlitePidTuningAudit,
+  twinModels as sqliteTwinModels,
+  twinCheckpoints as sqliteTwinCheckpoints,
 } from '../schema-sqlite';
 
 /**
@@ -76,6 +80,12 @@ const cases = [
   // configured, so a column that exists on only one of them would silently
   // drop part of a plant-change record.
   { name: 'pid_tuning_audit', pg: pgPidTuningAudit, sqlite: sqlitePidTuningAudit },
+  // #550: the digital-twin model registry and its committed checkpoints. A
+  // column present on only one dialect would drop part of a restored model or
+  // checkpoint, and a twin that comes back with partial state is worse than
+  // one that refuses to come back at all.
+  { name: 'twin_models', pg: pgTwinModels, sqlite: sqliteTwinModels },
+  { name: 'twin_checkpoints', pg: pgTwinCheckpoints, sqlite: sqliteTwinCheckpoints },
 ] as const;
 
 describe('schema parity (Postgres vs SQLite dev fallback)', () => {

--- a/shared/schema-sqlite.ts
+++ b/shared/schema-sqlite.ts
@@ -6,6 +6,7 @@
 
 import { sqliteTable, text, integer, real, blob } from "drizzle-orm/sqlite-core";
 import type { GainEnvelope, TuningGains } from "./types/tuning";
+import type { ProcessModel } from "./types/digital-twin";
 
 // Simplified schemas for SQLite (development mode)
 export const sites = sqliteTable("sites", {
@@ -410,6 +411,43 @@ export const pidTuningAudit = sqliteTable("pid_tuning_audit", {
   reasonCode: text("reason_code"),
   detail: text("detail"),
   recordedAt: integer("recorded_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+// ─── Digital Twin Persistence (ADR-0013 [13.3], #550) ────────────────────────
+// Dev-mode parity with `shared/schema.ts`, created in production by
+// migrations/0014_twin_persistence.sql. jsonb → text(mode json), timestamptz →
+// integer timestamp_ms, bigint → integer, double precision → real. The twin's
+// model registry must be durable on BOTH dialects: a registry that silently
+// resets on restart is exactly the defect #550 exists to remove.
+// Kept in sync by `shared/__tests__/schema-parity.test.ts`; the physical SQLite
+// DDL lives in `server/services/twin/persistence.ts`.
+export const twinModels = sqliteTable("twin_models", {
+  id: text("id").primaryKey(),
+  schemaVersion: integer("schema_version").notNull(),
+  definition: text("definition", { mode: "json" }).$type<ProcessModel>().notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+// No `status` column, matching Postgres: a restored simulation is always idle.
+export const twinCheckpoints = sqliteTable("twin_checkpoints", {
+  modelId: text("model_id")
+    .primaryKey()
+    .references(() => twinModels.id, { onDelete: "cascade" }),
+  schemaVersion: integer("schema_version").notNull(),
+  tick: integer("tick").notNull(),
+  timeMs: real("time_ms").notNull(),
+  componentStates: text("component_states", { mode: "json" })
+    .$type<Record<string, Record<string, number>>>()
+    .notNull(),
+  lastSyncAt: integer("last_sync_at"),
+  committedAt: integer("committed_at", { mode: "timestamp_ms" })
     .notNull()
     .$defaultFn(() => new Date()),
 });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -859,6 +859,61 @@ export const pluginInstallations = pgTable("plugin_installations", {
   statusIdx: index("idx_plugin_installations_status").on(table.status),
 }));
 
+// ─── Digital Twin Persistence (ADR-0013 [13.3], #550) ────────────────────────
+//
+// The twin runtime kept its model registry and simulation state in process
+// memory, so a restart lost both. These two tables make the registry and one
+// explicitly committed checkpoint per model durable.
+//
+// Physical DDL: migrations/0014_twin_persistence.sql (Postgres) and the
+// SQLITE_DDL in server/services/twin/persistence.ts (dev/test fallback).
+// Kept in sync by `shared/__tests__/schema-parity.test.ts`.
+
+/**
+ * One row per registered `ProcessModel`. `id` is the model id itself — the
+ * same natural key the in-memory registry is keyed by, so storage and runtime
+ * cannot disagree about which model a row describes.
+ *
+ * `schema_version` is the `TWIN_MODEL_SCHEMA_VERSION` the payload was written
+ * under. A loader that does not know the version refuses the row rather than
+ * decoding it under today's assumptions.
+ */
+export const twinModels = pgTable("twin_models", {
+  id: varchar("id", { length: 128 }).primaryKey(),
+  schemaVersion: integer("schema_version").notNull(),
+  // The full ProcessModel as authored, re-validated by the runtime on load.
+  definition: jsonb("definition").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+/**
+ * The LAST COMMITTED checkpoint for a model — at most one row per model,
+ * written in the same transaction as the model it belongs to. A model row
+ * without a checkpoint row is therefore a torn write, and the loader treats it
+ * as corrupt rather than seeding the model from authored initial conditions
+ * (which would silently substitute different state for real state).
+ *
+ * There is deliberately no `status` column: a restored simulation is always
+ * idle and only starts when an authorized caller starts or steps it.
+ */
+export const twinCheckpoints = pgTable("twin_checkpoints", {
+  modelId: varchar("model_id", { length: 128 })
+    .primaryKey()
+    .references(() => twinModels.id, { onDelete: "cascade" }),
+  schemaVersion: integer("schema_version").notNull(),
+  tick: bigint("tick", { mode: "number" }).notNull(),
+  // Simulated clock in ms. Double precision rather than bigint because the
+  // runtime carries it as a JS number and only requires it to stay finite.
+  timeMs: doublePrecision("time_ms").notNull(),
+  // Record<componentId, Record<parameter, number>>, re-validated against the
+  // model's components before it is admitted into the runtime.
+  componentStates: jsonb("component_states").notNull(),
+  // Epoch ms of the last live-tag assimilation folded into this checkpoint.
+  lastSyncAt: bigint("last_sync_at", { mode: "number" }),
+  committedAt: timestamp("committed_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
 // ─── Schema Exports ──────────────────────────────────────────────────────────
 
 // Insert schemas for validation
@@ -933,3 +988,7 @@ export type PluginRegistryRow = typeof pluginRegistry.$inferSelect;
 export type InsertPluginRegistryRow = typeof pluginRegistry.$inferInsert;
 export type PluginInstallationRow = typeof pluginInstallations.$inferSelect;
 export type InsertPluginInstallationRow = typeof pluginInstallations.$inferInsert;
+export type TwinModelRow = typeof twinModels.$inferSelect;
+export type InsertTwinModelRow = typeof twinModels.$inferInsert;
+export type TwinCheckpointRow = typeof twinCheckpoints.$inferSelect;
+export type InsertTwinCheckpointRow = typeof twinCheckpoints.$inferInsert;

--- a/shared/types/digital-twin.ts
+++ b/shared/types/digital-twin.ts
@@ -123,3 +123,62 @@ export interface RollbackSimulationResult {
   restoredValues: ScenarioModification[];
   result: SimulationResult;
 }
+
+// ── Durable persistence (#550) ─────────────────────────────────────────────
+//
+// Model definitions and simulation checkpoints outlive the process. Every
+// stored row carries the schema version it was written with, so a build that
+// does not understand a row refuses it instead of guessing at its shape.
+
+/**
+ * Version of the stored `ProcessModel` definition payload.
+ *
+ * There is exactly one version today. It exists so the loader can *refuse*
+ * a row it does not understand rather than mis-parse it: bump this constant
+ * (and add the corresponding decode branch) whenever the persisted shape
+ * changes incompatibly. Rows carrying any other version fail closed.
+ */
+export const TWIN_MODEL_SCHEMA_VERSION = 1;
+
+/** Version of the stored simulation-checkpoint payload. See above. */
+export const TWIN_CHECKPOINT_SCHEMA_VERSION = 1;
+
+/**
+ * A bounded, explicitly committed snapshot of one model's simulation state.
+ *
+ * Deliberately does NOT include `status`: a restored simulation always comes
+ * back idle. Persisting "running" would let a restart resume stepping without
+ * an authorized caller asking for it, and the digital twin's stopped state is
+ * the safe state (ADR-0009 — the twin is the sandbox, not the actuator).
+ */
+export interface TwinCheckpoint {
+  modelId: string;
+  schemaVersion: number;
+  tick: number;
+  timeMs: number;
+  componentStates: Record<string, Record<string, number>>;
+  /** Epoch ms of the last live-data assimilation captured by this checkpoint */
+  lastSyncAt?: number;
+  /** Epoch ms at which this checkpoint was committed to storage */
+  committedAt: number;
+}
+
+/** Why one persisted model was refused at load time. */
+export interface TwinRestoreFailure {
+  modelId: string;
+  /** Which stored artefact was rejected */
+  stage: 'model' | 'checkpoint';
+  reason: string;
+}
+
+/**
+ * Outcome of one restore pass. `failed` entries are left untouched in storage
+ * for operator inspection — nothing is repaired or invented on their behalf.
+ */
+export interface TwinRestoreReport {
+  /** Model rows examined */
+  scanned: number;
+  /** Ids registered into the runtime, all idle */
+  restored: string[];
+  failed: TwinRestoreFailure[];
+}


### PR DESCRIPTION
Closes #550.

## Problem

The digital-twin runtime kept its registered `ProcessModel` definitions and all simulation state in process memory (`server/services/twin/engine.ts`), so a restart lost the model registry and every useful checkpoint.

## What this adds

**Storage** — migration `0014_twin_persistence.sql` creates:

| Table | Contents |
| --- | --- |
| `twin_models` | one row per registered model: the authored definition, keyed by model id, plus the schema version it was written under |
| `twin_checkpoints` | the last explicitly committed simulation state per model: tick, simulated clock, per-component parameter values, last live-sync timestamp |

Declared for Postgres (`shared/schema.ts`) and the SQLite dev fallback (`shared/schema-sqlite.ts`), held together by `shared/__tests__/schema-parity.test.ts`. `server/services/twin/persistence.ts` is the store, following the existing tuning audit store: its own connection, Postgres via node-postgres and SQLite via the sqlite-proxy driver, connected lazily so importing the service opens nothing.

**A restart never resumes a simulation.** Run status is deliberately not persisted and the schema cannot express it. A restored simulation always comes back **idle**: restoring starts no timer, runs no tick and assimilates no live data. Only an explicit `start` or `step` from an authorized caller resumes it — including for a model that was running when its checkpoint was committed, and for one that had failed with a solver error. The twin stays advisory and read-only toward the plant; no plant-output or control-write path is introduced.

**Atomicity.** `server/services/twin/registry.ts` runs every registry mutation inside one database transaction and mutates the in-memory registry *inside* that transaction:

- the runtime rejects the model → nothing written, nothing changed;
- the durable write or the `COMMIT` fails → the transaction rolls back **and** the registry is restored from the snapshot taken beforehand, including the replaced model's simulation state and live actuals.

`POST /api/twin/models` and `DELETE /api/twin/models/:id` go through it; a storage failure answers `503` rather than `400`.

**Versioning and fail-closed loading.** `TWIN_MODEL_SCHEMA_VERSION` / `TWIN_CHECKPOINT_SCHEMA_VERSION` are stored on every row; there is one version today and the loader refuses a version it does not know instead of decoding it under current assumptions. Each stored model is decoded, version-checked, re-validated by the runtime, and its checkpoint validated against the model's components. Any failure is refused **for that model only** and reported in `GET /api/twin/status → persistence.lastRestore.failed`; unrelated valid models still load. Refused rows are left in storage untouched — never repaired — and can be cleared with `DELETE` or replaced by re-registering. A model row with no checkpoint row is a torn write, so it is refused rather than re-seeded from authored initial conditions: substituting authored state for real state would be indistinguishable from inventing it. Payloads over 16 MiB are refused outright; a checkpoint is never truncated.

**API.** New `POST /api/twin/models/:modelId/checkpoint` (`twin.operate`) commits the model's state at the instant of the call; an initial checkpoint is written in the same transaction as registration, so a registered model always has one. `GET /api/twin/status` reports the persistence backend, the last restore and its failures, or the error when storage could not be read at all.

## Acceptance criteria

| Criterion | Evidence |
| --- | --- |
| A registered model and its last committed checkpoint survive a clean restart | `restores a registered model and its last committed checkpoint`, `restores ticks the caller committed, not ticks run after the commit`, `carries the last live-sync timestamp into the restored checkpoint` |
| A restarted simulation is idle until an authorized caller starts or steps it | `restores a running simulation in a stopped state and does not resume it` (advances the step driver a simulated hour, then proves an explicit step works), `restores a simulation that failed with a solver error as idle, not error`, and the route-level restart assertion |
| Invalid/corrupt persisted data fails closed for that model without preventing unrelated valid models from loading | invalid JSON, unknown model schema version, unknown checkpoint schema version, checkpoint/model mismatch, non-finite state, torn write, id mismatch, unknown step function — each asserts the healthy sibling model still loads |
| CRUD failures do not leave storage and runtime state partially updated | transaction-rollback test on real SQLite, plus a store that fails at a chosen point asserting the registry is unchanged after failed create, failed replace (model, state and live actuals preserved), failed delete, failed commit and failed checkpoint |
| Automated tests cover restart recovery and failure atomicity | `server/services/twin/__tests__/twin-persistence.test.ts` (29 tests, real SQLite files, no stand-ins) and `server/routes/__tests__/twin-persistence-routes.test.ts` (HTTP → store → restart end to end) |

## Out of scope, as stated in the issue

Scenario result history stays ephemeral. Route scopes are unchanged apart from placing the new checkpoint route under the existing `twin.operate` scope (#545 still owns auth). Predictive-model persistence is #546.

## Verification

- `npx tsc --noEmit` — exits 0.
- `npx vitest run` — 3494 tests, +39 over the 3455-test baseline I measured on the clean tree before starting.

## Notes

- Only the SQLite backend is exercised by tests; no PostgreSQL server is available in this environment, so the Postgres branches and the migration SQL are unverified at runtime here (same position as the existing tuning audit store). The two dialects' table definitions are kept honest by the schema-parity suite.
- The suite has pre-existing load-sensitive timeout flakes on the machine used here (`scheduler-import-safety`, `blueprint-storage`, `marketplace-persistence`, `anchor-pipeline-latency`, `dnp3-outstation/bootstrap`). They also fail on the unmodified tree under the same load and pass in isolation on this branch; nothing in this change fails.
- Documentation: `docs/api/twin-persistence.md`.


🤖 
---

## Restore/register atomicity — found in review, fixed here

An adversarial correctness review caught a violation of this issue's own atomicity criterion, and it is fixed in this branch rather than deferred.

`PersistentTwinRegistry.restore()` called `store.load()` outside the store's mutex — only `transaction()` took `withLock`. A `registerModel` committing while the load was in flight was then silently overwritten in memory by restore's apply loop, leaving **storage with the new definition and the runtime with the stale restored one**. Reproduced before fixing:

```
AssertionError: expected 'v1' to be 'v2'
  (runtime holds the stale restored definition; storage holds the registration that committed during load)
```

**Fix:** `exclusive<T>(operation)` added to the `TwinPersistence` interface, implemented on `DrizzleTwinStore` as a one-line delegate to the pre-existing private `withLock`, so `transaction()` and `exclusive()` share one queue. `restore()` now runs *both* the `load()` and the apply loop inside a single hold. `load()` takes no lock, so it is safe inside `exclusive()` — verified against the real store, not reasoned about. Every `TwinPersistence` implementation gained `exclusive`, including the test double, so the contract is real rather than satisfied only by the production class.

**Independently confirmed.** A reviewer reproduced the race with no stubbing at all (40/40 divergences with the fix reverted, 0 after) and ran 11 deadlock probes — restore→transaction, transaction→restore, two concurrent restores, throwing operations, rejecting loads, close-during-restore, and 12 rounds of 7 interleaved operations — all settle with 0 divergences. `exclusive()` is deliberately **non-reentrant** and documented as such; nesting it deadlocks, and `restore()` is its only caller.

Two smaller items from the same review are also fixed: `close()` racing an in-flight `connect()` no longer leaks the handle, and `commitCheckpoint()`'s `runtime.getState()` moved inside the existing transaction so a concurrently deleted model reports as unknown (400) rather than as a foreign-key outage (503).

### Known gap, disclosed rather than papered over

`close()` racing an in-flight **`restore()`** still leaks a connection. It is pre-existing and not a regression from this change. The only real fixes are a `closed` latch making `connect()` refuse after `close()`, or `close()` taking the store lock — both semantic changes rather than cheap-and-safe ones, so they are left for a deliberate decision instead of being smuggled in here.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
