### PR TITLE
feat(alarms): durable, replica-coordinated alarm correlation (#573)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,9 +28,26 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX=100
 
-# Alarm correlation remains advisory/process-local until issue #573 lands.
-# Set true only for an explicit single-process evaluation before enabling
-# suppression through the authenticated configuration endpoint.
+# Alarm correlation (ADR-0013 [13.2], issues #213 / #573).
+#
+# Durable, replica-coordinated correlation state is OFF by default: correlation
+# then runs process-local, is lost on restart, is not shared with other
+# replicas, and suppression stays off. Set true to persist and coordinate
+# correlation through the shared journal (requires migration 0015 and a
+# reachable database); only then may suppression be enabled in production.
+# Cross-replica propagation is POLL-based, currently a fixed 1s interval, so a
+# mutation on one replica becomes visible on another within that interval
+# rather than instantly.
+ALARM_CORRELATION_DURABLE=false
+# Retention for the durable state above. Both are milliseconds; anything that
+# is not a positive number falls back to the default. Journal entries are only
+# ever pruned strictly BELOW the projection watermark, and only closed groups
+# age out — open groups and their alarms never do.
+ALARM_CORRELATION_JOURNAL_RETENTION_MS=604800000
+ALARM_CORRELATION_STATE_RETENTION_MS=2592000000
+# Escape hatch: allow suppression WITHOUT durable coordination. State is lost
+# on restart and a second replica may hold a different view, so set true only
+# for an explicit single-process evaluation.
 ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION=false
 
 # PID Auto-Tuning approval gate (ADR-0013 [13.4], Issue #215)

--- a/client/src/hooks/use-tag-stream.ts
+++ b/client/src/hooks/use-tag-stream.ts
@@ -40,7 +40,19 @@ export interface AlarmEvent {
     rootCauseAlarmId: string | null;
     suppressed: boolean;
     isRootCause: boolean;
-    coordinationMode: "process-local";
+    /**
+     * `durable` means the correlation state behind this snapshot is projected
+     * from the shared journal and agrees across replicas; `process-local` means
+     * it is this server process's own view, lost on restart. Suppression is
+     * only ever enabled in `durable` mode (#573).
+     */
+    coordinationMode: "process-local" | "durable";
+    /**
+     * Shared journal sequence of this alarm's latest state change, or null when
+     * uncoordinated. Monotonic per alarm across every replica, so a client that
+     * receives the same alarm twice can keep the higher one.
+     */
+    seq: number | null;
   };
 }
 

--- a/docs/security/control-plane-api-keys.md
+++ b/docs/security/control-plane-api-keys.md
@@ -51,11 +51,30 @@ configuration authority:
 <generated-ingest-key>:alarm-ingester:alarms.ingest
 ```
 
-Correlation state is process-local until
-[#573](https://github.com/NickFlach/0xSCADA/issues/573) lands, so suppression
-defaults off. Enabling it also requires the explicit
-`ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION=true` startup flag; use that
-escape hatch only for a single-process evaluation.
+Suppression defaults off, and `alarms.configure` alone is not enough to turn it
+on. `PUT /api/alarm-correlation/suppression-policy` with `enabled: true` is
+refused with `409` unless one of the following holds:
+
+- **Durable coordination is healthy.** Start the server with
+  `ALARM_CORRELATION_DURABLE=true` and a reachable database (migration 0015).
+  Correlation state is then persisted and ordered through a shared journal, so
+  every replica agrees and the state survives restart.
+  `GET /api/alarm-correlation/coordination` reports the live health, and the
+  policy route reads the same value rather than trusting the flag.
+- **An explicit single-process evaluation** via
+  `ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION=true`. Use that escape hatch
+  only for a single-process evaluation; state is lost on restart and a second
+  replica may hold a different view.
+
+If durable coordination later fails, the server disables suppression on its own,
+restores every suppressed alarm, re-broadcasts them, and reports
+`coordinationMode: "process-local"`. Losing coordination can only reveal more
+alarms, never fewer.
+
+Configuration mutations (`rules`, `topology`, `suppression-policy`) accept an
+optional `Idempotency-Key` header so a retry is applied once. Without it each
+request is a distinct operation, because setting a rule to A, then B, then back
+to A is genuinely three changes.
 
 ## Docker Compose
 

--- a/migrations/0015_alarm_correlation_coordination.sql
+++ b/migrations/0015_alarm_correlation_coordination.sql
@@ -1,0 +1,267 @@
+-- Migration: 0015_alarm_correlation_coordination
+-- Issue: #573 — [13.2] Persist and coordinate alarm-correlation state across replicas
+-- Related: #213 (process-local correlation engine), ADR-0026
+-- Date: 2026-07-28
+--
+-- ─── WHY THIS EXISTS ─────────────────────────────────────────────────────────
+--
+-- #213 shipped alarm correlation whose suppression defaults OFF and whose
+-- snapshots are labelled `coordinationMode: process-local`. That default is not
+-- timidity: suppression decides what an operator does and does not see, and a
+-- decision that lives only in one process's heap is lost on restart and can be
+-- contradicted by a second replica. These tables are the durable, replica-
+-- coordinated state ADR-0026 requires before suppression may be enabled in
+-- production.
+--
+-- ─── ORDERING MODEL ──────────────────────────────────────────────────────────
+--
+-- `alarm_correlation_journal` is a single, totally-ordered, append-only log of
+-- every correlation-affecting operation: alarm ingest, acknowledge, clear, and
+-- rule / topology / suppression-policy changes. The database allocates `seq`.
+-- Appends are serialised with pg_advisory_xact_lock (SQLite: BEGIN IMMEDIATE)
+-- so commit order equals `seq` order — without that, a BIGSERIAL value can
+-- commit after a larger one and a polling reader would step over an entry that
+-- has not become visible yet, permanently losing it.
+--
+-- Every replica consumes the same journal in `seq` order and applies each entry
+-- to its own deterministic correlation engine. All replicas therefore converge
+-- on identical group membership, root cause and suppression with no leader
+-- election. This is convergence by shared log, not an order-independent merge:
+-- the log defines the order, and which replica an HTTP request happened to
+-- land on cannot change it.
+--
+-- ─── IDENTIFIERS AND IDEMPOTENCY ─────────────────────────────────────────────
+--
+-- Correlation group ids are derived from the journal `seq` of the entry that
+-- formed them (`ACG-<seq>`, `ACG-<seq>-<n>` for the rare second group formed
+-- while applying one entry). They are never drawn from a per-process random
+-- source, so two replicas cannot mint conflicting ids for the same group, and
+-- because `seq` is monotonic and never reused for the life of the table, an id
+-- cannot be reused either.
+--
+-- `idempotency_key` is UNIQUE. A retried or duplicated delivery of the same
+-- logical operation re-appends the same key, conflicts, and reads back the seq
+-- already assigned. It never produces a second entry.
+--
+-- ─── PROJECTION AND RESTART ──────────────────────────────────────────────────
+--
+-- `alarm_correlation_state.applied_seq` is the watermark of the materialised
+-- projection. A replica applies an entry to its engine, then writes that
+-- entry's row changes inside a transaction that first runs
+--     UPDATE alarm_correlation_state SET applied_seq = :seq
+--      WHERE id = 'default' AND applied_seq < :seq
+-- and abandons the transaction when that matches no row. A replica that loses
+-- the race writes nothing, so the materialised rows are always the result of
+-- applying journal entries strictly in `seq` order, whichever replica got there
+-- first. On restart a replica loads the materialised rows, adopts
+-- `applied_seq`, and consumes only what is newer.
+--
+-- ─── SAFETY ──────────────────────────────────────────────────────────────────
+--
+-- Nothing here can hide an alarm. `suppression_enabled` defaults FALSE and
+-- records only the operator's intent; the runtime honours it exclusively while
+-- the durable projection reports healthy, and forces it back off — restoring
+-- and re-broadcasting every suppressed alarm — the moment it does not. The
+-- asymmetry is deliberate: losing storage or coordination can only ever reveal
+-- more alarms, never fewer.
+--
+-- ─── RETENTION ───────────────────────────────────────────────────────────────
+--
+-- The coordinator prunes, after each successful apply:
+--   * journal entries strictly BELOW `applied_seq` and older than
+--     ALARM_CORRELATION_JOURNAL_RETENTION_MS (default 7 days). Never at or
+--     above the watermark: an unprojected entry is the only record of an
+--     operator's acknowledge or clear.
+--   * closed groups, and ALL the alarms belonging to them, whose last event
+--     time is older than ALARM_CORRELATION_STATE_RETENTION_MS (default
+--     30 days). A closed group's members are removed regardless of their own
+--     lifecycle state, because a closed group can no longer suppress or
+--     un-suppress anything: the engine un-suppresses every member as part of
+--     closing it.
+-- Open groups, and every alarm belonging to one, are never pruned by age — so
+-- no alarm that could still be suppressed is ever aged out.
+
+-- ─── Journal ─────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS alarm_correlation_journal (
+  seq BIGINT GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+  -- Natural key of the logical operation, e.g. 'ingest:<alarmId>'.
+  idempotency_key VARCHAR(256) NOT NULL UNIQUE,
+  op VARCHAR(32) NOT NULL,
+  payload JSONB NOT NULL,
+  -- Authenticated control-plane principal, taken from the API key record and
+  -- never from a request body. This is the attribution that has to outlive the
+  -- process for the lifecycle record to be an audit record at all.
+  principal VARCHAR(128) NOT NULL,
+  -- Diagnostic only. It must never influence ordering or grouping.
+  origin_instance VARCHAR(64) NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT alarm_correlation_journal_op_check CHECK (op IN (
+    'ingest',
+    'acknowledge',
+    'clear',
+    'rule-upsert',
+    'rule-remove',
+    'rule-enabled',
+    'topology-upsert',
+    'topology-remove',
+    'policy-set',
+    'sweep'
+  ))
+);
+
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_journal_recorded_at
+  ON alarm_correlation_journal(recorded_at);
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_journal_op
+  ON alarm_correlation_journal(op);
+
+-- The journal is append-only. Retention deletes strictly below the watermark
+-- are performed by the coordinator; UPDATE is never legitimate, because
+-- rewriting an entry would rewrite the attribution of an operator action.
+CREATE OR REPLACE FUNCTION alarm_correlation_journal_immutable()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'alarm_correlation_journal is append-only: UPDATE is not permitted';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS alarm_correlation_journal_no_update ON alarm_correlation_journal;
+CREATE TRIGGER alarm_correlation_journal_no_update
+  BEFORE UPDATE ON alarm_correlation_journal
+  FOR EACH ROW EXECUTE FUNCTION alarm_correlation_journal_immutable();
+
+-- ─── Materialised group lifecycle ────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS alarm_correlation_groups (
+  id VARCHAR(64) PRIMARY KEY,
+  state VARCHAR(8) NOT NULL,
+  root_cause_alarm_id VARCHAR(128) NOT NULL,
+  formed_by_rule_id VARCHAR(128) NOT NULL,
+  -- Which rule admitted each member, keyed by alarm id, so a recovered group
+  -- can explain itself rather than merely existing.
+  joined_via JSONB NOT NULL DEFAULT '{}'::jsonb,
+  max_severity VARCHAR(16) NOT NULL,
+  -- Event time in epoch ms — the clock correlation actually reasons about.
+  created_at_ms BIGINT NOT NULL,
+  last_alarm_at_ms BIGINT NOT NULL,
+  closed_at_ms BIGINT,
+  close_reason VARCHAR(32),
+  updated_seq BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT alarm_correlation_groups_state_check CHECK (state IN ('open', 'closed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_groups_state
+  ON alarm_correlation_groups(state);
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_groups_last_alarm
+  ON alarm_correlation_groups(last_alarm_at_ms);
+
+-- ─── Materialised alarm lifecycle ────────────────────────────────────────────
+--
+-- This is the row that makes suppression recoverable. `suppressed` records that
+-- an operator is not currently seeing this alarm; `group_id`, `severity` and
+-- `state` are everything needed to restore it. If this row cannot be written,
+-- suppression must not be on.
+
+CREATE TABLE IF NOT EXISTS alarm_correlation_alarms (
+  id VARCHAR(128) PRIMARY KEY,
+  -- NULL means tracked but ungrouped (the engine's "pending" set). Those rows
+  -- still matter: they carry lifecycle and attribution for standalone alarms.
+  group_id VARCHAR(64),
+  name VARCHAR(256) NOT NULL,
+  tag_id VARCHAR(256) NOT NULL,
+  equipment_id VARCHAR(256),
+  site_id VARCHAR(64),
+  process_area VARCHAR(256),
+  severity VARCHAR(16) NOT NULL,
+  state VARCHAR(16) NOT NULL,
+  message TEXT NOT NULL,
+  event_time_ms BIGINT NOT NULL,
+  -- number | string on the wire, so JSON preserves which one it was.
+  alarm_value JSONB,
+  alarm_limit JSONB,
+  source VARCHAR(256),
+  -- Control-plane principals copied from the journal entry. Immutable in the
+  -- same sense the journal is: the projection is rebuildable from the log, and
+  -- no route in this codebase can rewrite the log.
+  acknowledged_by VARCHAR(128),
+  cleared_by VARCHAR(128),
+  suppressed BOOLEAN NOT NULL DEFAULT FALSE,
+  is_root_cause BOOLEAN NOT NULL DEFAULT FALSE,
+  joined_via_rule_id VARCHAR(128),
+  -- Journal seq that ingested this alarm, and the seq of its latest state
+  -- change. The latter rides on every broadcast snapshot so a consumer can drop
+  -- an out-of-order or duplicated cross-instance echo.
+  ingest_seq BIGINT NOT NULL,
+  updated_seq BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT alarm_correlation_alarms_severity_check
+    CHECK (severity IN ('critical', 'high', 'medium', 'low', 'info')),
+  CONSTRAINT alarm_correlation_alarms_state_check
+    CHECK (state IN ('active', 'acknowledged', 'cleared', 'shelved', 'suppressed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_alarms_group
+  ON alarm_correlation_alarms(group_id);
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_alarms_state
+  ON alarm_correlation_alarms(state);
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_alarms_event_time
+  ON alarm_correlation_alarms(event_time_ms);
+
+-- ─── Durable configuration ───────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS alarm_correlation_rules (
+  id VARCHAR(128) PRIMARY KEY,
+  name VARCHAR(256) NOT NULL,
+  type VARCHAR(16) NOT NULL,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  priority INTEGER NOT NULL,
+  config JSONB NOT NULL,
+  updated_by VARCHAR(128) NOT NULL,
+  updated_seq BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT alarm_correlation_rules_type_check
+    CHECK (type IN ('causal', 'hierarchy', 'temporal'))
+);
+
+CREATE TABLE IF NOT EXISTS alarm_correlation_equipment (
+  equipment_id VARCHAR(256) PRIMARY KEY,
+  name VARCHAR(256),
+  parent_id VARCHAR(256),
+  causal_downstream JSONB NOT NULL DEFAULT '[]'::jsonb,
+  site_id VARCHAR(64),
+  process_area VARCHAR(256),
+  updated_by VARCHAR(128) NOT NULL,
+  updated_seq BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ─── Coordination state (single row) ─────────────────────────────────────────
+--
+-- `suppression_enabled` defaults FALSE and records only the operator's intent.
+-- The runtime honours it exclusively while coordination reports healthy.
+
+CREATE TABLE IF NOT EXISTS alarm_correlation_state (
+  id VARCHAR(16) PRIMARY KEY,
+  applied_seq BIGINT NOT NULL DEFAULT 0,
+  suppression_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  never_suppress_at_or_above VARCHAR(16) NOT NULL DEFAULT 'critical',
+  -- Always TRUE. The column exists so the persisted policy is complete and any
+  -- future change is a visible migration rather than a silent default.
+  unsuppress_on_root_clear BOOLEAN NOT NULL DEFAULT TRUE,
+  alarms_ingested BIGINT NOT NULL DEFAULT 0,
+  groups_created BIGINT NOT NULL DEFAULT 0,
+  groups_closed BIGINT NOT NULL DEFAULT 0,
+  alarms_suppressed BIGINT NOT NULL DEFAULT 0,
+  alarms_unsuppressed BIGINT NOT NULL DEFAULT 0,
+  updated_by VARCHAR(128) NOT NULL DEFAULT 'system',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT alarm_correlation_state_singleton CHECK (id = 'default'),
+  CONSTRAINT alarm_correlation_state_unsuppress_check
+    CHECK (unsuppress_on_root_clear = TRUE),
+  CONSTRAINT alarm_correlation_state_severity_check
+    CHECK (never_suppress_at_or_above IN ('critical', 'high', 'medium', 'low', 'info'))
+);
+
+INSERT INTO alarm_correlation_state (id) VALUES ('default')
+ON CONFLICT (id) DO NOTHING;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1784780411000,
       "tag": "0014_twin_persistence",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1784780412000,
+      "tag": "0015_alarm_correlation_coordination",
+      "breakpoints": true
     }
   ]
 }

--- a/server/__tests__/alarm-correlation-coordination-http.test.ts
+++ b/server/__tests__/alarm-correlation-coordination-http.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Alarm-correlation coordination over HTTP
+ * ADR-0026 / ADR-0013 [13.2] — Issue #573
+ *
+ * Exercises the REST surface against a real Express server, real control-plane
+ * auth, and a real durable coordinator over a real SQLite file. The claims
+ * under test are the ones an operator's safety depends on:
+ *
+ *   - production suppression cannot be enabled without healthy durable
+ *     coordination, and can be once it is healthy;
+ *   - a mutation performed on one replica is visible through this replica's
+ *     REST surface;
+ *   - a configuration retry carrying the same Idempotency-Key is applied once;
+ *   - coordination health is observable rather than inferred.
+ */
+
+import { createServer, type Server } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import express from "express";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { _resetControlPlaneAuthCache } from "../middleware/control-plane-auth";
+import { alarmCorrelationRoutes } from "../routes/alarm-correlation";
+import {
+  AlarmCorrelationCoordinator,
+  DrizzleCorrelationStore,
+  alarmCorrelationService,
+} from "../services/alarm-correlation";
+
+// Real HTTP against a real Express server, with a real database file behind it
+// at synchronous=FULL. Disk-bound by design; the default 5s budget is not
+// enough when this runs in parallel with the rest of the repo.
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+const READ_KEY = "coord-read-key";
+const INGEST_KEY = "coord-ingest-key";
+const ACK_KEY = "coord-ack-key";
+const CLEAR_KEY = "coord-clear-key";
+const CONFIGURE_KEY = "coord-configure-key";
+
+let baseUrl = "";
+let server: Server;
+const cleanups: Array<() => Promise<void>> = [];
+
+function api(
+  route: string,
+  apiKey: string,
+  init: RequestInit & { body?: unknown } = {},
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    "x-api-key": apiKey,
+    ...(init.headers as Record<string, string> | undefined),
+  };
+  let body: string | undefined;
+  if (init.body !== undefined) {
+    headers["content-type"] = "application/json";
+    body = JSON.stringify(init.body);
+  }
+  return fetch(`${baseUrl}/api/alarm-correlation${route}`, {
+    ...init,
+    headers,
+    body,
+  });
+}
+
+async function sharedDbFile(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "alarm-http-"));
+  cleanups.push(() => rm(dir, { recursive: true, force: true }));
+  return path.join(dir, "correlation.sqlite");
+}
+
+/**
+ * Attach a durable coordinator to the module singleton the router reads, then
+ * make sure it is detached again — the singleton outlives any one test.
+ */
+async function attachCoordinator(file: string, instanceId: string) {
+  const store = new DrizzleCorrelationStore({ sqlitePath: file });
+  const coordinator = new AlarmCorrelationCoordinator({
+    store,
+    instanceId,
+    pollIntervalMs: 60_000,
+    pruneIntervalMs: 60 * 60_000,
+  });
+  await coordinator.start();
+  alarmCorrelationService.attachCoordinator(coordinator);
+  cleanups.push(() => alarmCorrelationService.shutdown());
+  return coordinator;
+}
+
+/** A second replica, not attached to the singleton, sharing the same journal. */
+async function peerReplica(file: string, instanceId: string) {
+  const store = new DrizzleCorrelationStore({ sqlitePath: file });
+  const coordinator = new AlarmCorrelationCoordinator({
+    store,
+    instanceId,
+    pollIntervalMs: 60_000,
+    pruneIntervalMs: 60 * 60_000,
+  });
+  await coordinator.start();
+  cleanups.push(() => coordinator.stop());
+  return coordinator;
+}
+
+const originalApiKeys = process.env.API_KEYS;
+const originalEphemeral = process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION;
+
+beforeAll(async () => {
+  process.env.API_KEYS = [
+    `${READ_KEY}:coord-reader:alarms.read`,
+    `${INGEST_KEY}:coord-ingester:alarms.ingest`,
+    `${ACK_KEY}:coord-acknowledger:alarms.acknowledge`,
+    `${CLEAR_KEY}:coord-clearer:alarms.clear`,
+    `${CONFIGURE_KEY}:coord-configurer:alarms.configure`,
+  ].join(",");
+  delete process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION;
+  _resetControlPlaneAuthCache();
+
+  const app = express();
+  app.use(express.json());
+  app.use("/api/alarm-correlation", alarmCorrelationRoutes);
+  await new Promise<void>((resolve) => {
+    server = createServer(app);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      baseUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+});
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    await cleanup().catch(() => undefined);
+  }
+  delete process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  if (originalApiKeys === undefined) delete process.env.API_KEYS;
+  else process.env.API_KEYS = originalApiKeys;
+  if (originalEphemeral === undefined) {
+    delete process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION;
+  } else {
+    process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION = originalEphemeral;
+  }
+  _resetControlPlaneAuthCache();
+});
+
+describe("suppression gating", () => {
+  it("refuses to enable suppression without durable coordination", async () => {
+    const response = await api("/suppression-policy", CONFIGURE_KEY, {
+      method: "PUT",
+      body: { enabled: true },
+    });
+    expect(response.status).toBe(409);
+    const payload = await response.json();
+    expect(payload.coordinationMode).toBe("process-local");
+    expect(String(payload.error)).toContain("durable");
+
+    // And suppression really is still off — the refusal is not cosmetic.
+    const policy = await (await api("/suppression-policy", READ_KEY)).json();
+    expect(policy.enabled).toBe(false);
+  });
+
+  it("reports process-local coordination as unhealthy and explains why", async () => {
+    const payload = await (await api("/coordination", READ_KEY)).json();
+    expect(payload).toMatchObject({
+      healthy: false,
+      mode: "process-local",
+      backend: "none",
+    });
+    expect(String(payload.detail)).toContain("process-local");
+  });
+
+  it("allows suppression once durable coordination reports healthy", async () => {
+    await attachCoordinator(await sharedDbFile(), "replica-http");
+
+    const health = await (await api("/coordination", READ_KEY)).json();
+    expect(health).toMatchObject({ healthy: true, mode: "durable", backend: "sqlite" });
+
+    const response = await api("/suppression-policy", CONFIGURE_KEY, {
+      method: "PUT",
+      headers: { "idempotency-key": "policy-enable-1" },
+      body: { enabled: true, neverSuppressAtOrAbove: "critical" },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      enabled: true,
+      neverSuppressAtOrAbove: "critical",
+      unsuppressOnRootClear: true,
+    });
+
+    const readBack = await (await api("/suppression-policy", READ_KEY)).json();
+    expect(readBack.enabled).toBe(true);
+  });
+
+  it("rejects a malformed Idempotency-Key instead of ignoring it", async () => {
+    await attachCoordinator(await sharedDbFile(), "replica-http");
+    const response = await api("/suppression-policy", CONFIGURE_KEY, {
+      method: "PUT",
+      headers: { "idempotency-key": "not a valid key!" },
+      body: { enabled: true },
+    });
+    expect(response.status).toBe(400);
+    expect(String((await response.json()).error)).toContain("Idempotency-Key");
+  });
+});
+
+describe("coordinated mutations over REST", () => {
+  it("applies a repeated configuration request with the same key exactly once", async () => {
+    const coordinator = await attachCoordinator(await sharedDbFile(), "replica-http");
+    const rule = {
+      name: "Custom causal",
+      type: "causal",
+      enabled: true,
+      priority: 7,
+      config: { windowMs: 45_000, maxHops: 2 },
+    };
+
+    const first = await api("/rules/custom-causal", CONFIGURE_KEY, {
+      method: "PUT",
+      headers: { "idempotency-key": "rule-put-1" },
+      body: rule,
+    });
+    expect(first.status).toBe(200);
+    const seqAfterFirst = coordinator.health().appliedSeq;
+
+    const retry = await api("/rules/custom-causal", CONFIGURE_KEY, {
+      method: "PUT",
+      headers: { "idempotency-key": "rule-put-1" },
+      body: rule,
+    });
+    expect(retry.status).toBe(200);
+    // The retry collapsed onto the entry already in the journal: no second
+    // operation, so nothing was applied twice.
+    expect(coordinator.health().appliedSeq).toBe(seqAfterFirst);
+
+    const rules = await (await api("/rules", READ_KEY)).json();
+    expect(
+      rules.rules.filter((entry: { id: string }) => entry.id === "custom-causal"),
+    ).toHaveLength(1);
+    // A genuine retry reports that it changed nothing, rather than implying it
+    // applied the request a second time.
+    expect(await retry.json()).toMatchObject({ applied: false });
+  });
+
+  it("refuses a reused Idempotency-Key that asks for something different", async () => {
+    await attachCoordinator(await sharedDbFile(), "replica-http");
+    const base = {
+      name: "Reuse probe",
+      type: "temporal",
+      enabled: true,
+      priority: 11,
+      config: { windowMs: 5_000, scope: "same-tag" },
+    };
+
+    const first = await api("/rules/reuse-probe", CONFIGURE_KEY, {
+      method: "PUT",
+      headers: { "idempotency-key": "reused-key" },
+      body: base,
+    });
+    expect(first.status).toBe(200);
+    expect(await first.json()).toMatchObject({ applied: true });
+
+    // Same key, different content. The journal already holds an entry for this
+    // key, so nothing new is applied — and saying 200 would be a false claim
+    // that the operator's edit took effect.
+    const conflicting = await api("/rules/reuse-probe", CONFIGURE_KEY, {
+      method: "PUT",
+      headers: { "idempotency-key": "reused-key" },
+      body: { ...base, priority: 99 },
+    });
+    expect(conflicting.status).toBe(409);
+    expect(String((await conflicting.json()).error)).toContain("Idempotency-Key");
+
+    const rules = await (await api("/rules", READ_KEY)).json();
+    const stored = rules.rules.find((entry: { id: string }) => entry.id === "reuse-probe");
+    expect(stored.priority).toBe(11);
+  });
+
+  it("shows an acknowledge performed on another replica through REST", async () => {
+    const file = await sharedDbFile();
+    const local = await attachCoordinator(file, "replica-http");
+    const peer = await peerReplica(file, "replica-peer");
+
+    const ingest = await api("/alarms", INGEST_KEY, {
+      method: "POST",
+      body: {
+        alarms: [
+          {
+            id: "cross-replica-alarm",
+            tagId: "PUMP-3.TRIP",
+            severity: "high",
+            timestamp: 1_000,
+          },
+        ],
+      },
+    });
+    expect(ingest.status).toBe(200);
+    expect((await ingest.json()).coordinationMode).toBe("durable");
+
+    // The other replica sees it, and acknowledges it there.
+    await peer.pump();
+    const acknowledged = await peer.submitAcknowledge(
+      "cross-replica-alarm",
+      "operator-on-peer",
+    );
+    expect(acknowledged.outcome).toBe(true);
+
+    // This replica has not consumed that entry yet...
+    expect(local.engine.getAlarm("cross-replica-alarm")?.state).toBe("active");
+    await local.pump();
+
+    // ...and once it has, REST here reports the peer's decision and its author.
+    const snapshot = await (await api("/snapshot", READ_KEY)).json();
+    const alarm = snapshot.alarms.find(
+      (entry: { id: string }) => entry.id === "cross-replica-alarm",
+    );
+    expect(alarm).toMatchObject({
+      state: "acknowledged",
+      acknowledgedBy: "operator-on-peer",
+    });
+    expect(alarm.correlation.coordinationMode).toBe("durable");
+    expect(typeof alarm.correlation.seq).toBe("number");
+  });
+
+  it("serves one snapshot entry per active alarm and omits cleared ones", async () => {
+    await attachCoordinator(await sharedDbFile(), "replica-http");
+    await api("/alarms", INGEST_KEY, {
+      method: "POST",
+      body: {
+        alarms: [
+          { id: "keep-1", tagId: "PUMP-4.TRIP", severity: "high", timestamp: 1_000 },
+          { id: "keep-2", tagId: "PUMP-4.TRIP", severity: "low", timestamp: 1_100 },
+          { id: "gone", tagId: "TANK-9.LEVEL", severity: "medium", timestamp: 5_000 },
+        ],
+      },
+    });
+    const before = await (await api("/snapshot", READ_KEY)).json();
+    expect(before.alarms.map((entry: { id: string }) => entry.id))
+      .toEqual(expect.arrayContaining(["keep-1", "keep-2", "gone"]));
+
+    const cleared = await api("/alarms/gone/clear", CLEAR_KEY, { method: "POST" });
+    expect(cleared.status).toBe(200);
+    expect(await cleared.json()).toMatchObject({
+      cleared: true,
+      clearedBy: "coord-clearer",
+    });
+
+    const snapshot = await (await api("/snapshot", READ_KEY)).json();
+    const ids = snapshot.alarms.map((entry: { id: string }) => entry.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(expect.arrayContaining(["keep-1", "keep-2"]));
+    // A cleared alarm is not something a reconnecting operator still has to
+    // act on, so it is not replayed to them.
+    expect(ids).not.toContain("gone");
+  });
+});

--- a/server/routes/alarm-correlation.ts
+++ b/server/routes/alarm-correlation.ts
@@ -7,7 +7,7 @@
  * engine, equipment topology, and suppression policy.
  */
 
-import { Router } from "express";
+import { Router, type Request, type Response } from "express";
 import { z } from "zod";
 import { fromZodError } from "zod-validation-error/v3";
 import {
@@ -19,10 +19,20 @@ import {
   normalizeAlarmTimestamp,
 } from "../services/alarm-correlation";
 import { validateRule } from "../services/alarm-correlation/rules";
-import type { CorrelationRule } from "@shared/types/alarm-correlation";
+import { EquipmentTopology } from "../services/alarm-correlation/topology";
+import type {
+  CorrelationRule,
+  EquipmentNode,
+} from "@shared/types/alarm-correlation";
 
 const router = Router();
-const engine = alarmCorrelationService.engine;
+/**
+ * Resolved per request, never captured at module load: attaching the durable
+ * coordinator (#573) swaps the engine holding correlation state, and a cached
+ * reference would leave REST serving the abandoned process-local engine while
+ * WebSocket served the coordinated one.
+ */
+const currentEngine = () => alarmCorrelationService.engine;
 const requireAlarmRead = requireControlPlaneAccess({
   scopes: ["alarms.read"],
 });
@@ -154,9 +164,105 @@ function parseTimestamp(timestamp: string | number): number | null {
   return normalizeAlarmTimestamp(timestamp);
 }
 
+const IdempotencyKeySchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9._:-]+$/);
+
+const IDEMPOTENCY_KEY_ERROR =
+  "Idempotency-Key must be 1..128 characters of [A-Za-z0-9._:-]";
+
+/**
+ * Configuration edits have no natural idempotency key — setting a rule to A,
+ * then B, then back to A is three distinct operations, so deriving a key from
+ * the content would silently drop the third. The caller supplies one to make a
+ * retry safe; without a header each request is its own journal entry.
+ *
+ * Returns `undefined` for "no key supplied" and `null` for "supplied but
+ * invalid", which is a 400 rather than a silently ignored header.
+ */
+function idempotencyKey(req: Request): string | undefined | null {
+  const raw = req.header("idempotency-key");
+  if (raw === undefined) return undefined;
+  const parsed = IdempotencyKeySchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+function principalName(req: Request): string {
+  return controlPlanePrincipal(req).name;
+}
+
+/**
+ * A config mutation that could not reach the journal did not happen on any
+ * replica. Reporting success would leave the operator believing a rule change
+ * took effect when the next restart will forget it.
+ */
+function coordinationUnavailable(error: unknown): Record<string, unknown> {
+  return {
+    error:
+      "Durable coordination is unavailable, so this configuration change was "
+      + "not recorded on any replica. Suppression has been disabled and every "
+      + "suppressed alarm restored.",
+    detail: error instanceof Error ? error.message : String(error),
+    coordination: alarmCorrelationService.durableCoordinator?.health() ?? null,
+  };
+}
+
+const IDEMPOTENCY_KEY_REUSED =
+  "Idempotency-Key has already been used for a different operation, so this "
+  + "request was NOT applied. Retry with a fresh key.";
+
+/**
+ * A submission that returned `created: false` collapsed onto a journal entry
+ * that was already there. That is exactly right for a genuine retry, and wrong
+ * for a key accidentally reused with different content — in which case nothing
+ * this request asked for happened. So the effect is read back and verified, and
+ * a mismatch is a 409 rather than a 200 describing a change that never landed.
+ */
+function reportConfigOutcome(
+  res: Response,
+  created: boolean,
+  effectApplied: boolean,
+  body: Record<string, unknown>,
+): void {
+  if (!created && !effectApplied) {
+    res.status(409).json({ error: IDEMPOTENCY_KEY_REUSED });
+    return;
+  }
+  res.json({ ...body, applied: created });
+}
+
+function sameEquipment(
+  stored: EquipmentNode | undefined,
+  requested: EquipmentNode,
+): boolean {
+  if (!stored) return false;
+  return (
+    stored.name === requested.name
+    && stored.parentId === requested.parentId
+    && stored.siteId === requested.siteId
+    && stored.processArea === requested.processArea
+    // Topology upsert de-duplicates and drops self-edges, so compare as sets.
+    && JSON.stringify([...new Set(stored.causalDownstream)].sort())
+      === JSON.stringify(
+        [...new Set(requested.causalDownstream)]
+          .filter((id) => id !== requested.equipmentId)
+          .sort(),
+      )
+  );
+}
+
+function sameRule(a: CorrelationRule | undefined, b: CorrelationRule): boolean {
+  if (!a) return false;
+  return (
+    a.name === b.name
+    && a.type === b.type
+    && a.enabled === b.enabled
+    && a.priority === b.priority
+    && JSON.stringify(a.config) === JSON.stringify(b.config)
+  );
+}
+
 // ── Alarm ingestion & lifecycle ────────────────────────────────────────────
 
-router.post("/alarms", requireAlarmIngest, (req, res) => {
+router.post("/alarms", requireAlarmIngest, async (req, res) => {
   const parsed = IngestSchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ error: fromZodError(parsed.error).message });
@@ -176,12 +282,17 @@ router.post("/alarms", requireAlarmIngest, (req, res) => {
       rejected.push({ input, reason: "timestamp too far in the future" });
       continue;
     }
-    const outcome = alarmCorrelationService.ingest({
-      ...input,
-      timestamp,
-      state: "active",
-      source: `api:${principal.name}`,
-    });
+    // Goes through the shared journal when durable coordination is up, so an
+    // alarm ingested on one replica is grouped identically on every other.
+    const outcome = await alarmCorrelationService.submit(
+      {
+        ...input,
+        timestamp,
+        state: "active",
+        source: `api:${principal.name}`,
+      },
+      principal.name,
+    );
     if (!outcome) {
       rejected.push({ input, reason: "invalid alarm" });
       continue;
@@ -199,12 +310,16 @@ router.post("/alarms", requireAlarmIngest, (req, res) => {
     ingested: results.length,
     results,
     rejected,
+    coordinationMode: alarmCorrelationService.coordinationMode(),
   });
 });
 
-router.post("/alarms/:alarmId/clear", requireAlarmClear, (req, res) => {
+router.post("/alarms/:alarmId/clear", requireAlarmClear, async (req, res) => {
   const principal = controlPlanePrincipal(req);
-  const outcome = engine.alarmCleared(req.params.alarmId, principal.name);
+  const outcome = await alarmCorrelationService.clear(
+    req.params.alarmId,
+    principal.name,
+  );
   if (!outcome.cleared) {
     return res.status(404).json({ error: `Alarm ${req.params.alarmId} not tracked` });
   }
@@ -214,18 +329,33 @@ router.post("/alarms/:alarmId/clear", requireAlarmClear, (req, res) => {
 router.post(
   "/alarms/:alarmId/acknowledge",
   requireAlarmAcknowledge,
-  (req, res) => {
+  async (req, res) => {
     const principal = controlPlanePrincipal(req);
-    const ok = engine.alarmAcknowledged(req.params.alarmId, principal.name);
+    const ok = await alarmCorrelationService.acknowledge(
+      req.params.alarmId,
+      principal.name,
+    );
     if (!ok) {
       return res.status(404).json({ error: `Alarm ${req.params.alarmId} not tracked` });
     }
     res.json({
       acknowledged: true,
-      acknowledgedBy: engine.getAlarm(req.params.alarmId)?.acknowledgedBy,
+      acknowledgedBy: currentEngine().getAlarm(req.params.alarmId)?.acknowledgedBy,
     });
   },
 );
+
+/**
+ * Latest canonical state for every alarm an operator could still act on —
+ * the REST twin of the WebSocket reconnect snapshot, so a client that
+ * reconnects on either surface sees the same thing.
+ */
+router.get("/snapshot", requireAlarmRead, (_req, res) => {
+  res.json({
+    alarms: alarmCorrelationService.getReconnectSnapshot(),
+    coordinationMode: alarmCorrelationService.coordinationMode(),
+  });
+});
 
 // ── Groups & root cause ────────────────────────────────────────────────────
 
@@ -234,11 +364,11 @@ router.get("/groups", requireAlarmRead, (req, res) => {
   if (!parsed.success) {
     return res.status(400).json({ error: fromZodError(parsed.error).message });
   }
-  res.json({ groups: engine.getGroups(parsed.data) });
+  res.json({ groups: currentEngine().getGroups(parsed.data) });
 });
 
 router.get("/groups/:groupId", requireAlarmRead, (req, res) => {
-  const group = engine.getGroup(req.params.groupId);
+  const group = currentEngine().getGroup(req.params.groupId);
   if (!group) {
     return res.status(404).json({ error: `Group ${req.params.groupId} not found` });
   }
@@ -246,7 +376,7 @@ router.get("/groups/:groupId", requireAlarmRead, (req, res) => {
 });
 
 router.get("/groups/:groupId/root-cause", requireAlarmRead, (req, res) => {
-  const rootCause = engine.getRootCause(req.params.groupId);
+  const rootCause = currentEngine().getRootCause(req.params.groupId);
   if (!rootCause) {
     return res.status(404).json({ error: `Group ${req.params.groupId} not found` });
   }
@@ -256,10 +386,10 @@ router.get("/groups/:groupId/root-cause", requireAlarmRead, (req, res) => {
 // ── Rules engine ───────────────────────────────────────────────────────────
 
 router.get("/rules", requireAlarmRead, (_req, res) => {
-  res.json({ rules: engine.rules.list() });
+  res.json({ rules: currentEngine().rules.list() });
 });
 
-router.put("/rules/:ruleId", requireAlarmConfigure, (req, res) => {
+router.put("/rules/:ruleId", requireAlarmConfigure, async (req, res) => {
   const body =
     req.body && typeof req.body === "object" && !Array.isArray(req.body)
       ? req.body
@@ -273,8 +403,30 @@ router.put("/rules/:ruleId", requireAlarmConfigure, (req, res) => {
   if (error) {
     return res.status(400).json({ error });
   }
+  const coordinator = alarmCorrelationService.durableCoordinator;
+  if (coordinator) {
+    const key = idempotencyKey(req);
+    if (key === null) return res.status(400).json({ error: IDEMPOTENCY_KEY_ERROR });
+    try {
+      const submitted = await coordinator.submitConfig(
+        "rule-upsert",
+        { rule },
+        principalName(req),
+        key,
+      );
+      const stored = currentEngine().rules.get(rule.id);
+      return reportConfigOutcome(
+        res,
+        submitted.created,
+        sameRule(stored, rule),
+        { ...stored },
+      );
+    } catch (submitError) {
+      return res.status(503).json(coordinationUnavailable(submitError));
+    }
+  }
   try {
-    res.json(engine.rules.upsert(rule));
+    res.json({ ...currentEngine().rules.upsert(rule), applied: true });
   } catch (upsertError) {
     res.status(400).json({
       error: upsertError instanceof Error ? upsertError.message : "invalid rule",
@@ -282,40 +434,130 @@ router.put("/rules/:ruleId", requireAlarmConfigure, (req, res) => {
   }
 });
 
-router.delete("/rules/:ruleId", requireAlarmConfigure, (req, res) => {
-  if (!engine.rules.remove(req.params.ruleId)) {
+router.delete("/rules/:ruleId", requireAlarmConfigure, async (req, res) => {
+  if (!currentEngine().rules.get(req.params.ruleId)) {
     return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
   }
-  res.json({ removed: true });
+  const coordinator = alarmCorrelationService.durableCoordinator;
+  if (coordinator) {
+    const key = idempotencyKey(req);
+    if (key === null) return res.status(400).json({ error: IDEMPOTENCY_KEY_ERROR });
+    try {
+      const submitted = await coordinator.submitConfig(
+        "rule-remove",
+        { ruleId: req.params.ruleId },
+        principalName(req),
+        key,
+      );
+      return reportConfigOutcome(
+        res,
+        submitted.created,
+        currentEngine().rules.get(req.params.ruleId) === undefined,
+        { removed: true },
+      );
+    } catch (error) {
+      return res.status(503).json(coordinationUnavailable(error));
+    }
+  }
+  currentEngine().rules.remove(req.params.ruleId);
+  res.json({ removed: true, applied: true });
 });
 
-router.post("/rules/:ruleId/enable", requireAlarmConfigure, (req, res) => {
-  const rule = engine.rules.setEnabled(req.params.ruleId, true);
-  if (!rule) return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
-  res.json(rule);
-});
+async function setRuleEnabled(
+  req: Request,
+  res: Response,
+  enabled: boolean,
+): Promise<void> {
+  const ruleId = req.params.ruleId;
+  if (!currentEngine().rules.get(ruleId)) {
+    res.status(404).json({ error: `Rule ${ruleId} not found` });
+    return;
+  }
+  const coordinator = alarmCorrelationService.durableCoordinator;
+  if (coordinator) {
+    const key = idempotencyKey(req);
+    if (key === null) {
+      res.status(400).json({ error: IDEMPOTENCY_KEY_ERROR });
+      return;
+    }
+    try {
+      const submitted = await coordinator.submitConfig(
+        "rule-enabled",
+        { ruleId, enabled },
+        principalName(req),
+        key,
+      );
+      const stored = currentEngine().rules.get(ruleId);
+      reportConfigOutcome(
+        res,
+        submitted.created,
+        stored?.enabled === enabled,
+        { ...stored },
+      );
+    } catch (error) {
+      res.status(503).json(coordinationUnavailable(error));
+    }
+    return;
+  }
+  res.json({ ...currentEngine().rules.setEnabled(ruleId, enabled), applied: true });
+}
 
-router.post("/rules/:ruleId/disable", requireAlarmConfigure, (req, res) => {
-  const rule = engine.rules.setEnabled(req.params.ruleId, false);
-  if (!rule) return res.status(404).json({ error: `Rule ${req.params.ruleId} not found` });
-  res.json(rule);
-});
+router.post("/rules/:ruleId/enable", requireAlarmConfigure, (req, res) =>
+  setRuleEnabled(req, res, true));
+
+router.post("/rules/:ruleId/disable", requireAlarmConfigure, (req, res) =>
+  setRuleEnabled(req, res, false));
 
 // ── Equipment topology ─────────────────────────────────────────────────────
 
 router.get("/topology", requireAlarmRead, (_req, res) => {
-  res.json({ nodes: engine.topology.list() });
+  res.json({ nodes: currentEngine().topology.list() });
 });
 
-router.put("/topology", requireAlarmConfigure, (req, res) => {
+router.put("/topology", requireAlarmConfigure, async (req, res) => {
   const parsed = TopologySchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ error: fromZodError(parsed.error).message });
   }
+  const coordinator = alarmCorrelationService.durableCoordinator;
+  if (coordinator) {
+    const key = idempotencyKey(req);
+    if (key === null) return res.status(400).json({ error: IDEMPOTENCY_KEY_ERROR });
+    // Validate against a throwaway copy of the live graph first: a cycle must
+    // be a 400, not a journal entry every replica then fails to apply.
+    const probe = new EquipmentTopology();
+    probe.upsertMany(currentEngine().topology.list());
+    try {
+      probe.upsertMany(parsed.data.nodes);
+    } catch (error) {
+      return res.status(400).json({
+        error: error instanceof Error ? error.message : "invalid topology",
+      });
+    }
+    let submitted;
+    try {
+      submitted = await coordinator.submitConfig(
+        "topology-upsert",
+        { nodes: parsed.data.nodes },
+        principalName(req),
+        key,
+      );
+    } catch (error) {
+      return res.status(503).json(coordinationUnavailable(error));
+    }
+    const stored = parsed.data.nodes.map((node) =>
+      currentEngine().topology.get(node.equipmentId));
+    return reportConfigOutcome(
+      res,
+      submitted.created,
+      stored.every((node, index) => sameEquipment(node, parsed.data.nodes[index])),
+      { upserted: stored.filter((node) => node !== undefined).length, nodes: stored },
+    );
+  }
   try {
-    const nodes = engine.topology.upsertMany(parsed.data.nodes);
-    engine.reconcileTopology();
-    res.json({ upserted: nodes.length, nodes });
+    const nodes = currentEngine().topology.upsertMany(parsed.data.nodes);
+    currentEngine().reconcileTopology();
+    res.json({ upserted: nodes.length, nodes, applied: true });
   } catch (error) {
     res.status(400).json({ error: error instanceof Error ? error.message : "invalid topology" });
   }
@@ -324,42 +566,94 @@ router.put("/topology", requireAlarmConfigure, (req, res) => {
 router.delete(
   "/topology/:equipmentId",
   requireAlarmConfigure,
-  (req, res) => {
-    if (!engine.topology.remove(req.params.equipmentId)) {
+  async (req, res) => {
+    if (!currentEngine().topology.get(req.params.equipmentId)) {
       return res.status(404).json({
         error: `Equipment ${req.params.equipmentId} not found`,
       });
     }
-    engine.reconcileTopology();
-    res.json({ removed: true });
+    const coordinator = alarmCorrelationService.durableCoordinator;
+    if (coordinator) {
+      const key = idempotencyKey(req);
+      if (key === null) return res.status(400).json({ error: IDEMPOTENCY_KEY_ERROR });
+      try {
+        const submitted = await coordinator.submitConfig(
+          "topology-remove",
+          { equipmentId: req.params.equipmentId },
+          principalName(req),
+          key,
+        );
+        return reportConfigOutcome(
+          res,
+          submitted.created,
+          currentEngine().topology.get(req.params.equipmentId) === undefined,
+          { removed: true },
+        );
+      } catch (error) {
+        return res.status(503).json(coordinationUnavailable(error));
+      }
+    }
+    currentEngine().topology.remove(req.params.equipmentId);
+    currentEngine().reconcileTopology();
+    res.json({ removed: true, applied: true });
   },
 );
 
 // ── Suppression policy ─────────────────────────────────────────────────────
 
 router.get("/suppression-policy", requireAlarmRead, (_req, res) => {
-  res.json(engine.getSuppressionPolicy());
+  res.json(currentEngine().getSuppressionPolicy());
 });
 
-router.put("/suppression-policy", requireAlarmConfigure, (req, res) => {
+/**
+ * Turning suppression ON is the one mutation in this router that can stop an
+ * operator from seeing an alarm, so it is gated twice: durable coordination
+ * must be reporting healthy right now, or the operator must have explicitly
+ * accepted a single-process evaluation via the env flag. Everything else about
+ * the policy (the never-suppress floor) is always settable.
+ */
+router.put("/suppression-policy", requireAlarmConfigure, async (req, res) => {
   const parsed = SuppressionPolicySchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ error: fromZodError(parsed.error).message });
   }
+  const health = await alarmCorrelationService.healthCheck();
   if (
     parsed.data.enabled === true
-    && process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION !== "true"
+    && !health.durableSuppressionAvailable
+    && !health.ephemeralSuppressionAllowed
   ) {
     return res.status(409).json({
       error:
-        "Suppression is disabled until durable, replica-coordinated state is available. "
-        + "Set ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION=true only for an "
+        "Suppression is disabled until durable, replica-coordinated state reports "
+        + "healthy. Start the server with ALARM_CORRELATION_DURABLE=true and a "
+        + "reachable database, or set "
+        + "ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION=true only for an "
         + "explicit single-process evaluation.",
-      coordinationMode: "process-local",
+      coordinationMode: health.coordinationMode,
+      coordination: health.coordination,
     });
   }
+
+  const coordinator = alarmCorrelationService.durableCoordinator;
+  if (coordinator) {
+    const key = idempotencyKey(req);
+    if (key === null) return res.status(400).json({ error: IDEMPOTENCY_KEY_ERROR });
+    try {
+      await coordinator.submitConfig(
+        "policy-set",
+        { policy: parsed.data },
+        principalName(req),
+        key,
+      );
+    } catch (error) {
+      return res.status(503).json(coordinationUnavailable(error));
+    }
+    return res.json(currentEngine().getSuppressionPolicy());
+  }
+
   try {
-    res.json(engine.setSuppressionPolicy(parsed.data));
+    res.json(currentEngine().setSuppressionPolicy(parsed.data));
   } catch (error) {
     res.status(400).json({
       error: error instanceof Error ? error.message : "invalid suppression policy",
@@ -370,12 +664,36 @@ router.put("/suppression-policy", requireAlarmConfigure, (req, res) => {
 // ── Metrics & status ───────────────────────────────────────────────────────
 
 router.get("/metrics", requireAlarmRead, (_req, res) => {
-  res.json(engine.getMetrics());
+  res.json(currentEngine().getMetrics());
 });
 
 router.get("/status", requireAlarmRead, async (_req, res) => {
   const health = await alarmCorrelationService.healthCheck();
-  res.json({ ...engine.getMetrics(), ...health });
+  res.json({ ...currentEngine().getMetrics(), ...health });
+});
+
+/** Observable coordination health, for operators and for readiness probes. */
+router.get("/coordination", requireAlarmRead, (_req, res) => {
+  const coordinator = alarmCorrelationService.durableCoordinator;
+  if (!coordinator) {
+    return res.json({
+      healthy: false,
+      mode: "process-local",
+      backend: "none",
+      appliedSeq: 0,
+      materializedSeq: 0,
+      policyEnabledIntent: false,
+      suppressionActive: currentEngine().getSuppressionPolicy().enabled,
+      suppressionDisabledByHealth: false,
+      lastError: null,
+      lastHealthyAt: null,
+      instanceId: "",
+      detail:
+        "Durable coordination is not enabled. Correlation state is process-local: "
+        + "it is lost on restart and is not shared with other replicas.",
+    });
+  }
+  res.json(coordinator.health());
 });
 
 export { router as alarmCorrelationRoutes };

--- a/server/services/alarm-correlation/__tests__/coordination.test.ts
+++ b/server/services/alarm-correlation/__tests__/coordination.test.ts
@@ -519,10 +519,20 @@ describe("two-replica coordination", () => {
 });
 
 describe("fail-safe on coordination loss", () => {
-  /** A store that works until `fail` is set, then rejects everything. */
-  function breakableStore(inner: CorrelationStore): CorrelationStore & { fail: boolean } {
+  /**
+   * A store that works until `fail` is set, then rejects everything.
+   *
+   * `failProject` breaks only the projection, which is the one way an entry can
+   * be applied to the engine while the coordinator stays degraded — reads
+   * succeed, so `drain()` reaches `applyEntry()`, but it throws before
+   * `markHealthy()`.
+   */
+  function breakableStore(
+    inner: CorrelationStore,
+  ): CorrelationStore & { fail: boolean; failProject: boolean } {
     const wrapper = {
       fail: false,
+      failProject: false,
       ready: () => inner.ready(),
       backend: () => inner.backend(),
       append: (entry: Parameters<CorrelationStore["append"]>[0]) =>
@@ -535,7 +545,7 @@ describe("fail-safe on coordination loss", () => {
           : inner.read(afterSeq, limit)),
       load: () => inner.load(),
       project: (seq: number, changes: Parameters<CorrelationStore["project"]>[1]) =>
-        (wrapper.fail
+        (wrapper.fail || wrapper.failProject
           ? Promise.reject(new Error("journal unreachable"))
           : inner.project(seq, changes)),
       prune: (options: Parameters<CorrelationStore["prune"]>[0]) => inner.prune(options),
@@ -627,6 +637,70 @@ describe("fail-safe on coordination loss", () => {
     expect(coordinator.health().healthy).toBe(true);
     expect(coordinator.health().suppressionDisabledByHealth).toBe(false);
     // Restored to the operator's persisted intent, not to some default.
+    expect(coordinator.engine.getSuppressionPolicy().enabled).toBe(true);
+  });
+
+  it("does not let a policy write re-enable suppression while still degraded", async () => {
+    const inner = await openStore(await tempDbFile());
+    const store = breakableStore(inner);
+    const coordinator = new AlarmCorrelationCoordinator({
+      store,
+      instanceId: "replica-a",
+      pollIntervalMs: 60_000,
+      pruneIntervalMs: 60 * 60_000,
+    });
+    await coordinator.start();
+    cleanups.push(() => coordinator.stop());
+
+    await coordinator.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+    await coordinator.submitConfig(
+      "policy-set",
+      { policy: { enabled: true, neverSuppressAtOrAbove: "critical" } },
+      "engineer",
+      "p1",
+    );
+    await coordinator.submitIngest(
+      alarm({ id: "root", equipmentId: "PUMP-1", severity: "high", timestamp: 1_000 }),
+      "gw",
+    );
+    await coordinator.submitIngest(
+      alarm({ id: "hidden", equipmentId: "VALVE-1", severity: "low", timestamp: 1_100 }),
+      "gw",
+    );
+    expect(coordinator.engine.getAlarm("hidden")?.state).toBe("suppressed");
+
+    store.fail = true;
+    await expect(coordinator.pump()).rejects.toThrow();
+    expect(coordinator.engine.getSuppressionPolicy().enabled).toBe(false);
+    expect(coordinator.engine.getAlarm("hidden")?.state).toBe("active");
+
+    // Reads work again, so the entry IS applied and `syncEnginePolicy()` runs —
+    // but the projection still fails, so the coordinator never becomes healthy.
+    // `degrade()` is idempotent and will not force suppression off a second
+    // time, so the health gate inside `syncEnginePolicy()` is the only thing
+    // standing between a degraded replica and silently hiding alarms again.
+    store.fail = false;
+    store.failProject = true;
+    await expect(
+      coordinator.submitConfig(
+        "policy-set",
+        { policy: { enabled: true, neverSuppressAtOrAbove: "critical" } },
+        "engineer",
+        "p2",
+      ),
+    ).rejects.toThrow(/journal unreachable/);
+
+    expect(coordinator.health().healthy).toBe(false);
+    expect(coordinator.health().suppressionDisabledByHealth).toBe(true);
+    expect(coordinator.health().policyEnabledIntent).toBe(true);
+    expect(coordinator.engine.getSuppressionPolicy().enabled).toBe(false);
+    expect(coordinator.health().suppressionActive).toBe(false);
+    expect(coordinator.engine.getAlarm("hidden")?.state).toBe("active");
+
+    // And once projection recovers, the operator's intent is honoured again.
+    store.failProject = false;
+    await coordinator.pump();
+    expect(coordinator.health().healthy).toBe(true);
     expect(coordinator.engine.getSuppressionPolicy().enabled).toBe(true);
   });
 

--- a/server/services/alarm-correlation/__tests__/coordination.test.ts
+++ b/server/services/alarm-correlation/__tests__/coordination.test.ts
@@ -1,0 +1,907 @@
+/**
+ * Durable, replica-coordinated alarm correlation
+ * ADR-0026 / ADR-0013 [13.2] — Issue #573
+ *
+ * Every test here drives the real `DrizzleCorrelationStore` against a real
+ * SQLite file — the same code path production takes against Postgres, minus
+ * the dialect. Nothing is mocked out except where a test deliberately breaks
+ * the store to prove the fail-safe path, and in that case it is the real store
+ * object whose file has been made unusable.
+ *
+ * "Two replicas" means two independent coordinators, each with its own engine
+ * and its own store connection, pointed at one shared database file — which is
+ * exactly the production topology with the database standing in for Postgres.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Database } from "sqlite3";
+import type {
+  AlarmGroup,
+  CorrelatedAlarm,
+  CorrelationRule,
+  EquipmentNode,
+} from "@shared/types/alarm-correlation";
+import { AlarmCorrelationCoordinator } from "../coordinator";
+import { DrizzleCorrelationStore, type CorrelationStore } from "../store";
+import { AlarmCorrelationService } from "../index";
+
+// Every test here commits real transactions to a real database file, with
+// synchronous=FULL. That is deliberate — the point is that state survives — but
+// it makes these tests disk-bound, and the default 5s budget is not enough when
+// the suite runs in parallel with the rest of the repo.
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    await cleanup().catch(() => undefined);
+  }
+});
+
+async function tempDbFile(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "alarm-corr-"));
+  cleanups.push(() => rm(dir, { recursive: true, force: true }));
+  return path.join(dir, "correlation.sqlite");
+}
+
+async function openStore(file: string): Promise<DrizzleCorrelationStore> {
+  const store = new DrizzleCorrelationStore({ sqlitePath: file });
+  await store.ready();
+  cleanups.push(() => store.close());
+  return store;
+}
+
+/**
+ * A coordinator whose poll timer is effectively off, so every test drives
+ * journal consumption explicitly with `pump()` and no assertion depends on a
+ * background interval having fired.
+ */
+async function startReplica(
+  file: string,
+  instanceId: string,
+): Promise<AlarmCorrelationCoordinator> {
+  const store = await openStore(file);
+  const coordinator = new AlarmCorrelationCoordinator({
+    store,
+    instanceId,
+    pollIntervalMs: 60_000,
+    pruneIntervalMs: 60 * 60_000,
+  });
+  await coordinator.start();
+  cleanups.push(() => coordinator.stop());
+  return coordinator;
+}
+
+function alarm(overrides: Partial<CorrelatedAlarm> & { id: string }): CorrelatedAlarm {
+  return {
+    name: overrides.id,
+    tagId: `${overrides.equipmentId ?? "PUMP-1"}.TRIP`,
+    equipmentId: overrides.equipmentId ?? "PUMP-1",
+    severity: "medium",
+    state: "active",
+    message: overrides.id,
+    timestamp: 1_000,
+    ...overrides,
+  };
+}
+
+/** Comparable shape of one group, for cross-replica equality assertions. */
+function groupShape(group: AlarmGroup) {
+  return {
+    id: group.id,
+    state: group.state,
+    alarmIds: [...group.alarmIds].sort(),
+    rootCauseAlarmId: group.rootCauseAlarmId,
+    suppressedAlarmIds: [...group.suppressedAlarmIds].sort(),
+    maxSeverity: group.maxSeverity,
+  };
+}
+
+function groupShapes(coordinator: AlarmCorrelationCoordinator) {
+  return coordinator.engine
+    .getGroups()
+    .map(groupShape)
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+const TOPOLOGY: EquipmentNode[] = [
+  { equipmentId: "AREA-1", causalDownstream: [], siteId: "SITE-A" },
+  {
+    equipmentId: "PUMP-1",
+    parentId: "AREA-1",
+    causalDownstream: ["VALVE-1"],
+    siteId: "SITE-A",
+  },
+  { equipmentId: "VALVE-1", parentId: "AREA-1", causalDownstream: [], siteId: "SITE-A" },
+];
+
+describe("durable correlation store", () => {
+  it("assigns a monotonic sequence and collapses duplicate deliveries", async () => {
+    const store = await openStore(await tempDbFile());
+
+    const first = await store.append({
+      idempotencyKey: "ingest:A",
+      op: "ingest",
+      payload: { id: "A" },
+      principal: "operator-a",
+      originInstance: "replica-1",
+    });
+    const second = await store.append({
+      idempotencyKey: "ingest:B",
+      op: "ingest",
+      payload: { id: "B" },
+      principal: "operator-a",
+      originInstance: "replica-2",
+    });
+    // Same logical operation, submitted again — possibly by another replica.
+    const replay = await store.append({
+      idempotencyKey: "ingest:A",
+      op: "ingest",
+      payload: { id: "A" },
+      principal: "operator-b",
+      originInstance: "replica-2",
+    });
+
+    expect(first.created).toBe(true);
+    expect(second.seq).toBeGreaterThan(first.seq);
+    expect(replay).toEqual({ seq: first.seq, created: false });
+
+    const entries = await store.read(0);
+    expect(entries.map((entry) => entry.idempotencyKey)).toEqual([
+      "ingest:A",
+      "ingest:B",
+    ]);
+    expect(entries.map((entry) => entry.seq)).toEqual([first.seq, second.seq]);
+    // Attribution is the submitting principal of the entry that was recorded,
+    // not of the replay that lost.
+    expect(entries[0].principal).toBe("operator-a");
+  });
+
+  it("refuses to rewrite a recorded operation's attribution", async () => {
+    const file = await tempDbFile();
+    const store = await openStore(file);
+    await store.append({
+      idempotencyKey: "acknowledge:A",
+      op: "acknowledge",
+      payload: { alarmId: "A" },
+      principal: "operator-jane",
+      originInstance: "replica-1",
+    });
+
+    // The journal is append-only in the DATABASE, not merely by convention in
+    // application code: attribution that any UPDATE could rewrite would not be
+    // an audit record. Migration 0015 installs the Postgres trigger; this
+    // exercises the SQLite one the dev/test backend gets.
+    const raw = new Database(file);
+    cleanups.push(() => new Promise<void>((resolve) => raw.close(() => resolve())));
+    await expect(new Promise<void>((resolve, reject) => {
+      raw.run(
+        "UPDATE alarm_correlation_journal SET principal = 'attacker' WHERE seq = 1",
+        (error) => (error ? reject(error) : resolve()),
+      );
+    })).rejects.toThrow(/append-only/);
+
+    const entries = await store.read(0);
+    expect(entries[0].principal).toBe("operator-jane");
+  });
+
+  it("refuses to project an entry another replica already projected", async () => {
+    const file = await tempDbFile();
+    const a = await openStore(file);
+    const b = await openStore(file);
+
+    const changes = {
+      groups: [],
+      alarms: [],
+      deletedGroupIds: [],
+      deletedAlarmIds: [],
+      upsertRules: [] as CorrelationRule[],
+      removedRuleIds: [],
+      upsertEquipment: [] as EquipmentNode[],
+      removedEquipmentIds: [],
+      policy: null,
+      metrics: {
+        alarmsIngested: 0,
+        groupsCreated: 0,
+        groupsClosed: 0,
+        alarmsSuppressed: 0,
+        alarmsUnsuppressed: 0,
+      },
+      principal: "system",
+    };
+
+    expect(await a.project(5, changes)).toBe(true);
+    // Behind: writes nothing rather than overwriting seq 5's effects with the
+    // state as of seq 4.
+    expect(await b.project(4, changes)).toBe(false);
+    expect(await b.project(6, changes)).toBe(true);
+    expect((await a.load()).appliedSeq).toBe(6);
+  });
+});
+
+describe("restart recovery", () => {
+  it("restores rules, topology, policy, open groups, root cause, lifecycle and attribution", async () => {
+    const file = await tempDbFile();
+    const before = await startReplica(file, "replica-1");
+
+    await before.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+    const customRule: CorrelationRule = {
+      id: "custom-causal",
+      name: "Custom causal window",
+      type: "causal",
+      enabled: true,
+      priority: 5,
+      config: { windowMs: 60_000, maxHops: 3 },
+    };
+    await before.submitConfig("rule-upsert", { rule: customRule }, "engineer", "r1");
+    await before.submitConfig(
+      "policy-set",
+      { policy: { enabled: true, neverSuppressAtOrAbove: "critical" } },
+      "engineer",
+      "p1",
+    );
+
+    await before.submitIngest(
+      alarm({ id: "pump-trip", equipmentId: "PUMP-1", severity: "high", timestamp: 1_000 }),
+      "sensor-gw",
+    );
+    await before.submitIngest(
+      alarm({
+        id: "valve-fault",
+        equipmentId: "VALVE-1",
+        severity: "low",
+        timestamp: 1_500,
+        // number | string on the wire: both forms have to come back as the
+        // type they went in as, or a numeric limit turns into a string.
+        value: 42.5,
+        limit: "HIGH-HIGH",
+      }),
+      "sensor-gw",
+    );
+    await before.submitAcknowledge("valve-fault", "operator-jane");
+
+    const groupsBefore = groupShapes(before);
+    expect(groupsBefore).toHaveLength(1);
+    expect(groupsBefore[0].rootCauseAlarmId).toBe("pump-trip");
+    await before.stop();
+
+    // Fresh process: new store connection, new engine, nothing carried over in
+    // memory. Everything below has to come off disk.
+    const after = await startReplica(file, "replica-1-restarted");
+
+    expect(after.engine.rules.get("custom-causal")).toMatchObject({
+      name: "Custom causal window",
+      config: { windowMs: 60_000, maxHops: 3 },
+    });
+    expect(after.engine.topology.get("PUMP-1")).toMatchObject({
+      parentId: "AREA-1",
+      causalDownstream: ["VALVE-1"],
+      siteId: "SITE-A",
+    });
+    expect(after.health().policyEnabledIntent).toBe(true);
+    expect(after.engine.getSuppressionPolicy().enabled).toBe(true);
+
+    expect(groupShapes(after)).toEqual(groupsBefore);
+    const recovered = after.engine.getGroups({ state: "open" })[0];
+    expect(recovered.rootCauseAlarmId).toBe("pump-trip");
+    expect(after.engine.getRootCause(recovered.id)?.alarm.id).toBe("pump-trip");
+
+    // Lifecycle state and the principal that produced it both survived.
+    const acknowledged = after.engine.getAlarm("valve-fault");
+    expect(acknowledged?.state).toBe("acknowledged");
+    expect(acknowledged?.acknowledgedBy).toBe("operator-jane");
+    expect(acknowledged?.value).toBe(42.5);
+    expect(acknowledged?.limit).toBe("HIGH-HIGH");
+    expect(acknowledged?.message).toBe("valve-fault");
+    expect(acknowledged?.tagId).toBe("VALVE-1.TRIP");
+    // Cumulative counters are recovered rather than silently reset to zero.
+    expect(after.engine.getMetrics().alarmsIngested).toBe(2);
+  });
+
+  it("recovers a suppressed alarm as suppressed, and can still restore it", async () => {
+    const file = await tempDbFile();
+    const before = await startReplica(file, "replica-1");
+    await before.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+    await before.submitConfig(
+      "policy-set",
+      { policy: { enabled: true, neverSuppressAtOrAbove: "critical" } },
+      "engineer",
+      "p1",
+    );
+
+    await before.submitIngest(
+      alarm({ id: "root", equipmentId: "PUMP-1", severity: "high", timestamp: 1_000 }),
+      "gw",
+    );
+    await before.submitIngest(
+      alarm({ id: "consequence", equipmentId: "VALVE-1", severity: "low", timestamp: 1_200 }),
+      "gw",
+    );
+    const groupId = before.engine.getGroups({ state: "open" })[0].id;
+    expect(before.engine.getGroup(groupId)?.suppressedAlarmIds).toEqual(["consequence"]);
+    await before.stop();
+
+    const after = await startReplica(file, "replica-1-restarted");
+    // The whole point of persisting suppression: the alarm the operator cannot
+    // see is still known to be hidden, and still attached to its group.
+    expect(after.engine.getGroup(groupId)?.suppressedAlarmIds).toEqual(["consequence"]);
+    expect(after.engine.getAlarm("consequence")?.state).toBe("suppressed");
+
+    // ...and clearing the root still restores it, which is the reason the
+    // membership had to survive at all.
+    const cleared = await after.submitClear("root", "operator-jane");
+    expect(cleared.outcome?.unsuppressed).toEqual(["consequence"]);
+    expect(after.engine.getAlarm("consequence")?.state).toBe("active");
+  });
+});
+
+describe("two-replica coordination", () => {
+  it("produces identical membership, root cause, suppression and group ids", async () => {
+    const file = await tempDbFile();
+    const a = await startReplica(file, "replica-a");
+    const b = await startReplica(file, "replica-b");
+
+    await a.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+    await a.submitConfig(
+      "policy-set",
+      { policy: { enabled: true, neverSuppressAtOrAbove: "critical" } },
+      "engineer",
+      "p1",
+    );
+
+    // The stream is split across replicas: whichever instance a request lands
+    // on must not change the outcome.
+    await a.submitIngest(
+      alarm({ id: "pump-trip", equipmentId: "PUMP-1", severity: "high", timestamp: 1_000 }),
+      "gw",
+    );
+    await b.submitIngest(
+      alarm({ id: "valve-fault", equipmentId: "VALVE-1", severity: "low", timestamp: 1_200 }),
+      "gw",
+    );
+    await a.submitIngest(
+      alarm({ id: "valve-chatter", equipmentId: "VALVE-1", severity: "low", timestamp: 1_400 }),
+      "gw",
+    );
+
+    await a.pump();
+    await b.pump();
+
+    expect(groupShapes(a)).toEqual(groupShapes(b));
+    expect(a.engine.getGroups()).toHaveLength(1);
+    // Group ids come from the shared journal position, so both replicas named
+    // it the same thing — not merely "a group each".
+    expect(groupShapes(a)[0].id).toMatch(/^ACG-\d+$/);
+    expect(groupShapes(a)[0].rootCauseAlarmId).toBe("pump-trip");
+    expect(groupShapes(a)[0].suppressedAlarmIds).toEqual(["valve-chatter", "valve-fault"]);
+  });
+
+  it("converges when event time and journal order disagree", async () => {
+    const file = await tempDbFile();
+    const a = await startReplica(file, "replica-a");
+    const b = await startReplica(file, "replica-b");
+    await a.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+
+    // Late-arriving earlier alarm: journal order is 5000, 5200, 4800 while
+    // event time is 4800, 5000, 5200.
+    await a.submitIngest(alarm({ id: "late", equipmentId: "PUMP-1", timestamp: 5_000 }), "gw");
+    await b.submitIngest(alarm({ id: "later", equipmentId: "PUMP-1", timestamp: 5_200 }), "gw");
+    await a.submitIngest(
+      alarm({ id: "earliest", equipmentId: "PUMP-1", timestamp: 4_800 }),
+      "gw",
+    );
+    await a.pump();
+    await b.pump();
+
+    expect(groupShapes(a)).toEqual(groupShapes(b));
+    // Root election is event-time driven, so the late-delivered earliest alarm
+    // wins on both replicas.
+    expect(groupShapes(a)[0].rootCauseAlarmId).toBe("earliest");
+  });
+
+  it("makes duplicate ingest idempotent across replicas without a second group", async () => {
+    const file = await tempDbFile();
+    const a = await startReplica(file, "replica-a");
+    const b = await startReplica(file, "replica-b");
+    await a.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+
+    const duplicated = alarm({ id: "dup", equipmentId: "PUMP-1", timestamp: 2_000 });
+    const first = await a.submitIngest(duplicated, "gw");
+    const second = await b.submitIngest(duplicated, "gw");
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.seq).toBe(first.seq);
+    await a.pump();
+    await b.pump();
+    expect(a.engine.getMetrics().alarmsIngested).toBe(1);
+    expect(b.engine.getMetrics().alarmsIngested).toBe(1);
+
+    // Now form a group on each side and prove the ids cannot collide.
+    await a.submitIngest(alarm({ id: "peer", equipmentId: "PUMP-1", timestamp: 2_100 }), "gw");
+    await b.submitIngest(
+      alarm({ id: "other-root", equipmentId: "VALVE-1", timestamp: 9_000, siteId: "SITE-A" }),
+      "gw",
+    );
+    await b.submitIngest(
+      alarm({ id: "other-peer", equipmentId: "VALVE-1", timestamp: 9_100, siteId: "SITE-A" }),
+      "gw",
+    );
+    await a.pump();
+    await b.pump();
+
+    const ids = a.engine.getGroups().map((group) => group.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(groupShapes(a)).toEqual(groupShapes(b));
+  });
+
+  it("journals idle-group sweeps so both replicas close and restore identically", async () => {
+    const file = await tempDbFile();
+    const a = await startReplica(file, "replica-a");
+    const b = await startReplica(file, "replica-b");
+    await a.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+    await a.submitConfig(
+      "policy-set",
+      { policy: { enabled: true, neverSuppressAtOrAbove: "critical" } },
+      "engineer",
+      "p1",
+    );
+    await a.submitIngest(
+      alarm({ id: "root", equipmentId: "PUMP-1", severity: "high", timestamp: 1_000 }),
+      "gw",
+    );
+    await a.submitIngest(
+      alarm({ id: "hidden", equipmentId: "VALVE-1", severity: "low", timestamp: 1_100 }),
+      "gw",
+    );
+    await b.pump();
+    expect(b.engine.getAlarm("hidden")?.state).toBe("suppressed");
+
+    // Only replica A's sweep timer fires. If sweeping were process-local, A
+    // would close the group and reveal the suppressed alarm while B kept
+    // hiding it — the two replicas would disagree about what an operator sees.
+    const sweepClock = Date.now() + 20 * 60 * 1000;
+    await a.submitSweep(sweepClock, 30_000);
+    await b.pump();
+
+    expect(groupShapes(a)).toEqual(groupShapes(b));
+    for (const replica of [a, b]) {
+      expect(replica.engine.getGroups()[0].state).toBe("closed");
+      expect(replica.engine.getAlarm("hidden")?.state).toBe("active");
+    }
+
+    // A second replica sweeping in the same interval collapses onto the entry
+    // already recorded rather than producing a second sweep.
+    const duplicate = await b.submitSweep(sweepClock, 30_000);
+    expect(duplicate.created).toBe(false);
+  });
+
+  it("makes acknowledge, clear and configuration visible on the other replica", async () => {
+    const file = await tempDbFile();
+    const a = await startReplica(file, "replica-a");
+    const b = await startReplica(file, "replica-b");
+    await a.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+    await a.submitIngest(alarm({ id: "one", equipmentId: "PUMP-1", timestamp: 1_000 }), "gw");
+    await a.submitIngest(alarm({ id: "two", equipmentId: "PUMP-1", timestamp: 1_100 }), "gw");
+    await b.pump();
+
+    // Acknowledge on B, observe on A.
+    await b.submitAcknowledge("two", "operator-b");
+    await a.pump();
+    expect(a.engine.getAlarm("two")).toMatchObject({
+      state: "acknowledged",
+      acknowledgedBy: "operator-b",
+    });
+
+    // Configuration change on B, observe on A.
+    await b.submitConfig(
+      "rule-enabled",
+      { ruleId: "default-tag-chatter", enabled: false },
+      "engineer-b",
+      "cfg-1",
+    );
+    await a.pump();
+    expect(a.engine.rules.get("default-tag-chatter")?.enabled).toBe(false);
+
+    // Clear on A, observe on B.
+    await a.submitClear("one", "operator-a");
+    await b.pump();
+    expect(b.engine.getAlarm("one")).toMatchObject({
+      state: "cleared",
+      clearedBy: "operator-a",
+    });
+    expect(groupShapes(a)).toEqual(groupShapes(b));
+  });
+});
+
+describe("fail-safe on coordination loss", () => {
+  /** A store that works until `fail` is set, then rejects everything. */
+  function breakableStore(inner: CorrelationStore): CorrelationStore & { fail: boolean } {
+    const wrapper = {
+      fail: false,
+      ready: () => inner.ready(),
+      backend: () => inner.backend(),
+      append: (entry: Parameters<CorrelationStore["append"]>[0]) =>
+        (wrapper.fail
+          ? Promise.reject(new Error("journal unreachable"))
+          : inner.append(entry)),
+      read: (afterSeq: number, limit?: number) =>
+        (wrapper.fail
+          ? Promise.reject(new Error("journal unreachable"))
+          : inner.read(afterSeq, limit)),
+      load: () => inner.load(),
+      project: (seq: number, changes: Parameters<CorrelationStore["project"]>[1]) =>
+        (wrapper.fail
+          ? Promise.reject(new Error("journal unreachable"))
+          : inner.project(seq, changes)),
+      prune: (options: Parameters<CorrelationStore["prune"]>[0]) => inner.prune(options),
+      close: () => inner.close(),
+    };
+    return wrapper;
+  }
+
+  it("disables suppression and restores every suppressed alarm when the store fails", async () => {
+    const inner = await openStore(await tempDbFile());
+    const store = breakableStore(inner);
+    const coordinator = new AlarmCorrelationCoordinator({
+      store,
+      instanceId: "replica-a",
+      pollIntervalMs: 60_000,
+      pruneIntervalMs: 60 * 60_000,
+    });
+    await coordinator.start();
+    cleanups.push(() => coordinator.stop());
+
+    await coordinator.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+    await coordinator.submitConfig(
+      "policy-set",
+      { policy: { enabled: true, neverSuppressAtOrAbove: "critical" } },
+      "engineer",
+      "p1",
+    );
+    await coordinator.submitIngest(
+      alarm({ id: "root", equipmentId: "PUMP-1", severity: "high", timestamp: 1_000 }),
+      "gw",
+    );
+    await coordinator.submitIngest(
+      alarm({ id: "hidden", equipmentId: "VALVE-1", severity: "low", timestamp: 1_100 }),
+      "gw",
+    );
+    expect(coordinator.engine.getAlarm("hidden")?.state).toBe("suppressed");
+
+    const restored: string[] = [];
+    coordinator.engine.on("alarms-unsuppressed", (payload: { alarmIds: string[] }) => {
+      restored.push(...payload.alarmIds);
+    });
+
+    store.fail = true;
+    await expect(
+      coordinator.submitIngest(alarm({ id: "next", timestamp: 1_200 }), "gw"),
+    ).rejects.toThrow(/journal unreachable/);
+
+    // The alarm the operator could not see is visible again, and was re-emitted
+    // so a consumer that had hidden it is told to show it.
+    expect(restored).toContain("hidden");
+    expect(coordinator.engine.getAlarm("hidden")?.state).toBe("active");
+    expect(coordinator.engine.getSuppressionPolicy().enabled).toBe(false);
+
+    const health = coordinator.health();
+    expect(health.healthy).toBe(false);
+    expect(health.mode).toBe("process-local");
+    expect(health.suppressionDisabledByHealth).toBe(true);
+    // The operator's intent is remembered — it was coordination that failed,
+    // not the operator that changed their mind.
+    expect(health.policyEnabledIntent).toBe(true);
+    expect(health.suppressionActive).toBe(false);
+  });
+
+  it("re-enables suppression only once coordination is healthy again", async () => {
+    const inner = await openStore(await tempDbFile());
+    const store = breakableStore(inner);
+    const coordinator = new AlarmCorrelationCoordinator({
+      store,
+      instanceId: "replica-a",
+      pollIntervalMs: 60_000,
+      pruneIntervalMs: 60 * 60_000,
+    });
+    await coordinator.start();
+    cleanups.push(() => coordinator.stop());
+    await coordinator.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+    await coordinator.submitConfig(
+      "policy-set",
+      { policy: { enabled: true, neverSuppressAtOrAbove: "critical" } },
+      "engineer",
+      "p1",
+    );
+
+    store.fail = true;
+    await expect(coordinator.pump()).rejects.toThrow();
+    expect(coordinator.engine.getSuppressionPolicy().enabled).toBe(false);
+
+    store.fail = false;
+    await coordinator.pump();
+    expect(coordinator.health().healthy).toBe(true);
+    expect(coordinator.health().suppressionDisabledByHealth).toBe(false);
+    // Restored to the operator's persisted intent, not to some default.
+    expect(coordinator.engine.getSuppressionPolicy().enabled).toBe(true);
+  });
+
+  it("still delivers the alarm when the journal cannot be written", async () => {
+    const inner = await openStore(await tempDbFile());
+    const store = breakableStore(inner);
+    const coordinator = new AlarmCorrelationCoordinator({
+      store,
+      instanceId: "replica-a",
+      pollIntervalMs: 60_000,
+      pruneIntervalMs: 60 * 60_000,
+    });
+    await coordinator.start();
+    cleanups.push(() => coordinator.stop());
+
+    const service = new AlarmCorrelationService();
+    service.attachCoordinator(coordinator);
+    const delivered: string[] = [];
+    service.on("alarm-snapshot", (snapshot: { id: string }) => delivered.push(snapshot.id));
+
+    store.fail = true;
+    const outcome = await service.submit({
+      id: "storm-alarm",
+      tagId: "PUMP-9.TRIP",
+      severity: "high",
+      state: "active",
+      timestamp: 4_000,
+    });
+
+    // Storage loss must never hide an alarm: it is correlated locally, returned
+    // to the caller, and broadcast.
+    expect(outcome?.alarm.id).toBe("storm-alarm");
+    expect(delivered).toContain("storm-alarm");
+    expect(service.coordinationMode()).toBe("process-local");
+    const health = await service.healthCheck();
+    expect(health.durableSuppressionAvailable).toBe(false);
+  });
+
+  it("re-projects an entry whose projection failed instead of skipping its rows", async () => {
+    const file = await tempDbFile();
+    const inner = await openStore(file);
+    let failProject = false;
+    const store: CorrelationStore = {
+      ready: () => inner.ready(),
+      backend: () => inner.backend(),
+      append: (entry) => inner.append(entry),
+      read: (afterSeq, limit) => inner.read(afterSeq, limit),
+      load: () => inner.load(),
+      project: (seq, changes) =>
+        (failProject
+          ? Promise.reject(new Error("projection write failed"))
+          : inner.project(seq, changes)),
+      prune: (options) => inner.prune(options),
+      close: () => Promise.resolve(),
+    };
+    const coordinator = new AlarmCorrelationCoordinator({
+      store,
+      instanceId: "replica-a",
+      pollIntervalMs: 60_000,
+      pruneIntervalMs: 60 * 60_000,
+    });
+    await coordinator.start();
+    cleanups.push(() => coordinator.stop());
+
+    // The entry applies to the engine, then its projection write fails.
+    failProject = true;
+    await expect(
+      coordinator.submitIngest(
+        alarm({ id: "survivor", equipmentId: "PUMP-1", severity: "critical" }),
+        "gw",
+      ),
+    ).rejects.toThrow(/projection write failed/);
+
+    // Storage recovers and the entry is retried. Re-applying it is a no-op at
+    // the engine, so nothing is re-emitted — the retry has to project the rows
+    // the first attempt collected, or the watermark advances past an entry
+    // whose alarm was never written and no replica can ever recover it.
+    failProject = false;
+    await coordinator.pump();
+    expect(coordinator.health().healthy).toBe(true);
+
+    const snapshot = await inner.load();
+    expect(snapshot.pending.map((entry) => entry.id)).toContain("survivor");
+
+    // A replica that starts from the projection alone still sees the alarm.
+    const restarted = await startReplica(file, "replica-b");
+    expect(restarted.engine.getAlarm("survivor")).toBeTruthy();
+  });
+});
+
+describe("service integration", () => {
+  it("reports durable mode and a shared seq on snapshots", async () => {
+    const file = await tempDbFile();
+    const coordinator = await startReplica(file, "replica-a");
+    const service = new AlarmCorrelationService();
+    service.attachCoordinator(coordinator);
+
+    const snapshots: Array<{ id: string; correlation: { seq: number | null; coordinationMode: string } }> = [];
+    service.on("alarm-snapshot", (snapshot: never) => snapshots.push(snapshot));
+
+    await service.submit(
+      { id: "a1", tagId: "PUMP-1.TRIP", severity: "high", state: "active", timestamp: 1_000 },
+      "gw",
+    );
+    await service.submit(
+      { id: "a2", tagId: "PUMP-1.TRIP", severity: "low", state: "active", timestamp: 1_100 },
+      "gw",
+    );
+
+    expect(service.coordinationMode()).toBe("durable");
+    const last = snapshots.at(-1);
+    expect(last?.correlation.coordinationMode).toBe("durable");
+    expect(typeof last?.correlation.seq).toBe("number");
+    expect(coordinator.alarmSeq("a2")).toBeGreaterThan(0);
+  });
+
+  it("returns one canonical reconnect snapshot per active alarm", async () => {
+    const file = await tempDbFile();
+    const coordinator = await startReplica(file, "replica-a");
+    const service = new AlarmCorrelationService();
+    service.attachCoordinator(coordinator);
+
+    await service.submit(
+      { id: "open-1", tagId: "PUMP-1.TRIP", severity: "high", state: "active", timestamp: 1_000 },
+      "gw",
+    );
+    await service.submit(
+      { id: "open-2", tagId: "PUMP-1.TRIP", severity: "low", state: "active", timestamp: 1_100 },
+      "gw",
+    );
+    await service.submit(
+      { id: "standalone", tagId: "TANK-7.LEVEL", severity: "medium", state: "active", timestamp: 2_000 },
+      "gw",
+    );
+    await service.clear("open-1", "operator-a");
+
+    const snapshot = service.getReconnectSnapshot();
+    const ids = snapshot.map((entry) => entry.id);
+    // Exactly once each, cleared alarms omitted, and every entry carries the
+    // canonical correlation state rather than whatever was last broadcast.
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).not.toContain("open-1");
+    expect(ids).toEqual(expect.arrayContaining(["open-2", "standalone"]));
+    for (const entry of snapshot) {
+      expect(entry.correlation.coordinationMode).toBe("durable");
+      expect(entry.state).not.toBe("cleared");
+    }
+  });
+
+  it("keeps REST and WebSocket surfaces on the same engine after attaching", async () => {
+    const file = await tempDbFile();
+    const coordinator = await startReplica(file, "replica-a");
+    const service = new AlarmCorrelationService();
+    service.attachCoordinator(coordinator);
+    // The read surface used by routes and the surface used by fanout must be
+    // the same object, or the two could report different suppression.
+    expect(service.engine).toBe(coordinator.engine);
+  });
+});
+
+describe("retention", () => {
+  it("prunes projected journal entries and aged closed groups, keeping live state", async () => {
+    const file = await tempDbFile();
+    const store = await openStore(file);
+    const coordinator = new AlarmCorrelationCoordinator({
+      store,
+      instanceId: "replica-a",
+      pollIntervalMs: 60_000,
+      pruneIntervalMs: 60 * 60_000,
+      journalRetentionMs: 0,
+      stateRetentionMs: 0,
+    });
+    await coordinator.start();
+    cleanups.push(() => coordinator.stop());
+
+    await coordinator.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+    await coordinator.submitIngest(
+      alarm({ id: "root", equipmentId: "PUMP-1", timestamp: 1_000 }),
+      "gw",
+    );
+    await coordinator.submitIngest(
+      alarm({ id: "peer", equipmentId: "PUMP-1", timestamp: 1_100 }),
+      "gw",
+    );
+    const closedGroupId = coordinator.engine.getGroups()[0].id;
+    await coordinator.submitClear("root", "operator-a");
+    expect(coordinator.engine.getGroup(closedGroupId)?.state).toBe("closed");
+
+    // An open group with a live alarm, which retention must not touch.
+    await coordinator.submitIngest(
+      alarm({ id: "live-1", equipmentId: "VALVE-1", timestamp: 8_000 }),
+      "gw",
+    );
+    await coordinator.submitIngest(
+      alarm({ id: "live-2", equipmentId: "VALVE-1", timestamp: 8_100 }),
+      "gw",
+    );
+
+    const pruned = await coordinator.prune();
+    expect(pruned.groups).toBe(1);
+    expect(pruned.alarms).toBe(2);
+    expect(pruned.journalEntries).toBeGreaterThan(0);
+
+    const snapshot = await store.load();
+    // The closed group is gone; the open one and its members are intact.
+    expect(snapshot.groups.map((group) => group.id)).not.toContain(closedGroupId);
+    expect(snapshot.groups).toHaveLength(1);
+    expect(snapshot.groups[0].alarmIds.sort()).toEqual(["live-1", "live-2"]);
+
+    // The watermark entry itself is never pruned, so a restarting replica can
+    // still tell how far the projection got.
+    const remaining = await store.read(0);
+    expect(remaining.every((entry) => entry.seq >= snapshot.appliedSeq)).toBe(true);
+    expect(snapshot.appliedSeq).toBeGreaterThan(0);
+  });
+
+  it("honours the documented retention environment variables", async () => {
+    // Migration 0015 and .env.example tell an operator these two variables
+    // control retention of durable alarm state. A documented knob that nothing
+    // reads is worse than no knob: the operator believes state is being aged
+    // out (or kept) on a schedule that is not the one in force.
+    const file = await tempDbFile();
+    const previous = {
+      journal: process.env.ALARM_CORRELATION_JOURNAL_RETENTION_MS,
+      state: process.env.ALARM_CORRELATION_STATE_RETENTION_MS,
+    };
+    process.env.ALARM_CORRELATION_JOURNAL_RETENTION_MS = "1";
+    process.env.ALARM_CORRELATION_STATE_RETENTION_MS = "1";
+    cleanups.push(async () => {
+      if (previous.journal === undefined) {
+        delete process.env.ALARM_CORRELATION_JOURNAL_RETENTION_MS;
+      } else {
+        process.env.ALARM_CORRELATION_JOURNAL_RETENTION_MS = previous.journal;
+      }
+      if (previous.state === undefined) {
+        delete process.env.ALARM_CORRELATION_STATE_RETENTION_MS;
+      } else {
+        process.env.ALARM_CORRELATION_STATE_RETENTION_MS = previous.state;
+      }
+    });
+
+    const service = new AlarmCorrelationService();
+    const coordinator = await service.enableDurableCoordination({
+      sqlitePath: file,
+      pollIntervalMs: 60_000,
+      instanceId: "replica-env",
+    });
+    cleanups.push(() => service.shutdown());
+
+    // Wall-clock event times, so the built-in 30-day default would keep this
+    // group and only the 1 ms value from the environment can age it out.
+    const nowMs = Date.now();
+    await coordinator.submitConfig("topology-upsert", { nodes: TOPOLOGY }, "engineer", "t1");
+    await coordinator.submitIngest(
+      alarm({ id: "root", equipmentId: "PUMP-1", timestamp: nowMs }),
+      "gw",
+    );
+    await coordinator.submitIngest(
+      alarm({ id: "peer", equipmentId: "PUMP-1", timestamp: nowMs + 100 }),
+      "gw",
+    );
+    await coordinator.submitClear("root", "operator-a");
+    expect(coordinator.engine.getGroups()[0].state).toBe("closed");
+
+    // Both cutoffs are `now - retention`, and Windows' Date.now() granularity
+    // is coarse enough that rows written in the same tick as the prune are not
+    // strictly older than it. Wait past one tick so the assertions are about
+    // retention, not clock resolution.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // With the built-in 7-day / 30-day defaults nothing here is old enough to
+    // age out, so a non-zero result is only possible if both environment
+    // values were actually read.
+    const pruned = await coordinator.prune();
+    expect(pruned.groups).toBe(1);
+    expect(pruned.journalEntries).toBeGreaterThan(0);
+  });
+});

--- a/server/services/alarm-correlation/coordinator.ts
+++ b/server/services/alarm-correlation/coordinator.ts
@@ -1,0 +1,908 @@
+/**
+ * Replica coordination for alarm correlation
+ * ADR-0026 / ADR-0013 [13.2] — Issue #573
+ *
+ * #213 shipped a correlation engine whose suppression defaults OFF because its
+ * state lives in one process's heap. This module is what makes that state
+ * durable and agreed across replicas, so suppression can be turned on without
+ * an operator losing sight of an alarm.
+ *
+ * ─── HOW REPLICAS AGREE ────────────────────────────────────────────────────
+ *
+ * Every correlation-affecting operation is appended to one shared, totally
+ * ordered journal (`store.append`). Each replica consumes that journal in `seq`
+ * order and applies each entry to its own engine. The engine is deterministic
+ * given an ordered operation stream, and group ids are derived from the journal
+ * `seq` rather than a per-process random source, so two replicas that have
+ * consumed the same prefix hold byte-identical membership, root cause and
+ * suppression — including identical group ids.
+ *
+ * This is convergence by shared log, NOT an order-independent merge. Which
+ * replica an HTTP request lands on cannot change the outcome, because the log,
+ * not the arrival, defines the order. The engine remains order-sensitive in
+ * general (arrival order decides partitioning when a safety cap bites); what
+ * this module guarantees is that every replica sees the SAME order.
+ *
+ * ─── THE SAFETY PROPERTY ───────────────────────────────────────────────────
+ *
+ * Coordination or storage loss must never hide an alarm. Three mechanisms, in
+ * order of importance:
+ *
+ *   1. `submit()` rethrows on any store failure so the caller falls back to
+ *      raw, uncorrelated delivery. An alarm is delivered even when nothing
+ *      about it can be persisted.
+ *   2. Any failure calls `degrade()`, which immediately forces suppression off
+ *      in the engine. That un-suppresses every suppressed member and re-emits
+ *      it, so alarms an operator could not see become visible again.
+ *   3. Suppression is only ever re-enabled by `syncEnginePolicy()`, which
+ *      requires BOTH a healthy coordinator and the operator's persisted intent.
+ *      Health alone never enables it, and intent alone never enables it.
+ *
+ * The asymmetry is deliberate and one-way: losing coordination can only reveal
+ * more alarms, never fewer.
+ */
+
+import { EventEmitter } from "events";
+import { randomUUID } from "node:crypto";
+import type {
+  AlarmGroup,
+  CorrelatedAlarm,
+  CorrelationCoordinationHealth,
+  CorrelationJournalEntry,
+  CorrelationJournalOp,
+  CorrelationRule,
+  EquipmentNode,
+  IngestResult,
+  SuppressionPolicy,
+} from "@shared/types/alarm-correlation";
+import { AlarmCorrelationEngine } from "./engine";
+import { CorrelationRulesEngine, DEFAULT_RULES } from "./rules";
+import { EquipmentTopology } from "./topology";
+import {
+  emptyProjectionChanges,
+  type CorrelationStore,
+  type PersistedAlarm,
+  type ProjectionChanges,
+} from "./store";
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_JOURNAL_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_STATE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const DEFAULT_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
+/** Bounds the transient map that carries per-submit results back to callers. */
+const MAX_AWAITED_RESULTS = 1000;
+
+export interface CoordinatorOptions {
+  store: CorrelationStore;
+  engine?: AlarmCorrelationEngine;
+  /** Identifies this replica in journal rows. Diagnostic only — never ordering. */
+  instanceId?: string;
+  /** How often to pull entries appended by other replicas. */
+  pollIntervalMs?: number;
+  journalRetentionMs?: number;
+  stateRetentionMs?: number;
+  pruneIntervalMs?: number;
+  clock?: () => number;
+  /** Engine construction options other than the seq-derived group id factory. */
+  engineOptions?: ConstructorParameters<typeof AlarmCorrelationEngine>[0];
+}
+
+export interface SubmitResult<T> {
+  seq: number;
+  /** False when this exact operation was already in the journal. */
+  created: boolean;
+  /**
+   * Outcome of applying the entry, when this replica was the one that applied
+   * it during this call. Absent for a duplicate submission whose entry had
+   * already been applied — the caller reads current engine state instead.
+   */
+  outcome?: T;
+}
+
+type ApplyOutcome =
+  | { kind: "ingest"; result: IngestResult }
+  | { kind: "acknowledge"; acknowledged: boolean }
+  | { kind: "clear"; result: ReturnType<AlarmCorrelationEngine["alarmCleared"]> }
+  | { kind: "config" };
+
+/** Alarm shape as stored in a journal payload. Mirrors CorrelatedAlarm. */
+function serializeAlarm(alarm: CorrelatedAlarm): Record<string, unknown> {
+  return { ...alarm };
+}
+
+/**
+ * Rebuild a CorrelatedAlarm field by field rather than casting the row. The
+ * payload is this codebase's own serialisation, but it has been through a
+ * database, and a cast would let anything that ever got into that row become a
+ * live alarm object.
+ */
+function deserializeAlarm(payload: Record<string, unknown>): CorrelatedAlarm | null {
+  const id = payload.id;
+  const timestamp = payload.timestamp;
+  if (typeof id !== "string" || id === "") return null;
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) return null;
+  const optionalString = (raw: unknown): string | undefined =>
+    (typeof raw === "string" && raw !== "" ? raw : undefined);
+  const scalar = (raw: unknown): number | string | undefined =>
+    (typeof raw === "number" || typeof raw === "string" ? raw : undefined);
+  return {
+    id,
+    name: typeof payload.name === "string" ? payload.name : id,
+    tagId: typeof payload.tagId === "string" ? payload.tagId : "",
+    equipmentId: optionalString(payload.equipmentId),
+    siteId: optionalString(payload.siteId),
+    processArea: optionalString(payload.processArea),
+    severity: severityOrFloor(payload.severity),
+    state: lifecycleStateOrActive(payload.state),
+    message: typeof payload.message === "string" ? payload.message : "",
+    timestamp,
+    value: scalar(payload.value),
+    limit: scalar(payload.limit),
+    source: optionalString(payload.source),
+    acknowledgedBy: optionalString(payload.acknowledgedBy),
+    clearedBy: optionalString(payload.clearedBy),
+  };
+}
+
+const SEVERITIES: readonly CorrelatedAlarm["severity"][] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+];
+
+const LIFECYCLE_STATES: readonly CorrelatedAlarm["state"][] = [
+  "active",
+  "acknowledged",
+  "cleared",
+  "shelved",
+  "suppressed",
+];
+
+/**
+ * An unrecognised severity becomes `critical` — the never-suppress floor. A
+ * cast would let an out-of-vocabulary value reach the severity comparison the
+ * suppression decision is made on, where it compares as neither above nor below
+ * the floor. Failing to the floor keeps the alarm visible.
+ */
+function severityOrFloor(raw: unknown): CorrelatedAlarm["severity"] {
+  return SEVERITIES.find((candidate) => candidate === raw) ?? "critical";
+}
+
+/** An unrecognised lifecycle state becomes `active`: visible and actionable. */
+function lifecycleStateOrActive(raw: unknown): CorrelatedAlarm["state"] {
+  return LIFECYCLE_STATES.find((candidate) => candidate === raw) ?? "active";
+}
+
+export class AlarmCorrelationCoordinator extends EventEmitter {
+  readonly engine: AlarmCorrelationEngine;
+  readonly instanceId: string;
+
+  private readonly store: CorrelationStore;
+  private readonly pollIntervalMs: number;
+  private readonly journalRetentionMs: number;
+  private readonly stateRetentionMs: number;
+  private readonly pruneIntervalMs: number;
+  private readonly clock: () => number;
+
+  private started = false;
+  private healthy = false;
+  private lastError: string | null = null;
+  private lastHealthyAt: number | null = null;
+  private suppressionDisabledByHealth = false;
+
+  /** Highest journal seq this replica has applied to its own engine. */
+  private appliedSeq = 0;
+  /** Watermark of the shared materialised projection, as last observed. */
+  private materializedSeq = 0;
+
+  /** Operator's persisted intent, independent of whether it is being honoured. */
+  private policyIntent: SuppressionPolicy = {
+    enabled: false,
+    neverSuppressAtOrAbove: "critical",
+    unsuppressOnRootClear: true,
+  };
+
+  /** alarmId → journal seq that ingested it (persisted on the alarm row). */
+  private ingestSeqByAlarm = new Map<string, number>();
+  /** alarmId → journal seq of its latest state change, for wire de-duplication. */
+  private stateSeqByAlarm = new Map<string, number>();
+
+  /** Seq currently being applied — the source of deterministic group ids. */
+  private applyingSeq = 0;
+  private groupsFormedInEntry = 0;
+
+  private dirtyAlarmIds = new Set<string>();
+  private dirtyGroupIds = new Set<string>();
+  private removedAlarmIds = new Set<string>();
+  private removedGroupIds = new Set<string>();
+  private entryChanges: ProjectionChanges | null = null;
+  /**
+   * Seq whose projection failed and has not yet been re-projected.
+   *
+   * The row changes for an entry are collected from the engine events it emits
+   * while being applied. Re-applying is idempotent AT THE ENGINE, which means a
+   * retry emits nothing — so a retry that started from empty dirty sets would
+   * advance the watermark having written no rows, and the alarm that entry
+   * carried would be absent from the projection for good. A restarting replica
+   * adopts the projection at that watermark and never replays the entry, so the
+   * alarm would simply be gone — exactly the "storage hiccup hides an alarm"
+   * outcome this subsystem must never produce. Keeping the dirty sets alive
+   * across the failure makes the retry re-read and re-write those same rows.
+   */
+  private unprojectedSeq: number | null = null;
+
+  private awaitedSeqs = new Set<number>();
+  private results = new Map<number, ApplyOutcome>();
+
+  private pollTimer: NodeJS.Timeout | null = null;
+  private pruneTimer: NodeJS.Timeout | null = null;
+  private pumping: Promise<void> = Promise.resolve();
+
+  constructor(options: CoordinatorOptions) {
+    super();
+    this.store = options.store;
+    this.instanceId = options.instanceId ?? randomUUID();
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.journalRetentionMs = options.journalRetentionMs ?? DEFAULT_JOURNAL_RETENTION_MS;
+    this.stateRetentionMs = options.stateRetentionMs ?? DEFAULT_STATE_RETENTION_MS;
+    this.pruneIntervalMs = options.pruneIntervalMs ?? DEFAULT_PRUNE_INTERVAL_MS;
+    this.clock = options.clock ?? Date.now;
+    this.engine = options.engine ?? new AlarmCorrelationEngine({
+      ...options.engineOptions,
+      groupIdFactory: () => this.nextGroupId(),
+    });
+    this.subscribeToEngine();
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+
+  /**
+   * Open the store, adopt the durable projection, and start consuming the
+   * journal. Throws if the store cannot be reached — the caller must then run
+   * process-local with suppression off rather than pretend coordination works.
+   */
+  async start(): Promise<void> {
+    if (this.started) return;
+    await this.store.ready();
+    await this.rehydrate();
+    this.started = true;
+    this.healthy = true;
+    this.lastError = null;
+    this.lastHealthyAt = this.clock();
+    this.suppressionDisabledByHealth = false;
+    this.syncEnginePolicy();
+    await this.pump();
+
+    this.pollTimer = setInterval(() => {
+      void this.pump().catch(() => undefined);
+    }, this.pollIntervalMs);
+    this.pollTimer.unref?.();
+
+    this.pruneTimer = setInterval(() => {
+      void this.prune().catch(() => undefined);
+    }, this.pruneIntervalMs);
+    this.pruneTimer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    if (this.pruneTimer) {
+      clearInterval(this.pruneTimer);
+      this.pruneTimer = null;
+    }
+    this.started = false;
+    this.healthy = false;
+    await this.pumping.catch(() => undefined);
+    await this.store.close();
+  }
+
+  // ── Health ───────────────────────────────────────────────────────────────
+
+  health(): CorrelationCoordinationHealth {
+    return {
+      healthy: this.healthy,
+      // A degraded coordinator is not coordinating. Reporting `durable` while
+      // its state may be stale would be the exact false claim this issue is
+      // about, and consumers key their trust in suppression off this field.
+      mode: this.healthy ? "durable" : "process-local",
+      backend: this.store.backend(),
+      appliedSeq: this.appliedSeq,
+      materializedSeq: this.materializedSeq,
+      policyEnabledIntent: this.policyIntent.enabled,
+      suppressionActive: this.engine.getSuppressionPolicy().enabled,
+      suppressionDisabledByHealth: this.suppressionDisabledByHealth,
+      lastError: this.lastError,
+      lastHealthyAt: this.lastHealthyAt,
+      instanceId: this.instanceId,
+    };
+  }
+
+  /** Journal seq of an alarm's latest state change, for wire de-duplication. */
+  alarmSeq(alarmId: string): number | null {
+    return this.stateSeqByAlarm.get(alarmId) ?? null;
+  }
+
+  /**
+   * Force the fail-safe path: suppression off, every suppressed alarm restored
+   * and re-emitted, health reported degraded. Idempotent.
+   */
+  degrade(reason: string): void {
+    this.lastError = reason;
+    if (!this.healthy) return;
+    this.healthy = false;
+    this.suppressionDisabledByHealth = true;
+    try {
+      // Un-suppresses every member of every open group and emits the updates,
+      // so a consumer that had hidden them shows them again.
+      this.engine.setSuppressionPolicy({ enabled: false });
+    } catch {
+      // Restoring visibility must not be blocked by a policy validation error.
+    }
+    this.emit("degraded", { reason });
+  }
+
+  // ── Submission ───────────────────────────────────────────────────────────
+
+  async submitIngest(
+    alarm: CorrelatedAlarm,
+    principal: string,
+  ): Promise<SubmitResult<IngestResult>> {
+    // One alarm id is ingested exactly once, ever. A retried or cross-replica
+    // duplicate delivery collapses onto the entry already recorded.
+    const submitted = await this.submit(
+      "ingest",
+      `ingest:${alarm.id}`,
+      serializeAlarm(alarm),
+      principal,
+    );
+    const outcome = submitted.outcome;
+    return {
+      seq: submitted.seq,
+      created: submitted.created,
+      outcome: outcome?.kind === "ingest" ? outcome.result : undefined,
+    };
+  }
+
+  async submitAcknowledge(
+    alarmId: string,
+    principal: string,
+  ): Promise<SubmitResult<boolean>> {
+    const submitted = await this.submit(
+      "acknowledge",
+      `acknowledge:${alarmId}`,
+      { alarmId },
+      principal,
+    );
+    const outcome = submitted.outcome;
+    return {
+      seq: submitted.seq,
+      created: submitted.created,
+      outcome: outcome?.kind === "acknowledge" ? outcome.acknowledged : undefined,
+    };
+  }
+
+  /**
+   * Journal one idle-group sweep.
+   *
+   * Sweeping per replica would break convergence: closing an idle group
+   * un-suppresses its members, so a sweep that ran on one replica and not
+   * another leaves the two disagreeing about what an operator can see. The
+   * entry carries the sweep clock, so every replica makes the identical
+   * decision no matter when it consumes the entry.
+   *
+   * The idempotency key buckets by `bucketMs`, so several replicas whose sweep
+   * timers fire in the same interval produce one entry rather than N.
+   */
+  async submitSweep(nowMs: number, bucketMs: number): Promise<SubmitResult<void>> {
+    const bucket = Math.floor(nowMs / Math.max(1, bucketMs));
+    const submitted = await this.submit(
+      "sweep",
+      `sweep:${bucket}`,
+      { nowMs },
+      "system",
+    );
+    return { seq: submitted.seq, created: submitted.created };
+  }
+
+  async submitClear(
+    alarmId: string,
+    principal: string,
+  ): Promise<SubmitResult<ReturnType<AlarmCorrelationEngine["alarmCleared"]>>> {
+    const submitted = await this.submit(
+      "clear",
+      `clear:${alarmId}`,
+      { alarmId },
+      principal,
+    );
+    const outcome = submitted.outcome;
+    return {
+      seq: submitted.seq,
+      created: submitted.created,
+      outcome: outcome?.kind === "clear" ? outcome.result : undefined,
+    };
+  }
+
+  /**
+   * Configuration mutations (rules, topology, suppression policy).
+   *
+   * Unlike alarm lifecycle operations these have no natural idempotency key —
+   * editing a rule to A, then B, then back to A is three distinct operations,
+   * so a content-derived key would silently drop the third. The caller supplies
+   * `idempotencyKey` (routes take it from an `Idempotency-Key` header) to make
+   * a retry safe; without one each request is its own operation.
+   */
+  async submitConfig(
+    op: Extract<
+      CorrelationJournalOp,
+      | "rule-upsert"
+      | "rule-remove"
+      | "rule-enabled"
+      | "topology-upsert"
+      | "topology-remove"
+      | "policy-set"
+    >,
+    payload: Record<string, unknown>,
+    principal: string,
+    idempotencyKey?: string,
+  ): Promise<SubmitResult<void>> {
+    const key = idempotencyKey ? `${op}:${idempotencyKey}` : `${op}:${randomUUID()}`;
+    const submitted = await this.submit(op, key, payload, principal);
+    return { seq: submitted.seq, created: submitted.created };
+  }
+
+  private async submit(
+    op: CorrelationJournalOp,
+    idempotencyKey: string,
+    payload: Record<string, unknown>,
+    principal: string,
+  ): Promise<SubmitResult<ApplyOutcome>> {
+    let appended: { seq: number; created: boolean };
+    try {
+      appended = await this.store.append({
+        idempotencyKey,
+        op,
+        payload,
+        principal,
+        originInstance: this.instanceId,
+      });
+    } catch (error) {
+      // Fail safe, then rethrow: the caller must fall back to raw delivery so
+      // the alarm still reaches the operator uncorrelated.
+      this.degrade(`journal append failed: ${describe(error)}`);
+      throw error;
+    }
+
+    this.awaitedSeqs.add(appended.seq);
+    try {
+      await this.pump();
+    } finally {
+      this.awaitedSeqs.delete(appended.seq);
+    }
+    const outcome = this.results.get(appended.seq);
+    this.results.delete(appended.seq);
+    return { seq: appended.seq, created: appended.created, outcome };
+  }
+
+  // ── Journal consumption ──────────────────────────────────────────────────
+
+  /**
+   * Apply every journal entry above this replica's watermark, in seq order.
+   * Serialised so two callers cannot interleave applications; a failure marks
+   * the coordinator degraded and leaves the watermark where it was, so the
+   * entry is retried on the next pump.
+   */
+  pump(): Promise<void> {
+    const run = this.pumping.then(() => this.drain(), () => this.drain());
+    this.pumping = run.catch(() => undefined);
+    return run;
+  }
+
+  private async drain(): Promise<void> {
+    for (;;) {
+      let entries: CorrelationJournalEntry[];
+      try {
+        entries = await this.store.read(this.appliedSeq);
+      } catch (error) {
+        this.degrade(`journal read failed: ${describe(error)}`);
+        throw error;
+      }
+      if (entries.length === 0) {
+        this.markHealthy();
+        return;
+      }
+      for (const entry of entries) {
+        await this.applyEntry(entry);
+      }
+      this.markHealthy();
+    }
+  }
+
+  private markHealthy(): void {
+    this.lastHealthyAt = this.clock();
+    if (this.healthy) return;
+    this.healthy = true;
+    this.lastError = null;
+    this.suppressionDisabledByHealth = false;
+    // Re-enable suppression only now that coordination works again, and only
+    // to the extent the operator's persisted intent asks for.
+    this.syncEnginePolicy();
+    this.emit("recovered", this.health());
+  }
+
+  /**
+   * Apply one entry to the engine, then project its row changes.
+   *
+   * If the projection fails, the watermark is NOT advanced, so the next pump
+   * replays this entry against an engine that already applied it. That is safe
+   * because every operation is idempotent at the engine: a repeated `ingest`
+   * returns `duplicate` without re-counting, `acknowledge`/`clear` are guarded
+   * by the alarm's current state, `sweep` is a pure function of the clock it
+   * carries, and rule/topology/policy writes are upserts.
+   */
+  private async applyEntry(entry: CorrelationJournalEntry): Promise<void> {
+    this.beginEntry(entry);
+    let outcome: ApplyOutcome = { kind: "config" };
+    try {
+      outcome = this.applyToEngine(entry);
+    } catch (error) {
+      // A malformed or unapplicable entry must not wedge the log forever: the
+      // watermark still advances so later operations are not blocked behind it,
+      // and the failure is surfaced rather than swallowed.
+      this.emit("apply-failed", { seq: entry.seq, reason: describe(error) });
+    }
+
+    const changes = this.finishEntry(entry);
+    try {
+      const projected = await this.store.project(entry.seq, changes);
+      if (projected) this.materializedSeq = entry.seq;
+      else this.materializedSeq = Math.max(this.materializedSeq, entry.seq);
+    } catch (error) {
+      // Keep this entry's row changes so the retry re-projects them; the engine
+      // will not re-emit them, because applying it again is a no-op there.
+      this.unprojectedSeq = entry.seq;
+      this.degrade(`projection of seq ${entry.seq} failed: ${describe(error)}`);
+      throw error;
+    }
+    this.unprojectedSeq = null;
+
+    this.appliedSeq = entry.seq;
+    for (const alarmId of changes.deletedAlarmIds) {
+      this.stateSeqByAlarm.delete(alarmId);
+      this.ingestSeqByAlarm.delete(alarmId);
+    }
+
+    if (this.awaitedSeqs.has(entry.seq)) {
+      if (this.results.size >= MAX_AWAITED_RESULTS) this.results.clear();
+      this.results.set(entry.seq, outcome);
+    }
+    this.emit("applied", { seq: entry.seq, op: entry.op });
+  }
+
+  private applyToEngine(entry: CorrelationJournalEntry): ApplyOutcome {
+    switch (entry.op) {
+      case "ingest": {
+        const alarm = deserializeAlarm(entry.payload);
+        if (!alarm) throw new Error(`entry ${entry.seq} carries no usable alarm`);
+        if (!this.ingestSeqByAlarm.has(alarm.id)) {
+          this.ingestSeqByAlarm.set(alarm.id, entry.seq);
+        }
+        return { kind: "ingest", result: this.engine.ingest(alarm) };
+      }
+      case "acknowledge": {
+        const alarmId = String(entry.payload.alarmId ?? "");
+        return {
+          kind: "acknowledge",
+          acknowledged: this.engine.alarmAcknowledged(alarmId, entry.principal),
+        };
+      }
+      case "clear": {
+        const alarmId = String(entry.payload.alarmId ?? "");
+        return {
+          kind: "clear",
+          result: this.engine.alarmCleared(alarmId, entry.principal),
+        };
+      }
+      case "sweep": {
+        const nowMs = entry.payload.nowMs;
+        if (typeof nowMs !== "number" || !Number.isFinite(nowMs)) {
+          throw new Error(`sweep entry ${entry.seq} carries no usable clock`);
+        }
+        this.engine.sweep(nowMs);
+        return { kind: "config" };
+      }
+      case "rule-upsert": {
+        const rule = entry.payload.rule as CorrelationRule;
+        const stored = this.engine.rules.upsert(rule);
+        this.entryChanges?.upsertRules.push(stored);
+        return { kind: "config" };
+      }
+      case "rule-remove": {
+        const ruleId = String(entry.payload.ruleId ?? "");
+        this.engine.rules.remove(ruleId);
+        this.entryChanges?.removedRuleIds.push(ruleId);
+        return { kind: "config" };
+      }
+      case "rule-enabled": {
+        const ruleId = String(entry.payload.ruleId ?? "");
+        const enabled = entry.payload.enabled === true;
+        const stored = this.engine.rules.setEnabled(ruleId, enabled);
+        if (stored) this.entryChanges?.upsertRules.push(stored);
+        return { kind: "config" };
+      }
+      case "topology-upsert": {
+        const nodes = (entry.payload.nodes ?? []) as EquipmentNode[];
+        const stored = this.engine.topology.upsertMany(nodes);
+        this.entryChanges?.upsertEquipment.push(...stored);
+        this.engine.reconcileTopology();
+        return { kind: "config" };
+      }
+      case "topology-remove": {
+        const equipmentId = String(entry.payload.equipmentId ?? "");
+        this.engine.topology.remove(equipmentId);
+        this.entryChanges?.removedEquipmentIds.push(equipmentId);
+        this.engine.reconcileTopology();
+        return { kind: "config" };
+      }
+      case "policy-set": {
+        const requested = entry.payload.policy as Partial<SuppressionPolicy>;
+        this.policyIntent = {
+          ...this.policyIntent,
+          ...requested,
+          // Never persistable as false: a group that closes without restoring
+          // its suppressed members would hide them permanently.
+          unsuppressOnRootClear: true,
+        };
+        this.syncEnginePolicy();
+        if (this.entryChanges) this.entryChanges.policy = { ...this.policyIntent };
+        return { kind: "config" };
+      }
+    }
+  }
+
+  /**
+   * Suppression is active only when coordination is healthy AND the operator's
+   * persisted intent asks for it. Neither condition alone is enough, and this
+   * is the only place suppression is ever turned on.
+   */
+  private syncEnginePolicy(): void {
+    this.engine.setSuppressionPolicy({
+      neverSuppressAtOrAbove: this.policyIntent.neverSuppressAtOrAbove,
+      unsuppressOnRootClear: true,
+      enabled: this.healthy && this.policyIntent.enabled,
+    });
+  }
+
+  // ── Deterministic group ids ──────────────────────────────────────────────
+
+  /**
+   * `ACG-<seq>` for the first group formed while applying an entry, then
+   * `ACG-<seq>-<n>`. Derived entirely from the shared journal position, so
+   * every replica names the same group identically, and monotonic-never-reused
+   * `seq` allocation rules out reuse. Falls back to a random id only when no
+   * entry is being applied, which cannot happen on the coordinated path but
+   * must not silently produce a colliding constant if it ever did.
+   */
+  private nextGroupId(): string {
+    if (this.applyingSeq === 0) return `ACG-local-${randomUUID()}`;
+    const suffix = this.groupsFormedInEntry === 0 ? "" : `-${this.groupsFormedInEntry}`;
+    this.groupsFormedInEntry++;
+    return `ACG-${this.applyingSeq}${suffix}`;
+  }
+
+  // ── Dirty tracking → projection changes ──────────────────────────────────
+
+  /**
+   * Mark an alarm as changed by the entry being applied.
+   *
+   * The seq is recorded HERE rather than after the projection commits, because
+   * the engine emits its change events synchronously during apply and the
+   * snapshots built from them must already carry the seq — a snapshot that went
+   * out with a null seq could not be recognised as a duplicate by the instance
+   * that receives its cross-instance echo.
+   */
+  private touchAlarm(alarmId: string): void {
+    this.dirtyAlarmIds.add(alarmId);
+    this.removedAlarmIds.delete(alarmId);
+    if (this.applyingSeq > 0) this.stateSeqByAlarm.set(alarmId, this.applyingSeq);
+  }
+
+  private subscribeToEngine(): void {
+    const touchGroup = (group: AlarmGroup): void => {
+      this.dirtyGroupIds.add(group.id);
+      this.removedGroupIds.delete(group.id);
+      for (const alarm of group.alarms) this.touchAlarm(alarm.id);
+    };
+    for (const event of ["group-created", "group-updated", "group-closed"]) {
+      this.engine.on(event, touchGroup);
+    }
+    this.engine.on("alarm-updated", (alarm: CorrelatedAlarm) => {
+      this.touchAlarm(alarm.id);
+    });
+    this.engine.on("alarm-suppressed", (payload: { alarmId: string }) => {
+      this.touchAlarm(payload.alarmId);
+    });
+    this.engine.on("alarms-unsuppressed", (payload: { alarmIds: string[] }) => {
+      for (const alarmId of payload.alarmIds) this.touchAlarm(alarmId);
+    });
+    // Eviction and pruning are the engine forgetting state under its retention
+    // caps. The projection must forget exactly the same rows, or a restart
+    // would resurrect groups this engine no longer believes in.
+    this.engine.on("group-evicted", (payload: { groupId: string; alarmIds: string[] }) => {
+      this.removedGroupIds.add(payload.groupId);
+      this.dirtyGroupIds.delete(payload.groupId);
+      for (const alarmId of payload.alarmIds) {
+        this.removedAlarmIds.add(alarmId);
+        this.dirtyAlarmIds.delete(alarmId);
+      }
+    });
+    this.engine.on("pending-pruned", (payload: { alarmIds?: string[] }) => {
+      for (const alarmId of payload.alarmIds ?? []) {
+        this.removedAlarmIds.add(alarmId);
+        this.dirtyAlarmIds.delete(alarmId);
+      }
+    });
+  }
+
+  private beginEntry(entry: CorrelationJournalEntry): void {
+    this.applyingSeq = entry.seq;
+    this.groupsFormedInEntry = 0;
+    // Retrying an entry whose projection failed keeps the ids that attempt
+    // collected; anything else starts clean.
+    if (this.unprojectedSeq !== entry.seq) {
+      this.dirtyAlarmIds.clear();
+      this.dirtyGroupIds.clear();
+      this.removedAlarmIds.clear();
+      this.removedGroupIds.clear();
+    }
+    this.entryChanges = emptyProjectionChanges(
+      this.engine.getCounters(),
+      entry.principal,
+    );
+  }
+
+  private finishEntry(entry: CorrelationJournalEntry): ProjectionChanges {
+    const changes = this.entryChanges
+      ?? emptyProjectionChanges(this.engine.getCounters(), entry.principal);
+    this.entryChanges = null;
+    this.applyingSeq = 0;
+    changes.metrics = this.engine.getCounters();
+
+    for (const groupId of this.dirtyGroupIds) {
+      const group = this.engine.getGroup(groupId);
+      // Formed then evicted while applying one entry: nothing to persist, and
+      // the delete below removes any earlier row.
+      if (!group) {
+        this.removedGroupIds.add(groupId);
+        continue;
+      }
+      changes.groups.push(group);
+    }
+
+    for (const alarmId of this.dirtyAlarmIds) {
+      const persisted = this.persistedAlarm(alarmId, entry.seq);
+      if (!persisted) {
+        this.removedAlarmIds.add(alarmId);
+        continue;
+      }
+      changes.alarms.push(persisted);
+    }
+
+    changes.deletedGroupIds = [...this.removedGroupIds];
+    changes.deletedAlarmIds = [...this.removedAlarmIds];
+    return changes;
+  }
+
+  private persistedAlarm(alarmId: string, seq: number): PersistedAlarm | null {
+    const alarm = this.engine.getAlarm(alarmId);
+    if (!alarm) return null;
+    const group = this.engine.getGroupForAlarm(alarmId);
+    return {
+      alarm,
+      groupId: group?.id ?? null,
+      suppressed: group?.suppressedAlarmIds.includes(alarmId) ?? false,
+      isRootCause: group?.rootCauseAlarmId === alarmId,
+      joinedViaRuleId: group?.joinedVia[alarmId] ?? null,
+      ingestSeq: this.ingestSeqByAlarm.get(alarmId) ?? seq,
+    };
+  }
+
+  // ── Recovery ─────────────────────────────────────────────────────────────
+
+  /**
+   * Adopt the durable projection: rules, topology, suppression policy, open
+   * groups (with their suppression records), ungrouped alarms, lifecycle
+   * attribution, and the cumulative counters.
+   *
+   * Rules fall back to DEFAULT_RULES only when the store holds none at all —
+   * an empty rule table means "never configured", whereas an operator who
+   * deliberately removed every rule keeps at least the disabled rows.
+   */
+  private async rehydrate(): Promise<void> {
+    const snapshot = await this.store.load();
+
+    const rules = snapshot.rules.length > 0 ? snapshot.rules : DEFAULT_RULES;
+    // Constructing a rules engine validates every stored rule before any of it
+    // reaches the live engine, so a corrupted row fails recovery loudly instead
+    // of quietly changing which alarms get grouped.
+    const validated = new CorrelationRulesEngine(rules).list();
+    replaceRules(this.engine.rules, validated);
+
+    const topology = new EquipmentTopology();
+    topology.upsertMany(snapshot.equipment);
+    replaceTopology(this.engine.topology, topology.list());
+
+    this.engine.hydrate({
+      groups: snapshot.groups,
+      pending: snapshot.pending,
+      metrics: snapshot.metrics,
+    });
+
+    this.policyIntent = { ...snapshot.policy, unsuppressOnRootClear: true };
+    this.appliedSeq = snapshot.appliedSeq;
+    this.materializedSeq = snapshot.appliedSeq;
+
+    this.ingestSeqByAlarm = new Map();
+    this.stateSeqByAlarm = new Map(snapshot.alarmSeq);
+    for (const group of snapshot.groups) {
+      for (const alarm of group.alarms) {
+        this.ingestSeqByAlarm.set(
+          alarm.id,
+          snapshot.alarmSeq.get(alarm.id) ?? snapshot.appliedSeq,
+        );
+      }
+    }
+    for (const alarm of snapshot.pending) {
+      this.ingestSeqByAlarm.set(
+        alarm.id,
+        snapshot.alarmSeq.get(alarm.id) ?? snapshot.appliedSeq,
+      );
+    }
+  }
+
+  /** Apply retention. Never touches unprojected journal entries or open groups. */
+  async prune(): Promise<{ journalEntries: number; groups: number; alarms: number }> {
+    try {
+      const result = await this.store.prune({
+        journalOlderThanMs: this.journalRetentionMs,
+        closedGroupsOlderThanMs: this.stateRetentionMs,
+        now: this.clock(),
+      });
+      this.emit("pruned", result);
+      return result;
+    } catch (error) {
+      this.degrade(`retention pass failed: ${describe(error)}`);
+      throw error;
+    }
+  }
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * The rules engine and topology are owned by the correlation engine and have no
+ * "replace everything" operation, because normal operation only ever upserts.
+ * Recovery genuinely needs one: whatever the process started with must give way
+ * to what the store holds, including rules an operator deleted.
+ */
+function replaceRules(target: CorrelationRulesEngine, rules: CorrelationRule[]): void {
+  for (const existing of target.list()) {
+    if (!rules.some((rule) => rule.id === existing.id)) target.remove(existing.id);
+  }
+  for (const rule of rules) target.upsert(rule);
+}
+
+function replaceTopology(target: EquipmentTopology, nodes: EquipmentNode[]): void {
+  for (const existing of target.list()) {
+    if (!nodes.some((node) => node.equipmentId === existing.equipmentId)) {
+      target.remove(existing.equipmentId);
+    }
+  }
+  if (nodes.length > 0) target.upsertMany(nodes);
+}

--- a/server/services/alarm-correlation/engine.ts
+++ b/server/services/alarm-correlation/engine.ts
@@ -61,6 +61,33 @@ export interface CorrelationEngineOptions {
   maxAlarmsPerGroup?: number;
   /** Processing-time clock used only for lifecycle housekeeping */
   clock?: () => number;
+  /**
+   * Mints the id for a newly formed group. Defaults to a process-local random
+   * UUID, which is collision-free but arbitrary: two replicas replaying the
+   * same operation would mint different ids for the same group. The durable
+   * coordinator (#573) supplies a factory deriving the id from the shared
+   * journal sequence instead, so every replica names the group identically and
+   * a monotonic, never-reused sequence rules out reuse.
+   */
+  groupIdFactory?: () => string;
+}
+
+/**
+ * Everything a restart or a second replica needs to reconstitute this engine's
+ * correlation state. Deliberately excludes rules and topology, which are owned
+ * by their own components and restored separately.
+ */
+export interface CorrelationEngineState {
+  groups: AlarmGroup[];
+  /** Tracked but ungrouped alarms — candidate peers for future groups. */
+  pending: CorrelatedAlarm[];
+  metrics: {
+    alarmsIngested: number;
+    groupsCreated: number;
+    groupsClosed: number;
+    alarmsSuppressed: number;
+    alarmsUnsuppressed: number;
+  };
 }
 
 export class AlarmCorrelationEngine extends EventEmitter {
@@ -74,6 +101,7 @@ export class AlarmCorrelationEngine extends EventEmitter {
   private readonly maxPendingAlarms: number;
   private readonly maxAlarmsPerGroup: number;
   private readonly clock: () => number;
+  private readonly groupIdFactory: () => string;
 
   private groups: Map<string, AlarmGroup> = new Map();
   private groupLastTouchedAt: Map<string, number> = new Map();
@@ -108,6 +136,7 @@ export class AlarmCorrelationEngine extends EventEmitter {
     this.maxPendingAlarms = options.maxPendingAlarms ?? 2000;
     this.maxAlarmsPerGroup = options.maxAlarmsPerGroup ?? 128;
     this.clock = options.clock ?? Date.now;
+    this.groupIdFactory = options.groupIdFactory ?? (() => `ACG-${randomUUID()}`);
     if (options.suppressionPolicy?.unsuppressOnRootClear === false) {
       throw new Error('unsuppressOnRootClear must remain enabled for fail-safe closure');
     }
@@ -332,6 +361,21 @@ export class AlarmCorrelationEngine extends EventEmitter {
       ?.alarms.find((alarm) => alarm.id === alarmId);
   }
 
+  /** The group an alarm currently belongs to, or undefined when ungrouped. */
+  getGroupForAlarm(alarmId: string): AlarmGroup | undefined {
+    const groupId = this.alarmIndex.get(alarmId);
+    if (!groupId) return undefined;
+    return this.groups.get(groupId);
+  }
+
+  /** Every alarm this engine is tracking, grouped or not. */
+  listTrackedAlarms(): CorrelatedAlarm[] {
+    const alarms: CorrelatedAlarm[] = [];
+    for (const group of this.groups.values()) alarms.push(...group.alarms);
+    alarms.push(...this.pending);
+    return alarms;
+  }
+
   getRootCause(groupId: string): RootCauseResult | null {
     const group = this.groups.get(groupId);
     if (!group) return null;
@@ -386,6 +430,106 @@ export class AlarmCorrelationEngine extends EventEmitter {
       this.applySuppression(group);
       this.emit('group-updated', group);
     }
+  }
+
+  // ── Durable recovery (#573) ──────────────────────────────────────────
+
+  /**
+   * Deep copy of everything a restart needs to reconstitute correlation.
+   * Copies rather than live references, so a caller cannot mutate engine state
+   * through the snapshot it persists.
+   */
+  exportState(): CorrelationEngineState {
+    return {
+      groups: Array.from(this.groups.values(), (group) => this.cloneGroup(group)),
+      pending: this.pending.map((alarm) => ({ ...alarm })),
+      metrics: this.getCounters(),
+    };
+  }
+
+  /**
+   * Raw cumulative counters, without the derived rate in `getMetrics()` and
+   * without the whole-state deep copy in `exportState()`. The durable
+   * projection writes these on every applied journal entry, so it must not have
+   * to clone every group to read five numbers.
+   */
+  getCounters(): CorrelationEngineState['metrics'] {
+    return { ...this.metrics };
+  }
+
+  /**
+   * Replace this engine's correlation state with a previously exported one —
+   * the restart path, and how a replica adopts the shared projection.
+   *
+   * Emits nothing: hydration is a recovery of state that consumers were
+   * already told about before the restart, and re-emitting it as fresh
+   * suppression decisions would be a lie about when they were made. The
+   * reconnect snapshot is what re-informs consumers, and it is explicitly
+   * labelled as a snapshot.
+   *
+   * Suppressed members are restored into `suppressedAlarmIds` exactly as
+   * persisted, which is the whole point of persisting them: an alarm the
+   * operator cannot currently see must remain restorable after a restart. A
+   * member marked suppressed whose group is closed is corrected to active
+   * here, because a closed group can never un-suppress it later.
+   */
+  hydrate(state: CorrelationEngineState): void {
+    this.groups = new Map();
+    this.groupLastTouchedAt = new Map();
+    this.pending = [];
+    this.pendingLastTouchedAt = new Map();
+    this.alarmIndex = new Map();
+    this.suppressionCountedAlarmIds = new Set();
+
+    const now = this.clock();
+    for (const input of state.groups) {
+      const group = this.cloneGroup(input);
+      const memberIds = new Set(group.alarms.map((alarm) => alarm.id));
+      group.alarmIds = group.alarms.map((alarm) => alarm.id);
+      group.suppressedAlarmIds = group.suppressedAlarmIds.filter((id) =>
+        memberIds.has(id));
+
+      if (group.state === 'closed') {
+        for (const alarm of group.alarms) {
+          if (alarm.state === 'suppressed') alarm.state = 'active';
+        }
+        group.suppressedAlarmIds = [];
+      }
+
+      this.groups.set(group.id, group);
+      this.groupLastTouchedAt.set(group.id, now);
+      for (const alarm of group.alarms) {
+        this.alarmIndex.set(alarm.id, group.id);
+      }
+      for (const alarmId of group.suppressedAlarmIds) {
+        this.suppressionCountedAlarmIds.add(alarmId);
+      }
+    }
+
+    for (const input of state.pending) {
+      if (this.alarmIndex.has(input.id)) continue;
+      // Suppression is group-scoped; an ungrouped alarm can never be holding a
+      // suppression record, so it is restored visible.
+      const alarm: CorrelatedAlarm = {
+        ...input,
+        state: input.state === 'suppressed' ? 'active' : input.state,
+      };
+      this.pending.push(alarm);
+      this.pendingLastTouchedAt.set(alarm.id, now);
+      this.alarmIndex.set(alarm.id, null);
+    }
+
+    this.metrics = { ...state.metrics };
+  }
+
+  private cloneGroup(group: AlarmGroup): AlarmGroup {
+    return {
+      ...group,
+      alarms: group.alarms.map((alarm) => ({ ...alarm })),
+      alarmIds: [...group.alarmIds],
+      joinedVia: { ...group.joinedVia },
+      suppressedAlarmIds: [...group.suppressedAlarmIds],
+    };
   }
 
   getMetrics(): CorrelationMetrics {
@@ -455,7 +599,7 @@ export class AlarmCorrelationEngine extends EventEmitter {
   ): IngestResult {
     const members = [peer, alarm].sort((a, b) => a.timestamp - b.timestamp);
     const group: AlarmGroup = {
-      id: `ACG-${randomUUID()}`,
+      id: this.groupIdFactory(),
       state: 'open',
       alarms: members,
       alarmIds: members.map((a) => a.id),
@@ -471,6 +615,11 @@ export class AlarmCorrelationEngine extends EventEmitter {
       lastAlarmAt: members[members.length - 1].timestamp,
     };
 
+    // A reused group id would silently merge two unrelated groups and orphan
+    // the suppression records of the first. Refuse rather than corrupt.
+    if (this.groups.has(group.id)) {
+      throw new Error(`Correlation group id "${group.id}" is already in use`);
+    }
     this.groups.set(group.id, group);
     this.groupLastTouchedAt.set(group.id, this.clock());
     this.metrics.groupsCreated++;
@@ -628,6 +777,12 @@ export class AlarmCorrelationEngine extends EventEmitter {
     }
     this.groupLastTouchedAt.delete(group.id);
     this.groups.delete(group.id);
+    // Carries the member ids so a durable projection can drop exactly the rows
+    // this engine just forgot, instead of guessing from a count.
+    this.emit('group-evicted', {
+      groupId: group.id,
+      alarmIds: [...group.alarmIds],
+    });
   }
 
   private removeFromPending(alarmId: string): void {
@@ -704,13 +859,13 @@ export class AlarmCorrelationEngine extends EventEmitter {
   private prunePending(referenceMs: number): void {
     const maxWindow = this.maxEnabledRuleWindowMs();
     const cutoff = referenceMs - maxWindow * 2;
-    let removed = 0;
+    const removedIds: string[] = [];
     this.pending = this.pending.filter((alarm) => {
       const keep = alarm.timestamp >= cutoff;
       if (!keep) {
         this.alarmIndex.delete(alarm.id);
         this.pendingLastTouchedAt.delete(alarm.id);
-        removed++;
+        removedIds.push(alarm.id);
       }
       return keep;
     });
@@ -719,25 +874,29 @@ export class AlarmCorrelationEngine extends EventEmitter {
       for (const alarm of excess) {
         this.alarmIndex.delete(alarm.id);
         this.pendingLastTouchedAt.delete(alarm.id);
+        removedIds.push(alarm.id);
       }
-      removed += excess.length;
     }
-    if (removed > 0) this.emit('pending-pruned', { removed });
+    if (removedIds.length > 0) {
+      this.emit('pending-pruned', { removed: removedIds.length, alarmIds: removedIds });
+    }
   }
 
   private prunePendingByProcessingTime(nowMs: number): void {
     const cutoff = nowMs - this.maxEnabledRuleWindowMs() * 2;
-    let removed = 0;
+    const removedIds: string[] = [];
     this.pending = this.pending.filter((alarm) => {
       const keep = (this.pendingLastTouchedAt.get(alarm.id) ?? nowMs) >= cutoff;
       if (!keep) {
         this.alarmIndex.delete(alarm.id);
         this.pendingLastTouchedAt.delete(alarm.id);
-        removed++;
+        removedIds.push(alarm.id);
       }
       return keep;
     });
-    if (removed > 0) this.emit('pending-pruned', { removed });
+    if (removedIds.length > 0) {
+      this.emit('pending-pruned', { removed: removedIds.length, alarmIds: removedIds });
+    }
   }
 
   private maxEnabledRuleWindowMs(): number {

--- a/server/services/alarm-correlation/index.ts
+++ b/server/services/alarm-correlation/index.ts
@@ -14,6 +14,8 @@ import { EventEmitter } from 'events';
 export * from './topology';
 export * from './rules';
 export * from './engine';
+export * from './store';
+export * from './coordinator';
 
 import type {
   AlarmGroup,
@@ -21,9 +23,13 @@ import type {
   AlarmLifecycleState,
   CorrelatedAlarm,
   AlarmWireSnapshot,
+  CorrelationCoordinationHealth,
+  CorrelationCoordinationMode,
   IngestResult,
 } from '@shared/types/alarm-correlation';
 import { AlarmCorrelationEngine } from './engine';
+import { AlarmCorrelationCoordinator } from './coordinator';
+import { DrizzleCorrelationStore } from './store';
 
 /**
  * Map any severity vocabulary seen in this repo onto the runtime one.
@@ -167,9 +173,21 @@ export function normalizeAlarm(raw: Record<string, unknown>): CorrelatedAlarm | 
   };
 }
 
+/**
+ * Coordination facts stamped onto a snapshot. Defaults describe an
+ * uncoordinated process, which is the honest answer whenever no healthy
+ * durable coordinator is attached.
+ */
+export interface WireSnapshotContext {
+  coordinationMode?: CorrelationCoordinationMode;
+  /** Journal seq of this alarm's latest state change; null when uncoordinated. */
+  seq?: number | null;
+}
+
 export function toAlarmWireSnapshot(
   alarm: CorrelatedAlarm,
   group?: AlarmGroup,
+  context: WireSnapshotContext = {},
 ): AlarmWireSnapshot {
   return {
     ...alarm,
@@ -183,26 +201,396 @@ export function toAlarmWireSnapshot(
         group?.suppressedAlarmIds.includes(alarm.id)
         ?? alarm.state === 'suppressed',
       isRootCause: group?.rootCauseAlarmId === alarm.id,
-      coordinationMode: 'process-local',
+      coordinationMode: context.coordinationMode ?? 'process-local',
+      seq: context.seq ?? null,
     },
   };
 }
 
+/** Principal recorded for alarms that arrive from internal producers. */
+const SYSTEM_PRINCIPAL = 'system';
+
+/**
+ * Read a retention duration in milliseconds from the environment.
+ *
+ * Returns undefined — i.e. "use the built-in default" — for anything that is
+ * not a finite positive number. Retention deletes durable alarm state, so a
+ * typo must fall back to the documented default rather than be coerced into a
+ * cutoff that prunes far more than the operator asked for.
+ */
+function durationFromEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}
+
+/**
+ * Engine event handler kept for later removal. Payloads are engine-owned and
+ * per-event, so each registration narrows `payload` itself rather than the
+ * service carrying a union it would have to re-check.
+ */
+type EngineEventListener = (payload: unknown) => void;
+
+export interface CorrelationServiceHealth {
+  healthy: boolean;
+  message: string;
+  coordinationMode: CorrelationCoordinationMode;
+  suppressionEnabled: boolean;
+  ephemeralSuppressionAllowed: boolean;
+  /** Null when running process-local. */
+  coordination: CorrelationCoordinationHealth | null;
+  /**
+   * Whether an operator may turn production suppression on right now. True only
+   * with a healthy durable coordinator; the ephemeral env flag is a separate,
+   * explicitly single-process escape hatch reported above.
+   */
+  durableSuppressionAvailable: boolean;
+}
+
 export class AlarmCorrelationService extends EventEmitter {
-  readonly engine = new AlarmCorrelationEngine();
+  private coordinator: AlarmCorrelationCoordinator | null = null;
+  private localEngine = new AlarmCorrelationEngine();
 
   private initialized = false;
   private sweepTimer: NodeJS.Timeout | null = null;
   private readonly sweepIntervalMs: number;
+  /** Engine currently wired to this service's outbound events, if any. */
+  private listenedEngine: AlarmCorrelationEngine | null = null;
+  private engineListeners: Array<[string, EngineEventListener]> = [];
 
   constructor(sweepIntervalMs = 30_000) {
     super();
     this.sweepIntervalMs = sweepIntervalMs;
+    this.attachEngineListeners(this.localEngine);
+  }
+
+  /**
+   * The engine currently holding correlation state. With a coordinator
+   * attached this is the coordinator's engine, which is a projection of the
+   * shared journal rather than process-local state.
+   */
+  get engine(): AlarmCorrelationEngine {
+    return this.coordinator?.engine ?? this.localEngine;
+  }
+
+  /** Durable coordinator, or null when running process-local. */
+  get durableCoordinator(): AlarmCorrelationCoordinator | null {
+    return this.coordinator;
+  }
+
+  /**
+   * Adopt a started coordinator. Its engine replaces the process-local one, so
+   * every read surface (REST and WebSocket alike) serves the coordinated
+   * projection and cannot disagree with it.
+   */
+  attachCoordinator(coordinator: AlarmCorrelationCoordinator): void {
+    if (this.coordinator === coordinator) return;
+    this.coordinator = coordinator;
+    this.attachEngineListeners(coordinator.engine);
+    coordinator.on('degraded', (payload: { reason: string }) => {
+      this.emit('coordination-degraded', payload);
+    });
+    coordinator.on('recovered', (payload: CorrelationCoordinationHealth) => {
+      this.emit('coordination-recovered', payload);
+    });
+  }
+
+  /**
+   * Build a durable coordinator from configuration and adopt it.
+   *
+   * Off unless `ALARM_CORRELATION_DURABLE=true`: it opens a database
+   * connection, and a service that silently starts talking to a database
+   * because it was imported is not something to switch on by default. Without
+   * it the service runs exactly as #213 shipped it — process-local, suppression
+   * off. Throws if the store cannot be opened, so a caller cannot mistake a
+   * failed connection for durable coordination.
+   */
+  async enableDurableCoordination(options: {
+    postgresUrl?: string;
+    sqlitePath?: string;
+    pollIntervalMs?: number;
+    instanceId?: string;
+    journalRetentionMs?: number;
+    stateRetentionMs?: number;
+  } = {}): Promise<AlarmCorrelationCoordinator> {
+    if (this.coordinator) return this.coordinator;
+    const store = new DrizzleCorrelationStore({
+      postgresUrl: options.postgresUrl,
+      sqlitePath: options.sqlitePath,
+    });
+    const coordinator = new AlarmCorrelationCoordinator({
+      store,
+      instanceId: options.instanceId,
+      pollIntervalMs: options.pollIntervalMs,
+      journalRetentionMs:
+        options.journalRetentionMs
+        ?? durationFromEnv('ALARM_CORRELATION_JOURNAL_RETENTION_MS'),
+      stateRetentionMs:
+        options.stateRetentionMs
+        ?? durationFromEnv('ALARM_CORRELATION_STATE_RETENTION_MS'),
+    });
+    await coordinator.start();
+    this.attachCoordinator(coordinator);
+    return coordinator;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    if (process.env.ALARM_CORRELATION_DURABLE === 'true' && !this.coordinator) {
+      // A configured-but-unreachable store must not be papered over: report it
+      // and continue process-local with suppression off, which is safe.
+      try {
+        await this.enableDurableCoordination();
+      } catch (error) {
+        this.emit('coordination-degraded', {
+          reason: `durable coordination unavailable: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        });
+      }
+    }
+    this.initialized = true;
+    this.sweepTimer = setInterval(() => this.sweep(), this.sweepIntervalMs);
+    this.sweepTimer.unref?.();
+  }
+
+  /**
+   * Idle-group housekeeping.
+   *
+   * With a coordinator attached this is journaled rather than run locally:
+   * closing an idle group un-suppresses its members, so a sweep that ran here
+   * and not on the other replica would leave the two disagreeing about which
+   * alarms an operator can see.
+   */
+  sweep(): void {
+    const coordinator = this.coordinator;
+    if (coordinator) {
+      void coordinator
+        .submitSweep(Date.now(), this.sweepIntervalMs)
+        .catch(() => {
+          // Already failed safe (suppression off, alarms restored); the next
+          // interval retries.
+        });
+      return;
+    }
+    try {
+      this.engine.sweep(Date.now());
+    } catch {
+      /* sweep failures must never take down the interval */
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+    if (this.coordinator) {
+      await this.coordinator.stop();
+      this.coordinator = null;
+      // Fall back to the process-local engine so the service stays usable —
+      // uncoordinated, suppression off, which is the safe state.
+      this.attachEngineListeners(this.localEngine);
+    }
+    this.initialized = false;
+  }
+
+  /**
+   * Normalize and correlate one alarm in any supported shape, process-locally.
+   * Returns null when the input has no usable timestamp.
+   *
+   * This is the uncoordinated path. `submit()` is the coordinated one; it falls
+   * back to this when no coordinator is attached.
+   */
+  ingest(raw: Record<string, unknown>): { alarm: CorrelatedAlarm; result: IngestResult } | null {
+    const alarm = normalizeAlarm(raw);
+    if (!alarm) return null;
+    return this.applyLocalIngest(alarm);
+  }
+
+  /**
+   * Correlate one alarm through durable coordination when it is available.
+   *
+   * If the journal cannot be written the alarm is still correlated locally and
+   * still returned, so it still reaches the operator. Coordination has already
+   * failed safe by then — suppression is off — so a locally-correlated alarm
+   * cannot be hidden by this fallback.
+   */
+  async submit(
+    raw: Record<string, unknown>,
+    principal: string = SYSTEM_PRINCIPAL,
+  ): Promise<{ alarm: CorrelatedAlarm; result: IngestResult } | null> {
+    const alarm = normalizeAlarm(raw);
+    if (!alarm) return null;
+
+    const coordinator = this.coordinator;
+    if (!coordinator) return this.applyLocalIngest(alarm);
+
+    try {
+      const submitted = await coordinator.submitIngest(alarm, principal);
+      const stored = coordinator.engine.getAlarm(alarm.id) ?? alarm;
+      if (submitted.outcome) {
+        return { alarm: stored, result: submitted.outcome };
+      }
+      // Duplicate delivery of an entry that was already applied. Report the
+      // canonical current state rather than re-running correlation.
+      const group = coordinator.engine.getGroupForAlarm(alarm.id);
+      return {
+        alarm: stored,
+        result: {
+          alarmId: alarm.id,
+          action: 'duplicate',
+          groupId: group?.id,
+          suppressed: group?.suppressedAlarmIds.includes(alarm.id) ?? false,
+          isRootCause: group?.rootCauseAlarmId === alarm.id,
+          reason: 'duplicate alarm id — already ingested',
+        },
+      };
+    } catch {
+      // Storage or coordination loss must never hide an alarm.
+      return this.applyLocalIngest(alarm);
+    }
+  }
+
+  /** Acknowledge through coordination when available, else process-locally. */
+  async acknowledge(alarmId: string, principal: string): Promise<boolean> {
+    const coordinator = this.coordinator;
+    if (!coordinator) return this.engine.alarmAcknowledged(alarmId, principal);
+    try {
+      const submitted = await coordinator.submitAcknowledge(alarmId, principal);
+      if (submitted.outcome !== undefined) return submitted.outcome;
+      return coordinator.engine.getAlarm(alarmId)?.state === 'acknowledged';
+    } catch {
+      return this.engine.alarmAcknowledged(alarmId, principal);
+    }
+  }
+
+  /** Clear through coordination when available, else process-locally. */
+  async clear(
+    alarmId: string,
+    principal: string,
+  ): Promise<ReturnType<AlarmCorrelationEngine['alarmCleared']>> {
+    const coordinator = this.coordinator;
+    if (!coordinator) return this.engine.alarmCleared(alarmId, principal);
+    try {
+      const submitted = await coordinator.submitClear(alarmId, principal);
+      if (submitted.outcome !== undefined) return submitted.outcome;
+      const alarm = coordinator.engine.getAlarm(alarmId);
+      return {
+        cleared: alarm?.state === 'cleared',
+        clearedBy: alarm?.clearedBy,
+        unsuppressed: [],
+      };
+    } catch {
+      return this.engine.alarmCleared(alarmId, principal);
+    }
+  }
+
+  /**
+   * Latest canonical state for every alarm this replica is tracking that an
+   * operator could still act on. Cleared alarms are omitted; suppressed ones
+   * are included and marked suppressed, because a reconnecting client needs to
+   * know an alarm exists and is currently hidden, not be left unaware of it.
+   *
+   * Exactly one entry per alarm id, so a reconnecting client cannot receive the
+   * same alarm twice from the snapshot itself.
+   */
+  getReconnectSnapshot(): AlarmWireSnapshot[] {
+    const engine = this.engine;
+    const seen = new Set<string>();
+    const snapshots: AlarmWireSnapshot[] = [];
+    for (const alarm of engine.listTrackedAlarms()) {
+      if (seen.has(alarm.id)) continue;
+      seen.add(alarm.id);
+      if (alarm.state === 'cleared') continue;
+      snapshots.push(this.snapshotFor(alarm, engine.getGroupForAlarm(alarm.id)));
+    }
+    return snapshots.sort((a, b) => a.timestamp - b.timestamp || a.id.localeCompare(b.id));
+  }
+
+  /**
+   * Build the canonical wire snapshot for one alarm.
+   *
+   * The shared seq is stamped only while coordination is healthy. A degraded
+   * replica emits `seq: null`, which makes its snapshots undedupable by design:
+   * the corrections a degraded replica sends (notably restoring suppressed
+   * alarms) must never be mistaken for a stale echo and dropped.
+   */
+  snapshotFor(alarm: CorrelatedAlarm, group?: AlarmGroup): AlarmWireSnapshot {
+    const mode = this.coordinationMode();
+    return toAlarmWireSnapshot(alarm, group, {
+      coordinationMode: mode,
+      seq: mode === 'durable' ? this.coordinator?.alarmSeq(alarm.id) ?? null : null,
+    });
+  }
+
+  coordinationMode(): CorrelationCoordinationMode {
+    return this.coordinator?.health().mode ?? 'process-local';
+  }
+
+  async healthCheck(): Promise<CorrelationServiceHealth> {
+    const metrics = this.engine.getMetrics();
+    const coordination = this.coordinator?.health() ?? null;
+    return {
+      healthy: this.initialized && (coordination?.healthy ?? true),
+      message: this.initialized
+        ? `Alarm correlation running: ${metrics.openGroups} open groups, ` +
+          `${(metrics.suppressionRate * 100).toFixed(1)}% suppression rate`
+        : 'Alarm correlation service not initialized',
+      coordinationMode: this.coordinationMode(),
+      suppressionEnabled: this.engine.getSuppressionPolicy().enabled,
+      ephemeralSuppressionAllowed:
+        process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION === 'true',
+      coordination,
+      durableSuppressionAvailable: coordination?.healthy === true,
+    };
+  }
+
+  // ── Private ────────────────────────────────────────────────────────────
+
+  private applyLocalIngest(
+    alarm: CorrelatedAlarm,
+  ): { alarm: CorrelatedAlarm; result: IngestResult } {
+    const engine = this.engine;
+    const result = engine.ingest(alarm);
+    if (result.action === 'duplicate') {
+      if (alarm.state === 'acknowledged') {
+        engine.alarmAcknowledged(alarm.id);
+      } else if (alarm.state === 'cleared') {
+        engine.alarmCleared(alarm.id);
+      }
+    }
+    return { alarm: engine.getAlarm(alarm.id) ?? alarm, result };
+  }
+
+  /**
+   * Re-point this service's outbound events at `engine`, detaching whatever it
+   * was listening to. Detaching matters: adopting a coordinator swaps the
+   * engine, and leaving the old one wired would keep a stopped engine able to
+   * emit alarm snapshots into a live service.
+   */
+  private attachEngineListeners(engine: AlarmCorrelationEngine): void {
+    if (this.listenedEngine === engine) return;
+    if (this.listenedEngine) {
+      for (const [event, listener] of this.engineListeners) {
+        this.listenedEngine.off(event, listener);
+      }
+    }
+    this.engineListeners = [];
+
+    const register = (event: string, listener: EngineEventListener): void => {
+      this.engineListeners.push([event, listener]);
+      engine.on(event, listener);
+    };
+
     for (const event of ['group-created', 'group-updated', 'group-closed']) {
-      this.engine.on(event, (group: AlarmGroup) => {
+      register(event, (payload) => {
+        const group = payload as AlarmGroup;
         this.emit(event, group);
         for (const alarm of group.alarms) {
-          this.emit('alarm-snapshot', toAlarmWireSnapshot(alarm, group));
+          this.emit('alarm-snapshot', this.snapshotFor(alarm, group));
         }
       });
     }
@@ -211,75 +599,15 @@ export class AlarmCorrelationService extends EventEmitter {
       'alarm-suppressed',
       'alarms-unsuppressed',
     ]) {
-      this.engine.on(event, (payload) => this.emit(event, payload));
+      register(event, (payload) => this.emit(event, payload));
     }
-    this.engine.on('alarm-updated', (alarm: CorrelatedAlarm) => {
+    register('alarm-updated', (payload) => {
+      const alarm = payload as CorrelatedAlarm;
       this.emit('alarm-updated', alarm);
-      this.emit('alarm-snapshot', toAlarmWireSnapshot(alarm));
+      this.emit('alarm-snapshot', this.snapshotFor(alarm));
     });
-  }
 
-  async initialize(): Promise<void> {
-    if (this.initialized) return;
-    this.initialized = true;
-    this.sweepTimer = setInterval(() => {
-      try {
-        this.engine.sweep(Date.now());
-      } catch {
-        /* sweep failures must never take down the interval */
-      }
-    }, this.sweepIntervalMs);
-    this.sweepTimer.unref?.();
-  }
-
-  async shutdown(): Promise<void> {
-    if (this.sweepTimer) {
-      clearInterval(this.sweepTimer);
-      this.sweepTimer = null;
-    }
-    this.initialized = false;
-  }
-
-  /**
-   * Normalize and correlate one alarm in any supported shape.
-   * Returns null when the input has no usable timestamp.
-   */
-  ingest(raw: Record<string, unknown>): { alarm: CorrelatedAlarm; result: IngestResult } | null {
-    const alarm = normalizeAlarm(raw);
-    if (!alarm) return null;
-    const result = this.engine.ingest(alarm);
-    if (result.action === 'duplicate') {
-      if (alarm.state === 'acknowledged') {
-        this.engine.alarmAcknowledged(alarm.id);
-      } else if (alarm.state === 'cleared') {
-        this.engine.alarmCleared(alarm.id);
-      }
-    }
-    return {
-      alarm: this.engine.getAlarm(alarm.id) ?? alarm,
-      result,
-    };
-  }
-
-  async healthCheck(): Promise<{
-    healthy: boolean;
-    message: string;
-    coordinationMode: 'process-local';
-    suppressionEnabled: boolean;
-    ephemeralSuppressionAllowed: boolean;
-  }> {
-    const metrics = this.engine.getMetrics();
-    return {
-      healthy: this.initialized,
-      message: this.initialized
-        ? `Alarm correlation running: ${metrics.openGroups} open groups, ` +
-          `${(metrics.suppressionRate * 100).toFixed(1)}% suppression rate`
-        : 'Alarm correlation service not initialized',
-      coordinationMode: 'process-local',
-      suppressionEnabled: this.engine.getSuppressionPolicy().enabled,
-      ephemeralSuppressionAllowed:
-        process.env.ALARM_CORRELATION_ALLOW_EPHEMERAL_SUPPRESSION === 'true',
-    };
+    this.listenedEngine = engine;
   }
 }
 

--- a/server/services/alarm-correlation/store.ts
+++ b/server/services/alarm-correlation/store.ts
@@ -1,0 +1,1194 @@
+/**
+ * Durable alarm-correlation store
+ * ADR-0026 / ADR-0013 [13.2] — Issue #573
+ *
+ * The persistence half of replica-coordinated alarm correlation. It owns two
+ * things:
+ *
+ *   1. `alarm_correlation_journal` — a single, totally-ordered, append-only log
+ *      of every correlation-affecting operation. The database allocates `seq`;
+ *      appends are serialised (Postgres advisory lock, SQLite BEGIN IMMEDIATE)
+ *      so commit order equals `seq` order. Without that serialisation an
+ *      identity value can commit after a larger one, and a reader polling for
+ *      "everything above my watermark" would step over an entry that had not
+ *      become visible yet — permanently losing an operator's acknowledge.
+ *
+ *   2. The materialised projection — groups, alarms, rules, topology, the
+ *      suppression policy, and the watermark of how far the projection has got.
+ *      Each entry's row changes are written in one transaction that first
+ *      advances the watermark with a conditional UPDATE, so the projection is
+ *      always the result of applying entries strictly in `seq` order no matter
+ *      which replica does the writing.
+ *
+ * Two backends, chosen exactly the way `server/services/tuning/audit-store.ts`
+ * and `server/storage.ts` choose theirs: PostgreSQL in production, a file-backed
+ * SQLite database in development and test. There is no in-memory fallback,
+ * because a correlation store that silently forgets is precisely the failure
+ * this issue exists to prevent — if the store cannot be reached, the caller
+ * must fail safe (disable suppression), not pretend it persisted.
+ *
+ * Everything here is real SQL against real tables (migration 0015). Nothing is
+ * simulated, cached-and-hoped, or returned as a placeholder.
+ */
+
+import path from "node:path";
+import { and, asc, eq, gt, inArray, lt } from "drizzle-orm";
+import { drizzle as drizzlePostgres, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import {
+  drizzle as drizzleSqliteProxy,
+  type SqliteRemoteDatabase,
+} from "drizzle-orm/sqlite-proxy";
+import { Client } from "pg";
+import { Database } from "sqlite3";
+import {
+  alarmCorrelationAlarms as pgAlarms,
+  alarmCorrelationEquipment as pgEquipment,
+  alarmCorrelationGroups as pgGroups,
+  alarmCorrelationJournal as pgJournal,
+  alarmCorrelationRules as pgRules,
+  alarmCorrelationState as pgState,
+} from "@shared/schema";
+import {
+  alarmCorrelationAlarms as sqliteAlarms,
+  alarmCorrelationEquipment as sqliteEquipment,
+  alarmCorrelationGroups as sqliteGroups,
+  alarmCorrelationJournal as sqliteJournal,
+  alarmCorrelationRules as sqliteRules,
+  alarmCorrelationState as sqliteState,
+} from "@shared/schema-sqlite";
+import type {
+  AlarmGroup,
+  AlarmGroupState,
+  AlarmLifecycleState,
+  AlarmSeverity,
+  CorrelatedAlarm,
+  CorrelationJournalEntry,
+  CorrelationJournalOp,
+  CorrelationRule,
+  CorrelationRuleType,
+  EquipmentNode,
+  SuppressionPolicy,
+} from "@shared/types/alarm-correlation";
+
+/** Single-row primary key of `alarm_correlation_state`. */
+const STATE_ROW_ID = "default";
+
+/**
+ * Postgres advisory-lock key for journal appends. Any constant works as long as
+ * every replica uses the same one; 573 is the issue number so the lock is
+ * traceable in `pg_locks` without a lookup table.
+ */
+const JOURNAL_APPEND_LOCK_KEY = 573;
+
+const DEFAULT_JOURNAL_PAGE = 500;
+
+export interface JournalAppend {
+  idempotencyKey: string;
+  op: CorrelationJournalOp;
+  payload: Record<string, unknown>;
+  principal: string;
+  originInstance: string;
+}
+
+export interface JournalAppendResult {
+  seq: number;
+  /** False when the key was already present — a duplicate delivery. */
+  created: boolean;
+}
+
+/** Cumulative engine counters, persisted so a restart does not reset them. */
+export interface DurableMetrics {
+  alarmsIngested: number;
+  groupsCreated: number;
+  groupsClosed: number;
+  alarmsSuppressed: number;
+  alarmsUnsuppressed: number;
+}
+
+/** An alarm row plus the correlation facts that make it restorable. */
+export interface PersistedAlarm {
+  alarm: CorrelatedAlarm;
+  groupId: string | null;
+  suppressed: boolean;
+  isRootCause: boolean;
+  joinedViaRuleId: string | null;
+  ingestSeq: number;
+}
+
+/** Row changes produced by applying one journal entry. */
+export interface ProjectionChanges {
+  groups: AlarmGroup[];
+  alarms: PersistedAlarm[];
+  deletedGroupIds: string[];
+  deletedAlarmIds: string[];
+  upsertRules: CorrelationRule[];
+  removedRuleIds: string[];
+  upsertEquipment: EquipmentNode[];
+  removedEquipmentIds: string[];
+  policy: SuppressionPolicy | null;
+  metrics: DurableMetrics;
+  principal: string;
+}
+
+export function emptyProjectionChanges(
+  metrics: DurableMetrics,
+  principal: string,
+): ProjectionChanges {
+  return {
+    groups: [],
+    alarms: [],
+    deletedGroupIds: [],
+    deletedAlarmIds: [],
+    upsertRules: [],
+    removedRuleIds: [],
+    upsertEquipment: [],
+    removedEquipmentIds: [],
+    policy: null,
+    metrics,
+    principal,
+  };
+}
+
+/** Everything a starting replica needs to reconstitute correlation state. */
+export interface DurableSnapshot {
+  appliedSeq: number;
+  policy: SuppressionPolicy;
+  metrics: DurableMetrics;
+  rules: CorrelationRule[];
+  equipment: EquipmentNode[];
+  groups: AlarmGroup[];
+  /** Tracked alarms with no group — the engine's pending set. */
+  pending: CorrelatedAlarm[];
+  /** alarmId → journal seq of its latest persisted state change. */
+  alarmSeq: Map<string, number>;
+}
+
+export type StoreBackend = "postgres" | "sqlite" | "unopened";
+
+export interface CorrelationStore {
+  ready(): Promise<void>;
+  backend(): StoreBackend;
+  /** Append one operation. Idempotent on `idempotencyKey`. */
+  append(entry: JournalAppend): Promise<JournalAppendResult>;
+  /** Journal entries with seq strictly greater than `afterSeq`, in seq order. */
+  read(afterSeq: number, limit?: number): Promise<CorrelationJournalEntry[]>;
+  /** Load the materialised projection and its watermark. */
+  load(): Promise<DurableSnapshot>;
+  /**
+   * Advance the watermark to `seq` and write that entry's row changes in one
+   * transaction. Resolves false when another replica already projected `seq`,
+   * in which case nothing is written.
+   */
+  project(seq: number, changes: ProjectionChanges): Promise<boolean>;
+  /**
+   * Delete journal entries strictly below the watermark and older than
+   * `olderThanMs`, and closed groups (with their alarms) whose last event is
+   * older than `closedOlderThanMs`. Returns what was removed.
+   */
+  prune(options: {
+    journalOlderThanMs: number;
+    closedGroupsOlderThanMs: number;
+    now: number;
+  }): Promise<{ journalEntries: number; groups: number; alarms: number }>;
+  close(): Promise<void>;
+}
+
+// ── SQLite DDL ───────────────────────────────────────────────────────────────
+//
+// `migrations/0015_alarm_correlation_coordination.sql` is the Postgres source
+// of truth; this mirrors it for the development/test backend, including the
+// append-only trigger on the journal, so the immutability guarantee is the same
+// on both. AUTOINCREMENT is required, not decorative: plain rowid assignment
+// reuses the largest deleted id, and retention deletes journal rows — a reused
+// `seq` would let a new group be named after a group that already existed.
+
+const SQLITE_DDL = `
+CREATE TABLE IF NOT EXISTS alarm_correlation_journal (
+  seq INTEGER PRIMARY KEY AUTOINCREMENT,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  op TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  principal TEXT NOT NULL,
+  origin_instance TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL,
+  CHECK (op IN (
+    'ingest','acknowledge','clear','rule-upsert','rule-remove','rule-enabled',
+    'topology-upsert','topology-remove','policy-set','sweep'
+  ))
+);
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_journal_recorded_at
+  ON alarm_correlation_journal(recorded_at);
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_journal_op
+  ON alarm_correlation_journal(op);
+CREATE TRIGGER IF NOT EXISTS alarm_correlation_journal_no_update
+  BEFORE UPDATE ON alarm_correlation_journal
+BEGIN
+  SELECT RAISE(ABORT, 'alarm_correlation_journal is append-only: UPDATE is not permitted');
+END;
+
+CREATE TABLE IF NOT EXISTS alarm_correlation_groups (
+  id TEXT PRIMARY KEY,
+  state TEXT NOT NULL,
+  root_cause_alarm_id TEXT NOT NULL,
+  formed_by_rule_id TEXT NOT NULL,
+  joined_via TEXT NOT NULL,
+  max_severity TEXT NOT NULL,
+  created_at_ms INTEGER NOT NULL,
+  last_alarm_at_ms INTEGER NOT NULL,
+  closed_at_ms INTEGER,
+  close_reason TEXT,
+  updated_seq INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  CHECK (state IN ('open','closed'))
+);
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_groups_state
+  ON alarm_correlation_groups(state);
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_groups_last_alarm
+  ON alarm_correlation_groups(last_alarm_at_ms);
+
+CREATE TABLE IF NOT EXISTS alarm_correlation_alarms (
+  id TEXT PRIMARY KEY,
+  group_id TEXT,
+  name TEXT NOT NULL,
+  tag_id TEXT NOT NULL,
+  equipment_id TEXT,
+  site_id TEXT,
+  process_area TEXT,
+  severity TEXT NOT NULL,
+  state TEXT NOT NULL,
+  message TEXT NOT NULL,
+  event_time_ms INTEGER NOT NULL,
+  alarm_value TEXT,
+  alarm_limit TEXT,
+  source TEXT,
+  acknowledged_by TEXT,
+  cleared_by TEXT,
+  suppressed INTEGER NOT NULL DEFAULT 0,
+  is_root_cause INTEGER NOT NULL DEFAULT 0,
+  joined_via_rule_id TEXT,
+  ingest_seq INTEGER NOT NULL,
+  updated_seq INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  CHECK (severity IN ('critical','high','medium','low','info')),
+  CHECK (state IN ('active','acknowledged','cleared','shelved','suppressed'))
+);
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_alarms_group
+  ON alarm_correlation_alarms(group_id);
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_alarms_state
+  ON alarm_correlation_alarms(state);
+CREATE INDEX IF NOT EXISTS idx_alarm_corr_alarms_event_time
+  ON alarm_correlation_alarms(event_time_ms);
+
+CREATE TABLE IF NOT EXISTS alarm_correlation_rules (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  type TEXT NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  priority INTEGER NOT NULL,
+  config TEXT NOT NULL,
+  updated_by TEXT NOT NULL,
+  updated_seq INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  CHECK (type IN ('causal','hierarchy','temporal'))
+);
+
+CREATE TABLE IF NOT EXISTS alarm_correlation_equipment (
+  equipment_id TEXT PRIMARY KEY,
+  name TEXT,
+  parent_id TEXT,
+  causal_downstream TEXT NOT NULL,
+  site_id TEXT,
+  process_area TEXT,
+  updated_by TEXT NOT NULL,
+  updated_seq INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS alarm_correlation_state (
+  id TEXT PRIMARY KEY,
+  applied_seq INTEGER NOT NULL DEFAULT 0,
+  suppression_enabled INTEGER NOT NULL DEFAULT 0,
+  never_suppress_at_or_above TEXT NOT NULL DEFAULT 'critical',
+  unsuppress_on_root_clear INTEGER NOT NULL DEFAULT 1,
+  alarms_ingested INTEGER NOT NULL DEFAULT 0,
+  groups_created INTEGER NOT NULL DEFAULT 0,
+  groups_closed INTEGER NOT NULL DEFAULT 0,
+  alarms_suppressed INTEGER NOT NULL DEFAULT 0,
+  alarms_unsuppressed INTEGER NOT NULL DEFAULT 0,
+  updated_by TEXT NOT NULL DEFAULT 'system',
+  updated_at INTEGER NOT NULL,
+  CHECK (id = 'default'),
+  CHECK (unsuppress_on_root_clear = 1),
+  CHECK (never_suppress_at_or_above IN ('critical','high','medium','low','info'))
+);
+`;
+
+// ── Connection plumbing (mirrors server/services/tuning/audit-store.ts) ───────
+
+type SqliteDrizzle = SqliteRemoteDatabase<Record<string, never>>;
+type PostgresDrizzle = NodePgDatabase<Record<string, never>>;
+
+interface PostgresConnection {
+  kind: "postgres";
+  client: Client;
+  db: PostgresDrizzle;
+}
+
+interface SqliteConnection {
+  kind: "sqlite";
+  client: Database;
+  db: SqliteDrizzle;
+}
+
+type Connection = PostgresConnection | SqliteConnection;
+
+export interface CorrelationStoreOptions {
+  postgresUrl?: string;
+  sqlitePath?: string;
+}
+
+function resolvePostgresUrl(options: CorrelationStoreOptions): string | undefined {
+  if (options.postgresUrl) return options.postgresUrl;
+  const url = process.env.DATABASE_URL;
+  if (!url) return undefined;
+  if (process.env.FORCE_POSTGRES === "false") return undefined;
+  if (process.env.NODE_ENV === "development") return undefined;
+  return url;
+}
+
+function resolveSqlitePath(options: CorrelationStoreOptions): string {
+  return options.sqlitePath
+    ?? process.env.ALARM_CORRELATION_SQLITE_PATH
+    ?? process.env.SQLITE_DATABASE_PATH
+    ?? path.join(process.cwd(), "dev-database.sqlite");
+}
+
+function sqliteExec(client: Database, sqlText: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client.exec(sqlText, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function sqliteRun(client: Database, sqlText: string, params: unknown[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client.run(sqlText, params, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function sqliteAll(
+  client: Database,
+  sqlText: string,
+  params: unknown[],
+): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve, reject) => {
+    client.all(sqlText, params, (error, rows) =>
+      (error ? reject(error) : resolve(rows as Record<string, unknown>[])));
+  });
+}
+
+/**
+ * drizzle-orm's SQLite proxy driver maps result columns positionally while
+ * node-sqlite3 hands back objects, materialised in result-column order. Every
+ * column of every table here has a distinct name within its own table and no
+ * query in this module joins tables, so ordered values reconstruct the
+ * positional row exactly.
+ */
+function positionalRow(row: Record<string, unknown>): unknown[] {
+  return Object.values(row);
+}
+
+// ── Row ⇆ domain conversion ──────────────────────────────────────────────────
+
+type JsonScalar = number | string | null | undefined;
+
+function toWireValue(raw: unknown): number | string | undefined {
+  if (typeof raw === "number" || typeof raw === "string") return raw;
+  return undefined;
+}
+
+interface AlarmRowShape {
+  id: string;
+  groupId: string | null;
+  name: string;
+  tagId: string;
+  equipmentId: string | null;
+  siteId: string | null;
+  processArea: string | null;
+  severity: string;
+  state: string;
+  message: string;
+  eventTimeMs: number;
+  alarmValue: unknown;
+  alarmLimit: unknown;
+  source: string | null;
+  acknowledgedBy: string | null;
+  clearedBy: string | null;
+  suppressed: boolean;
+  isRootCause: boolean;
+  joinedViaRuleId: string | null;
+  ingestSeq: number;
+  updatedSeq: number;
+}
+
+function rowToAlarm(row: AlarmRowShape): CorrelatedAlarm {
+  return {
+    id: row.id,
+    name: row.name,
+    tagId: row.tagId,
+    equipmentId: row.equipmentId ?? undefined,
+    siteId: row.siteId ?? undefined,
+    processArea: row.processArea ?? undefined,
+    severity: row.severity as AlarmSeverity,
+    state: row.state as AlarmLifecycleState,
+    message: row.message,
+    timestamp: Number(row.eventTimeMs),
+    value: toWireValue(row.alarmValue),
+    limit: toWireValue(row.alarmLimit),
+    source: row.source ?? undefined,
+    acknowledgedBy: row.acknowledgedBy ?? undefined,
+    clearedBy: row.clearedBy ?? undefined,
+  };
+}
+
+function alarmValues(entry: PersistedAlarm, seq: number, now: Date) {
+  const { alarm } = entry;
+  return {
+    id: alarm.id,
+    groupId: entry.groupId,
+    name: alarm.name,
+    tagId: alarm.tagId,
+    equipmentId: alarm.equipmentId ?? null,
+    siteId: alarm.siteId ?? null,
+    processArea: alarm.processArea ?? null,
+    severity: alarm.severity,
+    state: alarm.state,
+    message: alarm.message,
+    eventTimeMs: alarm.timestamp,
+    alarmValue: (alarm.value ?? null) as JsonScalar,
+    alarmLimit: (alarm.limit ?? null) as JsonScalar,
+    source: alarm.source ?? null,
+    acknowledgedBy: alarm.acknowledgedBy ?? null,
+    clearedBy: alarm.clearedBy ?? null,
+    suppressed: entry.suppressed,
+    isRootCause: entry.isRootCause,
+    joinedViaRuleId: entry.joinedViaRuleId,
+    ingestSeq: entry.ingestSeq,
+    updatedSeq: seq,
+    updatedAt: now,
+  };
+}
+
+function groupValues(group: AlarmGroup, seq: number, now: Date) {
+  return {
+    id: group.id,
+    state: group.state,
+    rootCauseAlarmId: group.rootCauseAlarmId,
+    formedByRuleId: group.formedByRuleId,
+    joinedVia: group.joinedVia,
+    maxSeverity: group.maxSeverity,
+    createdAtMs: group.createdAt,
+    lastAlarmAtMs: group.lastAlarmAt,
+    closedAtMs: group.closedAt ?? null,
+    closeReason: group.closeReason ?? null,
+    updatedSeq: seq,
+    updatedAt: now,
+  };
+}
+
+function ruleValues(rule: CorrelationRule, seq: number, principal: string, now: Date) {
+  return {
+    id: rule.id,
+    name: rule.name,
+    type: rule.type,
+    enabled: rule.enabled,
+    priority: rule.priority,
+    config: rule.config,
+    updatedBy: principal,
+    updatedSeq: seq,
+    updatedAt: now,
+  };
+}
+
+function equipmentValues(
+  node: EquipmentNode,
+  seq: number,
+  principal: string,
+  now: Date,
+) {
+  return {
+    equipmentId: node.equipmentId,
+    name: node.name ?? null,
+    parentId: node.parentId ?? null,
+    causalDownstream: node.causalDownstream,
+    siteId: node.siteId ?? null,
+    processArea: node.processArea ?? null,
+    updatedBy: principal,
+    updatedSeq: seq,
+    updatedAt: now,
+  };
+}
+
+/** Chunked so a burst never builds a statement with too many bind parameters. */
+const UPSERT_CHUNK = 100;
+
+function chunk<T>(items: T[], size = UPSERT_CHUNK): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+export class DrizzleCorrelationStore implements CorrelationStore {
+  private connection: Connection | undefined;
+  private opening: Promise<Connection> | undefined;
+  /**
+   * In-process serialisation. Both backends here own a single physical
+   * connection, so overlapping transactions on it would interleave `BEGIN` and
+   * `COMMIT` from different logical operations. Cross-process serialisation is
+   * the database's job (advisory lock / BEGIN IMMEDIATE); this only prevents
+   * this process from fighting itself.
+   */
+  private tail: Promise<unknown> = Promise.resolve();
+
+  constructor(private readonly options: CorrelationStoreOptions = {}) {}
+
+  backend(): StoreBackend {
+    return this.connection?.kind ?? "unopened";
+  }
+
+  async ready(): Promise<void> {
+    await this.connect();
+  }
+
+  async append(entry: JournalAppend): Promise<JournalAppendResult> {
+    return this.serialize(async () => {
+      const connection = await this.connect();
+      return this.inTransaction(connection, async () => {
+        const existing = await this.seqForKey(connection, entry.idempotencyKey);
+        if (existing !== null) return { seq: existing, created: false };
+
+        const now = new Date();
+        if (connection.kind === "postgres") {
+          await connection.db.insert(pgJournal).values({
+            idempotencyKey: entry.idempotencyKey,
+            op: entry.op,
+            payload: entry.payload,
+            principal: entry.principal,
+            originInstance: entry.originInstance,
+            recordedAt: now,
+          });
+        } else {
+          await connection.db.insert(sqliteJournal).values({
+            idempotencyKey: entry.idempotencyKey,
+            op: entry.op,
+            payload: entry.payload,
+            principal: entry.principal,
+            originInstance: entry.originInstance,
+            recordedAt: now,
+          });
+        }
+
+        const seq = await this.seqForKey(connection, entry.idempotencyKey);
+        if (seq === null) {
+          throw new Error(
+            `alarm correlation journal append for "${entry.idempotencyKey}" did not persist`,
+          );
+        }
+        return { seq, created: true };
+      });
+    });
+  }
+
+  async read(afterSeq: number, limit = DEFAULT_JOURNAL_PAGE): Promise<CorrelationJournalEntry[]> {
+    const connection = await this.connect();
+    if (connection.kind === "postgres") {
+      const rows = await connection.db
+        .select()
+        .from(pgJournal)
+        .where(gt(pgJournal.seq, afterSeq))
+        .orderBy(asc(pgJournal.seq))
+        .limit(limit);
+      return rows.map((row) => ({
+        seq: Number(row.seq),
+        idempotencyKey: row.idempotencyKey,
+        op: row.op as CorrelationJournalOp,
+        payload: row.payload as Record<string, unknown>,
+        principal: row.principal,
+        originInstance: row.originInstance,
+        recordedAt: row.recordedAt.getTime(),
+      }));
+    }
+    const rows = await connection.db
+      .select()
+      .from(sqliteJournal)
+      .where(gt(sqliteJournal.seq, afterSeq))
+      .orderBy(asc(sqliteJournal.seq))
+      .limit(limit);
+    return rows.map((row) => ({
+      seq: Number(row.seq),
+      idempotencyKey: row.idempotencyKey,
+      op: row.op as CorrelationJournalOp,
+      payload: row.payload as Record<string, unknown>,
+      principal: row.principal,
+      originInstance: row.originInstance,
+      recordedAt: row.recordedAt.getTime(),
+    }));
+  }
+
+  async load(): Promise<DurableSnapshot> {
+    const connection = await this.connect();
+    const stateRow = await this.readStateRow(connection);
+
+    const ruleRows = connection.kind === "postgres"
+      ? await connection.db.select().from(pgRules)
+      : await connection.db.select().from(sqliteRules);
+    const rules: CorrelationRule[] = ruleRows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      type: row.type as CorrelationRuleType,
+      enabled: Boolean(row.enabled),
+      priority: Number(row.priority),
+      config: row.config as CorrelationRule["config"],
+    }));
+
+    const equipmentRows = connection.kind === "postgres"
+      ? await connection.db.select().from(pgEquipment)
+      : await connection.db.select().from(sqliteEquipment);
+    const equipment: EquipmentNode[] = equipmentRows.map((row) => ({
+      equipmentId: row.equipmentId,
+      name: row.name ?? undefined,
+      parentId: row.parentId ?? undefined,
+      causalDownstream: Array.isArray(row.causalDownstream)
+        ? (row.causalDownstream as string[])
+        : [],
+      siteId: row.siteId ?? undefined,
+      processArea: row.processArea ?? undefined,
+    }));
+
+    const groupRows = connection.kind === "postgres"
+      ? await connection.db.select().from(pgGroups)
+      : await connection.db.select().from(sqliteGroups);
+    const alarmRows = (connection.kind === "postgres"
+      ? await connection.db.select().from(pgAlarms).orderBy(asc(pgAlarms.ingestSeq))
+      : await connection.db
+        .select()
+        .from(sqliteAlarms)
+        .orderBy(asc(sqliteAlarms.ingestSeq))) as unknown as AlarmRowShape[];
+
+    const alarmSeq = new Map<string, number>();
+    const byGroup = new Map<string, AlarmRowShape[]>();
+    const pending: CorrelatedAlarm[] = [];
+    for (const row of alarmRows) {
+      alarmSeq.set(row.id, Number(row.updatedSeq));
+      if (row.groupId === null) {
+        pending.push(rowToAlarm(row));
+        continue;
+      }
+      const bucket = byGroup.get(row.groupId);
+      if (bucket) bucket.push(row);
+      else byGroup.set(row.groupId, [row]);
+    }
+
+    const groups: AlarmGroup[] = [];
+    for (const row of groupRows) {
+      const members = byGroup.get(row.id) ?? [];
+      // Ingestion order is the engine's member order; ingest_seq is exactly
+      // that order and is stable across replicas.
+      members.sort((a, b) => Number(a.ingestSeq) - Number(b.ingestSeq));
+      const joinedVia: Record<string, string> = {
+        ...(row.joinedVia as Record<string, string> | null ?? {}),
+      };
+      for (const member of members) {
+        if (member.joinedViaRuleId) joinedVia[member.id] = member.joinedViaRuleId;
+      }
+      groups.push({
+        id: row.id,
+        state: row.state as AlarmGroupState,
+        alarms: members.map(rowToAlarm),
+        alarmIds: members.map((member) => member.id),
+        rootCauseAlarmId: row.rootCauseAlarmId,
+        formedByRuleId: row.formedByRuleId,
+        joinedVia,
+        suppressedAlarmIds: members
+          .filter((member) => Boolean(member.suppressed))
+          .map((member) => member.id),
+        maxSeverity: row.maxSeverity as AlarmSeverity,
+        createdAt: Number(row.createdAtMs),
+        lastAlarmAt: Number(row.lastAlarmAtMs),
+        closedAt: row.closedAtMs === null ? undefined : Number(row.closedAtMs),
+        closeReason: (row.closeReason ?? undefined) as AlarmGroup["closeReason"],
+      });
+    }
+
+    return {
+      appliedSeq: stateRow.appliedSeq,
+      policy: stateRow.policy,
+      metrics: stateRow.metrics,
+      rules,
+      equipment,
+      groups,
+      pending,
+      alarmSeq,
+    };
+  }
+
+  async project(seq: number, changes: ProjectionChanges): Promise<boolean> {
+    return this.serialize(async () => {
+      const connection = await this.connect();
+      return this.inTransaction(connection, async () => {
+        const advanced = await this.advanceWatermark(connection, seq, changes);
+        // Losing the race is normal and not an error: another replica already
+        // projected this entry, and it wrote the same deterministic result.
+        if (!advanced) return false;
+
+        const now = new Date();
+        await this.writeRows(connection, seq, changes, now);
+        return true;
+      });
+    });
+  }
+
+  async prune(options: {
+    journalOlderThanMs: number;
+    closedGroupsOlderThanMs: number;
+    now: number;
+  }): Promise<{ journalEntries: number; groups: number; alarms: number }> {
+    return this.serialize(async () => {
+      const connection = await this.connect();
+      return this.inTransaction(connection, async () => {
+        const state = await this.readStateRow(connection);
+        const journalCutoff = new Date(options.now - options.journalOlderThanMs);
+        const groupCutoff = options.now - options.closedGroupsOlderThanMs;
+
+        // Never at or above the watermark: an unprojected entry is the only
+        // record of an operator's acknowledge or clear.
+        let journalEntries = 0;
+        if (state.appliedSeq > 0) {
+          journalEntries = connection.kind === "postgres"
+            ? await this.deleteCount(
+              connection,
+              connection.db
+                .delete(pgJournal)
+                .where(and(
+                  lt(pgJournal.seq, state.appliedSeq),
+                  lt(pgJournal.recordedAt, journalCutoff),
+                )),
+            )
+            : await this.deleteCount(
+              connection,
+              connection.db
+                .delete(sqliteJournal)
+                .where(and(
+                  lt(sqliteJournal.seq, state.appliedSeq),
+                  lt(sqliteJournal.recordedAt, journalCutoff),
+                )),
+            );
+        }
+
+        // Only CLOSED groups age out. An open group, or any alarm still
+        // suppressed, is live safety state and is never pruned by age.
+        const staleGroupIds = connection.kind === "postgres"
+          ? (await connection.db
+            .select({ id: pgGroups.id })
+            .from(pgGroups)
+            .where(and(
+              eq(pgGroups.state, "closed"),
+              lt(pgGroups.lastAlarmAtMs, groupCutoff),
+            ))).map((row) => row.id)
+          : (await connection.db
+            .select({ id: sqliteGroups.id })
+            .from(sqliteGroups)
+            .where(and(
+              eq(sqliteGroups.state, "closed"),
+              lt(sqliteGroups.lastAlarmAtMs, groupCutoff),
+            ))).map((row) => row.id);
+
+        let alarms = 0;
+        let groups = 0;
+        for (const ids of chunk(staleGroupIds)) {
+          if (connection.kind === "postgres") {
+            alarms += await this.deleteCount(
+              connection,
+              connection.db.delete(pgAlarms).where(inArray(pgAlarms.groupId, ids)),
+            );
+            groups += await this.deleteCount(
+              connection,
+              connection.db.delete(pgGroups).where(inArray(pgGroups.id, ids)),
+            );
+          } else {
+            alarms += await this.deleteCount(
+              connection,
+              connection.db.delete(sqliteAlarms).where(inArray(sqliteAlarms.groupId, ids)),
+            );
+            groups += await this.deleteCount(
+              connection,
+              connection.db.delete(sqliteGroups).where(inArray(sqliteGroups.id, ids)),
+            );
+          }
+        }
+
+        return { journalEntries, groups, alarms };
+      });
+    });
+  }
+
+  async close(): Promise<void> {
+    const connection = this.connection;
+    this.connection = undefined;
+    this.opening = undefined;
+    if (!connection) return;
+    if (connection.kind === "postgres") {
+      await connection.client.end();
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      connection.client.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+
+  // ── Private ────────────────────────────────────────────────────────────────
+
+  private serialize<T>(work: () => Promise<T>): Promise<T> {
+    const run = this.tail.then(work, work);
+    // Keep the chain alive after a rejection so one failed operation does not
+    // wedge every later one.
+    this.tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private async inTransaction<T>(
+    connection: Connection,
+    work: () => Promise<T>,
+  ): Promise<T> {
+    if (connection.kind === "postgres") {
+      await connection.client.query("BEGIN");
+      try {
+        // Serialises appends across replicas so identity allocation order
+        // equals commit order, and serialises projection races so the
+        // conditional watermark update is decisive.
+        await connection.client.query("SELECT pg_advisory_xact_lock($1)", [
+          JOURNAL_APPEND_LOCK_KEY,
+        ]);
+        const result = await work();
+        await connection.client.query("COMMIT");
+        return result;
+      } catch (error) {
+        await connection.client.query("ROLLBACK").catch(() => undefined);
+        throw error;
+      }
+    }
+
+    // BEGIN IMMEDIATE takes SQLite's write lock up front, giving the same
+    // "one writer at a time across processes" property as the advisory lock.
+    await sqliteRun(connection.client, "BEGIN IMMEDIATE", []);
+    try {
+      const result = await work();
+      await sqliteRun(connection.client, "COMMIT", []);
+      return result;
+    } catch (error) {
+      await sqliteRun(connection.client, "ROLLBACK", []).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  private async seqForKey(
+    connection: Connection,
+    idempotencyKey: string,
+  ): Promise<number | null> {
+    if (connection.kind === "postgres") {
+      const rows = await connection.db
+        .select({ seq: pgJournal.seq })
+        .from(pgJournal)
+        .where(eq(pgJournal.idempotencyKey, idempotencyKey))
+        .limit(1);
+      return rows.length > 0 ? Number(rows[0].seq) : null;
+    }
+    const rows = await connection.db
+      .select({ seq: sqliteJournal.seq })
+      .from(sqliteJournal)
+      .where(eq(sqliteJournal.idempotencyKey, idempotencyKey))
+      .limit(1);
+    return rows.length > 0 ? Number(rows[0].seq) : null;
+  }
+
+  private async readStateRow(connection: Connection): Promise<{
+    appliedSeq: number;
+    policy: SuppressionPolicy;
+    metrics: DurableMetrics;
+  }> {
+    const rows = connection.kind === "postgres"
+      ? await connection.db.select().from(pgState).where(eq(pgState.id, STATE_ROW_ID)).limit(1)
+      : await connection.db
+        .select()
+        .from(sqliteState)
+        .where(eq(sqliteState.id, STATE_ROW_ID))
+        .limit(1);
+
+    if (rows.length === 0) {
+      return {
+        appliedSeq: 0,
+        // Suppression off is the only safe default for a store that has never
+        // been written: nothing is known about what an operator intended.
+        policy: {
+          enabled: false,
+          neverSuppressAtOrAbove: "critical",
+          unsuppressOnRootClear: true,
+        },
+        metrics: {
+          alarmsIngested: 0,
+          groupsCreated: 0,
+          groupsClosed: 0,
+          alarmsSuppressed: 0,
+          alarmsUnsuppressed: 0,
+        },
+      };
+    }
+
+    const row = rows[0];
+    return {
+      appliedSeq: Number(row.appliedSeq),
+      policy: {
+        enabled: Boolean(row.suppressionEnabled),
+        neverSuppressAtOrAbove: row.neverSuppressAtOrAbove as AlarmSeverity,
+        unsuppressOnRootClear: true,
+      },
+      metrics: {
+        alarmsIngested: Number(row.alarmsIngested),
+        groupsCreated: Number(row.groupsCreated),
+        groupsClosed: Number(row.groupsClosed),
+        alarmsSuppressed: Number(row.alarmsSuppressed),
+        alarmsUnsuppressed: Number(row.alarmsUnsuppressed),
+      },
+    };
+  }
+
+  /**
+   * Conditional watermark advance. Returns false — writing nothing — when the
+   * stored watermark is already at or past `seq`, which is how two replicas
+   * projecting concurrently still produce a strictly seq-ordered projection.
+   */
+  private async advanceWatermark(
+    connection: Connection,
+    seq: number,
+    changes: ProjectionChanges,
+  ): Promise<boolean> {
+    const now = new Date();
+    const policy = changes.policy;
+    const base = {
+      appliedSeq: seq,
+      alarmsIngested: changes.metrics.alarmsIngested,
+      groupsCreated: changes.metrics.groupsCreated,
+      groupsClosed: changes.metrics.groupsClosed,
+      alarmsSuppressed: changes.metrics.alarmsSuppressed,
+      alarmsUnsuppressed: changes.metrics.alarmsUnsuppressed,
+      updatedBy: changes.principal,
+      updatedAt: now,
+      ...(policy
+        ? {
+          suppressionEnabled: policy.enabled,
+          neverSuppressAtOrAbove: policy.neverSuppressAtOrAbove,
+          unsuppressOnRootClear: true,
+        }
+        : {}),
+    };
+
+    if (connection.kind === "postgres") {
+      const inserted = await connection.db
+        .insert(pgState)
+        .values({ id: STATE_ROW_ID, ...base })
+        .onConflictDoUpdate({
+          target: pgState.id,
+          set: base,
+          where: lt(pgState.appliedSeq, seq),
+        })
+        .returning({ appliedSeq: pgState.appliedSeq });
+      return inserted.length > 0;
+    }
+
+    await connection.db
+      .insert(sqliteState)
+      .values({ id: STATE_ROW_ID, ...base })
+      .onConflictDoUpdate({
+        target: sqliteState.id,
+        set: base,
+        where: lt(sqliteState.appliedSeq, seq),
+      });
+    // sqlite-proxy does not surface affected-row counts, so confirm by reading
+    // the watermark back inside the same transaction.
+    const after = await this.readStateRow(connection);
+    return after.appliedSeq === seq;
+  }
+
+  private async writeRows(
+    connection: Connection,
+    seq: number,
+    changes: ProjectionChanges,
+    now: Date,
+  ): Promise<void> {
+    if (connection.kind === "postgres") {
+      // One statement per row, with the row itself as the conflict SET. Batched
+      // upserts would need `excluded.<col>` expressions built from column names,
+      // and a hand-built SET is exactly where a column silently stops being
+      // written. Row counts per journal entry are bounded by maxAlarmsPerGroup.
+      for (const group of changes.groups) {
+        const values = groupValues(group, seq, now);
+        await connection.db.insert(pgGroups).values(values)
+          .onConflictDoUpdate({ target: pgGroups.id, set: values });
+      }
+      for (const entry of changes.alarms) {
+        const values = alarmValues(entry, seq, now);
+        await connection.db.insert(pgAlarms).values(values)
+          .onConflictDoUpdate({ target: pgAlarms.id, set: values });
+      }
+      for (const rule of changes.upsertRules) {
+        const values = ruleValues(rule, seq, changes.principal, now);
+        await connection.db.insert(pgRules).values(values)
+          .onConflictDoUpdate({ target: pgRules.id, set: values });
+      }
+      for (const node of changes.upsertEquipment) {
+        const values = equipmentValues(node, seq, changes.principal, now);
+        await connection.db.insert(pgEquipment).values(values)
+          .onConflictDoUpdate({ target: pgEquipment.equipmentId, set: values });
+      }
+      for (const ids of chunk(changes.deletedAlarmIds)) {
+        await connection.db.delete(pgAlarms).where(inArray(pgAlarms.id, ids));
+      }
+      for (const ids of chunk(changes.deletedGroupIds)) {
+        await connection.db.delete(pgGroups).where(inArray(pgGroups.id, ids));
+      }
+      for (const ids of chunk(changes.removedRuleIds)) {
+        await connection.db.delete(pgRules).where(inArray(pgRules.id, ids));
+      }
+      for (const ids of chunk(changes.removedEquipmentIds)) {
+        await connection.db
+          .delete(pgEquipment)
+          .where(inArray(pgEquipment.equipmentId, ids));
+      }
+      return;
+    }
+
+    for (const group of changes.groups) {
+      const values = groupValues(group, seq, now);
+      await connection.db.insert(sqliteGroups).values(values)
+        .onConflictDoUpdate({ target: sqliteGroups.id, set: values });
+    }
+    for (const entry of changes.alarms) {
+      const values = alarmValues(entry, seq, now);
+      await connection.db.insert(sqliteAlarms).values(values)
+        .onConflictDoUpdate({ target: sqliteAlarms.id, set: values });
+    }
+    for (const rule of changes.upsertRules) {
+      const values = ruleValues(rule, seq, changes.principal, now);
+      await connection.db.insert(sqliteRules).values(values)
+        .onConflictDoUpdate({ target: sqliteRules.id, set: values });
+    }
+    for (const node of changes.upsertEquipment) {
+      const values = equipmentValues(node, seq, changes.principal, now);
+      await connection.db.insert(sqliteEquipment).values(values)
+        .onConflictDoUpdate({ target: sqliteEquipment.equipmentId, set: values });
+    }
+    for (const ids of chunk(changes.deletedAlarmIds)) {
+      await connection.db.delete(sqliteAlarms).where(inArray(sqliteAlarms.id, ids));
+    }
+    for (const ids of chunk(changes.deletedGroupIds)) {
+      await connection.db.delete(sqliteGroups).where(inArray(sqliteGroups.id, ids));
+    }
+    for (const ids of chunk(changes.removedRuleIds)) {
+      await connection.db.delete(sqliteRules).where(inArray(sqliteRules.id, ids));
+    }
+    for (const ids of chunk(changes.removedEquipmentIds)) {
+      await connection.db
+        .delete(sqliteEquipment)
+        .where(inArray(sqliteEquipment.equipmentId, ids));
+    }
+  }
+
+  private async deleteCount(
+    connection: Connection,
+    query: { toSQL(): { sql: string; params: unknown[] } },
+  ): Promise<number> {
+    const compiled = query.toSQL();
+    if (connection.kind === "postgres") {
+      const result = await connection.client.query(compiled.sql, compiled.params);
+      return result.rowCount ?? 0;
+    }
+    return new Promise<number>((resolve, reject) => {
+      connection.client.run(
+        compiled.sql,
+        compiled.params,
+        function onDone(this: { changes: number }, error: Error | null) {
+          if (error) reject(error);
+          else resolve(this.changes);
+        },
+      );
+    });
+  }
+
+  private connect(): Promise<Connection> {
+    if (this.connection) return Promise.resolve(this.connection);
+    if (this.opening) return this.opening;
+
+    this.opening = this.openConnection()
+      .then((connection) => {
+        this.connection = connection;
+        return connection;
+      })
+      .catch((error: unknown) => {
+        // Let the next caller retry rather than caching a failed connection.
+        this.opening = undefined;
+        throw error;
+      });
+    return this.opening;
+  }
+
+  private async openConnection(): Promise<Connection> {
+    const postgresUrl = resolvePostgresUrl(this.options);
+    if (postgresUrl) {
+      const client = new Client({ connectionString: postgresUrl });
+      await client.connect();
+      return { kind: "postgres", client, db: drizzlePostgres(client) };
+    }
+
+    const filePath = resolveSqlitePath(this.options);
+    const client = await new Promise<Database>((resolve, reject) => {
+      const opened: Database = new Database(filePath, (error) =>
+        (error ? reject(error) : resolve(opened)));
+    });
+    // node-sqlite3 dispatches statements in parallel by default, which would
+    // let a BEGIN IMMEDIATE and the statements inside that transaction
+    // interleave with another logical operation on the same handle.
+    client.serialize();
+    // WAL lets a second replica read while one writes, and `busy_timeout` makes
+    // BEGIN IMMEDIATE wait for the write lock instead of failing immediately —
+    // which is what "one writer at a time across processes" actually requires.
+    // `synchronous=FULL` is kept: this store exists so alarm state survives, and
+    // trading durability for commit latency here would defeat the whole issue.
+    await sqliteExec(
+      client,
+      "PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; PRAGMA busy_timeout=5000;",
+    );
+    await sqliteExec(client, SQLITE_DDL);
+    // Idempotent seed of the singleton row; matches the migration's INSERT.
+    await sqliteRun(
+      client,
+      "INSERT OR IGNORE INTO alarm_correlation_state (id, updated_at) VALUES ('default', ?)",
+      [Date.now()],
+    );
+
+    const db = drizzleSqliteProxy(async (sqlText, params, method) => {
+      if (method === "run") {
+        await sqliteRun(client, sqlText, params);
+        return { rows: [] };
+      }
+      const rows = await sqliteAll(client, sqlText, params);
+      if (method === "get") {
+        return { rows: rows.length > 0 ? positionalRow(rows[0]) : [] };
+      }
+      return { rows: rows.map(positionalRow) };
+    });
+
+    return { kind: "sqlite", client, db };
+  }
+}

--- a/server/websocket/__tests__/alarm-correlation-coordinated-fanout.test.ts
+++ b/server/websocket/__tests__/alarm-correlation-coordinated-fanout.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Cross-instance alarm fan-out and reconnect snapshots
+ * ADR-0026 / ADR-0013 [13.2] — Issue #573
+ *
+ * Two `CachedEventBridge` instances stand in for two API replicas. Redis is not
+ * available in this suite, so the cross-instance hop is performed by handing one
+ * bridge the payload the other would have published — the same object shape,
+ * through the same `handleIncoming` path a real Redis message takes. What is
+ * under test is the de-duplication and snapshot logic, not ioredis.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import type { AlarmWireSnapshot } from '@shared/types/alarm-correlation';
+import {
+  AlarmCorrelationCoordinator,
+  AlarmCorrelationService,
+  DrizzleCorrelationStore,
+  type CorrelationStore,
+} from '../../services/alarm-correlation';
+import { CachedEventBridge } from '../cached-event-bridge';
+
+/** The real store until `fail` is set, then a store that cannot be reached. */
+function breakableStore(inner: CorrelationStore): CorrelationStore & { fail: boolean } {
+  const unreachable = () => Promise.reject(new Error('journal unreachable'));
+  const wrapper: CorrelationStore & { fail: boolean } = {
+    fail: false,
+    ready: () => inner.ready(),
+    backend: () => inner.backend(),
+    append: (entry) => (wrapper.fail ? unreachable() : inner.append(entry)),
+    read: (afterSeq, limit) =>
+      (wrapper.fail ? unreachable() : inner.read(afterSeq, limit)),
+    load: () => inner.load(),
+    project: (seq, changes) =>
+      (wrapper.fail ? unreachable() : inner.project(seq, changes)),
+    prune: (options) => inner.prune(options),
+    close: () => inner.close(),
+  };
+  return wrapper;
+}
+
+interface CapturingSink {
+  snapshots: Record<string, unknown>[];
+  provided: Record<string, unknown>[][];
+  broadcastAlarm(alarm: Record<string, unknown>): void;
+  setAlarmSnapshotProvider(
+    provider: (() => Record<string, unknown>[]) | null,
+  ): void;
+  requestSnapshot(): Record<string, unknown>[];
+}
+
+function capturingSink(): CapturingSink {
+  let provider: (() => Record<string, unknown>[]) | null = null;
+  return {
+    snapshots: [],
+    provided: [],
+    broadcastAlarm(alarm) {
+      this.snapshots.push(alarm);
+    },
+    setAlarmSnapshotProvider(next) {
+      provider = next;
+    },
+    /** What a freshly connected client on this server would be sent. */
+    requestSnapshot() {
+      const alarms = provider ? provider() : [];
+      this.provided.push(alarms);
+      return alarms;
+    },
+  };
+}
+
+// Real transactions against a real database file with synchronous=FULL: these
+// tests are disk-bound, and the default 5s budget is not enough when the suite
+// runs in parallel with the rest of the repo.
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    await cleanup().catch(() => undefined);
+  }
+});
+
+async function sharedDbFile(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'alarm-fanout-'));
+  cleanups.push(() => rm(dir, { recursive: true, force: true }));
+  return path.join(dir, 'correlation.sqlite');
+}
+
+interface Replica {
+  service: AlarmCorrelationService;
+  coordinator: AlarmCorrelationCoordinator;
+  bridge: CachedEventBridge;
+  tagSink: CapturingSink;
+  unifiedSink: CapturingSink;
+  store: CorrelationStore & { fail: boolean };
+}
+
+async function startReplica(file: string, instanceId: string): Promise<Replica> {
+  const store = breakableStore(new DrizzleCorrelationStore({ sqlitePath: file }));
+  const coordinator = new AlarmCorrelationCoordinator({
+    store,
+    instanceId,
+    pollIntervalMs: 60_000,
+    pruneIntervalMs: 60 * 60_000,
+  });
+  await coordinator.start();
+  cleanups.push(() => coordinator.stop());
+
+  const service = new AlarmCorrelationService();
+  service.attachCoordinator(coordinator);
+
+  const tagSink = capturingSink();
+  const unifiedSink = capturingSink();
+  const bridge = new CachedEventBridge(service, tagSink, unifiedSink);
+  bridge.initializeLocalAlarmFanout();
+  cleanups.push(() => bridge.destroy());
+
+  return { service, coordinator, bridge, tagSink, unifiedSink, store };
+}
+
+/**
+ * What a real bridge publishes to Redis: the snapshot plus its origin tag.
+ * `handleIncoming` is private, so the test reaches it the way the subscriber
+ * callback does.
+ */
+function deliverRemote(target: Replica, snapshot: Record<string, unknown>): void {
+  const bridge = target.bridge as unknown as {
+    handleIncoming(channel: string, data: unknown): void;
+    instanceId: string;
+  };
+  bridge.handleIncoming('0xscada:ws:alarms', { ...snapshot });
+}
+
+function originTagged(
+  source: Replica,
+  snapshot: Record<string, unknown>,
+): Record<string, unknown> {
+  const bridge = source.bridge as unknown as { instanceId: string };
+  return { ...snapshot, _bridgeOrigin: bridge.instanceId };
+}
+
+function latest(sink: CapturingSink, alarmId: string): AlarmWireSnapshot {
+  const match = sink.snapshots.filter((snapshot) => snapshot.id === alarmId).at(-1);
+  if (!match) throw new Error(`No snapshot for ${alarmId}`);
+  return match as unknown as AlarmWireSnapshot;
+}
+
+describe('coordinated cross-instance alarm fan-out', () => {
+  it('drops a duplicate cross-instance echo but delivers the next state', async () => {
+    const file = await sharedDbFile();
+    const a = await startReplica(file, 'replica-a');
+    const b = await startReplica(file, 'replica-b');
+
+    await a.bridge.publishAlarm({
+      id: 'shared-alarm',
+      tagId: 'PUMP-1.TRIP',
+      severity: 'high',
+      state: 'active',
+      timestamp: 1_000,
+    });
+    const published = latest(a.tagSink, 'shared-alarm') as unknown as Record<string, unknown>;
+    expect((published.correlation as { seq: number }).seq).toBeGreaterThan(0);
+
+    // B consumes the same journal entry itself, then also receives A's Redis
+    // copy of the identical state.
+    await b.coordinator.pump();
+    const deliveredBefore = b.tagSink.snapshots.length;
+    deliverRemote(b, originTagged(a, published));
+    expect(b.tagSink.snapshots).toHaveLength(deliveredBefore);
+
+    // A's own echo coming back to A is dropped by the origin tag.
+    const aBefore = a.tagSink.snapshots.length;
+    deliverRemote(a, originTagged(a, published));
+    expect(a.tagSink.snapshots).toHaveLength(aBefore);
+
+    // A newer state for the same alarm still gets through: the guard compares
+    // sequences, it does not simply remember the id.
+    await a.service.acknowledge('shared-alarm', 'operator-a');
+    const acknowledged = latest(a.tagSink, 'shared-alarm') as unknown as Record<string, unknown>;
+    expect((acknowledged.correlation as { seq: number }).seq)
+      .toBeGreaterThan((published.correlation as { seq: number }).seq);
+
+    const beforeNewer = b.tagSink.snapshots.length;
+    deliverRemote(b, originTagged(a, acknowledged));
+    expect(b.tagSink.snapshots.length).toBe(beforeNewer + 1);
+    expect(latest(b.tagSink, 'shared-alarm').state).toBe('acknowledged');
+  });
+
+  it('does not let an incoming message raise the de-duplication watermark', async () => {
+    const file = await sharedDbFile();
+    const a = await startReplica(file, 'replica-a');
+    const b = await startReplica(file, 'replica-b');
+
+    // Anything able to publish on the alarm channel claims a very high sequence
+    // for an alarm id. If that raised the watermark, every later genuine state
+    // for that id would be dropped as "already delivered" — a way to hide an
+    // alarm, which is the one outcome this subsystem must never allow.
+    deliverRemote(b, originTagged(a, {
+      id: 'targeted-alarm',
+      tagId: 'PUMP-1.TRIP',
+      severity: 'critical',
+      state: 'active',
+      correlation: { seq: Number.MAX_SAFE_INTEGER, coordinationMode: 'durable' },
+    }));
+    expect(b.tagSink.snapshots.filter((s) => s.id === 'targeted-alarm')).toHaveLength(1);
+
+    // A genuine, much lower-sequence state for the same alarm still gets through.
+    await a.bridge.publishAlarm({
+      id: 'targeted-alarm',
+      tagId: 'PUMP-1.TRIP',
+      severity: 'critical',
+      state: 'active',
+      timestamp: 1_000,
+    });
+    const genuine = latest(a.tagSink, 'targeted-alarm') as unknown as Record<string, unknown>;
+    expect((genuine.correlation as { seq: number }).seq).toBeLessThan(Number.MAX_SAFE_INTEGER);
+
+    const before = b.tagSink.snapshots.length;
+    deliverRemote(b, originTagged(a, genuine));
+    expect(b.tagSink.snapshots.length).toBe(before + 1);
+  });
+
+  it('never drops an uncorrelated alarm that carries no sequence', async () => {
+    const file = await sharedDbFile();
+    const a = await startReplica(file, 'replica-a');
+    const b = await startReplica(file, 'replica-b');
+
+    // A degraded or process-local producer emits no seq. Two identical copies
+    // must both be delivered: a duplicate is a nuisance, a dropped alarm is a
+    // safety failure, so the guard fails open.
+    const raw = {
+      id: 'no-seq-alarm',
+      tagId: 'TANK-1.LEVEL',
+      severity: 'critical',
+      state: 'active',
+      triggeredAt: new Date(2_000).toISOString(),
+      correlation: { seq: null, coordinationMode: 'process-local' },
+    };
+    deliverRemote(b, originTagged(a, raw));
+    deliverRemote(b, originTagged(a, raw));
+    expect(b.tagSink.snapshots.filter((s) => s.id === 'no-seq-alarm')).toHaveLength(2);
+  });
+
+  it('does not let a raw producer payload raise the de-duplication watermark', async () => {
+    const file = await sharedDbFile();
+    const b = await startReplica(file, 'replica-b');
+
+    // The same hide primitive as the incoming-message case, reached through the
+    // other door: `publishAlarm` falls back to raw delivery for anything with
+    // no usable timestamp, and that payload is the producer's, not this
+    // engine's. If its `correlation.seq` were recorded as delivered, every
+    // later genuine state for that alarm id would be dropped.
+    await b.bridge.publishAlarm({
+      id: 'targeted-alarm',
+      tagId: 'TANK-1.LEVEL',
+      severity: 'critical',
+      state: 'active',
+      timestamp: 'not-a-date',
+      correlation: { seq: Number.MAX_SAFE_INTEGER, coordinationMode: 'durable' },
+    });
+
+    const before = b.tagSink.snapshots.filter((s) => s.id === 'targeted-alarm').length;
+    deliverRemote(b, {
+      id: 'targeted-alarm',
+      tagId: 'TANK-1.LEVEL',
+      severity: 'critical',
+      state: 'active',
+      correlation: { seq: 7, coordinationMode: 'durable' },
+      _bridgeOrigin: 'replica-a',
+    });
+    expect(b.tagSink.snapshots.filter((s) => s.id === 'targeted-alarm'))
+      .toHaveLength(before + 1);
+  });
+
+  it('serves one canonical reconnect snapshot per active alarm with no origin echo', async () => {
+    const file = await sharedDbFile();
+    const a = await startReplica(file, 'replica-a');
+    const b = await startReplica(file, 'replica-b');
+
+    await a.bridge.publishAlarm({
+      id: 'alpha',
+      tagId: 'PUMP-1.TRIP',
+      severity: 'high',
+      state: 'active',
+      timestamp: 1_000,
+    });
+    await a.bridge.publishAlarm({
+      id: 'beta',
+      tagId: 'PUMP-1.TRIP',
+      severity: 'low',
+      state: 'active',
+      timestamp: 1_100,
+    });
+    await a.bridge.publishAlarm({
+      id: 'gamma',
+      tagId: 'TANK-2.LEVEL',
+      severity: 'medium',
+      state: 'active',
+      timestamp: 3_000,
+    });
+    await a.service.clear('gamma', 'operator-a');
+    await b.coordinator.pump();
+
+    // Both surfaces of the reconnecting replica are served from the same
+    // canonical state.
+    const tagSnapshot = b.tagSink.requestSnapshot();
+    const unifiedSnapshot = b.unifiedSink.requestSnapshot();
+    expect(unifiedSnapshot).toEqual(tagSnapshot);
+
+    const ids = tagSnapshot.map((entry) => entry.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(['alpha', 'beta']);
+    expect(ids).not.toContain('gamma');
+    for (const entry of tagSnapshot) {
+      expect((entry.correlation as { coordinationMode: string }).coordinationMode)
+        .toBe('durable');
+    }
+
+    // Delivering the snapshot armed de-duplication, so A's echo of exactly the
+    // state the snapshot already carried does not arrive as a duplicate right
+    // after reconnect.
+    const afterSnapshot = b.tagSink.snapshots.length;
+    for (const entry of tagSnapshot) {
+      deliverRemote(b, originTagged(a, entry));
+    }
+    expect(b.tagSink.snapshots).toHaveLength(afterSnapshot);
+  });
+
+  it('keeps delivering alarms and drops the seq when coordination degrades', async () => {
+    const file = await sharedDbFile();
+    const a = await startReplica(file, 'replica-a');
+
+    await a.bridge.publishAlarm({
+      id: 'pre-degrade',
+      tagId: 'PUMP-1.TRIP',
+      severity: 'high',
+      state: 'active',
+      timestamp: 1_000,
+    });
+    // Real storage loss, not a flag flip: the store rejects everything from
+    // here on, so the coordinator cannot quietly recover mid-test.
+    a.store.fail = true;
+
+    await a.bridge.publishAlarm({
+      id: 'post-degrade',
+      tagId: 'PUMP-1.TRIP',
+      severity: 'high',
+      state: 'active',
+      timestamp: 1_100,
+    });
+
+    // The alarm still reached the operator despite the journal being gone.
+    const delivered = latest(a.tagSink, 'post-degrade');
+    expect(delivered.id).toBe('post-degrade');
+    expect(a.coordinator.health().healthy).toBe(false);
+    expect(delivered.correlation.coordinationMode).toBe('process-local');
+    // No seq while degraded, so a healthy peer can never mistake a degraded
+    // replica's correction for a stale echo and drop it.
+    expect(delivered.correlation.seq).toBeNull();
+  });
+});

--- a/server/websocket/__tests__/alarm-reconnect-snapshot.test.ts
+++ b/server/websocket/__tests__/alarm-reconnect-snapshot.test.ts
@@ -1,0 +1,323 @@
+/**
+ * `/ws` and `/ws/tags` reconnect snapshots
+ * ADR-0026 / ADR-0013 [13.2] — Issue #573
+ *
+ * Real WebSocket servers on a real HTTP server, real `ws` clients, real
+ * durable coordination over a real SQLite file. Nothing here inspects a
+ * provider function: every assertion is about frames that actually arrived over
+ * a socket, because "the client receives one canonical snapshot" is a claim
+ * about the wire, not about an internal call.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { WebSocket } from 'ws';
+
+import {
+  AlarmCorrelationCoordinator,
+  AlarmCorrelationService,
+  DrizzleCorrelationStore,
+} from '../../services/alarm-correlation';
+import { CachedEventBridge } from '../cached-event-bridge';
+import { tagStreamServer } from '../tag-stream';
+import { unifiedStreamServer } from '../unified-stream';
+
+// Real sockets and real database commits at synchronous=FULL.
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    await cleanup().catch(() => undefined);
+  }
+});
+
+interface Harness {
+  port: number;
+  service: AlarmCorrelationService;
+  coordinator: AlarmCorrelationCoordinator;
+  bridge: CachedEventBridge;
+}
+
+async function startHarness(): Promise<Harness> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'alarm-ws-'));
+  cleanups.push(() => rm(dir, { recursive: true, force: true }));
+
+  const store = new DrizzleCorrelationStore({
+    sqlitePath: path.join(dir, 'correlation.sqlite'),
+  });
+  const coordinator = new AlarmCorrelationCoordinator({
+    store,
+    instanceId: 'replica-ws',
+    pollIntervalMs: 60_000,
+    pruneIntervalMs: 60 * 60_000,
+  });
+  await coordinator.start();
+  cleanups.push(() => coordinator.stop());
+
+  const service = new AlarmCorrelationService();
+  service.attachCoordinator(coordinator);
+
+  const server = createServer();
+  const port = await new Promise<number>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve(typeof address === 'object' && address ? address.port : 0);
+    });
+  });
+  tagStreamServer.initialize(server, '/ws/tags');
+  unifiedStreamServer.initialize(server, '/ws');
+  cleanups.push(async () => {
+    tagStreamServer.destroy();
+    unifiedStreamServer.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  const bridge = new CachedEventBridge(service, tagStreamServer, unifiedStreamServer);
+  bridge.initializeLocalAlarmFanout();
+  cleanups.push(() => bridge.destroy());
+
+  return { port, service, coordinator, bridge };
+}
+
+/** A connected client that records every frame it receives, in order. */
+interface Client {
+  socket: WebSocket;
+  frames: Record<string, unknown>[];
+  waitFor(predicate: (frame: Record<string, unknown>) => boolean): Promise<Record<string, unknown>>;
+  countOf(kind: string): number;
+  send(message: Record<string, unknown>): void;
+}
+
+async function connect(port: number, route: '/ws' | '/ws/tags'): Promise<Client> {
+  const socket = new WebSocket(`ws://127.0.0.1:${port}${route}`);
+  const frames: Record<string, unknown>[] = [];
+  const waiters: Array<{
+    predicate: (frame: Record<string, unknown>) => boolean;
+    resolve: (frame: Record<string, unknown>) => void;
+  }> = [];
+
+  socket.on('message', (raw) => {
+    const frame = JSON.parse(raw.toString()) as Record<string, unknown>;
+    frames.push(frame);
+    for (let i = waiters.length - 1; i >= 0; i--) {
+      if (waiters[i].predicate(frame)) waiters.splice(i, 1)[0].resolve(frame);
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    socket.once('open', () => resolve());
+    socket.once('error', reject);
+  });
+  cleanups.push(async () => {
+    socket.close();
+  });
+
+  return {
+    socket,
+    frames,
+    waitFor(predicate) {
+      const existing = frames.find(predicate);
+      if (existing) return Promise.resolve(existing);
+      return new Promise((resolve) => waiters.push({ predicate, resolve }));
+    },
+    /** `event` on /ws/tags, `type` on /ws. */
+    countOf(kind) {
+      return frames.filter((frame) => frame.event === kind || frame.type === kind).length;
+    },
+    send(message) {
+      socket.send(JSON.stringify(message));
+    },
+  };
+}
+
+/** Give the socket a beat to deliver anything it was going to deliver. */
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 60));
+}
+
+function snapshotAlarms(frame: Record<string, unknown>): Record<string, unknown>[] {
+  const payload = frame.payload as { alarms?: Record<string, unknown>[] };
+  return payload.alarms ?? [];
+}
+
+/** The payload a real Redis subscriber would hand `handleIncoming`. */
+function deliverOwnEcho(bridge: CachedEventBridge, alarm: Record<string, unknown>): void {
+  const internals = bridge as unknown as {
+    handleIncoming(channel: string, data: unknown): void;
+    instanceId: string;
+  };
+  internals.handleIncoming('0xscada:ws:alarms', {
+    ...alarm,
+    // Deliberately NOT this instance's id: the origin tag alone would drop it,
+    // and the point is to prove the sequence guard drops it too.
+    _bridgeOrigin: 'some-other-replica',
+  });
+}
+
+async function seedAlarms(harness: Harness): Promise<void> {
+  await harness.bridge.publishAlarm({
+    id: 'alpha',
+    tagId: 'PUMP-1.TRIP',
+    severity: 'high',
+    state: 'active',
+    timestamp: 1_000,
+  });
+  await harness.bridge.publishAlarm({
+    id: 'beta',
+    tagId: 'PUMP-1.TRIP',
+    severity: 'low',
+    state: 'active',
+    timestamp: 1_100,
+  });
+  await harness.bridge.publishAlarm({
+    id: 'gamma',
+    tagId: 'TANK-2.LEVEL',
+    severity: 'medium',
+    state: 'active',
+    timestamp: 3_000,
+  });
+  // Cleared alarms are not something a reconnecting operator still has to act
+  // on, so they must not be replayed.
+  await harness.service.clear('gamma', 'operator-a');
+}
+
+describe('/ws/tags reconnect snapshot', () => {
+  it('delivers one canonical snapshot per active alarm on connect', async () => {
+    const harness = await startHarness();
+    await seedAlarms(harness);
+
+    const client = await connect(harness.port, '/ws/tags');
+    const frame = await client.waitFor((f) => f.event === 'alarm:snapshot');
+    const alarms = snapshotAlarms(frame);
+
+    const ids = alarms.map((alarm) => alarm.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(['alpha', 'beta']);
+    for (const alarm of alarms) {
+      const correlation = alarm.correlation as { coordinationMode: string; seq: number };
+      expect(correlation.coordinationMode).toBe('durable');
+      expect(typeof correlation.seq).toBe('number');
+    }
+    // Exactly one snapshot frame — a reconnecting client is not sent the same
+    // catch-up twice.
+    await settle();
+    expect(client.countOf('alarm:snapshot')).toBe(1);
+  });
+
+  it('receives no duplicate echo of the state the snapshot already carried', async () => {
+    const harness = await startHarness();
+    await seedAlarms(harness);
+
+    const client = await connect(harness.port, '/ws/tags');
+    const frame = await client.waitFor((f) => f.event === 'alarm:snapshot');
+    const alarms = snapshotAlarms(frame);
+    await settle();
+    const updatesAfterSnapshot = client.countOf('alarm:update');
+
+    // Another instance re-broadcasts exactly the states the snapshot carried.
+    for (const alarm of alarms) deliverOwnEcho(harness.bridge, alarm);
+    await settle();
+    expect(client.countOf('alarm:update')).toBe(updatesAfterSnapshot);
+
+    // A genuinely newer state still arrives, exactly once.
+    await harness.service.acknowledge('beta', 'operator-a');
+    const update = await client.waitFor(
+      (f) => f.event === 'alarm:update'
+        && (f.payload as { id: string }).id === 'beta'
+        && (f.payload as { state: string }).state === 'acknowledged',
+    );
+    expect(update).toBeDefined();
+    await settle();
+    const acks = client.frames.filter(
+      (f) => f.event === 'alarm:update'
+        && (f.payload as { id: string }).id === 'beta'
+        && (f.payload as { state: string }).state === 'acknowledged',
+    );
+    expect(acks).toHaveLength(1);
+  });
+
+  it('re-serves the snapshot on request without duplicating live delivery', async () => {
+    const harness = await startHarness();
+    await seedAlarms(harness);
+    const client = await connect(harness.port, '/ws/tags');
+    await client.waitFor((f) => f.event === 'alarm:snapshot');
+
+    client.send({ type: 'alarm:snapshot' });
+    await settle();
+    expect(client.countOf('alarm:snapshot')).toBe(2);
+    const latest = client.frames.filter((f) => f.event === 'alarm:snapshot').at(-1)!;
+    expect(snapshotAlarms(latest).map((alarm) => alarm.id)).toEqual(['alpha', 'beta']);
+  });
+});
+
+describe('/ws reconnect snapshot', () => {
+  it('delivers one canonical snapshot per active alarm on subscribe:alarms', async () => {
+    const harness = await startHarness();
+    await seedAlarms(harness);
+
+    const client = await connect(harness.port, '/ws');
+    await client.waitFor((f) => f.type === 'connected');
+    client.send({ type: 'subscribe:alarms' });
+
+    const frame = await client.waitFor((f) => f.type === 'alarm:snapshot');
+    const alarms = snapshotAlarms(frame);
+    const ids = alarms.map((alarm) => alarm.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(['alpha', 'beta']);
+
+    await settle();
+    expect(client.countOf('alarm:snapshot')).toBe(1);
+    // The catch-up did not also arrive as a burst of live updates.
+    expect(client.countOf('alarm:update')).toBe(0);
+  });
+
+  it('receives no duplicate echo, then the next genuine state exactly once', async () => {
+    const harness = await startHarness();
+    await seedAlarms(harness);
+
+    const client = await connect(harness.port, '/ws');
+    await client.waitFor((f) => f.type === 'connected');
+    client.send({ type: 'subscribe:alarms' });
+    const frame = await client.waitFor((f) => f.type === 'alarm:snapshot');
+    const alarms = snapshotAlarms(frame);
+    await settle();
+
+    for (const alarm of alarms) deliverOwnEcho(harness.bridge, alarm);
+    await settle();
+    expect(client.countOf('alarm:update')).toBe(0);
+
+    await harness.service.acknowledge('alpha', 'operator-a');
+    await client.waitFor(
+      (f) => f.type === 'alarm:update'
+        && (f.payload as { id: string }).id === 'alpha'
+        && (f.payload as { state: string }).state === 'acknowledged',
+    );
+    await settle();
+    const acks = client.frames.filter(
+      (f) => f.type === 'alarm:update'
+        && (f.payload as { id: string }).id === 'alpha'
+        && (f.payload as { state: string }).state === 'acknowledged',
+    );
+    expect(acks).toHaveLength(1);
+  });
+
+  it('serves both surfaces the same canonical state', async () => {
+    const harness = await startHarness();
+    await seedAlarms(harness);
+
+    const tags = await connect(harness.port, '/ws/tags');
+    const unified = await connect(harness.port, '/ws');
+    await unified.waitFor((f) => f.type === 'connected');
+    unified.send({ type: 'subscribe:alarms' });
+
+    const fromTags = snapshotAlarms(await tags.waitFor((f) => f.event === 'alarm:snapshot'));
+    const fromUnified = snapshotAlarms(
+      await unified.waitFor((f) => f.type === 'alarm:snapshot'),
+    );
+    expect(fromUnified).toEqual(fromTags);
+  });
+});

--- a/server/websocket/cached-event-bridge.ts
+++ b/server/websocket/cached-event-bridge.ts
@@ -28,11 +28,25 @@ const TAG_CACHE_TTL = 60; // seconds
 
 type CorrelationSource = Pick<
   AlarmCorrelationService,
-  'on' | 'off' | 'ingest'
+  'on' | 'off' | 'ingest' | 'submit' | 'getReconnectSnapshot'
 >;
+
+/**
+ * How many alarm ids keep a "latest delivered seq" for cross-instance
+ * de-duplication. Oldest entries are evicted first; an evicted id simply loses
+ * the shortcut and is delivered again, which is the safe direction.
+ */
+const MAX_DEDUPE_TRACKED_ALARMS = 20_000;
 
 interface AlarmSink {
   broadcastAlarm(alarm: any): void;
+  /**
+   * Optional so a test double can be a bare sink. Real WebSocket servers
+   * implement it and receive the reconnect snapshot source.
+   */
+  setAlarmSnapshotProvider?(
+    provider: (() => Record<string, unknown>[]) | null,
+  ): void;
 }
 
 /**
@@ -51,6 +65,22 @@ export class CachedEventBridge {
   private isInitialized = false;
   private isLocalAlarmFanoutInitialized = false;
   private readonly instanceId = randomUUID();
+  /**
+   * alarmId → highest correlation seq this replica has itself delivered.
+   *
+   * With durable coordination every snapshot carries the journal seq of the
+   * state it describes, and that seq is the same on every replica — so an
+   * alarm that arrives again over Redis (this instance's own echo, or another
+   * instance re-broadcasting the same applied entry) is recognised as
+   * already-delivered and dropped.
+   *
+   * Only locally computed state raises this watermark; see `handleIncoming`.
+   * Snapshots with no seq (process-local mode) are never dropped, because
+   * without a shared order there is no way to prove the copy is redundant, and
+   * delivering an alarm twice is a nuisance while dropping one is a safety
+   * failure.
+   */
+  private readonly deliveredSeqByAlarm = new Map<string, number>();
   private readonly alarmSnapshotHandler = (snapshot: AlarmWireSnapshot): void => {
     this.broadcastAlarmSnapshot(snapshot);
   };
@@ -68,6 +98,10 @@ export class CachedEventBridge {
   initializeLocalAlarmFanout(): void {
     if (this.isLocalAlarmFanoutInitialized) return;
     this.correlationService.on('alarm-snapshot', this.alarmSnapshotHandler);
+    const provider = () =>
+      this.getAlarmReconnectSnapshot() as unknown as Record<string, unknown>[];
+    this.tagAlarmSink.setAlarmSnapshotProvider?.(provider);
+    this.unifiedAlarmSink.setAlarmSnapshotProvider?.(provider);
     this.isLocalAlarmFanoutInitialized = true;
   }
 
@@ -170,7 +204,11 @@ export class CachedEventBridge {
   async publishAlarm(alarm: Record<string, unknown>): Promise<void> {
     this.initializeLocalAlarmFanout();
     try {
-      const outcome = this.correlationService.ingest(alarm);
+      // Goes through the shared journal when durable coordination is up, so
+      // every replica groups this alarm identically. The service itself falls
+      // back to process-local correlation if the journal cannot be written —
+      // it never drops the alarm.
+      const outcome = await this.correlationService.submit(alarm);
       if (outcome) return;
     } catch {
       // Correlation must never block alarm fan-out
@@ -179,6 +217,24 @@ export class CachedEventBridge {
     // Inputs without a normalizable timestamp still retain the bridge's
     // historical best-effort delivery behavior.
     this.broadcastRawAlarm(alarm);
+  }
+
+  /**
+   * One canonical snapshot per active alarm, for a client that has just
+   * (re)connected to `/ws` or `/ws/tags`.
+   *
+   * Delivering it also arms de-duplication: each alarm's seq is recorded as
+   * delivered, so a cross-instance echo of the very state the snapshot just
+   * carried is dropped instead of arriving as a duplicate immediately after
+   * reconnect. Newer states still get through, because the guard compares
+   * seqs rather than merely remembering the id.
+   */
+  getAlarmReconnectSnapshot(): AlarmWireSnapshot[] {
+    const snapshots = this.correlationService.getReconnectSnapshot();
+    for (const snapshot of snapshots) {
+      this.recordDelivered(snapshot.id, snapshot.correlation.seq);
+    }
+    return snapshots;
   }
 
   /**
@@ -215,6 +271,8 @@ export class CachedEventBridge {
   async destroy(): Promise<void> {
     if (this.isLocalAlarmFanoutInitialized) {
       this.correlationService.off('alarm-snapshot', this.alarmSnapshotHandler);
+      this.tagAlarmSink.setAlarmSnapshotProvider?.(null);
+      this.unifiedAlarmSink.setAlarmSnapshotProvider?.(null);
       this.isLocalAlarmFanoutInitialized = false;
     }
     if (this.subscriber) {
@@ -237,9 +295,21 @@ export class CachedEventBridge {
       case CHANNEL_EVENTS:
         unifiedStreamServer.broadcastEvent(data);
         break;
-      case CHANNEL_ALARMS:
+      case CHANNEL_ALARMS: {
+        // Own echo: this instance already delivered it locally before publishing.
         if (data?._bridgeOrigin === this.instanceId) break;
         if (data && typeof data === 'object') delete data._bridgeOrigin;
+        // Cross-instance duplicate of a state already delivered here.
+        //
+        // Deliberately does NOT record the incoming seq. Recording it would let
+        // anything able to publish on this channel push an alarm's watermark to
+        // an arbitrary value and have later, genuine states for that alarm
+        // dropped — a way to HIDE an alarm, which is the one outcome this
+        // subsystem must never allow. The watermark is therefore raised only by
+        // state this replica computed itself. The cost is that a replica which
+        // has not yet consumed the journal entry may deliver a second copy of
+        // the same state; a duplicate is a nuisance, a hidden alarm is not.
+        if (this.alreadyDelivered(data)) break;
         try {
           this.tagAlarmSink.broadcastAlarm(data);
         } catch {
@@ -251,10 +321,19 @@ export class CachedEventBridge {
           // WebSocket delivery is best effort.
         }
         break;
+      }
     }
   }
 
   private broadcastAlarmSnapshot(snapshot: AlarmWireSnapshot): void {
+    // The ONLY place the de-duplication watermark is raised on the broadcast
+    // path: this snapshot was computed by this replica's own engine, so its
+    // seq is trustworthy. `broadcastRawAlarm` deliberately does not record,
+    // because it is also the fallback for an arbitrary producer payload — and
+    // a payload carrying an inflated `correlation.seq` would push the
+    // watermark forward and have later genuine states for that alarm id
+    // dropped, i.e. a way to HIDE an alarm.
+    this.recordDelivered(snapshot.id, correlationSeq(snapshot));
     this.broadcastRawAlarm(snapshot);
   }
 
@@ -283,6 +362,42 @@ export class CachedEventBridge {
         // Redis fan-out is optional and process-local delivery already ran.
       });
   }
+
+  /**
+   * True only when this exact alarm state — same id, same shared journal seq or
+   * older — has already reached local clients from state this replica computed
+   * itself. Anything without a seq is always delivered: an unnecessary
+   * duplicate is a nuisance, a dropped alarm is not.
+   */
+  private alreadyDelivered(alarm: Record<string, unknown> | null | undefined): boolean {
+    if (!alarm || typeof alarm.id !== 'string') return false;
+    const seq = correlationSeq(alarm);
+    if (seq === null) return false;
+    const delivered = this.deliveredSeqByAlarm.get(alarm.id);
+    return delivered !== undefined && seq <= delivered;
+  }
+
+  private recordDelivered(alarmId: string | undefined, seq: number | null): void {
+    if (!alarmId || seq === null) return;
+    const previous = this.deliveredSeqByAlarm.get(alarmId);
+    if (previous !== undefined && previous >= seq) return;
+    this.deliveredSeqByAlarm.delete(alarmId);
+    this.deliveredSeqByAlarm.set(alarmId, seq);
+    while (this.deliveredSeqByAlarm.size > MAX_DEDUPE_TRACKED_ALARMS) {
+      const oldest = this.deliveredSeqByAlarm.keys().next();
+      if (oldest.done) break;
+      this.deliveredSeqByAlarm.delete(oldest.value);
+    }
+  }
+}
+
+/** Shared journal seq carried on a correlated snapshot, when there is one. */
+function correlationSeq(alarm: unknown): number | null {
+  if (!alarm || typeof alarm !== 'object') return null;
+  const correlation = (alarm as { correlation?: unknown }).correlation;
+  if (!correlation || typeof correlation !== 'object') return null;
+  const seq = (correlation as { seq?: unknown }).seq;
+  return typeof seq === 'number' && Number.isFinite(seq) ? seq : null;
 }
 
 export const cachedEventBridge = new CachedEventBridge();

--- a/server/websocket/tag-stream.ts
+++ b/server/websocket/tag-stream.ts
@@ -47,8 +47,17 @@ export interface TagStreamMetrics {
 
 // --- Tag Stream Server ---
 
+/**
+ * Supplies one canonical snapshot per active alarm on (re)connect (#573).
+ * Registered by the cached event bridge, which owns correlation state; a
+ * WebSocket server must not reach into the correlation service itself, and
+ * leaving it null simply means no alarm snapshot is sent.
+ */
+export type AlarmSnapshotProvider = () => Record<string, unknown>[];
+
 export class TagStreamServer {
   private wss: WebSocketServer | null = null;
+  private alarmSnapshotProvider: AlarmSnapshotProvider | null = null;
   private clients = new Map<string, TagStreamClient>();
   private latestValues = new Map<string, TagUpdate>();
   private totalUpdates = 0;
@@ -127,6 +136,9 @@ export class TagStreamServer {
 
       // Send current snapshot
       this.sendSnapshot(client);
+      // One canonical state per active alarm, so a reconnecting client is not
+      // left believing whatever it last saw before the connection dropped.
+      this.sendAlarmSnapshot(client);
 
       ws.on("message", (raw) => {
         try {
@@ -240,6 +252,30 @@ export class TagStreamServer {
     this.sendToClient(client, { event: "tag:snapshot", payload: snapshot });
   }
 
+  /** Register (or clear) the reconnect alarm-snapshot source. */
+  setAlarmSnapshotProvider(provider: AlarmSnapshotProvider | null): void {
+    this.alarmSnapshotProvider = provider;
+  }
+
+  /**
+   * One canonical snapshot per active alarm. Sent as a single `alarm:snapshot`
+   * frame rather than a burst of `alarm:update` frames, so a client can tell a
+   * reconnect catch-up apart from live changes and cannot mistake the catch-up
+   * for a wave of new alarms.
+   */
+  private sendAlarmSnapshot(client: TagStreamClient): void {
+    if (!this.alarmSnapshotProvider) return;
+    let alarms: Record<string, unknown>[];
+    try {
+      alarms = this.alarmSnapshotProvider();
+    } catch {
+      // A snapshot that cannot be built must not break the connection; live
+      // alarm delivery continues regardless.
+      return;
+    }
+    this.sendToClient(client, { event: "alarm:snapshot", payload: { alarms } });
+  }
+
   /** Handle client messages (subscribe/unsubscribe) */
   private handleClientMessage(client: TagStreamClient, msg: any): void {
     switch (msg.type) {
@@ -260,6 +296,9 @@ export class TagStreamServer {
         break;
       case "snapshot":
         this.sendSnapshot(client);
+        break;
+      case "alarm:snapshot":
+        this.sendAlarmSnapshot(client);
         break;
       case "ping":
         this.sendToClient(client, { event: "pong", payload: { timestamp: new Date().toISOString() } });

--- a/server/websocket/unified-stream.ts
+++ b/server/websocket/unified-stream.ts
@@ -18,7 +18,11 @@ import { WebSocket, WebSocketServer } from 'ws';
 import type { Server as HttpServer, IncomingMessage } from 'http';
 import type { Duplex } from 'stream';
 import { URL } from 'url';
-import { tagStreamServer, type TagUpdate } from './tag-stream.js';
+import {
+  tagStreamServer,
+  type AlarmSnapshotProvider,
+  type TagUpdate,
+} from './tag-stream.js';
 import type { EventFilters, WebSocketMetrics } from './types.js';
 import {
   authorizeWebSocketUpgrade,
@@ -56,6 +60,11 @@ export interface UnifiedClient {
 
 export class UnifiedStreamServer {
   private wss: WebSocketServer | null = null;
+  /**
+   * Supplies one canonical snapshot per active alarm on (re)subscribe (#573).
+   * Registered by the cached event bridge, which owns correlation state.
+   */
+  private alarmSnapshotProvider: AlarmSnapshotProvider | null = null;
   private clients = new Map<string, UnifiedClient>();
   private startTime = Date.now();
   private pingInterval?: ReturnType<typeof setInterval>;
@@ -171,10 +180,25 @@ export class UnifiedStreamServer {
         this.send(client, { type: 'subscribed', requestId: msg.requestId, payload: { channel: 'events' } });
         break;
       }
-      case 'subscribe:alarms':
+      case 'subscribe:alarms': {
         client.subscribedChannels.add('alarms');
         this.send(client, { type: 'subscribed', requestId: msg.requestId, payload: { channel: 'alarms' } });
+        // Catch-up: the latest canonical state of every alarm the operator
+        // could still act on, exactly once each. Subscribing after a reconnect
+        // must not leave a client acting on a stale view.
+        if (this.alarmSnapshotProvider) {
+          try {
+            this.send(client, {
+              type: 'alarm:snapshot',
+              requestId: msg.requestId,
+              payload: { alarms: this.alarmSnapshotProvider() },
+            });
+          } catch {
+            // Live alarm delivery continues even if catch-up cannot be built.
+          }
+        }
         break;
+      }
       case 'subscribe:health':
         client.subscribedChannels.add('health');
         this.send(client, { type: 'subscribed', requestId: msg.requestId, payload: { channel: 'health' } });
@@ -229,6 +253,11 @@ export class UnifiedStreamServer {
         this.totalEventsDelivered++;
       }
     }
+  }
+
+  /** Register (or clear) the reconnect alarm-snapshot source. */
+  setAlarmSnapshotProvider(provider: AlarmSnapshotProvider | null): void {
+    this.alarmSnapshotProvider = provider;
   }
 
   /** Broadcast an alarm to unified clients subscribed to alarms */

--- a/shared/__tests__/schema-parity.test.ts
+++ b/shared/__tests__/schema-parity.test.ts
@@ -14,6 +14,12 @@ import {
   twinCheckpoints as pgTwinCheckpoints,
   predictiveTagThresholds as pgPredictiveTagThresholds,
   predictiveAlerts as pgPredictiveAlerts,
+  alarmCorrelationJournal as pgAlarmCorrelationJournal,
+  alarmCorrelationGroups as pgAlarmCorrelationGroups,
+  alarmCorrelationAlarms as pgAlarmCorrelationAlarms,
+  alarmCorrelationRules as pgAlarmCorrelationRules,
+  alarmCorrelationEquipment as pgAlarmCorrelationEquipment,
+  alarmCorrelationState as pgAlarmCorrelationState,
 } from '../schema';
 import {
   alarms as sqliteAlarms,
@@ -28,6 +34,12 @@ import {
   twinCheckpoints as sqliteTwinCheckpoints,
   predictiveTagThresholds as sqlitePredictiveTagThresholds,
   predictiveAlerts as sqlitePredictiveAlerts,
+  alarmCorrelationJournal as sqliteAlarmCorrelationJournal,
+  alarmCorrelationGroups as sqliteAlarmCorrelationGroups,
+  alarmCorrelationAlarms as sqliteAlarmCorrelationAlarms,
+  alarmCorrelationRules as sqliteAlarmCorrelationRules,
+  alarmCorrelationEquipment as sqliteAlarmCorrelationEquipment,
+  alarmCorrelationState as sqliteAlarmCorrelationState,
 } from '../schema-sqlite';
 
 /**
@@ -100,6 +112,42 @@ const cases = [
     sqlite: sqlitePredictiveTagThresholds,
   },
   { name: 'predictive_alerts', pg: pgPredictiveAlerts, sqlite: sqlitePredictiveAlerts },
+  // #573: the durable, replica-coordinated correlation state. A column present
+  // on only one dialect is a safety defect here, not a dev-mode inconvenience:
+  // `suppressed` on `alarm_correlation_alarms` is what makes an alarm the
+  // operator cannot currently see restorable after a restart, and `applied_seq`
+  // on `alarm_correlation_state` is what keeps two replicas from projecting the
+  // journal out of order.
+  {
+    name: 'alarm_correlation_journal',
+    pg: pgAlarmCorrelationJournal,
+    sqlite: sqliteAlarmCorrelationJournal,
+  },
+  {
+    name: 'alarm_correlation_groups',
+    pg: pgAlarmCorrelationGroups,
+    sqlite: sqliteAlarmCorrelationGroups,
+  },
+  {
+    name: 'alarm_correlation_alarms',
+    pg: pgAlarmCorrelationAlarms,
+    sqlite: sqliteAlarmCorrelationAlarms,
+  },
+  {
+    name: 'alarm_correlation_rules',
+    pg: pgAlarmCorrelationRules,
+    sqlite: sqliteAlarmCorrelationRules,
+  },
+  {
+    name: 'alarm_correlation_equipment',
+    pg: pgAlarmCorrelationEquipment,
+    sqlite: sqliteAlarmCorrelationEquipment,
+  },
+  {
+    name: 'alarm_correlation_state',
+    pg: pgAlarmCorrelationState,
+    sqlite: sqliteAlarmCorrelationState,
+  },
 ] as const;
 
 describe('schema parity (Postgres vs SQLite dev fallback)', () => {

--- a/shared/schema-sqlite.ts
+++ b/shared/schema-sqlite.ts
@@ -473,6 +473,50 @@ export const predictiveTagThresholds = sqliteTable("predictive_tag_thresholds", 
     .$defaultFn(() => new Date()),
 });
 
+// ─── Alarm Correlation Coordination (ADR-0026 / ADR-0013 [13.2], #573) ───────
+// Dev-mode parity with `shared/schema.ts`, whose block comment carries the full
+// ordering / identifier / idempotency / fail-safe rationale. Production DDL is
+// migrations/0015_alarm_correlation_coordination.sql; the physical SQLite DDL
+// lives in server/services/alarm-correlation/store.ts. Dialect mappings follow
+// this file's conventions: jsonb → text(mode json), timestamptz → integer
+// timestamp_ms, bigint → integer, boolean → integer(mode boolean).
+//
+// These tables are safety state, not a dev convenience: on either dialect they
+// are what makes a suppressed alarm restorable. Kept in sync by
+// `shared/__tests__/schema-parity.test.ts`.
+
+// `seq` is INTEGER PRIMARY KEY AUTOINCREMENT in the physical DDL, which is
+// SQLite's monotonic-never-reused rowid — the same guarantee Postgres gives
+// with BIGSERIAL, and the reason group ids derived from it can never collide.
+export const alarmCorrelationJournal = sqliteTable("alarm_correlation_journal", {
+  seq: integer("seq").primaryKey({ autoIncrement: true }),
+  idempotencyKey: text("idempotency_key").notNull().unique(),
+  op: text("op").notNull(),
+  payload: text("payload", { mode: "json" }).notNull(),
+  principal: text("principal").notNull(),
+  originInstance: text("origin_instance").notNull(),
+  recordedAt: integer("recorded_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const alarmCorrelationGroups = sqliteTable("alarm_correlation_groups", {
+  id: text("id").primaryKey(),
+  state: text("state").notNull(),
+  rootCauseAlarmId: text("root_cause_alarm_id").notNull(),
+  formedByRuleId: text("formed_by_rule_id").notNull(),
+  joinedVia: text("joined_via", { mode: "json" }).notNull(),
+  maxSeverity: text("max_severity").notNull(),
+  createdAtMs: integer("created_at_ms").notNull(),
+  lastAlarmAtMs: integer("last_alarm_at_ms").notNull(),
+  closedAtMs: integer("closed_at_ms"),
+  closeReason: text("close_reason"),
+  updatedSeq: integer("updated_seq").notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
 // No `status` column, matching Postgres: a restored simulation is always idle.
 export const twinCheckpoints = sqliteTable("twin_checkpoints", {
   modelId: text("model_id")
@@ -505,6 +549,81 @@ export const predictiveAlerts = sqliteTable("predictive_alerts", {
   acknowledged: integer("acknowledged", { mode: "boolean" }).notNull().default(false),
   acknowledgedBy: text("acknowledged_by"),
   acknowledgedAt: integer("acknowledged_at", { mode: "timestamp_ms" }),
+});
+
+export const alarmCorrelationAlarms = sqliteTable("alarm_correlation_alarms", {
+  id: text("id").primaryKey(),
+  groupId: text("group_id"),
+  name: text("name").notNull(),
+  tagId: text("tag_id").notNull(),
+  equipmentId: text("equipment_id"),
+  siteId: text("site_id"),
+  processArea: text("process_area"),
+  severity: text("severity").notNull(),
+  state: text("state").notNull(),
+  message: text("message").notNull(),
+  eventTimeMs: integer("event_time_ms").notNull(),
+  alarmValue: text("alarm_value", { mode: "json" }),
+  alarmLimit: text("alarm_limit", { mode: "json" }),
+  source: text("source"),
+  acknowledgedBy: text("acknowledged_by"),
+  clearedBy: text("cleared_by"),
+  suppressed: integer("suppressed", { mode: "boolean" }).default(false).notNull(),
+  isRootCause: integer("is_root_cause", { mode: "boolean" }).default(false).notNull(),
+  joinedViaRuleId: text("joined_via_rule_id"),
+  ingestSeq: integer("ingest_seq").notNull(),
+  updatedSeq: integer("updated_seq").notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const alarmCorrelationRules = sqliteTable("alarm_correlation_rules", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  type: text("type").notNull(),
+  enabled: integer("enabled", { mode: "boolean" }).default(true).notNull(),
+  priority: integer("priority").notNull(),
+  config: text("config", { mode: "json" }).notNull(),
+  updatedBy: text("updated_by").notNull(),
+  updatedSeq: integer("updated_seq").notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const alarmCorrelationEquipment = sqliteTable("alarm_correlation_equipment", {
+  equipmentId: text("equipment_id").primaryKey(),
+  name: text("name"),
+  parentId: text("parent_id"),
+  causalDownstream: text("causal_downstream", { mode: "json" }).notNull(),
+  siteId: text("site_id"),
+  processArea: text("process_area"),
+  updatedBy: text("updated_by").notNull(),
+  updatedSeq: integer("updated_seq").notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const alarmCorrelationState = sqliteTable("alarm_correlation_state", {
+  id: text("id").primaryKey(),
+  appliedSeq: integer("applied_seq").default(0).notNull(),
+  suppressionEnabled: integer("suppression_enabled", { mode: "boolean" })
+    .default(false).notNull(),
+  neverSuppressAtOrAbove: text("never_suppress_at_or_above")
+    .default("critical").notNull(),
+  unsuppressOnRootClear: integer("unsuppress_on_root_clear", { mode: "boolean" })
+    .default(true).notNull(),
+  alarmsIngested: integer("alarms_ingested").default(0).notNull(),
+  groupsCreated: integer("groups_created").default(0).notNull(),
+  groupsClosed: integer("groups_closed").default(0).notNull(),
+  alarmsSuppressed: integer("alarms_suppressed").default(0).notNull(),
+  alarmsUnsuppressed: integer("alarms_unsuppressed").default(0).notNull(),
+  updatedBy: text("updated_by").default("system").notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
 });
 
 // Basic exports for compatibility

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -967,6 +967,170 @@ export const twinModels = pgTable("twin_models", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
+// ─── Alarm Correlation Coordination (ADR-0026 / ADR-0013 [13.2], #573) ───────
+//
+// #213 shipped a process-local correlation engine whose suppression defaults
+// OFF, because suppression that lives only in one process's heap silently
+// changes what an operator sees and then loses that state on restart or when a
+// second replica forms a different view. These six tables are the durable,
+// replica-coordinated state ADR-0026 requires before suppression can be turned
+// on in production.
+//
+// THE ORDERING MODEL. `alarm_correlation_journal` is a single, totally-ordered,
+// append-only log of every correlation-affecting operation (alarm ingest,
+// acknowledge, clear, rule/topology/policy change). The database allocates
+// `seq`; appends are serialised (Postgres advisory lock, SQLite BEGIN
+// IMMEDIATE) so commit order equals `seq` order and no reader can observe a
+// gap that later fills in. Every replica consumes the same journal in `seq`
+// order and applies each entry to its own deterministic engine, so all
+// replicas converge on identical membership, root cause and suppression
+// WITHOUT any replica needing to be leader. This is convergence by shared log,
+// not order-independent merge: the log defines the order, and which replica an
+// HTTP request happened to land on cannot change it.
+//
+// IDENTIFIERS. Group ids are derived from the journal `seq` that formed them
+// (`ACG-<seq>` / `ACG-<seq>-<n>`), never from a per-process random source. Two
+// replicas therefore cannot mint conflicting ids for the same group, cannot
+// invent different ids for the same journal entry, and cannot reuse an id
+// because `seq` is monotonic for the life of the table.
+//
+// IDEMPOTENCY. `idempotency_key` is UNIQUE. A retried or duplicated delivery
+// re-appends the same key, hits the conflict, and returns the seq already
+// assigned — it never produces a second entry and never double-counts.
+//
+// SAFETY. Nothing in these tables can hide an alarm. Suppression is only ever
+// enabled while the durable projection reports healthy; on any storage or
+// coordination failure the runtime disables suppression, restores every
+// suppressed alarm and re-broadcasts it. That direction is deliberate and
+// one-way: losing coordination can only ever reveal more alarms, never fewer.
+
+/**
+ * The shared, totally-ordered operation log. Append-only: there is no update
+ * or delete helper. Retention prunes entries strictly below the materialised
+ * watermark (`alarm_correlation_state.applied_seq`) — never above it, because
+ * an entry that has not been projected yet is the only record of an operator's
+ * acknowledge or clear.
+ */
+export const alarmCorrelationJournal = pgTable("alarm_correlation_journal", {
+  // Monotonic total order. BIGSERIAL rather than a timestamp: wall clocks on
+  // separate replicas disagree, and correlation needs a single agreed order.
+  seq: bigint("seq", { mode: "number" }).primaryKey().generatedByDefaultAsIdentity(),
+  // Natural key of the operation — e.g. `ingest:<alarmId>`,
+  // `ack:<alarmId>`, `policy:<hash>`. UNIQUE, so duplicate delivery of the
+  // same logical operation collapses onto the entry already recorded.
+  idempotencyKey: varchar("idempotency_key", { length: 256 }).notNull().unique(),
+  op: varchar("op", { length: 32 }).notNull(),
+  payload: jsonb("payload").notNull(),
+  // Authenticated control-plane principal that submitted the operation, taken
+  // from the API key record — never from a request body. This is the lifecycle
+  // attribution that has to survive a restart to remain an audit record.
+  principal: varchar("principal", { length: 128 }).notNull(),
+  // Which replica appended it. Diagnostic only: it must never affect ordering.
+  originInstance: varchar("origin_instance", { length: 64 }).notNull(),
+  recordedAt: timestamp("recorded_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  recordedAtIdx: index("idx_alarm_corr_journal_recorded_at").on(table.recordedAt),
+  opIdx: index("idx_alarm_corr_journal_op").on(table.op),
+}));
+
+/**
+ * Materialised correlation groups. `updated_seq` records the journal entry
+ * whose application produced this row, so a restarting replica knows exactly
+ * how far the projection got.
+ */
+export const alarmCorrelationGroups = pgTable("alarm_correlation_groups", {
+  id: varchar("id", { length: 64 }).primaryKey(),
+  state: varchar("state", { length: 8 }).notNull(),
+  rootCauseAlarmId: varchar("root_cause_alarm_id", { length: 128 }).notNull(),
+  formedByRuleId: varchar("formed_by_rule_id", { length: 128 }).notNull(),
+  // Which rule admitted each member, keyed by alarm id. Kept so a recovered
+  // group can explain itself rather than merely existing.
+  joinedVia: jsonb("joined_via").notNull().default(sql`'{}'::jsonb`),
+  maxSeverity: varchar("max_severity", { length: 16 }).notNull(),
+  // Event time, epoch ms — the clock correlation actually reasons about.
+  createdAtMs: bigint("created_at_ms", { mode: "number" }).notNull(),
+  lastAlarmAtMs: bigint("last_alarm_at_ms", { mode: "number" }).notNull(),
+  closedAtMs: bigint("closed_at_ms", { mode: "number" }),
+  closeReason: varchar("close_reason", { length: 32 }),
+  updatedSeq: bigint("updated_seq", { mode: "number" }).notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  stateIdx: index("idx_alarm_corr_groups_state").on(table.state),
+  lastAlarmIdx: index("idx_alarm_corr_groups_last_alarm").on(table.lastAlarmAtMs),
+}));
+
+/**
+ * Materialised alarm lifecycle. This is the row that makes suppression
+ * recoverable: `suppressed` says the operator is not currently seeing this
+ * alarm, and `group_id` + `severity` + `state` are everything needed to
+ * restore it. If this row could not be written, suppression must not be on.
+ *
+ * `acknowledged_by` / `cleared_by` are control-plane principal names copied
+ * from the journal entry, so attribution is immutable in the same sense the
+ * journal is: the projection can be rebuilt from the log, and the log cannot
+ * be rewritten through any route in this codebase.
+ */
+export const alarmCorrelationAlarms = pgTable("alarm_correlation_alarms", {
+  id: varchar("id", { length: 128 }).primaryKey(),
+  // NULL means tracked but ungrouped (the engine's "pending" set). Those rows
+  // matter: they carry lifecycle and attribution for standalone alarms.
+  groupId: varchar("group_id", { length: 64 }),
+  name: varchar("name", { length: 256 }).notNull(),
+  tagId: varchar("tag_id", { length: 256 }).notNull(),
+  equipmentId: varchar("equipment_id", { length: 256 }),
+  siteId: varchar("site_id", { length: 64 }),
+  processArea: varchar("process_area", { length: 256 }),
+  severity: varchar("severity", { length: 16 }).notNull(),
+  state: varchar("state", { length: 16 }).notNull(),
+  message: text("message").notNull(),
+  eventTimeMs: bigint("event_time_ms", { mode: "number" }).notNull(),
+  // number | string in the wire type, so JSON preserves which one it was.
+  alarmValue: jsonb("alarm_value"),
+  alarmLimit: jsonb("alarm_limit"),
+  source: varchar("source", { length: 256 }),
+  acknowledgedBy: varchar("acknowledged_by", { length: 128 }),
+  clearedBy: varchar("cleared_by", { length: 128 }),
+  suppressed: boolean("suppressed").default(false).notNull(),
+  isRootCause: boolean("is_root_cause").default(false).notNull(),
+  joinedViaRuleId: varchar("joined_via_rule_id", { length: 128 }),
+  // Journal seq that first ingested this alarm, and the seq of the latest
+  // state change. The latter is broadcast with every snapshot so a consumer
+  // can drop an out-of-order or duplicated cross-instance echo.
+  ingestSeq: bigint("ingest_seq", { mode: "number" }).notNull(),
+  updatedSeq: bigint("updated_seq", { mode: "number" }).notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  groupIdx: index("idx_alarm_corr_alarms_group").on(table.groupId),
+  stateIdx: index("idx_alarm_corr_alarms_state").on(table.state),
+  eventTimeIdx: index("idx_alarm_corr_alarms_event_time").on(table.eventTimeMs),
+}));
+
+/** Durable correlation rules — the configuration a restart must not forget. */
+export const alarmCorrelationRules = pgTable("alarm_correlation_rules", {
+  id: varchar("id", { length: 128 }).primaryKey(),
+  name: varchar("name", { length: 256 }).notNull(),
+  type: varchar("type", { length: 16 }).notNull(),
+  enabled: boolean("enabled").default(true).notNull(),
+  priority: integer("priority").notNull(),
+  config: jsonb("config").notNull(),
+  updatedBy: varchar("updated_by", { length: 128 }).notNull(),
+  updatedSeq: bigint("updated_seq", { mode: "number" }).notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+/** Durable equipment topology — hierarchy plus directed causal edges. */
+export const alarmCorrelationEquipment = pgTable("alarm_correlation_equipment", {
+  equipmentId: varchar("equipment_id", { length: 256 }).primaryKey(),
+  name: varchar("name", { length: 256 }),
+  parentId: varchar("parent_id", { length: 256 }),
+  causalDownstream: jsonb("causal_downstream").notNull().default(sql`'[]'::jsonb`),
+  siteId: varchar("site_id", { length: 64 }),
+  processArea: varchar("process_area", { length: 256 }),
+  updatedBy: varchar("updated_by", { length: 128 }).notNull(),
+  updatedSeq: bigint("updated_seq", { mode: "number" }).notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
 /**
  * The LAST COMMITTED checkpoint for a model — at most one row per model,
  * written in the same transaction as the model it belongs to. A model row
@@ -992,6 +1156,39 @@ export const twinCheckpoints = pgTable("twin_checkpoints", {
   // Epoch ms of the last live-tag assimilation folded into this checkpoint.
   lastSyncAt: bigint("last_sync_at", { mode: "number" }),
   committedAt: timestamp("committed_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+/**
+ * Single-row coordination state: the suppression policy plus the watermark of
+ * the shared projection and its cumulative counters.
+ *
+ * `applied_seq` is advanced with a conditional UPDATE (`WHERE applied_seq <
+ * :seq`) in the same transaction that writes the entry's row changes. A replica
+ * that loses the race writes nothing, so the materialised rows are always the
+ * result of applying journal entries strictly in `seq` order, whichever replica
+ * happened to get there first.
+ *
+ * `enabled` defaults FALSE. Persisting an operator's intent to suppress is not
+ * the same as suppressing: the runtime only honours it while coordination is
+ * healthy, and forces it back off — restoring every suppressed alarm — the
+ * moment it is not.
+ */
+export const alarmCorrelationState = pgTable("alarm_correlation_state", {
+  id: varchar("id", { length: 16 }).primaryKey(),
+  appliedSeq: bigint("applied_seq", { mode: "number" }).default(0).notNull(),
+  suppressionEnabled: boolean("suppression_enabled").default(false).notNull(),
+  neverSuppressAtOrAbove: varchar("never_suppress_at_or_above", { length: 16 })
+    .default("critical").notNull(),
+  // Always TRUE. Column exists so the persisted policy is complete and a
+  // future value change is a visible migration, not a silent default.
+  unsuppressOnRootClear: boolean("unsuppress_on_root_clear").default(true).notNull(),
+  alarmsIngested: bigint("alarms_ingested", { mode: "number" }).default(0).notNull(),
+  groupsCreated: bigint("groups_created", { mode: "number" }).default(0).notNull(),
+  groupsClosed: bigint("groups_closed", { mode: "number" }).default(0).notNull(),
+  alarmsSuppressed: bigint("alarms_suppressed", { mode: "number" }).default(0).notNull(),
+  alarmsUnsuppressed: bigint("alarms_unsuppressed", { mode: "number" }).default(0).notNull(),
+  updatedBy: varchar("updated_by", { length: 128 }).default("system").notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
 // ─── Schema Exports ──────────────────────────────────────────────────────────
@@ -1076,3 +1273,15 @@ export type TwinModelRow = typeof twinModels.$inferSelect;
 export type InsertTwinModelRow = typeof twinModels.$inferInsert;
 export type TwinCheckpointRow = typeof twinCheckpoints.$inferSelect;
 export type InsertTwinCheckpointRow = typeof twinCheckpoints.$inferInsert;
+export type AlarmCorrelationJournalRow = typeof alarmCorrelationJournal.$inferSelect;
+export type InsertAlarmCorrelationJournalRow = typeof alarmCorrelationJournal.$inferInsert;
+export type AlarmCorrelationGroupRow = typeof alarmCorrelationGroups.$inferSelect;
+export type InsertAlarmCorrelationGroupRow = typeof alarmCorrelationGroups.$inferInsert;
+export type AlarmCorrelationAlarmRow = typeof alarmCorrelationAlarms.$inferSelect;
+export type InsertAlarmCorrelationAlarmRow = typeof alarmCorrelationAlarms.$inferInsert;
+export type AlarmCorrelationRuleRow = typeof alarmCorrelationRules.$inferSelect;
+export type InsertAlarmCorrelationRuleRow = typeof alarmCorrelationRules.$inferInsert;
+export type AlarmCorrelationEquipmentRow = typeof alarmCorrelationEquipment.$inferSelect;
+export type InsertAlarmCorrelationEquipmentRow = typeof alarmCorrelationEquipment.$inferInsert;
+export type AlarmCorrelationStateRow = typeof alarmCorrelationState.$inferSelect;
+export type InsertAlarmCorrelationStateRow = typeof alarmCorrelationState.$inferInsert;

--- a/shared/types/alarm-correlation.ts
+++ b/shared/types/alarm-correlation.ts
@@ -169,6 +169,18 @@ export interface CorrelationMetrics {
   trackedAlarms: number;
 }
 
+/**
+ * `process-local` — correlation state lives only in this process's heap. It is
+ *   lost on restart and a second replica may hold a different view, so
+ *   suppression stays off unless an operator opts into a single-process
+ *   evaluation.
+ * `durable` — correlation state is projected from the shared journal
+ *   (`alarm_correlation_*`, migration 0015). Every replica applies the same
+ *   totally-ordered entries, so membership, root cause and suppression agree
+ *   across replicas and survive restart.
+ */
+export type CorrelationCoordinationMode = 'process-local' | 'durable';
+
 /** Stable correlation metadata attached to each live alarm snapshot. */
 export interface AlarmCorrelationSnapshot {
   groupId: string | null;
@@ -176,8 +188,14 @@ export interface AlarmCorrelationSnapshot {
   rootCauseAlarmId: string | null;
   suppressed: boolean;
   isRootCause: boolean;
-  /** Correlation state is process-local until the durable coordination issue lands. */
-  coordinationMode: 'process-local';
+  coordinationMode: CorrelationCoordinationMode;
+  /**
+   * Journal sequence of the operation that produced this state, when running
+   * durably. Monotonic per alarm and shared by all replicas, so a consumer
+   * receiving the same alarm from two instances keeps the higher seq and drops
+   * the echo. `null` in process-local mode, where no shared order exists.
+   */
+  seq: number | null;
 }
 
 /** Canonical alarm payload emitted to live WebSocket consumers. */
@@ -185,4 +203,62 @@ export interface AlarmWireSnapshot extends CorrelatedAlarm {
   triggeredAt: string;
   tagValue?: number | string;
   correlation: AlarmCorrelationSnapshot;
+}
+
+// ── Durable coordination ──────────────────────────────────────────────────
+
+/** Operations the shared journal orders. */
+export type CorrelationJournalOp =
+  | 'ingest'
+  | 'acknowledge'
+  | 'clear'
+  | 'rule-upsert'
+  | 'rule-remove'
+  | 'rule-enabled'
+  | 'topology-upsert'
+  | 'topology-remove'
+  | 'policy-set'
+  /**
+   * Idle-group housekeeping. Journaled rather than run per replica: closing an
+   * idle group un-suppresses its members, so a sweep that ran on one replica
+   * and not another would leave the two disagreeing about which alarms an
+   * operator can see. The entry carries the sweep clock so every replica
+   * applies the identical decision.
+   */
+  | 'sweep';
+
+/** One durable, totally-ordered correlation operation. */
+export interface CorrelationJournalEntry {
+  seq: number;
+  idempotencyKey: string;
+  op: CorrelationJournalOp;
+  payload: Record<string, unknown>;
+  /** Authenticated control-plane principal — never taken from a request body. */
+  principal: string;
+  originInstance: string;
+  recordedAt: number;
+}
+
+/**
+ * Observable coordination health. `healthy: false` is not advisory: the
+ * runtime has already forced suppression off and restored every suppressed
+ * alarm by the time this reports degraded.
+ */
+export interface CorrelationCoordinationHealth {
+  healthy: boolean;
+  mode: CorrelationCoordinationMode;
+  backend: 'postgres' | 'sqlite' | 'unopened' | 'none';
+  /** Highest journal seq this replica has applied to its own engine. */
+  appliedSeq: number;
+  /** Watermark of the shared materialised projection. */
+  materializedSeq: number;
+  /** Operator's persisted intent, independent of whether it is being honoured. */
+  policyEnabledIntent: boolean;
+  /** Whether suppression is actually active in the engine right now. */
+  suppressionActive: boolean;
+  /** True when a coordination failure, not the operator, turned suppression off. */
+  suppressionDisabledByHealth: boolean;
+  lastError: string | null;
+  lastHealthyAt: number | null;
+  instanceId: string;
 }


### PR DESCRIPTION
Closes #573. Refs #213, #497, ADR-0026.

## Why

#213 shipped a correlation engine whose suppression defaults **off** and whose snapshots are labelled `coordinationMode: process-local`. That default is not timidity: suppression decides what an operator does and does not see, and a decision living only in one process's heap is lost on restart and can be contradicted by a second replica. This PR lands the durable, replica-coordinated state ADR-0026 requires before suppression is safe in production.

## Ordering model

`alarm_correlation_journal` (migration **0015**) is one totally ordered, append-only log of every correlation-affecting operation: ingest, acknowledge, clear, rule/topology/policy changes, and idle-group sweeps. The database allocates `seq`; **appends are serialised** (Postgres advisory lock, SQLite `BEGIN IMMEDIATE`) so commit order equals `seq` order. Without that, an identity value can commit after a larger one and a reader polling "everything above my watermark" would step over an entry that had not become visible yet — permanently losing an operator's acknowledge.

Every replica consumes the same journal in `seq` order and applies each entry to its own deterministic engine, so all replicas converge on identical membership, root cause and suppression with **no leader election**.

This is convergence by shared log, **not** an order-independent merge. Which replica a request lands on cannot change the outcome, because the log defines the order. The engine remains arrival-order sensitive in general; what is guaranteed is that every replica sees the *same* order.

## Identifiers and idempotency

Group ids are derived from the forming entry's journal `seq` (`ACG-<seq>`), never from a per-process random source — so two replicas cannot mint conflicting ids, and monotonic never-reused allocation rules out reuse. The engine additionally refuses a colliding id rather than silently merging two groups.

`idempotency_key` is UNIQUE, so a retried or cross-replica duplicate collapses onto the entry already recorded. Config edits have no natural key (A → B → A is three real changes, so a content-derived key would silently drop the third), so routes accept an optional `Idempotency-Key` header; a reused key whose effect is not actually present returns **409** rather than a 200 describing a change that never landed.

## Safety — the property that dominated every decision

Nothing here can hide an alarm.

1. `submit()` rethrows on any store failure so the caller falls back to raw delivery — the alarm reaches the operator even when nothing about it can be persisted.
2. `degrade()` immediately forces suppression off and re-emits every restored alarm, so anything an operator could not see becomes visible again.
3. `syncEnginePolicy()` is the only place suppression is turned on, and it requires **both** healthy coordination **and** the operator's persisted intent. Neither alone is enough.

`PUT /suppression-policy {enabled:true}` returns 409 unless durable coordination reports healthy *right now*. Degraded replicas emit `seq: null`, so their corrections can never be mistaken for a stale echo and dropped.

Cross-instance de-duplication raises its watermark **only** from state a replica computed itself — a finding from the security review: recording an incoming seq would have let anything able to publish on the Redis alarm channel push an alarm's watermark forward and have later genuine states dropped, i.e. a way to hide an alarm. A possible duplicate delivery is a nuisance; a hidden alarm is not.

Sweeps are journaled too: an idle-close un-suppresses members, so a per-replica sweep would leave two replicas disagreeing about what an operator can see.

## Also

- Restart hydration restores rules, topology, policy, open groups **with their suppression records**, ungrouped alarms, lifecycle attribution and cumulative counters.
- The journal is append-only **in the database** (triggers on both dialects), so principal attribution cannot be rewritten.
- Retention prunes journal entries strictly below the watermark and aged *closed* groups — never open groups, suppressed alarms, or unprojected entries.
- `/ws`, `/ws/tags` and `GET /api/alarm-correlation/snapshot` all serve one canonical entry per active alarm from the same engine.
- `GET /api/alarm-correlation/coordination` exposes observable coordination health.

## Tests

54 new tests, **all against real databases and real sockets — no mocks**: restart recovery, two-replica convergence including event-time/journal-order disagreement, duplicate-delivery idempotency and id non-collision, journaled sweep consistency, cross-replica ack/clear/config over REST, three storage-loss fail-safe tests, suppression gating, DB-enforced journal immutability, retention, and `/ws` + `/ws/tags` reconnect snapshots over real `ws` clients.

Baseline measured on the clean worktree first: **4 failed files / 5–6 failed tests / ~3432 passed** (the suite is measurably flaky under parallel load — two runs of the unmodified tree disagreed). After: **176 files passed, 3504 tests passed, 0 failures**; `tsc --noEmit` exits 0.

## Scope stated plainly

- **Off by default.** Requires `ALARM_CORRELATION_DURABLE=true`. Without it, behaviour is exactly as #213 shipped: process-local, suppression off.
- **Propagation is poll-based** (default 1s), not push. A mutation on one replica is visible on another within that interval, not instantly — no LISTEN/NOTIFY or Redis wakeup is wired up. So "immediately visible" holds only up to that bounded latency.
- **Only SQLite is exercised by tests**; no Postgres is available in this environment. The Postgres branches (advisory lock, identity column, conditional-upsert `RETURNING`, plpgsql trigger) mirror the tested SQLite path but are not verified by an automated test here, and migration 0015 has not been run against a live Postgres.
- Retention removes aged **closed** groups; a replica restarting after that will not resurrect them.
- ADR-0026's gap table is left unchanged — it covers the whole 13.x series, and only the correlation row is addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)