### PR TITLE
fix(geometry): refuse unwired classification overrides (#641)

### DIFF
--- a/server/routes/__tests__/geometry-rules-contract.test.ts
+++ b/server/routes/__tests__/geometry-rules-contract.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Contract tests for the custom geometry classification-rule surface (#641).
+ *
+ * The classifier has no custom-rule input. The route must therefore refuse a
+ * write instead of storing and echoing a rule that classification never reads.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import { createServer, type Server } from "node:http";
+
+import { _resetControlPlaneAuthCache } from "../../middleware/control-plane-auth";
+import { geometryRoutes } from "../geometry";
+
+const WRITE_KEY = "geometry-rules-contract-write";
+const READ_ONLY_KEY = "geometry-rules-contract-read";
+
+let server: Server;
+let base: string;
+let originalApiKeys: string | undefined;
+let originalApiKeysFile: string | undefined;
+
+interface ApiResponse {
+  status: number;
+  json: Record<string, unknown>;
+  text: string;
+}
+
+async function api(
+  method: "GET" | "POST",
+  path: string,
+  key?: string,
+  body?: unknown,
+): Promise<ApiResponse> {
+  const headers: Record<string, string> = {};
+  if (key) headers["x-api-key"] = key;
+  if (body !== undefined) headers["content-type"] = "application/json";
+
+  const response = await fetch(`${base}${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  return {
+    status: response.status,
+    json: text ? (JSON.parse(text) as Record<string, unknown>) : {},
+    text,
+  };
+}
+
+beforeAll(async () => {
+  originalApiKeys = process.env.API_KEYS;
+  originalApiKeysFile = process.env.API_KEYS_FILE;
+  process.env.API_KEYS =
+    `${WRITE_KEY}:geometry-rule-writer:geometry.write,` +
+    `${READ_ONLY_KEY}:geometry-rule-reader:geometry.read`;
+  delete process.env.API_KEYS_FILE;
+  _resetControlPlaneAuthCache();
+
+  const app = express();
+  app.use(express.json());
+  app.use("/api/geometry", geometryRoutes(null));
+
+  server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  base = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+
+  if (originalApiKeys === undefined) delete process.env.API_KEYS;
+  else process.env.API_KEYS = originalApiKeys;
+  if (originalApiKeysFile === undefined) delete process.env.API_KEYS_FILE;
+  else process.env.API_KEYS_FILE = originalApiKeysFile;
+  _resetControlPlaneAuthCache();
+});
+
+describe("custom geometry classification rules", () => {
+  it("keeps the unavailable mutation behind geometry.write", async () => {
+    const unauthenticated = await api("POST", "/api/geometry/rules", undefined, {});
+    expect(unauthenticated.status).toBe(401);
+
+    const readOnly = await api("POST", "/api/geometry/rules", READ_ONLY_KEY, {});
+    expect(readOnly.status).toBe(403);
+    expect(readOnly.json.requiredScopes).toEqual(["geometry.write"]);
+  });
+
+  it("returns an honest 501 and never stores or echoes the requested override", async () => {
+    const before = await api("GET", "/api/geometry/rules");
+    expect(before.status).toBe(200);
+    expect(before.json).toMatchObject({
+      configured: false,
+      rules: [],
+    });
+    expect(before.json.detail).toMatch(/not implemented/i);
+    expect(before.json.reference).toContain("641");
+
+    const requestedRule = {
+      pattern: "^PUMP-OVERRIDE-PROBE$",
+      quadrant: 3,
+      triality: 2,
+      slot: 7,
+    };
+    const refused = await api("POST", "/api/geometry/rules", WRITE_KEY, requestedRule);
+
+    expect(refused.status).toBe(501);
+    expect(refused.json).toMatchObject({
+      error: "not_implemented",
+      detail: before.json.detail,
+      reference: before.json.reference,
+    });
+    expect(refused.json).not.toHaveProperty("message");
+    expect(refused.json).not.toHaveProperty("totalRules");
+    expect(refused.json).not.toHaveProperty("rule");
+
+    const after = await api("GET", "/api/geometry/rules");
+    expect(after.text).toBe(before.text);
+    expect(after.text).not.toContain(requestedRule.pattern);
+  });
+});

--- a/server/routes/geometry.ts
+++ b/server/routes/geometry.ts
@@ -7,7 +7,7 @@
  * GET  /api/geometry/fano/cycles      — detected feedback loops (#335)
  * GET  /api/geometry/fano/gaps        — uncovered process areas (#335)
  * GET  /api/geometry/classes          — all 96 classes with entity counts (#336)
- * POST /api/geometry/rules            — custom classification overrides (#336)
+ * POST /api/geometry/rules            — explicit refusal for unwired overrides (#641)
  * POST /api/geometry/recalibrate      — re-classify all entities (#336)
  */
 
@@ -15,43 +15,17 @@ import { Router, type Request, type Response } from "express";
 import { FluxPublisher } from "../services/flux/index.js";
 import { FANO_LINES, isFanoRelated, geometricSimilarity } from "../services/geometry/fano.js";
 import { decodeClassIndex, Quadrant, Triality, type ClassComponents } from "../services/geometry/types.js";
-import { classify, classifyEntity } from "../services/geometry/classifier.js";
+import { classifyEntity } from "../services/geometry/classifier.js";
 import { requireControlPlaneAccess } from "../middleware/control-plane-auth";
-
-/** Max allowed regex pattern length to mitigate ReDoS */
-const MAX_REGEX_PATTERN_LENGTH = 200;
 
 const requireGeometryWrite = requireControlPlaneAccess({
   scopes: ["geometry.write"],
 });
 
-/** Validate and sanitize a regex pattern string */
-function validateRegexPattern(pattern: string): { valid: boolean; error?: string } {
-  if (pattern.length > MAX_REGEX_PATTERN_LENGTH) {
-    return { valid: false, error: `Pattern too long (max ${MAX_REGEX_PATTERN_LENGTH} chars)` };
-  }
-  // Reject patterns with known ReDoS-prone constructs
-  if (/(\.\*){3,}|(\+\+)|(\*\*)|(\{\d{4,}\})/.test(pattern)) {
-    return { valid: false, error: "Pattern contains potentially unsafe constructs" };
-  }
-  try {
-    new RegExp(pattern);
-    return { valid: true };
-  } catch (e) {
-    return { valid: false, error: `Invalid regex: ${(e as Error).message}` };
-  }
-}
-
-/** In-memory classification rule overrides (#336) */
-interface ClassificationOverride {
-  pattern: string;         // regex pattern for entity type/id
-  quadrant?: number;       // force h2
-  triality?: number;       // force d
-  slot?: number;           // force l
-  createdAt: number;
-}
-
-const overrides: ClassificationOverride[] = [];
+const CUSTOM_RULES_REFERENCE = "https://github.com/NickFlach/0xSCADA/issues/641";
+const CUSTOM_RULES_DETAIL =
+  "Custom geometry classification overrides are not implemented. The classifier and " +
+  "recalibration path do not consume custom rules, so no rule was stored or applied.";
 
 const QUADRANT_NAMES = ["sensor", "control", "alarm", "maintenance"];
 const TRIALITY_NAMES = ["site", "asset", "event"];
@@ -271,38 +245,22 @@ export function geometryRoutes(fluxPublisher: FluxPublisher | null): Router {
     });
   });
 
-  // ── Custom classification rules (#336) ─────────────────────────────────────
-  router.post("/rules", requireGeometryWrite, (req: Request, res: Response) => {
-    const { pattern, quadrant, triality, slot } = req.body || {};
-    if (!pattern || typeof pattern !== "string") {
-      return res.status(400).json({ error: "pattern (string) is required" });
-    }
-
-    // Validate and sanitize regex pattern
-    const validation = validateRegexPattern(pattern);
-    if (!validation.valid) {
-      return res.status(400).json({ error: validation.error });
-    }
-
-    const override: ClassificationOverride = {
-      pattern,
-      quadrant: quadrant != null ? Number(quadrant) : undefined,
-      triality: triality != null ? Number(triality) : undefined,
-      slot: slot != null ? Number(slot) : undefined,
-      createdAt: Date.now(),
-    };
-
-    overrides.push(override);
-
-    res.status(201).json({
-      message: "Classification rule added",
-      totalRules: overrides.length,
-      rule: override,
+  // ── Unavailable custom classification rules (#641) ─────────────────────────
+  router.post("/rules", requireGeometryWrite, (_req: Request, res: Response) => {
+    res.status(501).json({
+      error: "not_implemented",
+      detail: CUSTOM_RULES_DETAIL,
+      reference: CUSTOM_RULES_REFERENCE,
     });
   });
 
   router.get("/rules", (_req: Request, res: Response) => {
-    res.json({ rules: overrides });
+    res.json({
+      configured: false,
+      rules: [],
+      detail: CUSTOM_RULES_DETAIL,
+      reference: CUSTOM_RULES_REFERENCE,
+    });
   });
 
   // ── Recalibrate all entities (#336) ────────────────────────────────────────


### PR DESCRIPTION
Closes #641.

## What changed

`POST /api/geometry/rules` now returns an explicit `501 not_implemented` response instead of storing and acknowledging a rule the classifier never consumes. `GET /api/geometry/rules` remains available but reports the truth:

```json
{
  "configured": false,
  "rules": []
}
```

The unused in-memory override array and misleading regex "safety" denylist were removed. The write endpoint remains protected by the real `geometry.write` control-plane scope.

## Why

The prior route returned `201 Classification rule added`, echoed the rule through GET, and left classification unchanged. That was a privileged no-op presented as a successful control-plane mutation. Refusing an unavailable capability is safer than claiming it is active.

The regex denylist was also not a sound ReDoS boundary. Removing the unwired feature removes that latent trap; any future implementation must choose a real bounded or linear-time matching strategy.

## Verification

- Baseline reproduction: POST returned 201, GET echoed the override, and recalculation kept the same class.
- `npx vitest run server/routes/__tests__/geometry-rules-contract.test.ts --reporter=verbose` — 2/2 pass.
- `npx tsc --noEmit` — pass.
- `git diff --check` — pass.
