### PR TITLE
test: replace load-dependent Merkle and GOOSE assertions (#642)

### DIFF
--- a/server/__tests__/merkle-proof-verification.test.ts
+++ b/server/__tests__/merkle-proof-verification.test.ts
@@ -559,35 +559,44 @@ describe("Property-Based Tests", () => {
 });
 
 // =============================================================================
-// PERFORMANCE TESTS
+// LARGE-TREE COMPLEXITY INVARIANTS
 // =============================================================================
 
-describe("Performance Tests", () => {
-  it("should build large tree (10000 events) in reasonable time", () => {
-    const start = performance.now();
+describe("Large-tree complexity invariants", () => {
+  it("should build a 10000-event tree with a linear total node count", () => {
     const hashes = generateHashes(10000);
     const tree = buildMerkleTree(hashes);
-    const duration = performance.now() - start;
+    const paddedLeafCount = nextPowerOf2(hashes.length);
+    const layerSizes = tree.layers.map((layer) => layer.length);
 
     expect(tree.root).toBeDefined();
-    expect(duration).toBeLessThan(1000); // Should complete in < 1 second
-    console.log(`Built 10000-event tree in ${duration.toFixed(2)}ms`);
+    expect(tree.leaves).toHaveLength(hashes.length);
+    expect(layerSizes[0]).toBe(paddedLeafCount);
+    expect(layerSizes).toHaveLength(Math.log2(paddedLeafCount) + 1);
+    for (let i = 1; i < layerSizes.length; i++) {
+      expect(layerSizes[i]).toBe(layerSizes[i - 1] / 2);
+    }
+    // A complete binary tree has 2n - 1 total nodes: construction work and
+    // retained structure therefore grow linearly with the padded leaf count.
+    expect(layerSizes.reduce((total, size) => total + size, 0)).toBe(
+      2 * paddedLeafCount - 1,
+    );
   });
 
-  it("should generate and verify proof efficiently", () => {
+  it("should generate logarithmic proofs and verify them for a large tree", () => {
     const hashes = generateHashes(10000);
     const tree = buildMerkleTree(hashes);
+    const expectedProofLength = Math.log2(nextPowerOf2(hashes.length));
 
-    const start = performance.now();
+    // Cover 100 deterministic positions spread through the tree. Proof
+    // generation walks one sibling per layer and verification consumes exactly
+    // that proof, so this pins O(log n) work without consulting wall clock.
     for (let i = 0; i < 100; i++) {
-      const idx = Math.floor(Math.random() * hashes.length);
+      const idx = (i * 7919) % hashes.length;
       const proof = getMerkleProof(tree, idx);
-      verifyMerkleProof(hashes[idx], proof, tree.root, idx);
+      expect(proof).toHaveLength(expectedProofLength);
+      expect(verifyMerkleProof(hashes[idx], proof, tree.root, idx)).toBe(true);
     }
-    const duration = performance.now() - start;
-
-    expect(duration).toBeLessThan(100); // 100 verifications in < 100ms
-    console.log(`100 proof generations + verifications in ${duration.toFixed(2)}ms`);
   });
 });
 

--- a/server/protocols/iec61850-goose/__tests__/live-backend.test.ts
+++ b/server/protocols/iec61850-goose/__tests__/live-backend.test.ts
@@ -698,11 +698,21 @@ describe("live capture — failure modes", () => {
   it("never fabricates a frame when capture cannot start", async () => {
     const frames: Buffer[] = [];
     const backend = new GooseLiveCaptureBackend({
-      command: fakeCapture({ exitCode: 1, stderr: "dumpcap: permission denied" }),
+      // This invariant does not need another Node process. An unsupported
+      // platform refuses synchronously before spawn, so worker load cannot race
+      // child startup against Vitest's timeout. Subprocess exit diagnostics are
+      // exercised independently by the preceding failure-mode tests.
+      platform: "win32",
     });
-    await expect(backend.open((frame) => frames.push(frame))).rejects.toThrow();
+    await expect(backend.open((frame) => frames.push(frame))).rejects.toThrow(/not supported/i);
     expect(frames).toHaveLength(0);
-    expect(backend.getStats().gooseFrames).toBe(0);
+    expect(backend.getStats()).toMatchObject({
+      bytesRead: 0,
+      recordsDecoded: 0,
+      gooseFrames: 0,
+    });
+    expect(backend.isRunning()).toBe(false);
+    await backend.completion();
     await backend.close();
   });
 });
@@ -752,37 +762,33 @@ describe("live capture — lifecycle", () => {
       "listeners.pcap",
       encodePcap([{ timestampMs: Date.now(), data: canonicalFrame() }]),
     );
-    const before = process.listenerCount("exit");
-    for (let i = 0; i < 5; i++) {
-      const backend = new GooseLiveCaptureBackend({
-        command: fakeCapture({ pcapPath: path, hang: true }),
-      });
-      await backend.open(() => {});
-      // The hook that kills an orphaned capture tool is installed while running.
-      expect(process.listenerCount("exit")).toBe(before + 1);
-      await backend.close();
-    }
-    expect(process.listenerCount("exit")).toBe(before);
-  });
-
-  it("can be reopened after a clean close", async () => {
-    const path = writeCapture(
-      "reopen.pcap",
-      encodePcap([{ timestampMs: Date.now(), data: canonicalFrame() }]),
-    );
     const backend = new GooseLiveCaptureBackend({
       command: fakeCapture({ pcapPath: path, hang: true }),
     });
+    const before = process.listenerCount("exit");
     const first: Buffer[] = [];
-    await backend.open((frame) => first.push(frame));
-    await backend.close();
-
     const second: Buffer[] = [];
-    await backend.open((frame) => second.push(frame));
-    await backend.close();
+
+    try {
+      await backend.open((frame) => first.push(frame));
+      // Exactly one orphan guard exists while the first capture is live.
+      expect(process.listenerCount("exit")).toBe(before + 1);
+      await backend.close();
+      expect(process.listenerCount("exit")).toBe(before);
+
+      // Reopening the same backend replaces, rather than adds to, that guard.
+      await backend.open((frame) => second.push(frame));
+      expect(process.listenerCount("exit")).toBe(before + 1);
+      await backend.close();
+    } finally {
+      // Do not leave the fake capture or its process listener behind if an
+      // assertion above fails.
+      await backend.close();
+    }
 
     expect(first).toHaveLength(1);
     expect(second).toHaveLength(1);
+    expect(process.listenerCount("exit")).toBe(before);
   });
 });
 

--- a/server/protocols/iec61850-goose/__tests__/pcap-replay.test.ts
+++ b/server/protocols/iec61850-goose/__tests__/pcap-replay.test.ts
@@ -10,7 +10,7 @@
  * Issue: #465
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { readFile } from "node:fs/promises";
 import {
   GooseSubscriber,
@@ -219,6 +219,7 @@ describe("pcap replay → subscriber", () => {
 
 describe("pcap replay — timing", () => {
   const GAP_MS = 150;
+  const WALL_START_MS = 10_000;
 
   /** Two GOOSE frames GAP_MS apart in recorded capture time. */
   function twoFrameCapture(): Buffer {
@@ -242,40 +243,79 @@ describe("pcap replay — timing", () => {
     ]);
   }
 
-  /** Replay in realtime mode, returning wall-clock arrival offsets in ms. */
-  async function realtimeArrivals(speed: number): Promise<number[]> {
+  it("schedules frames at their recorded offsets from replay start", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(WALL_START_MS);
+    const backend = new GoosePcapReplayBackend({
+      buffer: twoFrameCapture(),
+      realtime: true,
+      speed: 1,
+    });
+    const arrivals: number[] = [];
+
+    try {
+      await backend.open(() => arrivals.push(Date.now()));
+      expect(arrivals).toEqual([]);
+
+      // Realtime scheduling targets each recorded offset from replay start. A
+      // callback-to-callback wall-clock measurement is not equivalent: if the
+      // first zero-delay timer is starved, the replay deliberately catches up.
+      await vi.advanceTimersToNextTimerAsync();
+      expect(arrivals).toEqual([WALL_START_MS]);
+
+      await vi.advanceTimersByTimeAsync(GAP_MS - 1);
+      expect(arrivals).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(arrivals).toEqual([WALL_START_MS, WALL_START_MS + GAP_MS]);
+      await expect(backend.completion()).resolves.toMatchObject({ delivered: 2 });
+    } finally {
+      await backend.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("scales the recorded offset by the speed multiplier", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(WALL_START_MS);
+    const speed = 5;
+    const scaledGapMs = GAP_MS / speed;
     const backend = new GoosePcapReplayBackend({
       buffer: twoFrameCapture(),
       realtime: true,
       speed,
     });
     const arrivals: number[] = [];
-    const started = Date.now();
-    await backend.open(() => arrivals.push(Date.now() - started));
-    await backend.completion();
-    await backend.close();
-    return arrivals;
-  }
 
-  it("honours the recorded inter-frame gap in realtime mode", async () => {
-    const arrivals = await realtimeArrivals(1);
-    expect(arrivals).toHaveLength(2);
-    // Timer coarseness only ever delays; the gap must not collapse to zero.
-    expect(arrivals[1] - arrivals[0]).toBeGreaterThanOrEqual(GAP_MS * 0.7);
+    try {
+      await backend.open(() => arrivals.push(Date.now()));
+      await vi.advanceTimersToNextTimerAsync();
+      expect(arrivals).toEqual([WALL_START_MS]);
+
+      await vi.advanceTimersByTimeAsync(scaledGapMs - 1);
+      expect(arrivals).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(arrivals).toEqual([WALL_START_MS, WALL_START_MS + scaledGapMs]);
+      await expect(backend.completion()).resolves.toMatchObject({ delivered: 2 });
+    } finally {
+      await backend.close();
+      vi.useRealTimers();
+    }
   });
 
-  it("compresses the gap by the speed multiplier", async () => {
-    const arrivals = await realtimeArrivals(5);
-    expect(arrivals).toHaveLength(2);
-    expect(arrivals[1] - arrivals[0]).toBeLessThan(GAP_MS * 0.8);
-  });
+  it("drains the whole capture before open() resolves in no-delay mode", async () => {
+    const backend = new GoosePcapReplayBackend({
+      buffer: encodeReplayPcap(),
+      realtime: false,
+    });
+    const delivered: Buffer[] = [];
 
-  it("drains the whole capture immediately in no-delay mode", async () => {
-    const started = Date.now();
-    const { backend } = await replayFixture();
+    await backend.open((frame) => delivered.push(frame));
+    // No-delay mode has no timer chain: every GOOSE frame is delivered
+    // synchronously inside open(), before its promise resolves.
+    expect(delivered).toHaveLength(8);
     expect(backend.getStats().delivered).toBe(8);
-    // The capture spans 440 ms of recorded time; no-delay replay must not sleep.
-    expect(Date.now() - started).toBeLessThan(300);
+    await expect(backend.completion()).resolves.toMatchObject({ delivered: 8 });
+    await backend.close();
   });
 });
 


### PR DESCRIPTION
Closes #642.

## What changed

### Merkle proof tests

- Replaced wall-clock thresholds with deterministic structural invariants.
- The 10,000-leaf tree must have a linear total node count.
- Proofs must have logarithmic length and verify at 100 deterministic positions.
- Removed random indices and timing-dependent console output.

### GOOSE live-capture tests

- The no-frame refusal case now uses deterministic pre-spawn unavailability instead of racing a child process against Vitest's timeout.
- Combined listener cleanup and reopen coverage into two stateful capture cycles with exact listener-count checks and `finally` cleanup.
- Removed six redundant child-process launches while preserving the lifecycle properties.

### GOOSE replay tests

- Replaced callback-to-callback wall-clock thresholds with Vitest virtual timers.
- Proves the second frame is absent one millisecond before its recorded offset and is delivered exactly at that offset.
- Proves speed scaling changes a 150 ms replay offset to 30 ms at 5x.
- Replaced the arbitrary no-delay deadline with the stronger invariant that all frames arrive before `open()` resolves.

## Why

These are correctness tests, not benchmarks. Their result changed with worker load even when the algorithms and runtime behavior were correct, training developers to ignore a red local suite. The replacement assertions pin the actual properties without depending on scheduler luck.

## Verification

- Merkle file — 76/76 pass.
- GOOSE file — 46/46 pass.
- GOOSE replay file — 27/27 pass; all three former timing cases also pass with a 100 ms test timeout.
- Former no-frame case with `--testTimeout=100`: baseline timed out; fixed case passed in 5 ms.
- Exact listener test: 356 ms focused versus 912 ms baseline.
- `npx tsc --noEmit` — pass.
- Full suite with Git's OpenSSL on PATH: 178 files passed, 2 skipped; 3,498 tests passed, 5 skipped. All three changed files passed under full-suite load.
- `git diff --check` — pass.
