### PR TITLE
fix(storage): fsync directories after atomic rename (#643)

### DIFF
--- a/docs/architecture/offline-edge-resilience.md
+++ b/docs/architecture/offline-edge-resilience.md
@@ -8,7 +8,8 @@ This document is the executable companion to
 `StoreAndForwardService.store(data, driverId)` entry point while making the
 queue durable and the reconnect path verifiable:
 
-- `JsonFileEdgeQueue` persists snapshots using fsync plus atomic rename; a
+- `JsonFileEdgeQueue` persists snapshots using file fsync, atomic rename, and,
+  where the platform supports it, containing-directory fsync; a
   `DurableEdgeQueue` port permits SQLite or another local store.
 - Capacity is fail-closed: unacknowledged records are never silently evicted.
 - Every recovered record is checked with SHA-256, and every forwarded batch

--- a/server/__tests__/atomic-file-ordering.test.ts
+++ b/server/__tests__/atomic-file-ordering.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mkdir: vi.fn(),
+  open: vi.fn(),
+  rename: vi.fn(),
+  rm: vi.fn(),
+  randomUUID: vi.fn(() => "fixed-uuid"),
+  file: {
+    writeFile: vi.fn(),
+    sync: vi.fn(),
+    close: vi.fn(),
+  },
+  directory: {
+    sync: vi.fn(),
+    close: vi.fn(),
+  },
+}));
+
+vi.mock("node:crypto", () => ({
+  randomUUID: mocks.randomUUID,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  mkdir: mocks.mkdir,
+  open: mocks.open,
+  rename: mocks.rename,
+  rm: mocks.rm,
+}));
+
+import { writeFileAtomicDurable } from "../atomic-file";
+
+describe("writeFileAtomicDurable ordering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.rm.mockResolvedValue(undefined);
+    mocks.open.mockImplementation(async (_path, flags) =>
+      flags === "wx" ? mocks.file : mocks.directory,
+    );
+  });
+
+  it("fsyncs the file, renames it, then fsyncs the containing directory", async () => {
+    const target = "state/queue.json";
+    const temporary = `${target}.${process.pid}.fixed-uuid.tmp`;
+
+    await writeFileAtomicDurable(target, "payload");
+
+    expect(mocks.mkdir).toHaveBeenCalledWith("state", { recursive: true });
+    expect(mocks.open).toHaveBeenNthCalledWith(1, temporary, "wx");
+    expect(mocks.file.writeFile).toHaveBeenCalledWith("payload");
+    expect(mocks.rename).toHaveBeenCalledWith(temporary, target);
+    expect(mocks.open).toHaveBeenNthCalledWith(2, "state", "r");
+
+    const order = [
+      mocks.file.writeFile,
+      mocks.file.sync,
+      mocks.file.close,
+      mocks.rename,
+      mocks.open,
+      mocks.directory.sync,
+      mocks.directory.close,
+    ].map((mock) => mock.mock.invocationCallOrder.at(-1));
+    expect(order.every((call, index) =>
+      index === 0 || call! > order[index - 1]!,
+    )).toBe(true);
+    expect(mocks.rm).not.toHaveBeenCalled();
+  });
+
+  it("closes the file and removes its unique temporary file on failure", async () => {
+    const failure = new Error("file fsync failed");
+    mocks.file.sync.mockRejectedValueOnce(failure);
+    const target = "state/queue.json";
+    const temporary = `${target}.${process.pid}.fixed-uuid.tmp`;
+
+    await expect(writeFileAtomicDurable(target, "payload")).rejects.toBe(
+      failure,
+    );
+
+    expect(mocks.file.close).toHaveBeenCalledOnce();
+    expect(mocks.rename).not.toHaveBeenCalled();
+    expect(mocks.rm).toHaveBeenCalledWith(temporary, { force: true });
+  });
+
+  it("closes the directory and reports a directory-fsync failure", async () => {
+    const failure = Object.assign(new Error("directory fsync failed"), {
+      code: "EIO",
+    });
+    mocks.directory.sync.mockRejectedValueOnce(failure);
+
+    await expect(
+      writeFileAtomicDurable("state/queue.json", "payload"),
+    ).rejects.toBe(failure);
+
+    expect(mocks.rename).toHaveBeenCalledOnce();
+    expect(mocks.directory.close).toHaveBeenCalledOnce();
+    expect(mocks.rm).toHaveBeenCalledOnce();
+  });
+});

--- a/server/__tests__/atomic-file.test.ts
+++ b/server/__tests__/atomic-file.test.ts
@@ -1,0 +1,39 @@
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeFileAtomicDurable } from "../atomic-file";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("writeFileAtomicDurable compatibility", () => {
+  it("creates missing parents and atomically replaces an existing file", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "0xscada-atomic-"));
+    temporaryDirectories.push(directory);
+    const parent = join(directory, "nested");
+    const target = join(parent, "state.json");
+
+    await writeFileAtomicDurable(target, "first\n");
+    expect(await readFile(target, "utf8")).toBe("first\n");
+
+    await writeFile(target, "old contents", "utf8");
+    await writeFileAtomicDurable(target, new TextEncoder().encode("second\n"));
+
+    expect(await readFile(target, "utf8")).toBe("second\n");
+    expect(await readdir(parent)).toEqual(["state.json"]);
+  });
+});

--- a/server/atomic-file.ts
+++ b/server/atomic-file.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, open, rename, rm } from "node:fs/promises";
+import { dirname } from "node:path";
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const directory = await open(path, "r");
+  try {
+    try {
+      await directory.sync();
+    } catch (error) {
+      // Node can open directories on Windows, but FlushFileBuffers on that
+      // handle is unsupported. POSIX filesystems must not silently lose the
+      // durability guarantee when directory fsync fails.
+      if (
+        process.platform !== "win32" ||
+        !isNodeError(error) ||
+        (error.code !== "EPERM" && error.code !== "EINVAL")
+      ) {
+        throw error;
+      }
+    }
+  } finally {
+    await directory.close();
+  }
+}
+
+/**
+ * Atomically replaces a file and makes both its contents and containing
+ * directory entry durable before resolving on platforms that support
+ * directory fsync. Node rejects directory fsync on Windows, where the helper
+ * still provides file fsync plus atomic replacement.
+ *
+ * The parent directory is created when absent. A failed write removes its
+ * unique temporary file and preserves the original error.
+ */
+export async function writeFileAtomicDurable(
+  path: string,
+  contents: string | Uint8Array,
+): Promise<void> {
+  const parent = dirname(path);
+  await mkdir(parent, { recursive: true });
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+
+  try {
+    const file = await open(temporary, "wx");
+    try {
+      await file.writeFile(contents);
+      await file.sync();
+    } finally {
+      await file.close();
+    }
+
+    await rename(temporary, path);
+    await syncDirectory(parent);
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}

--- a/server/gateway/store-and-forward.ts
+++ b/server/gateway/store-and-forward.ts
@@ -8,8 +8,9 @@
 
 import { EventEmitter } from "node:events";
 import { randomUUID } from "node:crypto";
-import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { writeFileAtomicDurable } from "../atomic-file";
 import { log, logError } from "../logger";
 import {
   canonicalJson,
@@ -86,8 +87,10 @@ interface QueueFile {
 }
 
 /**
- * Crash-safe single-file queue: write complete snapshot, then atomically rename.
- * A database-backed adapter can implement the same contract for larger queues.
+ * Power-loss-durable single-file queue on platforms with directory fsync:
+ * fsync a complete snapshot, atomically rename it, then fsync the containing
+ * directory. A database-backed adapter can implement the same contract for
+ * larger queues.
  */
 export class JsonFileEdgeQueue implements DurableEdgeQueue {
   constructor(readonly path: string) {}
@@ -110,25 +113,14 @@ export class JsonFileEdgeQueue implements DurableEdgeQueue {
   }
 
   async save(records: readonly StoredRecord[]): Promise<void> {
-    await mkdir(dirname(this.path), { recursive: true });
-    const temporary = `${this.path}.${process.pid}.${randomUUID()}.tmp`;
     const payload: QueueFile = {
       version: 1,
       records: records.map(serializeRecord),
     };
-    try {
-      const handle = await open(temporary, "wx");
-      try {
-        await handle.writeFile(`${canonicalJson(payload)}\n`, "utf8");
-        await handle.sync();
-      } finally {
-        await handle.close();
-      }
-      await rename(temporary, this.path);
-    } catch (error) {
-      await rm(temporary, { force: true }).catch(() => undefined);
-      throw error;
-    }
+    await writeFileAtomicDurable(
+      this.path,
+      `${canonicalJson(payload)}\n`,
+    );
   }
 }
 


### PR DESCRIPTION
Closes #643.

## What changed

Added a shared `writeFileAtomicDurable(path, contents)` primitive and moved `JsonFileEdgeQueue.save()` onto it. A successful write now orders:

1. create a unique `wx` temporary file;
2. write and fsync its contents;
3. close it;
4. atomically rename it over the target;
5. open, fsync, and close the containing directory.

Failures close handles, remove the temporary file when it still exists, and propagate the original error. The offline-edge durability documentation now states the complete guarantee.

## Why

File fsync plus rename is atomic, but on POSIX the renamed directory entry is not power-loss durable until the containing directory is fsynced. The old queue could therefore recover the old file—or no file—after an abrupt host power loss despite having reported a successful save.

## Verification

- Ordering tests prove file write/fsync/close precede rename and directory fsync/close.
- Failure tests prove cleanup and original-error propagation.
- Real-filesystem tests cover missing parents, replacing an existing target, string/byte payloads, and no leftover temp files.
- `npx vitest run server/__tests__/atomic-file-ordering.test.ts server/__tests__/atomic-file.test.ts server/gateway/__tests__/store-and-forward.test.ts` — 14/14 pass.
- `npm run typecheck` — pass.
- `git diff --check` — pass.

## Platform and draft-PR notes

Node does not expose a supported directory fsync on Windows (`EPERM`/`EINVAL`), so Windows retains file-fsync-plus-atomic-rename behavior. POSIX directory-fsync failures remain fatal.

Draft PR #630 contains a second copy in `JsonFileUpgradeJournal.save()`. It should merge or rebase after this helper, replace that duplicate block with `writeFileAtomicDurable`, and run the upgrade suites. This PR deliberately does not mix the unrelated upgrade feature into the mainline durability fix.
