### PR TITLE
fix(logging): structure uploaded blueprint filenames (#644)

### DIFF
--- a/server/blueprints/__tests__/parser-logging.test.ts
+++ b/server/blueprints/__tests__/parser-logging.test.ts
@@ -1,0 +1,122 @@
+import { readdir, readFile } from "node:fs/promises";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const warn = vi.hoisted(() => vi.fn());
+
+vi.mock("../../logger", () => ({
+  default: { warn },
+}));
+
+import { parseCMTypeMarkdown } from "../cm-type-parser";
+import { importBlueprints } from "../importer";
+import { parsePhaseTypeMarkdown } from "../phase-type-parser";
+import { parseUnitTypeMarkdown } from "../unit-type-parser";
+
+async function productionTypeScriptModules(directory: URL): Promise<URL[]> {
+  const modules: URL[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name !== "__tests__") {
+      modules.push(
+        ...(await productionTypeScriptModules(
+          new URL(`${entry.name}/`, directory),
+        )),
+      );
+    } else if (entry.isFile() && entry.name.endsWith(".ts")) {
+      modules.push(new URL(entry.name, directory));
+    }
+  }
+  return modules;
+}
+
+describe("blueprint parser logging", () => {
+  beforeEach(() => {
+    warn.mockClear();
+  });
+
+  it("keeps uploaded filenames out of log messages for every parser", () => {
+    const forged = "\r\n{\"level\":50,\"msg\":\"FORGED\"}\u001b[31m";
+    const names = {
+      cm: `cm-type-uploaded${forged}.md`,
+      unit: `unit-type-uploaded${forged}.md`,
+      phase: `phase-type-uploaded${forged}.md`,
+    };
+
+    const result = importBlueprints({
+      cmTypePackage: [{ name: names.cm, content: "invalid" }],
+      designSpec: {
+        cmInstances: [],
+        unitTypes: [{ name: names.unit, content: "invalid" }],
+        unitInstances: [],
+        phaseTypes: [{ name: names.phase, content: "invalid" }],
+      },
+    });
+
+    expect(result.warnings).toHaveLength(3);
+    expect(warn.mock.calls).toEqual([
+      [
+        { sourceFile: names.cm },
+        "Could not find CM TYPE header in blueprint file",
+      ],
+      [
+        { sourceFile: names.unit },
+        "Could not find UNIT TYPE header in blueprint file",
+      ],
+      [
+        { sourceFile: names.phase },
+        "Could not find PHASE TYPE header in blueprint file",
+      ],
+    ]);
+    for (const [, message] of warn.mock.calls) {
+      expect(message).not.toContain("uploaded");
+      expect(message).not.toContain("\n");
+      expect(message).not.toContain("\r");
+      expect(message).not.toContain("\u001b");
+    }
+  });
+
+  it("preserves ordinary missing-header behavior with structured context", () => {
+    expect(parseCMTypeMarkdown("invalid", "cm-type-pump.md")).toBeNull();
+    expect(parseUnitTypeMarkdown("invalid", "unit-type-line.md")).toBeNull();
+    expect(parsePhaseTypeMarkdown("invalid", "phase-type-fill.md")).toBeNull();
+
+    expect(warn.mock.calls).toEqual([
+      [
+        { sourceFile: "cm-type-pump.md" },
+        "Could not find CM TYPE header in blueprint file",
+      ],
+      [
+        { sourceFile: "unit-type-line.md" },
+        "Could not find UNIT TYPE header in blueprint file",
+      ],
+      [
+        { sourceFile: "phase-type-fill.md" },
+        "Could not find PHASE TYPE header in blueprint file",
+      ],
+    ]);
+  });
+
+  it("does not warn for valid files and preserves their source filenames", () => {
+    expect(
+      parseCMTypeMarkdown("# CM TYPE: Pump", "cm-type-pump.md"),
+    ).toMatchObject({ name: "Pump", sourceFile: "cm-type-pump.md" });
+    expect(
+      parseUnitTypeMarkdown("# UNIT TYPE: Line", "unit-type-line.md"),
+    ).toMatchObject({ name: "Line", sourceFile: "unit-type-line.md" });
+    expect(
+      parsePhaseTypeMarkdown("# PHASE TYPE: Fill", "phase-type-fill.md"),
+    ).toMatchObject({ name: "Fill", sourceFile: "phase-type-fill.md" });
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("blueprint production logging guard", () => {
+  it("does not bypass the structured logger with console calls", async () => {
+    const directory = new URL("..", import.meta.url);
+    const modules = await productionTypeScriptModules(directory);
+
+    for (const module of modules) {
+      const source = await readFile(module, "utf8");
+      expect(source, module.pathname).not.toMatch(/\bconsole\s*\./);
+    }
+  });
+});

--- a/server/blueprints/cm-type-parser.ts
+++ b/server/blueprints/cm-type-parser.ts
@@ -1,4 +1,5 @@
 import type { ParsedCMType, CMTypeInput, CMTypeOutput, CMTypeInOut } from "./types";
+import logger from "../logger";
 
 /**
  * Parses a Control Module Type markdown file from the blueprints format.
@@ -10,7 +11,10 @@ export function parseCMTypeMarkdown(content: string, sourceFile?: string): Parse
   // Extract CM Type name from header
   const nameMatch = content.match(/^#\s*CM\s*TYPE:\s*(.+)$/m);
   if (!nameMatch) {
-    console.warn(`Could not find CM TYPE header in ${sourceFile}`);
+    logger.warn(
+      { sourceFile },
+      "Could not find CM TYPE header in blueprint file",
+    );
     return null;
   }
   

--- a/server/blueprints/phase-type-parser.ts
+++ b/server/blueprints/phase-type-parser.ts
@@ -5,6 +5,7 @@ import type {
   PhaseSequence,
   PhaseSequenceStep 
 } from "./types";
+import logger from "../logger";
 
 /**
  * Parses a Phase Type markdown file from the blueprints format.
@@ -16,7 +17,10 @@ export function parsePhaseTypeMarkdown(content: string, sourceFile?: string): Pa
   // Extract Phase Type name from header
   const nameMatch = content.match(/^#\s*PHASE\s*TYPE:\s*(.+)$/m);
   if (!nameMatch) {
-    console.warn(`Could not find PHASE TYPE header in ${sourceFile}`);
+    logger.warn(
+      { sourceFile },
+      "Could not find PHASE TYPE header in blueprint file",
+    );
     return null;
   }
   

--- a/server/blueprints/unit-type-parser.ts
+++ b/server/blueprints/unit-type-parser.ts
@@ -1,4 +1,5 @@
 import type { ParsedUnitType, UnitTypeVariable } from "./types";
+import logger from "../logger";
 
 /**
  * Parses a Unit Type markdown file from the blueprints format.
@@ -10,7 +11,10 @@ export function parseUnitTypeMarkdown(content: string, sourceFile?: string): Par
   // Extract Unit Type name from header
   const nameMatch = content.match(/^#\s*UNIT\s*TYPE:\s*(.+)$/m);
   if (!nameMatch) {
-    console.warn(`Could not find UNIT TYPE header in ${sourceFile}`);
+    logger.warn(
+      { sourceFile },
+      "Could not find UNIT TYPE header in blueprint file",
+    );
     return null;
   }
   


### PR DESCRIPTION
Closes #644.

## Security outcome: fixed

### Vulnerable path

`POST /api/blueprints/import` request body → `BlueprintFiles` → `importBlueprints()` → attacker-controlled uploaded `file.name` → parser `sourceFile` → interpolated raw `console.warn`.

A newline-bearing filename produced a forged standalone stderr line in every environment.

### Patch

The CM, unit, and phase parsers now log a constant message through Pino and attach the uploaded filename only as structured data:

```ts
logger.warn(
  { sourceFile },
  "Could not find … header in blueprint file",
);
```

The affected `server/blueprints` subsystem now has a recursive guard prohibiting production `console.*` calls.

### Proof

- Pre-fix real importer reproducer emitted forged standalone lines for CM, unit, and phase filenames.
- Regression coverage exercises CRLF, forged JSON, and ANSI control sequences through the real importer path.
- Ordinary missing-header behavior is preserved.
- Valid files still parse, retain their source filename, and emit no warning.
- Post-fix real Pino reproducer emitted exactly three parseable one-line JSON records; attacker bytes stayed escaped inside `sourceFile` and every `msg` stayed constant.
- `npx vitest run server/blueprints/__tests__/parser-logging.test.ts server/blueprints/__tests__/generators.test.ts server/blueprints/__tests__/importer-validation.test.ts server/blueprints/__tests__/parser-prototype-pollution.test.ts` — 23/23 pass.
- `npm run typecheck` — pass.
- `git diff --check` — pass.

## CodeQL disposition

- The three parser alerts are genuine and should close from the post-merge scan.
- The four `server/logger.ts` production alerts are false positives: Pino JSON serialization emits one record and escapes attacker-controlled messages and fields. The low-severity `pino-pretty` development-console caveat remains documented in #644.
- The ten `examples/websocket-consumer.ts` alerts are non-shipped example code. Prefer excluding `examples/` from the production scan scope; otherwise dismiss them as `won't fix` for that scope reason, not as false positives.

The broader server still has existing `console.*` calls outside `server/blueprints`. Migrating those unrelated sites is deliberately not part of this security boundary fix.
