### PR TITLE
test(nodes): prove observed liveness end-to-end, and record why a poll failed (#456)

### DIFF
--- a/client/src/pages/SlashingVisualizer.tsx
+++ b/client/src/pages/SlashingVisualizer.tsx
@@ -98,7 +98,10 @@ function formatDuration(ms: number): string {
 
 // --- small presentational helpers ---------------------------------------------
 
-const StatusCell: React.FC<{ bucket: TimelineBucket }> = ({ bucket }) => {
+const StatusCell: React.FC<{ bucket: TimelineBucket; observedLiveness: boolean }> = ({
+  bucket,
+  observedLiveness,
+}) => {
   // Colour the cell by the worst status present (miss > late > hit > empty).
   let color = "#1f2937";
   if (bucket.total > 0) {
@@ -106,9 +109,13 @@ const StatusCell: React.FC<{ bucket: TimelineBucket }> = ({ bucket }) => {
     else if (bucket.late > 0) color = C.late;
     else color = C.hit;
   }
+  // An empty bucket must not be described in consensus vocabulary when the
+  // records are poll observations — same rule as the card's counters below.
   const title =
     bucket.total === 0
-      ? "no duties"
+      ? observedLiveness
+        ? "no poll rounds"
+        : "no duties"
       : `${bucket.hits} hit / ${bucket.misses} miss / ${bucket.late} late`;
   return (
     <div
@@ -373,7 +380,7 @@ const ValidatorCard: React.FC<{
       {/* timeline */}
       <div style={{ display: "flex", gap: 2, marginBottom: 8 }}>
         {buckets.map((b) => (
-          <StatusCell key={b.index} bucket={b} />
+          <StatusCell key={b.index} bucket={b} observedLiveness={observedLiveness} />
         ))}
       </div>
       <div style={{ display: "flex", justifyContent: "space-between", fontSize: 11, color: C.muted, marginBottom: 12 }}>

--- a/docs/api/attestation-history.md
+++ b/docs/api/attestation-history.md
@@ -116,7 +116,11 @@ carries `X-Data-Provenance: live:<kind>`.
 is never replaced with substituted data.
 
 **503** — no source is registered (the default deployment). The endpoint
-**never** substitutes generated records, not even when the demo flag is enabled:
+**never** substitutes generated records, not even when the demo flag is enabled.
+`reason` keeps two facts apart on purpose: consensus attestation duty history is
+unavailable in this *build* and no configuration changes that, whereas the
+observed-liveness feed is merely not running on this *deployment* — which is the
+part an operator can act on (see below):
 
 ```json
 {
@@ -124,7 +128,7 @@ is never replaced with substituted data.
   "synthetic": false,
   "provenance": "live",
   "message": "No live attestation history is available. This endpoint fails closed rather than returning generated data.",
-  "reason": "No live attestation feed is compiled into this build. ...",
+  "reason": "No live source is registered on this deployment. Consensus attestation duty history is unavailable in this build at all: ... An observed-liveness feed IS available ... but it is opt-in: set VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true and configure ANCHOR_NODE_URLS. ...",
   "demo": {
     "available": false,
     "path": "/api/nodes/attestation-history/demo",

--- a/server/blockchain/__tests__/liveness-collector-e2e.test.ts
+++ b/server/blockchain/__tests__/liveness-collector-e2e.test.ts
@@ -1,0 +1,297 @@
+/**
+ * End-to-end proof of the acceptance criterion "UI shows hypothetical penalties
+ * against the ACTUAL history" (issue #456), with nothing injected at the seams
+ * the other suites stub out.
+ *
+ * `liveness-collector-durability.test.ts` already drives the collector against a
+ * real SQLite database, but it hands it a `fetchImpl` stub, so the transport
+ * path is never exercised; and `server/__tests__/nodes-attestation-history-http.test.ts`
+ * already exercises the HTTP route, but registers a hand-written fake source, so
+ * the real `ObservedLivenessSource` never serves a request. Nothing joined the
+ * two. This does:
+ *
+ *   a real HTTP node on a real socket
+ *     -> the production bounded transport (global fetch, no fetchImpl)
+ *       -> the real collector and the real SQLite store
+ *         -> a genuinely refused TCP connection for the outage rounds
+ *           -> the real ObservedLivenessSource registered through the real seam
+ *             -> the real Express route, over real HTTP, with an operator key
+ *               -> the UNMODIFIED client simulator, over the parsed JSON body
+ *
+ * The misses here are not an injected `Error("ECONNREFUSED")`: the node's
+ * listener is closed, so the connection is refused by the OS. What the assertion
+ * at the end projects penalties from is therefore the same bytes an operator's
+ * browser would receive.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type * as StorageModule from "../../storage";
+import {
+  ObservedLivenessSource,
+  ValidatorLivenessCollector,
+  OBSERVED_LIVENESS_SOURCE_ID,
+  defaultLivenessObservationStore,
+  loadLivenessCollectorConfig,
+} from "../liveness-collector";
+import {
+  clearLiveAttestationSource,
+  nodesRoutes,
+  registerLiveAttestationSource,
+} from "../../routes/nodes";
+import { _resetControlPlaneAuthCache } from "../../middleware/control-plane-auth";
+import { parseRulePhrase, simulateRule } from "../../../client/src/lib/slashing-simulator";
+import type { LiveAttestationHistoryResponse } from "@shared/types/slashing";
+
+const OPERATOR_KEY = "liveness-e2e-operator-key";
+
+let storage: typeof StorageModule;
+let databaseDirectory: string;
+
+/** The node under observation, and the API server that reads it back. */
+let nodePort = 0;
+let nodeServer: Server | null = null;
+let apiServer: Server;
+let apiBaseUrl: string;
+
+/** Height the fake node reports; bumped between rounds to produce a `hit`. */
+let nodeHeight = 5_000;
+
+const originalEnv = {
+  forcePostgres: process.env.FORCE_POSTGRES,
+  sqlitePath: process.env.SQLITE_DATABASE_PATH,
+  apiKeys: process.env.API_KEYS,
+  anchorNodeUrls: process.env.ANCHOR_NODE_URLS,
+  collectorEnabled: process.env.VALIDATOR_LIVENESS_COLLECTOR_ENABLED,
+};
+
+/** An oxscada `/status` payload, shaped per `parseOxscadaStatus`. */
+function statusPayload(): string {
+  return JSON.stringify({
+    node_id: "node-e2e",
+    height: nodeHeight,
+    role: "validator",
+    order_parameter: 0.98,
+    mean_phase: 1.2,
+    local_phase: 1.19,
+    peer_phases: [],
+    peers: 3,
+    mempool: 1,
+    uptime_ticks: nodeHeight * 10,
+  });
+}
+
+/** Bind the fake node. On the first call the OS assigns the port we then reuse. */
+function openNode(): Promise<void> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      if (req.url === "/status") {
+        const body = statusPayload();
+        res.writeHead(200, {
+          "content-type": "application/json",
+          "content-length": String(Buffer.byteLength(body)),
+        });
+        res.end(body);
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    server.listen(nodePort, "127.0.0.1", () => {
+      const address = server.address();
+      if (typeof address === "object" && address) nodePort = address.port;
+      nodeServer = server;
+      resolve();
+    });
+  });
+}
+
+/**
+ * Close the listener so the port stops accepting. Subsequent polls get a real
+ * connection refusal from the OS rather than a stubbed rejection.
+ */
+function closeNode(): Promise<void> {
+  const server = nodeServer;
+  nodeServer = null;
+  if (!server) return Promise.resolve();
+  return new Promise((resolve) => {
+    server.closeAllConnections?.();
+    server.close(() => resolve());
+  });
+}
+
+function startApi(): Promise<void> {
+  const app = express();
+  app.use("/api/nodes", nodesRoutes);
+  return new Promise((resolve) => {
+    const server = createServer(app);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      apiServer = server;
+      apiBaseUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+}
+
+describe("observed liveness end-to-end: real socket -> real DB -> real route -> simulator", () => {
+  beforeAll(async () => {
+    process.env.FORCE_POSTGRES = "false";
+    databaseDirectory = mkdtempSync(join(tmpdir(), "oxscada-liveness-e2e-"));
+    process.env.SQLITE_DATABASE_PATH = join(databaseDirectory, "liveness-e2e.sqlite");
+    process.env.API_KEYS = `${OPERATOR_KEY}:liveness-e2e-operator:operator`;
+    _resetControlPlaneAuthCache();
+
+    storage = await import("../../storage");
+    await storage.initializeDatabase();
+    // Start from an empty table regardless of what else ran in this worker.
+    await storage.pruneValidatorLivenessObservations(Number.MAX_SAFE_INTEGER);
+
+    await openNode();
+    await startApi();
+    // Module transform + import on a cold cache can exceed the 10s hook budget.
+  }, 60_000);
+
+  afterAll(async () => {
+    clearLiveAttestationSource();
+    await closeNode();
+    await new Promise<void>((resolve) => apiServer.close(() => resolve()));
+    await storage.closeDatabase();
+    for (const [key, value] of [
+      ["FORCE_POSTGRES", originalEnv.forcePostgres],
+      ["SQLITE_DATABASE_PATH", originalEnv.sqlitePath],
+      ["API_KEYS", originalEnv.apiKeys],
+      ["ANCHOR_NODE_URLS", originalEnv.anchorNodeUrls],
+      ["VALIDATOR_LIVENESS_COLLECTOR_ENABLED", originalEnv.collectorEnabled],
+    ] as const) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    _resetControlPlaneAuthCache();
+    rmSync(databaseDirectory, { recursive: true, force: true });
+  });
+
+  it("projects penalties from history the operator's own HTTP response carried", async () => {
+    const nodeUrl = `http://127.0.0.1:${nodePort}`;
+    process.env.ANCHOR_NODE_URLS = nodeUrl;
+    process.env.VALIDATOR_LIVENESS_COLLECTOR_ENABLED = "true";
+    // Read the config through the production loader so the opt-in gate itself is
+    // exercised, not hand-built around.
+    const config = loadLivenessCollectorConfig();
+    expect(config.enabled).toBe(true);
+    expect(config.nodeUrls).toEqual([nodeUrl]);
+
+    // Wall clock would put every round in the same millisecond, which is fine
+    // for a 1h window but leaves the timeline unreadable; step a synthetic clock
+    // instead. Only the timestamps are synthetic — every status below is decided
+    // by a real request to a real socket.
+    let clock = Date.now() - 30 * 60_000;
+    const collector = new ValidatorLivenessCollector({
+      config,
+      store: defaultLivenessObservationStore,
+      now: () => clock,
+      // NO fetchImpl: this is the production bounded transport over global fetch.
+    });
+
+    // Round 1 — node is up. First observation of a validator is a baseline.
+    await collector.runRound();
+
+    // Rounds 2..5 — take the listener away. The port is closed, so connecting is
+    // refused by the OS; the collector records what it actually failed to reach.
+    await closeNode();
+    for (let i = 0; i < 4; i += 1) {
+      clock += 60_000;
+      await collector.runRound();
+    }
+
+    // Round 6 — bring the node back at a higher height: answered AND advanced.
+    nodeHeight += 1;
+    await openNode();
+    clock += 60_000;
+    await collector.runRound();
+    await collector.stop();
+
+    // The refusals were transport-level, not fabricated: the stored reason is
+    // whatever the OS/undici actually reported.
+    const rows = await storage.listValidatorLivenessObservations(0);
+    expect(rows).toHaveLength(6);
+    expect(rows.map((r) => r.status)).toEqual(["late", "miss", "miss", "miss", "miss", "hit"]);
+    // `detail` is a nullable column; the collector always writes one, and that
+    // is part of what is being asserted.
+    const missDetails = rows
+      .filter((r) => r.status === "miss")
+      .map((r) => {
+        expect(typeof r.detail).toBe("string");
+        // Nothing is carried forward from the round before it.
+        expect(r.observedHeight).toBeNull();
+        expect(r.reportedNodeId).toBeNull();
+        return r.detail ?? "";
+      });
+    expect(missDetails).toHaveLength(4);
+    for (const detail of missDetails) {
+      expect(detail.startsWith("no answer:")).toBe(true);
+      // The audited reason is the errno the OS actually reported, not `fetch`'s
+      // opaque "fetch failed". This is the assertion the stubbed suites cannot
+      // make: they inject the very message they then assert on.
+      expect(detail).toMatch(/\(E[A-Z0-9_]+\)$/);
+    }
+    // The rounds that dialled the closed port fresh were refused. (The first
+    // miss can be ECONNRESET instead: the keep-alive socket opened by round 1
+    // is destroyed when the listener closes, and that is an equally real
+    // reason — which is the point of recording the code rather than guessing.)
+    expect(missDetails.some((d) => d.includes("ECONNREFUSED"))).toBe(true);
+    expect(rows[5].previousHeight).toBe(rows[0].observedHeight);
+
+    // ── Serve it through the real seam and the real route, over real HTTP.
+    registerLiveAttestationSource(
+      new ObservedLivenessSource(defaultLivenessObservationStore, config, () => clock),
+    );
+    const res = await fetch(`${apiBaseUrl}/api/nodes/attestation-history?window=1h`, {
+      headers: { "x-api-key": OPERATOR_KEY },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-data-provenance")).toBe("live:observed-liveness");
+
+    const body = (await res.json()) as LiveAttestationHistoryResponse;
+    expect(body.synthetic).toBe(false);
+    expect(body.source).toBe(OBSERVED_LIVENESS_SOURCE_ID);
+    // The descriptor the UI branches on to say "Poll rounds" instead of "Duties".
+    expect(body.observation.kind).toBe("observed-liveness");
+    expect(body.observation.consensusAttestation.available).toBe(false);
+    expect(body.validators).toHaveLength(1);
+
+    // ── The criterion: the UNMODIFIED simulator, over the response body.
+    const history = body.validators[0];
+    expect(history.records.map((r) => r.status)).toEqual([
+      "late",
+      "miss",
+      "miss",
+      "miss",
+      "miss",
+      "hit",
+    ]);
+
+    const rule = parseRulePhrase("slash 1% per miss after 2 in 1h");
+    expect(rule).not.toBeNull();
+    const result = simulateRule(history, { ...rule!, livenessRunThreshold: 3 }, "1h", clock);
+
+    expect(result.summary.total).toBe(6);
+    expect(result.summary.misses).toBe(4);
+    // Four misses, the first two free: two penalised at 1% each.
+    expect(result.penalties).toHaveLength(2);
+    expect(result.totalPenaltyPct).toBeCloseTo(2, 10);
+    // The outage is one consecutive-miss run, above the threshold of 3.
+    expect(result.livenessFaults).toHaveLength(1);
+    expect(result.livenessFaults[0].length).toBe(4);
+    // No stake source exists in this build, so the absolute amount stays 0 and
+    // the descriptor says the percentage is the only meaningful output.
+    expect(body.observation.stake.available).toBe(false);
+    expect(result.totalPenaltyAmount).toBe(0);
+  }, 60_000);
+});

--- a/server/blockchain/__tests__/validator-dashboard.test.ts
+++ b/server/blockchain/__tests__/validator-dashboard.test.ts
@@ -18,6 +18,7 @@ import {
   _resetValidatorDashboardCache,
   buildOverview,
   collectValidatorOverview,
+  describeFetchFailure,
   getValidatorOverview,
   kuramotoCoherence,
   loadValidatorDashboardConfig,
@@ -209,6 +210,27 @@ describe('pollNodeStatus', () => {
     expect(view.error).toContain('503');
   });
 
+  it('records the errno behind a connection failure, not just "fetch failed"', async () => {
+    // What the global fetch actually throws when a port is closed: an opaque
+    // message with the actionable reason hidden on `cause`. The recorded string
+    // is the only account of why a node was unreachable — it becomes the
+    // `detail` of a `miss` row an operator may later slash on.
+    const failure = new TypeError('fetch failed');
+    (failure as { cause?: unknown }).cause = Object.assign(
+      new Error('connect ECONNREFUSED 127.0.0.1:9090'),
+      { code: 'ECONNREFUSED' },
+    );
+    const view = await pollNodeStatus('http://node-a:9090', {
+      timeoutMs: 1000,
+      fetchImpl: () => Promise.reject(failure),
+    });
+    expect(view.reachable).toBe(false);
+    expect(view.error).toBe('fetch failed (ECONNREFUSED)');
+    // The cause's own message embeds the address that was dialled; only the
+    // code is surfaced, so no topology detail is added that the URL withheld.
+    expect(view.error).not.toContain('127.0.0.1');
+  });
+
   it('captures a schema-drifted payload instead of throwing', async () => {
     const view = await pollNodeStatus('http://node-a:9090', {
       timeoutMs: 1000,
@@ -286,6 +308,86 @@ describe('pollNodeStatus', () => {
       fetchImpl: () => Promise.reject(new Error('x'.repeat(5000))),
     });
     expect(view.error?.length).toBeLessThanOrEqual(200);
+  });
+});
+
+describe('describeFetchFailure', () => {
+  const withCode = (message: string, code: string): Error =>
+    Object.assign(new Error(message), { code });
+
+  it('appends the errno hidden on `cause`', () => {
+    const err = new TypeError('fetch failed');
+    (err as { cause?: unknown }).cause = withCode('connect ECONNREFUSED', 'ECONNREFUSED');
+    expect(describeFetchFailure(err)).toBe('fetch failed (ECONNREFUSED)');
+  });
+
+  it('finds an errno inside an AggregateError, as happens with multiple addresses', () => {
+    const err = new TypeError('fetch failed');
+    (err as { cause?: unknown }).cause = new AggregateError([
+      withCode('connect ENETUNREACH ::1:9090', 'ENETUNREACH'),
+      withCode('connect ECONNREFUSED 127.0.0.1:9090', 'ECONNREFUSED'),
+    ]);
+    // The first branch reported is the one surfaced; both are real reasons.
+    expect(describeFetchFailure(err)).toBe('fetch failed (ENETUNREACH)');
+  });
+
+  it('reports an aborted request as a timeout', () => {
+    // The only thing that aborts a poll here is `timeoutMs` elapsing.
+    const err = new Error('This operation was aborted');
+    err.name = 'AbortError';
+    expect(describeFetchFailure(err)).toBe('This operation was aborted (timeout)');
+  });
+
+  it('leaves a message that already names its code unchanged', () => {
+    expect(describeFetchFailure(withCode('connect ECONNREFUSED', 'ECONNREFUSED'))).toBe(
+      'connect ECONNREFUSED',
+    );
+  });
+
+  it('passes through an error with no errno anywhere in the chain', () => {
+    expect(describeFetchFailure(new Error('/status returned HTTP 503'))).toBe(
+      '/status returned HTTP 503',
+    );
+  });
+
+  it('ignores a non-errno `code` rather than appending noise', () => {
+    // e.g. a numeric DOMException code, or a free-text application code.
+    expect(describeFetchFailure(Object.assign(new Error('boom'), { code: 20 }))).toBe('boom');
+    expect(describeFetchFailure(Object.assign(new Error('boom'), { code: 'nope' }))).toBe('boom');
+  });
+
+  it('terminates on a self-referential cause chain', () => {
+    const err = new Error('looping');
+    (err as { cause?: unknown }).cause = err;
+    expect(describeFetchFailure(err)).toBe('looping');
+  });
+
+  it('handles a non-Error rejection', () => {
+    expect(describeFetchFailure('plain string')).toBe('plain string');
+  });
+
+  it('survives a very wide AggregateError instead of throwing out of the poll', () => {
+    // The width of `errors` is one entry per address the resolver returned, so
+    // it is not ours to choose. Spreading it into `push` overflows the argument
+    // stack; this function throwing would break `pollNodeStatus`'s contract that
+    // it never throws, losing the whole round rather than one node's row.
+    const err = new TypeError('fetch failed');
+    (err as { cause?: unknown }).cause = new AggregateError(
+      Array.from({ length: 200_000 }, () => new Error('x')),
+      'all addresses failed',
+    );
+    expect(describeFetchFailure(err)).toBe('fetch failed');
+  });
+
+  it('still finds the errno when it is on an early branch of a wide AggregateError', () => {
+    const err = new TypeError('fetch failed');
+    (err as { cause?: unknown }).cause = new AggregateError([
+      Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:9090'), {
+        code: 'ECONNREFUSED',
+      }),
+      ...Array.from({ length: 100_000 }, () => new Error('x')),
+    ]);
+    expect(describeFetchFailure(err)).toBe('fetch failed (ECONNREFUSED)');
   });
 });
 

--- a/server/blockchain/validator-dashboard.ts
+++ b/server/blockchain/validator-dashboard.ts
@@ -200,6 +200,62 @@ export interface PollOptions {
 }
 
 /**
+ * Describe why a poll failed, in terms an operator can act on.
+ *
+ * `fetch` reports every connection-level failure with the same opaque message,
+ * "fetch failed", and puts the actionable reason on `err.cause` — an
+ * `AggregateError` when several addresses were tried. That message is the ONLY
+ * record of why a node was unreachable: it becomes `ValidatorNodeView.error` on
+ * the dashboard and, via `classifyObservation`, the `detail` column of every
+ * `miss` row in `validator_liveness_observations`. "fetch failed" alone cannot
+ * tell an operator auditing a slashing projection whether the node was down
+ * (ECONNREFUSED), the hostname does not resolve (ENOTFOUND), or the poll timed
+ * out — three findings with three different responses.
+ *
+ * Only the error CODE is appended, never the cause's message: causes embed the
+ * address that was dialled, which is exactly the topology detail the URL is
+ * deliberately kept out of. An aborted request is reported as a timeout,
+ * because the abort signal here has one cause — `options.timeoutMs` elapsing.
+ *
+ * Pure; exported for tests.
+ */
+export function describeFetchFailure(err: unknown): string {
+  const base = err instanceof Error ? err.message : String(err);
+  if (err instanceof Error && err.name === 'AbortError') {
+    return `${base} (timeout)`;
+  }
+
+  // Walk the cause chain, and the branches of any AggregateError within it, for
+  // the first errno-style code. Depth-bounded so a self-referential cause (or a
+  // hostile deep chain) cannot spin here.
+  const queue: unknown[] = [err];
+  for (let depth = 0; depth < 8 && queue.length > 0; depth += 1) {
+    const current = queue.shift();
+    if (typeof current !== 'object' || current === null) continue;
+    const code = (current as { code?: unknown }).code;
+    // errno-style codes only (ECONNREFUSED, ENOTFOUND, ...); a numeric or
+    // free-text `code` carries nothing an operator can look up.
+    if (typeof code === 'string' && /^[A-Z][A-Z0-9_]{2,31}$/.test(code)) {
+      return base.includes(code) ? base : `${base} (${code})`;
+    }
+    const errors = (current as { errors?: unknown }).errors;
+    if (Array.isArray(errors)) {
+      // Push branch-by-branch, never `push(...errors)`: the array width is one
+      // entry per address the resolver returned, so it is not ours to choose,
+      // and spreading a wide one overflows the argument stack. This function
+      // throwing would break `pollNodeStatus`'s documented contract that it
+      // never throws — costing the whole poll round, not one node's row. Only
+      // as many branches as the depth bound can examine are queued at all.
+      for (const branch of errors.slice(0, 8)) queue.push(branch);
+    }
+    const cause = (current as { cause?: unknown }).cause;
+    if (cause !== undefined) queue.push(cause);
+  }
+
+  return base;
+}
+
+/**
  * Poll one node's `/status`. Exactly one attempt, no retry. Never throws:
  * failures are captured into the returned view so one dead node cannot fail the
  * whole request.
@@ -235,7 +291,7 @@ export async function pollNodeStatus(
       status: toStatusView(parsed),
     };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = describeFetchFailure(err);
     return {
       label,
       reachable: false,


### PR DESCRIPTION
## Summary

Close-out audit of #456 against current `main`. Three of the four acceptance criteria were met by #608; #619 closed the fourth ("UI shows hypothetical penalties against the actual history"). This does **not** re-litigate that — it closes two gaps the audit turned up while verifying it, one of which is a real defect.

Closes #456.

## Attribution

City-Agent: Codex

## 1. Nothing exercised the whole path

Every existing test stubs one of the two ends. The durability suite drives a real SQLite database but hands the collector a `fetchImpl`, so the transport is never exercised; the HTTP suite serves the real route but registers a hand-written fake source, so `ObservedLivenessSource` never answers a request. Nothing joined them — and the disputed criterion is a claim about the *joined* path.

`server/blockchain/__tests__/liveness-collector-e2e.test.ts` (new, 297 lines) runs it with **nothing injected**: a real HTTP node on a real socket → the production bounded transport over global `fetch` → the real collector and the real file-backed SQLite store → the listener closed so the OS genuinely refuses the outage rounds → the real source registered through the real seam → the real Express route over real HTTP with an operator key → the **unmodified** client simulator, over the parsed JSON body.

`parseRulePhrase("slash 1% per miss after 2 in 1h")` over 4 observed misses yields 2 penalty events and 2%, and one consecutive-miss run of 4.

## 2. A `miss` did not record why — found by running the above

Every outage round persisted `detail` as `"no answer: fetch failed"`. `fetch` reports all connection-level failures with that one opaque message and puts the actionable reason on `err.cause` (an `AggregateError` when several addresses were tried).

That string is the **only** account of why a node was unreachable — it is `ValidatorNodeView.error` on the dashboard and, via `classifyObservation`, the `detail` column of every `miss` row in `validator_liveness_observations`. An operator auditing a slashing projection could not tell a node that was **down** from a hostname that **does not resolve** from a poll that **timed out**.

The existing suite could not catch this: it asserts `"ECONNREFUSED"` appears, having injected an `Error` whose message already said `ECONNREFUSED`. Against a real refused socket it never appears.

`describeFetchFailure()` walks the cause chain and the branches of any `AggregateError` for the first errno-style code and appends **the code only** — never the cause's message, because causes embed the address that was dialled, and that is exactly the topology detail the URL is deliberately kept out of. An aborted request is reported as a timeout, since the only thing that aborts a poll here is `timeoutMs` elapsing. The walk is depth-bounded so a self-referential cause cannot spin.

Misses now read `"no answer: fetch failed (ECONNREFUSED)"`.

## 3. Two honesty fixes

- `docs/api/attestation-history.md` quoted #608's 503 `reason` verbatim, which #619 replaced. The stale text said the feed "is not compiled into this build" — now wrong and actively misleading, since it implies a rebuild where the live source is a configuration opt-in.
- `SlashingVisualizer.tsx`: an empty timeline bucket rendered the tooltip `"no duties"` even when the records are poll observations rather than consensus duties. It now reads `"no poll rounds"` when `observedLiveness` is set — the same rule the card's counters below it already followed.

## Scope

No route, schema, migration, or simulator change. The only production changes are the `detail` error string and the tooltip label above. The collector remains **off** unless `VALIDATOR_LIVENESS_COLLECTOR_ENABLED=true` with `ANCHOR_NODE_URLS` set.

## Verification

Rebased onto current `main` (`cef694f2d`) and re-verified there — the cherry-pick is clean.

```bash
npx tsc --noEmit
# exit 0, no output

npx vitest run server/blockchain/__tests__/liveness-collector-e2e.test.ts \
                server/blockchain/__tests__/validator-dashboard.test.ts
# Test Files  2 passed (2)
#      Tests  52 passed (52)

npx vitest run server/blockchain server/routes/__tests__/nodes
# Test Files  5 passed (5)
#      Tests  96 passed (96)
```

**Pre-existing flake, not introduced here:** a full-suite run on this repo intermittently reds one of `server/__tests__/blueprint-storage.test.ts`, `iec61850-goose/__tests__/live-backend.test.ts` or the SQLite durability suites with `Test timed out in 5000ms`. I measured it on **unmodified `origin/main`** as well — the failing member differs between identical runs and every one passes in isolation. It is the class tracked by #642 and is unrelated to this diff. If CI reds on one of those, a re-run is the correct response.

## Gate self-check

- [x] Commit is signed off (`Signed-off-by`, DCO)
- [x] The `City-Agent:` line above is filled in
- [x] `npx tsc --noEmit` is clean
- [x] No new `any` types
- [x] Barrel exports updated where new modules were added (none added)
- [x] Tests added/updated for every claim in the summary
- [x] PR is scoped to a single issue
