### PR TITLE
fix(upgrades): route the upgrade journal through writeFileAtomicDurable (completes #643)

### DIFF
--- a/server/scaling/upgrade.ts
+++ b/server/scaling/upgrade.ts
@@ -1,12 +1,5 @@
-import { randomUUID } from "node:crypto";
-import {
-  mkdir,
-  open,
-  readFile,
-  rename,
-  rm,
-} from "node:fs/promises";
-import { dirname } from "node:path";
+import { readFile } from "node:fs/promises";
+import { writeFileAtomicDurable } from "../atomic-file";
 import { canonicalJson, hash64 } from "./hash";
 
 export interface VersionTransition {
@@ -527,8 +520,6 @@ export class JsonFileUpgradeJournal implements UpgradeJournal {
   }
 
   private async save(entries: readonly UpgradeJournalEntry[]): Promise<void> {
-    await mkdir(dirname(this.path), { recursive: true });
-    const temporary = `${this.path}.${process.pid}.${randomUUID()}.tmp`;
     const payload: UpgradeJournalFile = {
       version: 1,
       entries: entries.map((entry) => ({
@@ -536,19 +527,11 @@ export class JsonFileUpgradeJournal implements UpgradeJournal {
         timestamp: entry.timestamp.toISOString(),
       })),
     };
-    try {
-      const handle = await open(temporary, "wx");
-      try {
-        await handle.writeFile(`${canonicalJson(payload)}\n`, "utf8");
-        await handle.sync();
-      } finally {
-        await handle.close();
-      }
-      await rename(temporary, this.path);
-    } catch (error) {
-      await rm(temporary, { force: true }).catch(() => undefined);
-      throw error;
-    }
+    // Durability here is the whole point of the journal: recovery after a
+    // controller restart during a drain/deploy boundary. `rename` is atomic but
+    // its directory entry is not durable until the parent directory is fsynced,
+    // so the shared helper owns both syncs rather than each call site.
+    await writeFileAtomicDurable(this.path, `${canonicalJson(payload)}\n`);
   }
 
   private async serialized<T>(work: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
Follow-up to #651, which added `server/atomic-file.ts` and converted the offline edge queue. **#643 named two call sites; this closes the second.**

`UpgradeJournal.save` still had its own hand-rolled write-then-rename with no directory fsync:

```
server/scaling/upgrade.ts:547:      await rename(temporary, this.path);
```

`rename` is atomic, but the directory entry it creates is not durable until the containing directory is fsynced — so an unclean power loss can leave the old journal, or neither, even though the temp file's contents reached the disk.

That matters here specifically: this journal exists to recover a *"controller restart during a drain/deploy boundary"*, which is precisely the abrupt kind of restart. Write-then-rename survives a process crash; it does not survive power loss.

## Change

~20 lines of duplicated temp-file / fsync / rename / cleanup replaced with one call to the shared helper, plus removal of the now-unused `randomUUID`, `mkdir`, `open`, `rename`, `rm` and `dirname` imports. `readFile` stays for `load()`.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `server/scaling` + atomic-file suites | **53 passed / 9 files** |
| Mutation: remove `syncDirectory` from the shared helper | **2 failed** across the upgrade *and* atomic-file suites |

That last row is the point — it confirms the journal genuinely routes through the shared helper rather than keeping a private path that merely looks converted.

## Remaining

The SRE audit sink in #631 is described as "fsync JSONL audit storage" and is the third candidate for this helper. Worth checking when that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)