### PR TITLE
fix(gateway): make the app-wide rate limit visible to static analysis (unblocks #645/#646/#647/#649)

### DIFF
--- a/server/middleware/api-gateway.ts
+++ b/server/middleware/api-gateway.ts
@@ -12,6 +12,7 @@ import { Request, Response, NextFunction, Router, Express } from 'express';
 import crypto from 'crypto';
 import { readFileSync } from 'fs';
 import { z, ZodSchema } from 'zod';
+import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import {
   createRateLimiter,
   type CreateRateLimiterOptions,
@@ -424,7 +425,34 @@ export function setupApiGateway(app: Express, config: Partial<ApiGatewayConfig> 
   // Order matters
   app.use(requestIdMiddleware());
   app.use(corsMiddleware(cfg.corsOrigins));
+  // Two limiters, deliberately, at the same bound.
+  //
+  // `rateLimitMiddleware` is the real one: it can be backed by Redis
+  // (RATE_LIMITER_BACKEND=redis), so under multiple replicas it enforces the
+  // limit fleet-wide rather than per process. It is hand-rolled, which means
+  // static analysis cannot recognise it as a rate limiter — every `/api` route
+  // handler is reported as `js/missing-rate-limiting` even though all of them
+  // sit behind this line.
+  //
+  // `express-rate-limit` is modelled by CodeQL. Layering it here at the same
+  // window and limit makes the protection visible to the scanner once, for the
+  // whole surface, instead of requiring a second limiter on every new route
+  // (the per-route approach taken in #631). It is per-process, so it never
+  // loosens the shared bound — it is a local backstop for when Redis is
+  // unavailable, which is exactly when a process-local limit matters most.
   app.use('/api/', rateLimitMiddleware(cfg.rateLimit));
+  app.use(
+    '/api/',
+    expressRateLimit({
+      windowMs: cfg.rateLimit.windowMs,
+      limit: cfg.rateLimit.maxRequests,
+      standardHeaders: false,
+      // `rateLimitMiddleware` above already owns the response headers and the
+      // 429 body; this layer must not overwrite them when it is not the one
+      // rejecting.
+      legacyHeaders: false,
+    }),
+  );
   if (cfg.enableApiKeyAuth) {
     app.use('/api/', apiKeyMiddleware(keyManager.getKeysMap(), cfg.publicRoutes));
     app.use('/api/', mutationAuthorizationMiddleware());


### PR DESCRIPTION
Restoring CodeQL in #639 surfaced 94 `js/missing-rate-limiting` alerts. **That class is now failing otherwise-good PRs** — and none of them is a real gap.

| PR | New alerts blocking it | All of type |
|---|---|---|
| #645 predictive | 4 | `js/missing-rate-limiting` |
| #646 twin | 3 | `js/missing-rate-limiting` |
| #647 alarm-correlation | 10 | `js/missing-rate-limiting` |
| #649 geometry | 1 | `js/missing-rate-limiting` |

Every one of those routes already sits behind the gateway limiter at `api-gateway.ts:427`. The scanner simply cannot see it.

## Why it cannot see it

`rateLimitMiddleware` is hand-rolled, so CodeQL has no model for it. This is not fixable with a model pack: CodeQL's JS data extensions only cover `sourceModel`, `sinkModel`, `summaryModel` and `typeModel` — **rate limiters are recognised via library classes a data extension cannot contribute to**. So the options are a modelled library, or a custom query pack.

#631 took the modelled-library route, adding a second scanner-visible limiter to two SRE routes. That works, but per-route means every new route pays the tax forever — and four PRs are already paying it.

## What this does

Adds `express-rate-limit` alongside the existing limiter at `/api/`, once, at the same window and limit.

**The hand-rolled limiter stays and remains the real control.** It can be Redis-backed (`RATE_LIMITER_BACKEND=redis`), so under multiple replicas it enforces the limit *fleet-wide*. The added layer is per-process at an identical bound, so it cannot loosen the shared limit — it is a local backstop for exactly the case where Redis is unavailable, which is when a process-local bound matters most.

`standardHeaders` and `legacyHeaders` are both off so the new layer cannot overwrite the `X-RateLimit-*` headers or the 429 body the existing middleware already owns.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| middleware + gateway suites | **62 passed / 5 files** |

**The CodeQL effect cannot be checked locally — this PR is the experiment.** Watch the `Analyze` job here: if the alert count drops toward zero, the same mechanism unblocks #645/#646/#647/#649 once they rebase onto it. If it does not, the alternative is a custom query pack, and I would rather find that out on a 28-line change than after four PRs are rewritten.

## Note

I introduced this problem by restoring the scanner with `security-extended` in #639, so this is mine to clean up rather than something the four blocked PRs should each work around.

Refs #639, #631, #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)