### PR TITLE
fix(validators): walk past undici's UND_ERR_* code to the real errno

### DIFF
--- a/server/blockchain/__tests__/liveness-collector-e2e.test.ts
+++ b/server/blockchain/__tests__/liveness-collector-e2e.test.ts
@@ -239,7 +239,13 @@ describe("observed liveness end-to-end: real socket -> real DB -> real route -> 
       // The audited reason is the errno the OS actually reported, not `fetch`'s
       // opaque "fetch failed". This is the assertion the stubbed suites cannot
       // make: they inject the very message they then assert on.
+      //
+      // `UND_ERR_*` is explicitly NOT accepted here. Undici wraps the libuv
+      // error in a SocketError whose code is errno-shaped, and surfacing that
+      // instead would satisfy a laxer pattern while telling an auditor nothing
+      // — see `describeFetchFailure`, which walks past it to the real errno.
       expect(detail).toMatch(/\(E[A-Z0-9_]+\)$/);
+      expect(detail).not.toMatch(/\(UND_/);
     }
     // The rounds that dialled the closed port fresh were refused. (The first
     // miss can be ECONNRESET instead: the keep-alive socket opened by round 1

--- a/server/blockchain/__tests__/validator-dashboard.test.ts
+++ b/server/blockchain/__tests__/validator-dashboard.test.ts
@@ -331,6 +331,26 @@ describe('describeFetchFailure', () => {
     expect(describeFetchFailure(err)).toBe('fetch failed (ENETUNREACH)');
   });
 
+  it('prefers the real errno over undici\'s UND_ERR_* classification', () => {
+    // What a destroyed keep-alive socket actually produces: undici wraps the
+    // libuv error in a SocketError whose own `code` is errno-SHAPED but tells
+    // an auditor nothing. Reporting it would leave the row as uninformative as
+    // the bare "fetch failed" this function exists to replace.
+    const err = new TypeError('fetch failed');
+    (err as { cause?: unknown }).cause = Object.assign(
+      new Error('other side closed'),
+      { code: 'UND_ERR_SOCKET', cause: withCode('read ECONNRESET', 'ECONNRESET') },
+    );
+    expect(describeFetchFailure(err)).toBe('fetch failed (ECONNRESET)');
+  });
+
+  it('falls back to the UND_ERR_* code when no real errno exists', () => {
+    // Better than nothing: it is still a code an operator can look up.
+    const err = new TypeError('fetch failed');
+    (err as { cause?: unknown }).cause = withCode('other side closed', 'UND_ERR_SOCKET');
+    expect(describeFetchFailure(err)).toBe('fetch failed (UND_ERR_SOCKET)');
+  });
+
   it('reports an aborted request as a timeout', () => {
     // The only thing that aborts a poll here is `timeoutMs` elapsing.
     const err = new Error('This operation was aborted');

--- a/server/blockchain/validator-dashboard.ts
+++ b/server/blockchain/validator-dashboard.ts
@@ -217,6 +217,9 @@ export interface PollOptions {
  * deliberately kept out of. An aborted request is reported as a timeout,
  * because the abort signal here has one cause — `options.timeoutMs` elapsing.
  *
+ * A real errno beats undici's `UND_ERR_*` classification wherever both appear
+ * in the chain; see the comment on the walk below.
+ *
  * Pure; exported for tests.
  */
 export function describeFetchFailure(err: unknown): string {
@@ -228,6 +231,13 @@ export function describeFetchFailure(err: unknown): string {
   // Walk the cause chain, and the branches of any AggregateError within it, for
   // the first errno-style code. Depth-bounded so a self-referential cause (or a
   // hostile deep chain) cannot spin here.
+  //
+  // Undici classifies its own failures with `UND_ERR_*` codes and wraps the
+  // real errno underneath. Those codes are errno-SHAPED but not errno: a
+  // `UND_ERR_SOCKET` row tells an auditor no more than "fetch failed" did,
+  // which is the outcome this function exists to prevent. So a `UND_ERR_*` code
+  // is only remembered as a fallback and the walk continues to the real one.
+  let undiciCode: string | null = null;
   const queue: unknown[] = [err];
   for (let depth = 0; depth < 8 && queue.length > 0; depth += 1) {
     const current = queue.shift();
@@ -236,7 +246,11 @@ export function describeFetchFailure(err: unknown): string {
     // errno-style codes only (ECONNREFUSED, ENOTFOUND, ...); a numeric or
     // free-text `code` carries nothing an operator can look up.
     if (typeof code === 'string' && /^[A-Z][A-Z0-9_]{2,31}$/.test(code)) {
-      return base.includes(code) ? base : `${base} (${code})`;
+      if (code.startsWith('UND_')) {
+        undiciCode ??= code;
+      } else {
+        return base.includes(code) ? base : `${base} (${code})`;
+      }
     }
     const errors = (current as { errors?: unknown }).errors;
     if (Array.isArray(errors)) {
@@ -250,6 +264,12 @@ export function describeFetchFailure(err: unknown): string {
     }
     const cause = (current as { cause?: unknown }).cause;
     if (cause !== undefined) queue.push(cause);
+  }
+
+  // No real errno anywhere in the chain — undici's own classification is still
+  // better than nothing, and is at least a code an operator can look up.
+  if (undiciCode !== null) {
+    return base.includes(undiciCode) ? base : `${base} (${undiciCode})`;
   }
 
   return base;


### PR DESCRIPTION
## The defect

`describeFetchFailure` exists so a `miss` row in `validator_liveness_observations` names *why* a node did not answer. Its own docblock states the point:

> "fetch failed" alone cannot tell an operator auditing a slashing projection whether the node was down (ECONNREFUSED), the hostname does not resolve (ENOTFOUND), or the poll timed out — three findings with three different responses.

Undici defeats that. It wraps the libuv error in a `SocketError` whose own `code` is `UND_ERR_SOCKET` — **errno-shaped**, so it matched the walk's `/^[A-Z][A-Z0-9_]{2,31}$/` pattern and returned before reaching the real errno one level deeper in `.cause`.

The result is an audit row reading `no answer: fetch failed (UND_ERR_SOCKET)`, which tells an auditor nothing the bare message did not already say. The function returned the very outcome it was written to prevent, in a shape that looks like it worked.

## The fix

A `UND_` code is remembered as a fallback and the walk continues:

```ts
if (code.startsWith('UND_')) {
  undiciCode ??= code;
} else {
  return base.includes(code) ? base : `${base} (${code})`;
}
```

It is still reported when the chain carries no real errno anywhere — it is at least a code an operator can look up, and dropping it would be a regression against `fetch failed` alone.

## It also fixes an intermittent CI failure

`liveness-collector-e2e` asserts the detail ends in an errno. The keep-alive socket destroyed when the test's listener closes surfaces as `UND_ERR_SOCKET` often enough to fail runs on unrelated PRs — most recently #648, where it was the only failure in 205 passing files.

I deliberately did **not** widen the regex to accept `UND_`. The e2e now asserts the opposite as well:

```ts
expect(detail).toMatch(/\(E[A-Z0-9_]+\)$/);
expect(detail).not.toMatch(/\(UND_/);
```

Loosening the pattern would have made CI green by writing the defect into the specification. The flake was the test correctly reporting a real gap in the code.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `validator-dashboard`, `liveness-collector`, `liveness-collector-e2e`, `validator-health` | **93 passed** |
| Mutation: neutralise the `UND_` guard | **1 failed** ✅ |

Two unit cases were added — one for the wrapped-errno chain undici actually produces (`UND_ERR_SOCKET` → `ECONNRESET`), one pinning the fallback so a later cleanup cannot silently drop the code entirely.