### PR TITLE
fix(server): make the static-surface rate limits visible to static analysis

### DIFF
--- a/server/__tests__/static-surface-rate-limits.test.ts
+++ b/server/__tests__/static-surface-rate-limits.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The non-`/api` surfaces that touch the filesystem must stay rate-limited
+ * (CodeQL js/missing-rate-limiting #2, #3, #15, #122).
+ *
+ * Each of `static.ts`, `vite.ts` and `swagger.ts` already ran the hand-rolled
+ * `rateLimitMiddleware`, which is the real bound — it can be Redis-backed and
+ * so applies fleet-wide. It is invisible to static analysis, so each of them
+ * also runs an `express-rate-limit` limiter at the same window and limit.
+ *
+ * The regression this guards against is someone deleting the second limiter as
+ * redundant. It is not redundant: it is the only one a scanner can see, and
+ * being per-process it is the one that still holds when Redis is unavailable.
+ */
+
+import { readFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import express from "express";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { swaggerRouter } from "../swagger";
+
+const SERVER_DIR = path.dirname(fileURLToPath(new URL("../swagger.ts", import.meta.url)));
+
+const GUARDED_MODULES = ["static.ts", "vite.ts", "swagger.ts"] as const;
+
+/**
+ * Names bound to `factory(...)` in this source, that are also referenced
+ * somewhere else in it.
+ *
+ * Counting references, not just the declaration, is the whole point: a limiter
+ * that is constructed and never passed to `use()`/`get()` reads exactly like a
+ * working one, and an assertion that only matched `factory(` would pass while
+ * the surface sat wide open.
+ */
+function installedLimiters(source: string, factory: string): string[] {
+  const declarations = [...source.matchAll(
+    new RegExp(`const\\s+(\\w+)\\s*=\\s*${factory}\\(`, "g"),
+  )].map((match) => match[1]);
+
+  return declarations.filter((name) => {
+    const uses = source.match(new RegExp(`\\b${name}\\b`, "g")) ?? [];
+    return uses.length > 1;
+  });
+}
+
+describe("scanner-visible limiters are wired on every filesystem surface", () => {
+  it.each(GUARDED_MODULES)("%s imports express-rate-limit", (file) => {
+    const source = readFileSync(path.join(SERVER_DIR, file), "utf8");
+    expect(source).toMatch(/from ['"]express-rate-limit['"]/);
+  });
+
+  it.each(GUARDED_MODULES)("%s installs an express-rate-limit limiter", (file) => {
+    const source = readFileSync(path.join(SERVER_DIR, file), "utf8");
+    // Either bound to a name that is then used, or passed inline to `use(`.
+    const named = installedLimiters(source, "expressRateLimit").length > 0;
+    const inline = /use\(\s*\n?\s*expressRateLimit\(\{/.test(source);
+    expect(named || inline).toBe(true);
+  });
+
+  it.each(GUARDED_MODULES)("%s still installs the real Redis-capable limiter", (file) => {
+    // The express-rate-limit layer is a backstop, not a replacement: dropping
+    // `rateLimitMiddleware` would silently narrow the bound to one process.
+    const source = readFileSync(path.join(SERVER_DIR, file), "utf8");
+    expect(installedLimiters(source, "rateLimitMiddleware")).not.toEqual([]);
+  });
+});
+
+describe("the swagger router actually rejects a flood", () => {
+  // A real socket rather than an injected request: the limiter keys on the
+  // client address, which only exists on a genuine connection.
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use("/api/docs", swaggerRouter);
+    await new Promise<void>((resolve) => {
+      server = createServer(app);
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        baseUrl = `http://127.0.0.1:${port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("returns 429 once the window limit is exceeded", async () => {
+    const limit = 100;
+    let sawTooManyRequests = false;
+
+    // The two limiters share a 60s window, so a single pass past the limit is
+    // enough — nothing resets between iterations.
+    for (let i = 0; i < limit + 5; i += 1) {
+      const res = await fetch(`${baseUrl}/api/docs/openapi.yaml`);
+      await res.arrayBuffer();
+      if (res.status === 429) {
+        sawTooManyRequests = true;
+        break;
+      }
+    }
+
+    expect(sawTooManyRequests).toBe(true);
+  }, 30_000);
+});

--- a/server/static.ts
+++ b/server/static.ts
@@ -3,18 +3,37 @@
  */
 import express from 'express';
 import path from 'path';
+import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import { rateLimitMiddleware } from './middleware/api-gateway';
 
+const WINDOW_MS = 60_000;
+const MAX_REQUESTS = 200;
+
 export const serveStatic = (app: express.Application) => {
-  // Rate limit for static file serving (generous limit)
-  const staticRateLimit = rateLimitMiddleware({ windowMs: 60_000, maxRequests: 200 });
+  // Rate limit for static file serving (generous limit).
+  //
+  // Two limiters at the same window and limit, for the reason documented on the
+  // `/api/` pair in `middleware/api-gateway.ts`: `rateLimitMiddleware` is the
+  // real one — it can be Redis-backed and so bounds the fleet rather than one
+  // process — but it is hand-rolled, so static analysis cannot recognise it and
+  // reports every handler behind it as unlimited. `express-rate-limit` is
+  // modelled by CodeQL. It is per-process, so it can only ever be stricter than
+  // the shared bound, never looser.
+  const staticRateLimit = rateLimitMiddleware({ windowMs: WINDOW_MS, maxRequests: MAX_REQUESTS });
+  const scannerVisibleLimit = expressRateLimit({
+    windowMs: WINDOW_MS,
+    limit: MAX_REQUESTS,
+    // `rateLimitMiddleware` owns the response headers and the 429 body.
+    standardHeaders: false,
+    legacyHeaders: false,
+  });
 
   // Serve built client files
   const clientPath = path.join(process.cwd(), 'dist', 'client');
-  app.use(staticRateLimit, express.static(clientPath));
-  
+  app.use(staticRateLimit, scannerVisibleLimit, express.static(clientPath));
+
   // SPA fallback - serve index.html for unmatched routes
-  app.get('*', staticRateLimit, (req, res) => {
+  app.get('*', staticRateLimit, scannerVisibleLimit, (req, res) => {
     res.sendFile(path.join(clientPath, 'index.html'));
   });
 };

--- a/server/swagger.ts
+++ b/server/swagger.ts
@@ -10,13 +10,27 @@
 import { Router } from "express";
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
+import { rateLimit as expressRateLimit } from "express-rate-limit";
 import { rateLimitMiddleware } from "./middleware/api-gateway";
 
 export const swaggerRouter = Router();
 
-// Rate limit for documentation endpoints (generous limit for static content)
+// Rate limit for documentation endpoints (generous limit for static content).
+//
+// Paired for the reason documented on the `/api/` limiters in
+// `middleware/api-gateway.ts`: `rateLimitMiddleware` is the real, optionally
+// Redis-backed one but is invisible to static analysis; `express-rate-limit` is
+// modelled by CodeQL and, being per-process, can only be stricter.
 const docsRateLimit = rateLimitMiddleware({ windowMs: 60_000, maxRequests: 100 });
 swaggerRouter.use(docsRateLimit);
+swaggerRouter.use(
+  expressRateLimit({
+    windowMs: 60_000,
+    limit: 100,
+    standardHeaders: false,
+    legacyHeaders: false,
+  }),
+);
 
 // Get the path to the OpenAPI spec
 function getSpecPath(): string {

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -6,6 +6,7 @@ import type { Server } from "http";
 import { createServer as createViteServer } from "vite";
 import path from "path";
 import fs from "fs";
+import { rateLimit as expressRateLimit } from "express-rate-limit";
 import { rateLimitMiddleware } from "./middleware/api-gateway";
 
 export async function setupVite(httpServer: Server, app: Application) {
@@ -23,11 +24,22 @@ export async function setupVite(httpServer: Server, app: Application) {
   // Use Vite's connect instance as middleware
   app.use(vite.middlewares);
 
-  // Rate limit for SPA fallback file system access
+  // Rate limit for SPA fallback file system access.
+  //
+  // Paired for the reason documented on the `/api/` limiters in
+  // `middleware/api-gateway.ts`: `rateLimitMiddleware` is the real, optionally
+  // Redis-backed one but is invisible to static analysis; `express-rate-limit`
+  // is modelled by CodeQL and, being per-process, can only be stricter.
   const spaRateLimit = rateLimitMiddleware({ windowMs: 60_000, maxRequests: 200 });
+  const scannerVisibleLimit = expressRateLimit({
+    windowMs: 60_000,
+    limit: 200,
+    standardHeaders: false,
+    legacyHeaders: false,
+  });
 
   // Serve index.html for all non-API routes (SPA fallback)
-  app.use("*", spaRateLimit, async (req, res, next) => {
+  app.use("*", spaRateLimit, scannerVisibleLimit, async (req, res, next) => {
     const url = req.originalUrl;
 
     // Skip API routes


### PR DESCRIPTION
Closes CodeQL alerts #2, #3, #15, #122 (`js/missing-rate-limiting`).

## These were already rate-limited

`static.ts`, `vite.ts` and `swagger.ts` serve files outside `/api/`, and all three already ran `rateLimitMiddleware`:

```ts
const docsRateLimit = rateLimitMiddleware({ windowMs: 60_000, maxRequests: 100 });
swaggerRouter.use(docsRateLimit);
```

That is the **real** bound — it can be Redis-backed, so under multiple replicas it limits the fleet rather than one process. It is also hand-rolled, so CodeQL cannot recognise it as a limiter and reports every handler behind it as unlimited.

Same remedy #655 used for `/api/`: layer an `express-rate-limit` limiter at the identical window and limit. CodeQL models that one. Being per-process it can only ever be **stricter** than the shared bound, never looser — and it is the limit that still holds when Redis is unavailable, which is exactly when a process-local one matters.

## The interesting part: my first source guard was vacuous

I wrote the obvious assertion first:

```ts
expect(source).toMatch(/rateLimitMiddleware\(/);
```

Then mutated `swagger.ts` to delete `swaggerRouter.use(docsRateLimit)` — leaving the limiter constructed but never installed, the surface wide open. **All 7 tests passed.** The regex matched the `const docsRateLimit = rateLimitMiddleware({...})` declaration, which the mutation left untouched.

That is the same defect class as a fabricated service: a check that reads like protection and enforces nothing. Rewritten to count **references**, so a name that is bound and never used fails:

```ts
function installedLimiters(source: string, factory: string): string[] {
  const declarations = [...source.matchAll(new RegExp(`const\s+(\w+)\s*=\s*${factory}\(`, 'g'))]
    .map((m) => m[1]);
  return declarations.filter((name) => (source.match(new RegExp(`\b${name}\b`, 'g')) ?? []).length > 1);
}
```

## Mutation results

| Mutation | Before | After |
|---|---|---|
| `swagger.ts` declares `docsRateLimit`, never installs it | 7 passed ❌ | **1 failed** ✅ |
| `static.ts` declares `scannerVisibleLimit`, never installs it | — | **1 failed** ✅ |
| `swagger.ts` drops the `expressRateLimit` block entirely | — | **1 failed** ✅ |

## What the behavioural test does and does not prove

There is also a real-socket test that floods `/api/docs/openapi.yaml` and expects a 429. Worth being precise about it: it passed **with the `express-rate-limit` layer removed**, because `rateLimitMiddleware` was still enforcing 100/60s. That is correct behaviour, not a weak test — the two assertions answer different questions:

- the flood test proves **a bound exists**
- the source guards prove **the scanner-visible one exists**

Neither substitutes for the other, which is why both are here.

## Also dismissed in this pass

| Alerts | Reason |
|---|---|
| #1 `server/routes/events.ts` | `eventRoutes` mounts at `/api/v2/events`, already behind the gateway's `/api/` limiters. CodeQL does not connect a router's mount point to app-level middleware. |
| #30, #31, #32 | Express apps built inside a vitest suite; never mounted, never listen. |

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| New suite | **10 passed** |
| New suite + `server/middleware` | **72 passed / 6 files** |