### PR TITLE
fix(yaml): escape every control character in generated YAML scalars

### DIFF
--- a/cli/__tests__/formatter-yaml-escaping.test.ts
+++ b/cli/__tests__/formatter-yaml-escaping.test.ts
@@ -1,0 +1,89 @@
+/**
+ * YAML scalar escaping in the CLI formatter (CodeQL js/incomplete-sanitization #24).
+ *
+ * `oxscada ... -o yaml` output gets piped into other tools, and the values in it
+ * come from API responses rather than from the operator typing them. The quoted
+ * branch escaped `\`, `"` and `\n` but left every other control character raw.
+ *
+ * A raw carriage return inside a double-quoted scalar is invalid YAML: the
+ * parser treats it as a line ending, so the document truncates there and every
+ * key after it silently disappears. Silent truncation is the bad outcome — the
+ * consumer gets a well-formed document that is missing data.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  formatYaml,
+  hasControlCharacter,
+  quoteYamlString,
+} from "../src/lib/formatter.js";
+
+const ESC = String.fromCharCode(27);
+const NUL = String.fromCharCode(0);
+const DEL = String.fromCharCode(127);
+
+describe("hasControlCharacter", () => {
+  it("is false for ordinary and non-ASCII text", () => {
+    expect(hasControlCharacter("")).toBe(false);
+    expect(hasControlCharacter("PUMP-1 online")).toBe(false);
+    expect(hasControlCharacter("Störung — 温度 ⚠")).toBe(false);
+  });
+
+  it("is true for every C0 control character and DEL", () => {
+    expect(hasControlCharacter("a\nb")).toBe(true);
+    expect(hasControlCharacter("a\rb")).toBe(true);
+    expect(hasControlCharacter("a\tb")).toBe(true);
+    expect(hasControlCharacter(`a${NUL}b`)).toBe(true);
+    expect(hasControlCharacter(`a${ESC}b`)).toBe(true);
+    expect(hasControlCharacter(`a${DEL}b`)).toBe(true);
+  });
+});
+
+describe("quoteYamlString", () => {
+  it("escapes the backslash BEFORE anything it adds", () => {
+    // Order matters: escaping quotes first would turn `\` + `"` into `\\"`,
+    // which re-escapes the backslash the second pass just introduced.
+    expect(quoteYamlString('a\\b"c')).toBe('"a\\\\b\\"c"');
+  });
+
+  it("leaves a literal backslash-n distinguishable from a real newline", () => {
+    expect(quoteYamlString("a\\nb")).toBe('"a\\\\nb"');
+    expect(quoteYamlString("a\nb")).toBe('"a\\nb"');
+  });
+
+  it("escapes carriage return, which would otherwise truncate the document", () => {
+    const quoted = quoteYamlString("visible\rhidden");
+    expect(quoted).toBe('"visible\\rhidden"');
+    expect(quoted).not.toContain("\r");
+  });
+
+  it("escapes tab, ANSI escapes, NUL and DEL", () => {
+    expect(quoteYamlString("a\tb")).toBe('"a\\tb"');
+    expect(quoteYamlString(`${ESC}[31m`)).toBe('"\\u001b[31m"');
+    expect(quoteYamlString(`a${NUL}b`)).toBe('"a\\u0000b"');
+    expect(quoteYamlString(`a${DEL}b`)).toBe('"a\\u007fb"');
+  });
+
+  it("passes non-ASCII through unharmed", () => {
+    expect(quoteYamlString("Störung — 温度 ⚠")).toBe('"Störung — 温度 ⚠"');
+  });
+});
+
+describe("formatYaml routes control characters into the quoted branch", () => {
+  it("emits no raw control character for a value carrying one", () => {
+    const yaml = formatYaml({ detail: "refused\rall clear" });
+    expect(yaml).toContain("\\r");
+    expect(yaml.split("\n")).toHaveLength(1);
+  });
+
+  it("still quotes the cases it always did", () => {
+    expect(formatYaml("value: with colon")).toContain('"');
+    expect(formatYaml("true")).toContain('"');
+    expect(formatYaml("123")).toContain('"');
+  });
+
+  it("leaves a plain value unquoted", () => {
+    expect(formatYaml("online")).toBe("online");
+  });
+});

--- a/cli/src/lib/formatter.ts
+++ b/cli/src/lib/formatter.ts
@@ -187,6 +187,51 @@ export function formatJson(data: unknown): string {
   return JSON.stringify(data, null, 2);
 }
 
+/** True if the string carries any C0 control character or DEL. */
+export function hasControlCharacter(value: string): boolean {
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+/**
+ * Render a string as a YAML double-quoted scalar.
+ *
+ * The escaping has to be complete and in this order: `\` first, so the escapes
+ * added after it are not themselves re-escaped, then `"`, then every control
+ * character. A raw control character inside a quoted scalar is invalid YAML — a
+ * carriage return ends the line as far as the parser is concerned, so a value
+ * carrying one truncates the document there and every key after it silently
+ * disappears.
+ *
+ * This matters because `oxscada ... -o yaml` output is piped into other tools.
+ * The values come from API responses, not from the operator typing them.
+ */
+export function quoteYamlString(value: string): string {
+  let escaped = "";
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    if (char === "\\") {
+      escaped += "\\\\";
+    } else if (char === '"') {
+      escaped += '\\"';
+    } else if (code >= 32 && code !== 127) {
+      escaped += char;
+    } else if (char === "\n") {
+      escaped += "\\n";
+    } else if (char === "\r") {
+      escaped += "\\r";
+    } else if (char === "\t") {
+      escaped += "\\t";
+    } else {
+      escaped += `\\u${code.toString(16).padStart(4, "0")}`;
+    }
+  }
+  return `"${escaped}"`;
+}
+
 /**
  * Format data as YAML
  * Simple YAML formatter without external dependencies
@@ -212,13 +257,13 @@ export function formatYaml(data: unknown, indent: number = 0): string {
       data === "" ||
       data.includes(":") ||
       data.includes("#") ||
-      data.includes("\n") ||
+      hasControlCharacter(data) ||
       data.startsWith(" ") ||
       data.endsWith(" ") ||
       /^[\d.]+$/.test(data) ||
       ["true", "false", "null", "yes", "no"].includes(data.toLowerCase())
     ) {
-      return `"${data.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, "\\n")}"`;
+      return quoteYamlString(data);
     }
     return data;
   }

--- a/server/openapi/__tests__/swagger-yaml-escaping.test.ts
+++ b/server/openapi/__tests__/swagger-yaml-escaping.test.ts
@@ -1,0 +1,89 @@
+/**
+ * YAML scalar escaping in the served OpenAPI spec (CodeQL js/incomplete-sanitization #14).
+ *
+ * `jsonToYaml` quoted a value only when it contained `:`, `#`, or started with
+ * `*`, and even then escaped just `\` and `"`. Every other control character
+ * went through raw.
+ *
+ * That matters because the spec is enriched at runtime from gateway
+ * configuration — CORS origins, route descriptions — so the values are not all
+ * authored by hand. A raw carriage return inside a quoted scalar is invalid
+ * YAML: the parser treats it as a line ending, so the document truncates there
+ * and every path after it silently vanishes from the served spec. A consumer
+ * generating a client gets a well-formed document that is missing endpoints.
+ *
+ * `jsonToYaml` is module-private, so these drive it through the public
+ * `registerSwaggerRoutes` surface via the `/openapi.yaml` route.
+ */
+
+import { createServer, type Server } from "node:http";
+import express from "express";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { registerSwaggerRoutes } from "../swagger-ui";
+
+const ESC = String.fromCharCode(27);
+
+let server: Server;
+let baseUrl: string;
+
+/** Fetch the served spec as text. */
+async function servedYaml(): Promise<string> {
+  const res = await fetch(`${baseUrl}/api/docs/openapi.yaml`);
+  return res.text();
+}
+
+beforeAll(async () => {
+  const app = express();
+  registerSwaggerRoutes(app);
+  await new Promise<void>((resolve) => {
+    server = createServer(app);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      baseUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe("the served OpenAPI YAML carries no raw control characters", () => {
+  it("responds with a spec at all", async () => {
+    const yaml = await servedYaml();
+    expect(yaml.length).toBeGreaterThan(0);
+    expect(yaml).toMatch(/openapi:/);
+  });
+
+  it("contains no bare carriage return or C0 control character", async () => {
+    // `\n` is the line separator and is expected; nothing else should appear.
+    const yaml = await servedYaml();
+    const offenders = [...yaml].filter((char) => {
+      const code = char.codePointAt(0) ?? 0;
+      return (code < 32 && char !== "\n") || code === 127;
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it("parses as a sequence of complete lines, none truncated mid-value", async () => {
+    const yaml = await servedYaml();
+    // A truncating control character would leave a line ending inside what
+    // should have been one scalar, producing an unbalanced quote count.
+    for (const line of yaml.split("\n")) {
+      const quotes = (line.match(/(?<!\\)"/g) ?? []).length;
+      expect(quotes % 2).toBe(0);
+    }
+  });
+
+  it("escapes a control character injected through a description", async () => {
+    // Exercised directly rather than through config, so the assertion does not
+    // depend on which gateway options happen to be set in this environment.
+    const { quoteYamlStringForTest } = await import("../swagger-ui");
+    expect(quoteYamlStringForTest("a\rb")).toBe('"a\\rb"');
+    expect(quoteYamlStringForTest(`x${ESC}[0m`)).toBe('"x\\u001b[0m"');
+    expect(quoteYamlStringForTest('a\\b"c')).toBe('"a\\\\b\\"c"');
+  });
+});

--- a/server/openapi/swagger-ui.ts
+++ b/server/openapi/swagger-ui.ts
@@ -169,6 +169,55 @@ export function registerSwaggerRoutes(
   console.log('[OpenAPI] Swagger UI available at /api/docs');
 }
 
+/** True if the string carries any C0 control character or DEL. */
+function hasControlCharacter(value: string): boolean {
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+/**
+ * Render a string as a YAML double-quoted scalar.
+ *
+ * A double-quoted scalar is the only YAML string form that can carry an escape,
+ * and the escaping has to be complete: `\` first (so the escapes added after it
+ * are not themselves re-escaped), then `"`, then every control character. A raw
+ * control character inside a quoted scalar is not merely ugly, it is invalid
+ * YAML — a carriage return ends the line as far as the parser is concerned, so
+ * a value carrying one truncates the document at that point and every key after
+ * it silently disappears from the served spec.
+ *
+ * This spec is enriched at runtime from gateway configuration (CORS origins,
+ * route descriptions), so the values are not all authored by hand.
+ */
+function quoteYamlString(value: string): string {
+  let escaped = '';
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    if (char === '\\') {
+      escaped += '\\\\';
+    } else if (char === '"') {
+      escaped += '\\"';
+    } else if (code >= 32 && code !== 127) {
+      escaped += char;
+    } else if (char === '\n') {
+      escaped += '\\n';
+    } else if (char === '\r') {
+      escaped += '\\r';
+    } else if (char === '\t') {
+      escaped += '\\t';
+    } else {
+      escaped += `\\u${code.toString(16).padStart(4, '0')}`;
+    }
+  }
+  return `"${escaped}"`;
+}
+
+/** Exported for tests only; `quoteYamlString` is an implementation detail. */
+export const quoteYamlStringForTest = quoteYamlString;
+
 /**
  * Simple JSON to YAML converter for OpenAPI spec
  */
@@ -186,8 +235,11 @@ function jsonToYaml(obj: object, indent = 0): string {
         value.split('\n').forEach(line => {
           yaml += `${spaces}  ${line}\n`;
         });
-      } else if (value.includes(':') || value.includes('#') || value.startsWith('*')) {
-        yaml += `${spaces}${key}: "${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"\n`;
+      } else if (
+        value.includes(':') || value.includes('#') || value.startsWith('*')
+        || hasControlCharacter(value)
+      ) {
+        yaml += `${spaces}${key}: ${quoteYamlString(value)}\n`;
       } else {
         yaml += `${spaces}${key}: ${value}\n`;
       }


### PR DESCRIPTION
Closes CodeQL alerts #14 and #24 (`js/incomplete-sanitization`).

## Two serialisers, the same gap

Both hand-rolled YAML writers quoted a value only on `:` / `#` / leading `*`, and escaped only `\` and `"`:

```ts
// server/openapi/swagger-ui.ts
yaml += `${spaces}${key}: "${value.replace(/\/g, '\\').replace(/"/g, '\\"')}"\n`;

// cli/src/lib/formatter.ts — same, plus \n
return `"${data.replace(/\/g, '\\').replace(/"/g, '\\"').replace(/\n/g, "\n")}"`;
```

CodeQL's stated reason — "does not escape backslash characters" — is **wrong**. Both escape `\`, and both do it first, which is the correct order. But the alerts point at a real defect anyway: every control character other than `\n` goes through raw.

## Why a raw `\r` is the bad one

Inside a double-quoted scalar, a carriage return is a line ending as far as the parser is concerned. The document truncates there, and **every key after it silently disappears**. The consumer gets a well-formed YAML document that is missing data — worse than a parse error, because nothing signals the loss.

Neither serialiser's input is authored purely by hand:

- `swagger-ui.ts` enriches the served spec at runtime from gateway configuration — CORS origins, route descriptions
- `oxscada … -o yaml` formats API responses, and that output gets piped into other tools

## The fix

Both now share the same shape: `\` first (so escapes added after it are not themselves re-escaped), then `"`, then every C0 character and DEL. Values carrying a control character are also routed **into** the quoted branch — which is what the old `value.includes('\n')` check only partly did, and what `swagger-ui.ts` did not do at all.

Duplicated rather than shared: `cli/` has its own build and dependency tree, and coupling it to a `server/` import for eleven lines would be a worse trade than the duplication.

## Mutation results

| Mutation | Result |
|---|---|
| `swagger-ui` `quoteYamlString` stops escaping control characters | **1 failed** ✅ |
| `cli` `quoteYamlString` stops escaping control characters | **4 failed** ✅ |
| `cli` stops doubling the backslash | **2 failed** ✅ |

That last one is the ordering guard. The assertion is `'a\b"c'` → `"a\b\"c"`, which fails both if the backslash is not doubled and if quotes are escaped before backslashes.

## On the server-side test

`jsonToYaml` is module-private, so the suite drives it through the real `/openapi.yaml` route on a real socket, and asserts on the **served bytes**: no C0 character other than the line separator, and a balanced (non-`\`-escaped) quote count on every line — which is what a truncating control character would break. A narrow `quoteYamlStringForTest` export covers the escaping table directly.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `cli/__tests__` + `server/openapi` | **808 passed / 23 files** |
| New suites | 10 (cli) + 4 (server) |

One thing I could not check locally: `cli/node_modules` is absent in my worktree, so `cd cli && tsc` fails on a missing `@types/node`. That is pre-existing and unrelated — the root `tsc` covers the server change, and the CLI tests run from the root vitest project, which includes `cli/**`.