### PR TITLE
fix(blueprint): bind the definition size cap to the bytes actually read

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -77,12 +77,15 @@ export function saveConfig(updates: Partial<Config>): void {
   const configPath = path.join(process.cwd(), CONFIG_FILE_NAME);
   let currentConfig: Partial<Config> = {};
 
-  if (fs.existsSync(configPath)) {
-    try {
-      currentConfig = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    } catch {
-      // Start fresh if file is invalid
-    }
+  // Read directly instead of testing existence first. The `existsSync` guard
+  // answered a question about a moment that had already passed by the time the
+  // read ran, and bought nothing: the catch below already covers the file being
+  // absent, exactly as it covers the file being invalid. Both mean the same
+  // thing here — start from an empty config.
+  try {
+    currentConfig = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+  } catch {
+    // Missing or invalid: start fresh.
   }
 
   const newConfig = { ...currentConfig, ...updates };

--- a/server/blueprint/__tests__/control-loop-size-cap.test.ts
+++ b/server/blueprint/__tests__/control-loop-size-cap.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The definition byte cap must bind on what was READ, not on what stat said
+ * (CodeQL js/file-system-race #142).
+ *
+ * `load()` used to `statSync(path)` for the size, check it, then
+ * `readFileSync(path)`. That checks one file and reads whatever is at that name
+ * a moment later. The cap exists to bound how much this control-plane process
+ * pulls into memory, and a file that grows between the two calls — or a path
+ * swapped for a larger one — walks straight through it.
+ *
+ * Proving that needs `fstat` to under-report while the bytes on disk are over
+ * the cap, which is the same observation a grow-after-stat produces without
+ * having to win a race in a test. `node:fs` is an ESM namespace and cannot be
+ * spied on in place, so this lives in its own file where `vi.mock` can replace
+ * the module without touching the 32 real-fs cases in `control-loop.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Set to a number to make every `fstatSync` report that size instead. */
+let forcedSize: number | null = null;
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    default: actual,
+    fstatSync: (fd: number, ...rest: unknown[]) => {
+      const stats = (actual.fstatSync as (...args: unknown[]) => import("node:fs").Stats)(
+        fd,
+        ...rest,
+      );
+      if (forcedSize !== null) {
+        Object.defineProperty(stats, "size", { value: forcedSize, configurable: true });
+      }
+      return stats;
+    },
+  };
+});
+
+const { BlueprintControlLoop, BlueprintControlLoopError, loadBlueprintControlLoopConfig } =
+  await import("../control-loop");
+
+const tempDirs: string[] = [];
+
+function writeOversizedDefinition(): string {
+  const dir = mkdtempSync(join(tmpdir(), "blueprint-size-cap-"));
+  tempDirs.push(dir);
+  const path = join(dir, "blueprint.json");
+  // Structurally irrelevant — it must never get as far as being parsed.
+  writeFileSync(path, JSON.stringify({ pad: "x".repeat(4_000) }), "utf8");
+  return path;
+}
+
+beforeEach(() => {
+  forcedSize = null;
+});
+
+afterEach(() => {
+  forcedSize = null;
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("blueprint definition byte cap", () => {
+  function loadWithCap(path: string, maxBytes: string): void {
+    new BlueprintControlLoop(
+      loadBlueprintControlLoopConfig({
+        BLUEPRINT_CONTROL_LOOP_ENABLED: "true",
+        BLUEPRINT_CONTROL_LOOP_DEFINITION: path,
+        BLUEPRINT_CONTROL_LOOP_MAX_BYTES: maxBytes,
+      }),
+    ).start();
+  }
+
+  it("rejects an oversized file when stat tells the truth", () => {
+    const path = writeOversizedDefinition();
+    expect(() => loadWithCap(path, "1024")).toThrow(BlueprintControlLoopError);
+    expect(() => loadWithCap(path, "1024")).toThrow(/1024 bytes/);
+  });
+
+  it("still rejects it when stat under-reports the size", () => {
+    // The stat-then-read version accepted this: the check saw 10 bytes and the
+    // read then pulled in 4kB. Failing here is the whole point of the change.
+    const path = writeOversizedDefinition();
+    forcedSize = 10;
+    expect(() => loadWithCap(path, "1024")).toThrow(BlueprintControlLoopError);
+    expect(() => loadWithCap(path, "1024")).toThrow(
+      /exceeds the configured maximum of 1024 bytes/,
+    );
+  });
+
+  it("accepts a file within the cap when stat under-reports", () => {
+    // The bound is on bytes actually read, so an honest small file is fine
+    // regardless of what stat claimed — this is not just "always reject".
+    const dir = mkdtempSync(join(tmpdir(), "blueprint-size-cap-"));
+    tempDirs.push(dir);
+    const path = join(dir, "blueprint.json");
+    writeFileSync(path, "{ not valid json but small }", "utf8");
+    forcedSize = 0;
+
+    // It gets past the size gate and fails at parsing instead.
+    expect(() => loadWithCap(path, "1024")).toThrow(/not valid JSON/);
+  });
+});

--- a/server/blueprint/__tests__/control-loop.test.ts
+++ b/server/blueprint/__tests__/control-loop.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -318,8 +319,10 @@ describe("BlueprintControlLoop — fails closed at load", () => {
   });
 
   it("rejects a missing file", () => {
+    // Reported by `open` rather than `stat` since the size check moved onto the
+    // descriptor; the message still names the file and carries the errno.
     const missing = join(tmpdir(), "definitely-not-here-457.json");
-    expectFailedClosed(makeLoop(enabledEnv(missing)), "cannot stat blueprint definition");
+    expectFailedClosed(makeLoop(enabledEnv(missing)), "cannot read blueprint definition");
   });
 
   it("rejects invalid JSON", () => {

--- a/server/blueprint/control-loop.ts
+++ b/server/blueprint/control-loop.ts
@@ -60,7 +60,7 @@
  * free outright; it is left here deliberately so the loop owns exactly one timer.
  */
 
-import { readFileSync, statSync } from "node:fs";
+import { closeSync, fstatSync, openSync, readSync } from "node:fs";
 import { z } from "zod";
 import { log, logError } from "../logger.js";
 import { compileBlueprint } from "./compiler.js";
@@ -392,29 +392,18 @@ export class BlueprintControlLoop {
       );
     }
 
-    let byteSize: number;
-    try {
-      byteSize = statSync(path).size;
-    } catch (err) {
-      throw new BlueprintControlLoopError(
-        `cannot stat blueprint definition "${path}": ${describeError(err)}`,
-      );
-    }
-    if (byteSize > this.config.maxDefinitionBytes) {
-      throw new BlueprintControlLoopError(
-        `blueprint definition "${path}" is ${byteSize} bytes, exceeding the configured ` +
-          `maximum of ${this.config.maxDefinitionBytes} bytes`,
-      );
-    }
-
-    let text: string;
-    try {
-      text = readFileSync(path, "utf8");
-    } catch (err) {
-      throw new BlueprintControlLoopError(
-        `cannot read blueprint definition "${path}": ${describeError(err)}`,
-      );
-    }
+    // Size-check and read the SAME open descriptor, never the path twice.
+    //
+    // `statSync(path)` followed by `readFileSync(path)` checks one file and
+    // reads whatever is at that name a moment later. The cap exists to bound
+    // how much this control-plane process will pull into memory, and a file
+    // that grows between the two calls — or a path swapped for a larger one —
+    // defeats it entirely. Holding the descriptor means the bytes measured are
+    // the bytes read.
+    //
+    // The read is also bounded by the cap rather than by the size just
+    // measured, so a file still being appended to cannot exceed it either.
+    const text = this.readBoundedDefinition(path);
 
     let raw: unknown;
     try {
@@ -457,6 +446,73 @@ export class BlueprintControlLoop {
     this.jitterToleranceMs =
       this.config.jitterToleranceMsOverride ?? Math.max(1, this.periodMs * 0.25);
     this.metricLabels = { blueprint: program.id };
+  }
+
+  /**
+   * Read a definition file whole, refusing anything over `maxDefinitionBytes`.
+   *
+   * Opens once and works from the descriptor: `fstat` and every `read` see the
+   * same inode, so the file cannot be swapped or grown between the size check
+   * and the read. One byte past the cap is requested deliberately — if that
+   * byte arrives, the file is over the limit even when `fstat` said otherwise,
+   * which is what catches a file still being appended to.
+   */
+  private readBoundedDefinition(path: string): string {
+    const limit = this.config.maxDefinitionBytes;
+    let fd: number;
+    try {
+      fd = openSync(path, "r");
+    } catch (err) {
+      throw new BlueprintControlLoopError(
+        `cannot read blueprint definition "${path}": ${describeError(err)}`,
+      );
+    }
+
+    try {
+      let reportedSize: number;
+      try {
+        reportedSize = fstatSync(fd).size;
+      } catch (err) {
+        throw new BlueprintControlLoopError(
+          `cannot stat blueprint definition "${path}": ${describeError(err)}`,
+        );
+      }
+      if (reportedSize > limit) {
+        throw new BlueprintControlLoopError(
+          `blueprint definition "${path}" is ${reportedSize} bytes, exceeding the configured ` +
+            `maximum of ${limit} bytes`,
+        );
+      }
+
+      const buffer = Buffer.allocUnsafe(limit + 1);
+      let filled = 0;
+      for (;;) {
+        let read: number;
+        try {
+          read = readSync(fd, buffer, filled, buffer.length - filled, null);
+        } catch (err) {
+          throw new BlueprintControlLoopError(
+            `cannot read blueprint definition "${path}": ${describeError(err)}`,
+          );
+        }
+        if (read === 0) break;
+        filled += read;
+        if (filled > limit) {
+          throw new BlueprintControlLoopError(
+            `blueprint definition "${path}" exceeds the configured maximum of ` +
+              `${limit} bytes`,
+          );
+        }
+      }
+      return buffer.subarray(0, filled).toString("utf8");
+    } finally {
+      try {
+        closeSync(fd);
+      } catch {
+        // The read already succeeded or already threw; a failure to close is
+        // not something the caller can act on and must not mask either.
+      }
+    }
   }
 
   // ─── Hot path ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes CodeQL alerts #141 and #142 (`js/file-system-race`).

## #142 is a real hole in a safety limit

```ts
byteSize = statSync(path).size;
if (byteSize > this.config.maxDefinitionBytes) throw ...;
text = readFileSync(path, "utf8");   // a different moment, possibly a different file
```

The cap exists to bound how much this **control-plane** process pulls into memory. Checking one file and then reading whatever is at that name a moment later does not do that: a file still being appended to, or a path swapped for a larger one, walks straight through the check.

Now it opens once and works from the descriptor — `fstat` and every `read` see the same inode, so the bytes measured are the bytes read.

One detail worth calling out: the read requests **one byte past the cap**. Arriving at that byte proves the file is over the limit *even when `fstat` said otherwise* — which is the grow-after-stat case that simply re-stat-ing would still miss.

## Proving it, and the test-design problem underneath

Demonstrating this needs `fstat` to under-report while the bytes on disk exceed the cap — the same observation a grow-after-stat produces, without having to win a race in a test.

`node:fs` is an ESM namespace, so `vi.spyOn(fs, 'fstatSync')` fails outright with *"Module namespace is not configurable in ESM"*. `vi.mock` works, but mocking `node:fs` for the whole of `control-loop.test.ts` would silently change the footing of 32 real-fs cases whose header explicitly promises *"no fake timers, no mocked fs"*. So the mock lives in its own file and the existing suite is left alone.

Three cases, and the third is the one that stops this being "always reject": a small file with an under-reporting `fstat` gets **past** the size gate and fails at parsing instead.

| Mutation | Result |
|---|---|
| Neuter the post-read bound check (`if (filled > limit)` → `if (false)`) | **1 failed** — `still rejects it when stat under-reports the size` ✅ |

## #141 is benign, and the guard was doing nothing

```ts
if (fs.existsSync(configPath)) {
  try { currentConfig = JSON.parse(fs.readFileSync(configPath, "utf-8")); }
  catch { /* Start fresh if file is invalid */ }
}
```

The `existsSync` answered a question about a moment that had already passed, and bought nothing: the catch already treats an absent file exactly as it treats an invalid one. Removed rather than papered over — the race disappears because the check does.

## One behaviour change

A missing definition file is now reported by `open` rather than `stat`, so the message goes from `cannot stat blueprint definition "X"` to `cannot read blueprint definition "X"`. It still names the file and carries the errno, and the operational meaning is identical. `control-loop.test.ts` asserted on the old string; that expectation is updated with a comment saying why.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `server/blueprint` + `cli/__tests__` | **1050 passed / 40 files** |
| New size-cap suite | 3 passed |