### PR TITLE
fix(cli): stop the server choosing where blueprint exports are written

### DIFF
--- a/cli/__tests__/safe-path.test.ts
+++ b/cli/__tests__/safe-path.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Path safety for server-supplied export filenames (CodeQL js/http-to-file-access
+ * #144-147).
+ *
+ * `oxscada blueprints export` and `export-all` named their output files after
+ * fields in the API response. Neither `path.join` nor `path.resolve` sanitises
+ * anything, so a hostile or compromised server choosing `blueprint.name` chose
+ * where the CLI wrote — anywhere the operator could write, on what is typically
+ * an engineering workstation.
+ */
+
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+import { resolveWithinDirectory, safeFileName } from "../src/lib/safe-path.js";
+
+const NUL = String.fromCharCode(0);
+
+describe("safeFileName", () => {
+  it("leaves an ordinary name alone", () => {
+    expect(safeFileName("PIDController")).toBe("PIDController");
+    expect(safeFileName("Pump 1 (spare)")).toBe("Pump 1 (spare)");
+  });
+
+  it("flattens every path separator", () => {
+    expect(safeFileName("a/b")).toBe("a_b");
+    expect(safeFileName("a\\b")).toBe("a_b");
+    expect(safeFileName("../../etc/passwd")).toBe("_.._etc_passwd");
+  });
+
+  it("refuses to produce a traversal segment", () => {
+    for (const name of ["..", ".", "...", "./..", "../"]) {
+      const safe = safeFileName(name);
+      expect(safe).not.toBe("..");
+      expect(safe).not.toContain("/");
+      expect(safe).not.toContain("\\");
+    }
+  });
+
+  it("strips a leading dot so the file is not hidden", () => {
+    expect(safeFileName(".bashrc")).toBe("bashrc");
+  });
+
+  it("strips trailing dots and spaces, which Windows drops anyway", () => {
+    // Otherwise "report." and "report" collide and one silently overwrites
+    // the other.
+    expect(safeFileName("report.")).toBe("report");
+    expect(safeFileName("report ")).toBe("report");
+  });
+
+  it("removes control characters", () => {
+    expect(safeFileName(`a${NUL}b`)).toBe("a_b");
+  });
+
+  it("falls back rather than yielding an empty name", () => {
+    expect(safeFileName("")).toBe("unnamed");
+    expect(safeFileName("...")).toBe("unnamed");
+    expect(safeFileName("   ")).toBe("unnamed");
+    expect(safeFileName("", "blueprint")).toBe("blueprint");
+  });
+
+  it("defuses Windows reserved device names", () => {
+    // Opening `CON` or `NUL` talks to a device, not a file.
+    for (const reserved of ["CON", "nul", "COM1", "lpt9", "AUX.yaml"]) {
+      expect(safeFileName(reserved, "bp")).toMatch(/^bp-/);
+    }
+  });
+});
+
+describe("resolveWithinDirectory", () => {
+  const base = path.resolve("exports", "cm-types");
+
+  it("resolves an ordinary name inside the directory", () => {
+    const resolved = resolveWithinDirectory(base, "Valve.yaml");
+    expect(resolved).toBe(path.join(base, "Valve.yaml"));
+  });
+
+  it("contains a traversal attempt instead of escaping", () => {
+    const resolved = resolveWithinDirectory(base, "../../../pwned.yaml");
+    expect(path.dirname(resolved)).toBe(base);
+    expect(resolved.startsWith(base)).toBe(true);
+  });
+
+  it("contains an absolute path, which path.join would have honoured", () => {
+    const resolved = resolveWithinDirectory(base, "/etc/cron.d/backdoor");
+    expect(path.dirname(resolved)).toBe(base);
+  });
+
+  it("contains a Windows absolute path", () => {
+    const resolved = resolveWithinDirectory(base, "C:\\Windows\\System32\\evil.yaml");
+    expect(path.dirname(resolved)).toBe(base);
+  });
+
+  it("never returns the directory itself", () => {
+    // A name reducing to nothing must become a file in the directory, not the
+    // directory — writing to it would fail with EISDIR at best.
+    const resolved = resolveWithinDirectory(base, "..", "fallback");
+    expect(resolved).not.toBe(base);
+    expect(path.dirname(resolved)).toBe(base);
+  });
+});
+
+describe("the pre-fix behaviour these replace", () => {
+  it("path.join did escape the directory", () => {
+    // Documents why the change was needed: this is what the code did before.
+    expect(path.join("exports/cm-types", "../../../pwned.yaml")).toBe(
+      path.join("..", "pwned.yaml"),
+    );
+  });
+
+  it("path.resolve discarded the base entirely for an absolute name", () => {
+    expect(path.resolve("exports", "/etc/passwd")).toBe(path.resolve("/etc/passwd"));
+  });
+});

--- a/cli/src/commands/blueprints.ts
+++ b/cli/src/commands/blueprints.ts
@@ -3,6 +3,7 @@ import ora from "ora";
 import fs from "fs";
 import path from "path";
 import yaml from "js-yaml";
+import { resolveWithinDirectory, safeFileName } from "../lib/safe-path.js";
 import { getApiClient } from "../api.js";
 import {
   output,
@@ -541,10 +542,17 @@ export function registerBlueprintsCommand(program: Command): void {
           return;
         }
 
-        // Determine output file
+        // Determine output file.
+        //
+        // `--output` is the operator's own choice and is honoured as given. The
+        // DEFAULT is named after `blueprint.name`, which came from the server —
+        // so it is reduced to a single inert segment first. `path.resolve` on a
+        // raw `../../.ssh/authorized_keys` would otherwise leave the working
+        // directory entirely.
         const ext = options.format === "json" ? ".json" : ".yaml";
-        const outputFile = options.output || `${blueprint.name}${ext}`;
-        const outputPath = path.resolve(outputFile);
+        const outputPath = options.output
+          ? path.resolve(options.output)
+          : path.resolve(`${safeFileName(blueprint.name, "blueprint")}${ext}`);
 
         // Format and write
         let content: string;
@@ -601,7 +609,7 @@ export function registerBlueprintsCommand(program: Command): void {
             if (!fs.existsSync(cmDir)) fs.mkdirSync(cmDir, { recursive: true });
 
             for (const cm of cmResponse.data) {
-              const filePath = path.join(cmDir, `${cm.name}${ext}`);
+              const filePath = resolveWithinDirectory(cmDir, `${safeFileName(cm.name, "cm-type")}${ext}`);
               const content = options.format === "json"
                 ? JSON.stringify(cm, null, 2)
                 : yaml.dump(cm, { indent: 2 });
@@ -619,7 +627,7 @@ export function registerBlueprintsCommand(program: Command): void {
             if (!fs.existsSync(unitDir)) fs.mkdirSync(unitDir, { recursive: true });
 
             for (const unit of unitResponse.data) {
-              const filePath = path.join(unitDir, `${unit.name}${ext}`);
+              const filePath = resolveWithinDirectory(unitDir, `${safeFileName(unit.name, "unit-type")}${ext}`);
               const content = options.format === "json"
                 ? JSON.stringify(unit, null, 2)
                 : yaml.dump(unit, { indent: 2 });
@@ -637,7 +645,7 @@ export function registerBlueprintsCommand(program: Command): void {
             if (!fs.existsSync(phaseDir)) fs.mkdirSync(phaseDir, { recursive: true });
 
             for (const phase of phaseResponse.data) {
-              const filePath = path.join(phaseDir, `${phase.name}${ext}`);
+              const filePath = resolveWithinDirectory(phaseDir, `${safeFileName(phase.name, "phase-type")}${ext}`);
               const content = options.format === "json"
                 ? JSON.stringify(phase, null, 2)
                 : yaml.dump(phase, { indent: 2 });

--- a/cli/src/lib/safe-path.ts
+++ b/cli/src/lib/safe-path.ts
@@ -1,0 +1,70 @@
+/**
+ * Turning server-supplied names into filenames, safely.
+ *
+ * The export commands name their output files after fields in the API response
+ * — `blueprint.name`, `cm.name`, `unit.name`, `phase.name`. Neither `path.join`
+ * nor `path.resolve` sanitises anything: `path.join("out/cm-types",
+ * "../../../pwned.yaml")` yields `../pwned.yaml`, and `path.resolve` on an
+ * absolute name discards the base directory entirely.
+ *
+ * A CLI writing where the operator asked is fine. A CLI writing where the
+ * SERVER asked is not — the operator running `oxscada blueprints export-all`
+ * on an engineering workstation is not consenting to arbitrary file writes, and
+ * the interesting targets (`~/.ssh/authorized_keys`, shell rc files, a startup
+ * folder) are all reachable with their own permissions.
+ */
+
+import path from "path";
+
+/** Characters that cannot appear in a filename on Windows, plus separators. */
+const UNSAFE_CHARACTERS = /[\u0000-\u001F<>:"/\\|?*]/g;
+
+/**
+ * Reduce an untrusted string to a single, inert path segment.
+ *
+ * Deliberately conservative: this is a filename, not a path, so every separator
+ * is replaced rather than interpreted. Names that reduce to nothing usable —
+ * `..`, `.`, an empty string, a Windows reserved device name — fall back to
+ * `fallback` rather than being silently skipped, so an export never loses an
+ * entry without saying so.
+ */
+export function safeFileName(name: string, fallback = "unnamed"): string {
+  const flattened = name.replace(UNSAFE_CHARACTERS, "_").trim();
+  // Trailing dots and spaces are stripped by Windows, which would let "a. "
+  // and "a" collide; and a leading dot would hide the file on POSIX.
+  const trimmed = flattened.replace(/^\.+/, "").replace(/[. ]+$/, "");
+
+  if (trimmed === "") return fallback;
+  // CON, PRN, AUX, NUL, COM1-9, LPT1-9 — reserved on Windows with or without
+  // an extension, and opening one talks to a device instead of a file.
+  if (/^(con|prn|aux|nul|com\d|lpt\d)$/i.test(trimmed.split(".")[0])) {
+    return `${fallback}-${trimmed}`;
+  }
+  return trimmed;
+}
+
+/**
+ * Join a sanitised filename onto a directory, then prove the result stayed
+ * inside it.
+ *
+ * `safeFileName` alone should be sufficient; the containment check is here
+ * because a path-safety helper that is merely *believed* correct is worth
+ * little. If the two ever disagree, this throws rather than writing.
+ */
+export function resolveWithinDirectory(
+  directory: string,
+  untrustedName: string,
+  fallback?: string,
+): string {
+  const base = path.resolve(directory);
+  const candidate = path.resolve(base, safeFileName(untrustedName, fallback));
+
+  const relative = path.relative(base, candidate);
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(
+      `refusing to write outside "${directory}": server-supplied name "${untrustedName}" ` +
+        `resolved to "${candidate}"`,
+    );
+  }
+  return candidate;
+}


### PR DESCRIPTION
Closes CodeQL alerts #144, #145, #146, #147 (`js/http-to-file-access`).

## This one is a real path traversal

I opened these expecting to dismiss them — a CLI writing a file the operator asked for is the command working, not a vulnerability. Four of the five were not that.

```ts
const outputFile = options.output || `${blueprint.name}${ext}`;   // blueprint.name is from the API
const outputPath = path.resolve(outputFile);

const filePath = path.join(cmDir, `${cm.name}${ext}`);            // so is cm.name
```

Neither function sanitises anything:

```
path.join("exports/cm-types", "../../../pwned.yaml")  ->  ../pwned.yaml
path.resolve("exports", "/etc/passwd")                ->  /etc/passwd
```

So the **server** chose the write path, not the operator. `oxscada blueprints export-all` normally runs on an engineering workstation, where the operator's own permissions reach `~/.ssh/authorized_keys`, shell rc files, and a startup folder. `export-all` makes it worse: one response writes as many files as it has entries.

The distinction that matters is **who names the file**. `--output` is the operator's own choice and is still honoured exactly as given — that path is untouched. Only the server-derived default is sanitised.

## The fix

`safeFileName` reduces an untrusted name to a single inert segment: separators and control characters flattened, leading dots stripped (so the file is not hidden), trailing dots and spaces stripped (Windows drops them anyway, so `report.` and `report` would otherwise collide and one would silently overwrite the other), Windows reserved device names defused (`CON`, `NUL`, `COM1` — opening one talks to a device), and an empty result replaced by a fallback rather than skipped, so an export never quietly loses an entry.

`resolveWithinDirectory` then proves the result stayed inside the target directory.

## Mutation results, including one that did not bind

| Mutation | Result |
|---|---|
| `safeFileName` becomes the identity function | **6 failed** ✅ |
| `resolveWithinDirectory`'s containment check removed | **15 passed** ⚠️ |

The second is worth being explicit about rather than leaving for a reviewer to find. The containment check is **unreachable while `safeFileName` is correct** — sanitisation already prevents the escape, so nothing can drive the throw. No test binds it and none can without reaching inside the module.

I kept it anyway, and the docblock says why: a path-safety helper that is merely *believed* correct is worth little, and this is the assertion that turns a future bug in `safeFileName` into a thrown error instead of a file written outside the directory. But its coverage is genuinely zero, and that is a real gap in this PR rather than something the table papers over.

## Also dismissed in this pass

| Alert | Reason |
|---|---|
| #148 `cli/src/commands/logs.ts` | The path is `options.output` or a `logs-<timestamp>.json` default — no server data in either. |
| #143 `cli/src/api.ts` (`js/file-access-to-http`) | The CLI reads its own config file for the API URL and token, then calls that API. That is what a CLI is. |

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `cli/__tests__` | **809 passed / 22 files** |
| New `safe-path` suite | 15 passed |

The suite also pins the pre-fix behaviour (`path.join` escaping, `path.resolve` discarding the base), so the reason for the helper stays legible if someone later wonders why the plain calls were not good enough.