### PR TITLE
test(liveness): stop demanding an errno the host may not have

### DIFF
--- a/server/blockchain/__tests__/liveness-collector-e2e.test.ts
+++ b/server/blockchain/__tests__/liveness-collector-e2e.test.ts
@@ -236,22 +236,25 @@ describe("observed liveness end-to-end: real socket -> real DB -> real route -> 
     expect(missDetails).toHaveLength(4);
     for (const detail of missDetails) {
       expect(detail.startsWith("no answer:")).toBe(true);
-      // The audited reason is the errno the OS actually reported, not `fetch`'s
-      // opaque "fetch failed". This is the assertion the stubbed suites cannot
-      // make: they inject the very message they then assert on.
-      //
-      // `UND_ERR_*` is explicitly NOT accepted here. Undici wraps the libuv
-      // error in a SocketError whose code is errno-shaped, and surfacing that
-      // instead would satisfy a laxer pattern while telling an auditor nothing
-      // — see `describeFetchFailure`, which walks past it to the real errno.
-      expect(detail).toMatch(/\(E[A-Z0-9_]+\)$/);
-      expect(detail).not.toMatch(/\(UND_/);
+      // The guarantee `describeFetchFailure` actually makes: never `fetch`'s
+      // bare, opaque "fetch failed", always a code an auditor can look up.
+      // This is the assertion the stubbed suites cannot make — they inject the
+      // very message they then assert on.
+      expect(detail).toMatch(/\((E[A-Z0-9_]+|UND_ERR_[A-Z0-9_]+)\)$/);
     }
-    // The rounds that dialled the closed port fresh were refused. (The first
-    // miss can be ECONNRESET instead: the keep-alive socket opened by round 1
-    // is destroyed when the listener closes, and that is an equally real
-    // reason — which is the point of recording the code rather than guessing.)
+
+    // The rounds that dialled the closed port fresh are refused by the OS, and
+    // that is a real errno every time.
+    const withRealErrno = missDetails.filter((d) => /\(E[A-Z0-9_]+\)$/.test(d));
+    expect(withRealErrno.length).toBeGreaterThanOrEqual(3);
     expect(missDetails.some((d) => d.includes("ECONNREFUSED"))).toBe(true);
+
+    // The FIRST miss is the exception, and deliberately not pinned to an errno.
+    // It reuses the keep-alive socket opened by round 1, which `closeAllConnections()`
+    // destroys locally — so on some hosts there is no OS error to report at all
+    // and undici's own `UND_ERR_SOCKET` is the most specific thing that exists.
+    // Demanding an errno there asserted a property of the runner, not of the
+    // code, and failed CI on unrelated PRs.
     expect(rows[5].previousHeight).toBe(rows[0].observedHeight);
 
     // ── Serve it through the real seam and the real route, over real HTTP.


### PR DESCRIPTION
**This corrects my own claim in #656.** That PR said the `UND_ERR_SOCKET` failure was "an intermittent CI failure" that walking past undici's classification would fix. Walking past it was right and I stand by that change — but the diagnosis was incomplete, and CI still fails, because on some hosts **there is no errno underneath to walk to**.

## What actually happens

The test closes the node's listener and then polls it four times. Three of those dial the closed port fresh and are refused by the OS — real `ECONNREFUSED` every time. The **first** one reuses the keep-alive socket opened by round 1, which `closeAllConnections()` destroys *locally*.

There is no OS error in that case. Undici raises its own `SocketError` with nothing beneath it, so `describeFetchFailure` falls back to `UND_ERR_SOCKET` — which is correct behaviour, and the most specific thing that exists.

Locally the chain does carry an errno:

```
depth 0: name=TypeError code=(none)        msg=fetch failed
depth 1: name=Error     code=ECONNREFUSED  msg=connect ECONNREFUSED 127.0.0.1:63967
```

On the GitHub runner it does not. So the blanket assertion over all four misses was testing a property of the **runner**, not of the code — and it has been failing unrelated PRs (#648 earlier, #659 most recently).

## What it asserts now

| Property | Assertion |
|---|---|
| Never `fetch`'s bare opaque message | every miss matches `/\((E[A-Z0-9_]+\|UND_ERR_[A-Z0-9_]+)\)$/` |
| The fresh dials give a real errno | at least 3 of 4 match `/\(E[A-Z0-9_]+\)$/` |
| The refusal is named | some detail contains `ECONNREFUSED` |
| The keep-alive miss | deliberately exempt, with the reason written down |

## It still binds

| Mutation | Result |
|---|---|
| `describeFetchFailure` returns `base` without appending the code | **1 failed** ✅ |

That is the regression worth catching — the audit row falling back to bare `no answer: fetch failed`. Loosening the pattern to accept `UND_ERR_*` does not give that up, because the alternation still requires *some* code.

I originally wrote `expect(detail).not.toMatch(/\(UND_/)` in #656 specifically to stop this being "fixed" by loosening the pattern. That instinct was right in general and wrong here: the case it was guarding against is real, and I had the wrong model of when `UND_ERR_SOCKET` appears.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `server/blockchain` | **98 passed / 5 files** |

This unblocks #659 and any other PR that happens to land on a runner where the keep-alive socket dies without an errno.