### PR TITLE
fix(logger): stop escapeLogMessage throwing inside catch blocks; restore a neutered redaction test

### DIFF
--- a/server/logger.ts
+++ b/server/logger.ts
@@ -36,6 +36,25 @@ const logger = pino({
  * they remain the right place to put an untrusted value.
  */
 export function escapeLogMessage(message: string): string {
+  // Total by construction. The declared type says `string`, but `logError` is
+  // `(error: unknown, message?: string)` and six call sites pass it
+  // message-first with an `as any` on the second argument — so an Error object
+  // arrives here, `for…of` throws "message is not iterable", and the throw
+  // escapes the CATCH BLOCK that was trying to report the original failure.
+  // `FluxCommander.pollAll` died that way and took its ack POST with it.
+  //
+  // pino tolerated the swapped arguments before this escaping existed, which is
+  // why the argument-order bug survived unnoticed. Restoring that tolerance is
+  // the right call regardless of the call sites: on a control-plane surface a
+  // logging helper must never be able to kill a polling loop, and it has no
+  // business being the thing that decides a caller's fate.
+  //
+  // Non-strings are returned untouched rather than coerced — pino formats them
+  // itself, and `String(err)` would flatten an Error to "Error: ..." and lose
+  // the stack that makes it useful.
+  if (typeof message !== 'string') {
+    return message as unknown as string;
+  }
   let escaped = '';
   for (const char of message) {
     const code = char.codePointAt(0) ?? 0;

--- a/server/middleware/__tests__/control-route-policy.test.ts
+++ b/server/middleware/__tests__/control-route-policy.test.ts
@@ -74,7 +74,17 @@ const openServers: Server[] = [];
 async function startApp(logs: string[] = []): Promise<string> {
   const app = express();
   app.use(express.json());
-  app.use(requestLoggingMiddleware((line) => logs.push(line)));
+  // Capture the structured payload as well as the message. The CodeQL
+  // log-injection autofix in #658 moved the request details out of the
+  // formatted message and into pino's structured field — which is the right
+  // place for untrusted values, since pino encodes them — but this sink only
+  // recorded the first argument, so the redaction assertions below were
+  // silently checking a string that no longer contains the response at all.
+  app.use(
+    requestLoggingMiddleware((message, ...args) =>
+      logs.push(args.length > 0 ? `${message} ${JSON.stringify(args)}` : message),
+    ),
+  );
   setupApiGateway(app, {
     enableApiKeyAuth: true,
     apiKeys: new Map(records.map((record) => [record.key, record])),


### PR DESCRIPTION
fix(logger): stop escapeLogMessage throwing inside catch blocks; restore a neutered redaction test

`main` is red. Both failures trace to #658, and one of them had quietly
disabled a security assertion rather than breaking it loudly.

**1. `escapeLogMessage` throws on non-string input.**

```
TypeError: message is not iterable
 ❯ escapeLogMessage server/logger.ts:40
 ❯ logError        server/logger.ts:61
 ❯ FluxCommander.pollAll server/services/flux/flux-commander.ts:62
```

`logError` is `(error: unknown, message?: string)`, and six call sites
pass it message-first:

```ts
logError(`⚡ Flux command poll failed: ${entitySuffix}`, error as any);
```

`error: unknown` swallows the string, and the `as any` suppresses the one
check that would have caught the swap — so an `Error` reaches
`escapeLogMessage`, and `for…of` throws. pino tolerated the reversed
arguments for as long as they have existed, which is why nobody noticed.

Every one of those six sites is a `catch` block, so the throw escapes
*error handling*. `pollAll` died mid-loop and took its failure-ack POST
with it. On a control-plane surface a logging helper must never be able
to kill a polling loop, so the function is now total: non-strings are
returned untouched, restoring pino's prior behaviour. Not coerced —
`String(err)` would flatten an Error to "Error: …" and lose the stack.

The reversed call sites are still wrong and are NOT touched here. That
bug predates #658 and deserves its own commit with the `as any` removed
so the compiler enforces the order.

**2. The redaction test stopped testing redaction.**

The CodeQL log-injection autofix (ada1f74) changed:

```ts
writeLog(formatRequestLog({ … }))            // one formatted line
writeLog("HTTP request completed", { … })    // message + structured field
```

That is the right direction — untrusted values belong in pino's
structured fields, exactly as #658's own docstring argues. But the test
sink was `(line) => logs.push(line)`, capturing only the first argument.
So `logs` became the bare string "HTTP request completed", and

```ts
expect(logs.join("\n")).toContain(SENSITIVE_RESPONSE_LOG_MARKER);
expect(logs.join("\n")).not.toContain(body.key);
```

were asserting against a string that no longer contained the response at
all. The visible symptom was a failing `toContain`; the invisible one is
that `not.toContain(body.key)` — "a returned API key must never appear
in logs" — could no longer fail. The sink now captures the structured
payload too.

Confirmed non-vacuous: deleting the redaction ternary in
`request-logging.ts` now fails the test. Before this change it passed
with the redaction gone.

Local: both suites green, 23/23.
