### PR TITLE
test(gateway): take the connect timer out of the 502-vs-504 race

### DIFF
--- a/gateway/proxy.test.ts
+++ b/gateway/proxy.test.ts
@@ -423,10 +423,25 @@ describe("HTTP proxy", () => {
   });
 
   it("returns generic 502 and 504 responses without exposing the target", async () => {
+    // 502 and 504 are the two outcomes of the SAME upstream failure, chosen by
+    // `handleProxyError`: a `ProxyTimeoutError` becomes 504, anything else 502.
+    // Whichever of the connection error and the connect timer arrives first
+    // decides the status, so `connectMs` here is load-bearing, not decoration
+    // (see #665, where this returned 504 on CI and 502 on a re-run of the same
+    // commit). Both budgets below are sized so the outcome under test wins by a
+    // wide margin; do not tighten them back to ~100ms.
     const unavailable = await reserveUnusedOrigin();
     const disconnected = await startGateway(unavailable, {
       serverUrl: unavailable,
-      timeouts: { connectMs: 100, responseHeadersMs: 200 },
+      // Nothing is listening, so the refusal is immediate and this returns at
+      // once — the large connect budget costs no wall-clock, it only removes
+      // the timer from the race.
+      //
+      // `responseHeadersMs` stays SHORT on purpose. It is unreachable on a
+      // refused connection, so it only matters if the reserved port were
+      // re-bound by a parallel worker before this ran; in that case the test
+      // should fail in 200ms with a clear 504, not hang for the connect budget.
+      timeouts: { connectMs: 10_000, responseHeadersMs: 200 },
     });
     const badGateway = await request(disconnected.origin, "/api/data");
     expect(badGateway.statusCode).toBe(502);
@@ -439,7 +454,12 @@ describe("HTTP proxy", () => {
     const slowOrigin = await listen(slowUpstream);
     const slowGateway = await startGateway(slowOrigin, {
       serverUrl: slowOrigin,
-      timeouts: { connectMs: 100, responseHeadersMs: 75 },
+      // The connect budget is generous for the same reason, but inverted: the
+      // socket IS listening, so connect succeeds and only the headers timeout
+      // can fire. That pins this 504 to the response-headers timeout rather
+      // than letting a slow connect produce the right status for the wrong
+      // reason — which would leave the headers path untested.
+      timeouts: { connectMs: 10_000, responseHeadersMs: 75 },
     });
     const timeout = await request(slowGateway.origin, "/api/slow");
     expect(timeout.statusCode).toBe(504);


### PR DESCRIPTION
Closes #665.

## The race

`handleProxyError` picks the status from the error type: a `ProxyTimeoutError` becomes **504**, anything else **502**. The 502 case pointed the gateway at a port nothing was listening on, but gave the connect timer only 100ms — so the status depended on whether `ECONNREFUSED` was delivered before that timer fired.

`connectMs` is now 10s in both halves:

- **502 case** — nothing is listening, so the refusal is immediate and the budget is never consumed. The suite still runs in ~1.3s.
- **504 case** — the socket *is* listening, so a large connect budget pins that 504 to the **response-headers** timeout rather than letting a slow connect produce the right status for the wrong reason. That half was previously proving less than it looked like it proved.

`responseHeadersMs` deliberately stays at **200ms** in the 502 case. It is unreachable on a refused connection, so it only matters if the reserved port were re-bound by a parallel worker — and then the test should fail fast and visibly rather than hang for the connect budget. My first draft raised it to 10s; that would have turned a rare failure into a rare 10-second hang.

## I could not reproduce it, and here is what I ruled out

Stating this plainly because the fix is hardening against a mechanism I could not demonstrate, not a confirmed root cause.

| Hypothesis | Experiment | Result |
|---|---|---|
| Connect timer beats the refusal | Set `connectMs: 1` and run the suite | **502** — still passed |
| libuv runs timers before poll, so a blocked loop lets an expired timer win | Standalone repro: arm a 100ms timer, block the loop 2s, then let `ECONNREFUSED` land | **502** every time, at 100ms/2s and 10s/2s |
| Ephemeral port reuse — a parallel worker grabs the reserved port, so the connection succeeds and the headers timeout gives 504 | 200 reserve-then-rebind rounds | **0 collisions** |

So the reported flip is real (same SHA, two verdicts, per the issue) but its mechanism is unconfirmed. What this change does is remove the one timing dependency I could identify in the 502 path, and it cannot make the observed failure more likely.

If it recurs, the useful thing to capture is the **response body** — `Bad gateway` vs `Gateway timeout` distinguishes an error-classification problem from a genuine timeout, which the status code alone does not.

## What I did not do

Assert the class — `expect([502, 504]).toContain(res.status)`. The issue argues against it and is right: 502 and 504 mean different things to an operator, and a test that accepts either stops testing the distinction it exists to cover.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `gateway/proxy.test.ts` × 3 consecutive runs | **15 passed** each, ~1.3s |