### PR TITLE
feat(observability): show the blueprint scan loop on the control-loop dashboard

### DIFF
--- a/ops/alertmanager/control-loop-rules.yml
+++ b/ops/alertmanager/control-loop-rules.yml
@@ -239,3 +239,63 @@ groups:
             has exceeded 120s at P95. Note this interval includes the pipeline's
             batching window, so compare it against windowSizeMs/flushIntervalMs
             before treating it as a chain problem.
+
+      # ── Blueprint control loop ────────────────────────────────────────────
+      #
+      # These cover the scan loop itself, which is a DIFFERENT subsystem from
+      # the anchor pipeline above. It does not feed the pipeline, so it has no
+      # stage in the tick -> batch -> sign -> anchor -> confirm chain and never
+      # will; anchoring every scan would be absurd volume. Its own metrics are
+      # the platform's actual "tick" measurement, and until now nothing
+      # displayed or alerted on them.
+      #
+      # Every rule is gated on blueprint_control_loop_running == 1. The loop is
+      # opt-in (BLUEPRINT_CONTROL_LOOP_ENABLED), and a deployment that does not
+      # run it must not page.
+
+      - alert: BlueprintControlLoopOverrunning
+        expr: |
+          rate(blueprint_control_loop_overruns_total[5m]) > 0
+          and on(blueprint) blueprint_control_loop_running == 1
+        for: 5m
+        labels:
+          severity: critical
+          area: integrity-pipeline
+        annotations:
+          summary: "Blueprint control-loop scans exceed their scan period"
+          description: >-
+            A scan took longer to execute than the configured period, so the
+            loop cannot hold its cadence regardless of scheduling. This is the
+            more serious of the two timing faults: unlike a missed deadline it
+            is not a scheduling delay, it is the work itself not fitting.
+
+      - alert: BlueprintControlLoopMissingDeadlines
+        expr: |
+          rate(blueprint_control_loop_missed_deadlines_total[5m]) > 0
+          and on(blueprint) blueprint_control_loop_running == 1
+        for: 15m
+        labels:
+          severity: warning
+          area: integrity-pipeline
+        annotations:
+          summary: "Blueprint control-loop scans are being delivered late"
+          description: >-
+            Scans arrived later than period + jitter tolerance. Sustained misses
+            with no overruns point at event-loop contention from other work on
+            this process rather than at the blueprint program.
+
+      - alert: BlueprintControlLoopStopped
+        expr: |
+          blueprint_control_loop_enabled == 1
+          and on() blueprint_control_loop_running == 0
+        for: 2m
+        labels:
+          severity: critical
+          area: integrity-pipeline
+        annotations:
+          summary: "Blueprint control loop is enabled but not running"
+          description: >-
+            Configuration asks for the loop but no scan timer is armed — it
+            failed to load, or was stopped and not restarted. Check
+            blueprint_control_loop_load_failures_total. Absence of scans is
+            silent otherwise, which is what this rule exists to prevent.

--- a/ops/grafana/control-loop-latency.json
+++ b/ops/grafana/control-loop-latency.json
@@ -37,7 +37,12 @@
         "title": "Round-Trip P95 (batch -> confirmed)",
         "type": "stat",
         "description": "End-to-end scada_control_loop_roundtrip_latency_seconds. Only confirmed batches contribute; a batch that never confirms is counted in the outcome panel instead.",
-        "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 0,
+          "y": 0
+        },
         "targets": [
           {
             "expr": "histogram_quantile(0.95, sum by (le) (rate(scada_control_loop_roundtrip_latency_seconds_bucket{source=~\"$source\"}[5m])))",
@@ -49,9 +54,18 @@
             "unit": "s",
             "thresholds": {
               "steps": [
-                { "color": "green", "value": null },
-                { "color": "yellow", "value": 15 },
-                { "color": "red", "value": 30.5 }
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 15
+                },
+                {
+                  "color": "red",
+                  "value": 30.5
+                }
               ]
             }
           }
@@ -62,7 +76,12 @@
         "title": "Stages In SLO",
         "type": "stat",
         "description": "min of scada_control_loop_stage_slo_ok — 0 means at least one stage's last measurement breached its budget.",
-        "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 6,
+          "y": 0
+        },
         "targets": [
           {
             "expr": "min(scada_control_loop_stage_slo_ok{source=~\"$source\"})",
@@ -74,8 +93,14 @@
             "unit": "bool_on_off",
             "thresholds": {
               "steps": [
-                { "color": "red", "value": null },
-                { "color": "green", "value": 1 }
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
               ]
             }
           }
@@ -86,21 +111,35 @@
         "title": "Confirmed Anchors / s",
         "type": "stat",
         "description": "Rate of batches whose trace closed as confirmed (scada_control_loop_cycles_total).",
-        "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 12,
+          "y": 0
+        },
         "targets": [
           {
             "expr": "sum(rate(scada_control_loop_cycles_total{source=~\"$source\",outcome=\"confirmed\"}[5m]))",
             "legendFormat": "confirmed/s"
           }
         ],
-        "fieldConfig": { "defaults": { "unit": "ops" } }
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ops"
+          }
+        }
       },
       {
         "id": 4,
         "title": "Sentinel Probe Up",
         "type": "stat",
         "description": "scada_control_loop_probe_up. Published as 0 whenever the opt-in sentinel probe (CONTROL_LOOP_LATENCY_PROBE=true) is not running, so 'no probe' is visible rather than absent. This is the series the ControlLoopProbeDown alert fires on.",
-        "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 18,
+          "y": 0
+        },
         "targets": [
           {
             "expr": "scada_control_loop_probe_up",
@@ -112,8 +151,14 @@
             "unit": "bool_on_off",
             "thresholds": {
               "steps": [
-                { "color": "red", "value": null },
-                { "color": "green", "value": 1 }
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
               ]
             }
           }
@@ -123,7 +168,12 @@
         "id": 5,
         "title": "Per-Stage Latency P95 (batch / sign / anchor-enqueue / confirm)",
         "type": "timeseries",
-        "gridPos": { "h": 9, "w": 12, "x": 0, "y": 4 },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 4
+        },
         "targets": [
           {
             "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(scada_control_loop_stage_latency_seconds_bucket{source=~\"$source\"}[5m])))",
@@ -133,7 +183,10 @@
         "fieldConfig": {
           "defaults": {
             "unit": "s",
-            "custom": { "lineWidth": 2, "fillOpacity": 10 }
+            "custom": {
+              "lineWidth": 2,
+              "fillOpacity": 10
+            }
           }
         }
       },
@@ -141,7 +194,12 @@
         "id": 6,
         "title": "Per-Stage Latency P50 vs P99",
         "type": "timeseries",
-        "gridPos": { "h": 9, "w": 12, "x": 12, "y": 4 },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 4
+        },
         "targets": [
           {
             "expr": "histogram_quantile(0.50, sum by (le, stage) (rate(scada_control_loop_stage_latency_seconds_bucket{source=~\"$source\"}[5m])))",
@@ -155,7 +213,10 @@
         "fieldConfig": {
           "defaults": {
             "unit": "s",
-            "custom": { "lineWidth": 1, "fillOpacity": 5 }
+            "custom": {
+              "lineWidth": 1,
+              "fillOpacity": 5
+            }
           }
         }
       },
@@ -164,7 +225,12 @@
         "title": "Stage SLO Compliance (1=ok, 0=breach)",
         "type": "state-timeline",
         "description": "Drives the ControlLoopStageBudgetBreached alert (== 0 for 5m).",
-        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 13
+        },
         "targets": [
           {
             "expr": "scada_control_loop_stage_slo_ok{source=~\"$source\"}",
@@ -176,8 +242,14 @@
             "unit": "bool_on_off",
             "thresholds": {
               "steps": [
-                { "color": "red", "value": null },
-                { "color": "green", "value": 1 }
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
               ]
             }
           }
@@ -187,7 +259,12 @@
         "id": 8,
         "title": "Round-Trip Latency Heatmap",
         "type": "heatmap",
-        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 13
+        },
         "targets": [
           {
             "expr": "sum by (le) (rate(scada_control_loop_roundtrip_latency_seconds_bucket{source=~\"$source\"}[5m]))",
@@ -195,14 +272,23 @@
             "format": "heatmap"
           }
         ],
-        "fieldConfig": { "defaults": { "unit": "s" } }
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s"
+          }
+        }
       },
       {
         "id": 9,
         "title": "Trace Outcomes / s",
         "type": "timeseries",
         "description": "confirmed / failed / unconfirmed. A batch that fails or is never confirmed has no round-trip measurement at all, so this panel is the only place it is visible.",
-        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 21
+        },
         "targets": [
           {
             "expr": "sum by (outcome) (rate(scada_control_loop_cycles_total{source=~\"$source\"}[5m]))",
@@ -212,7 +298,10 @@
         "fieldConfig": {
           "defaults": {
             "unit": "ops",
-            "custom": { "lineWidth": 2, "fillOpacity": 10 }
+            "custom": {
+              "lineWidth": 2,
+              "fillOpacity": 10
+            }
           }
         }
       },
@@ -221,7 +310,12 @@
         "title": "Sentinel Round-Trip P95 — requires the opt-in probe",
         "type": "timeseries",
         "description": "EMPTY UNLESS THE SENTINEL PROBE IS ENABLED (CONTROL_LOOP_LATENCY_PROBE=true). Flip-to-confirmation of the batch carrying a sentinel tag flip. Includes the pipeline's batching window, which normally dominates it. Check the 'Sentinel Probe Up' panel before reading this one.",
-        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 21
+        },
         "targets": [
           {
             "expr": "histogram_quantile(0.95, sum by (le) (rate(scada_control_loop_sentinel_roundtrip_seconds_bucket[15m])))",
@@ -235,7 +329,10 @@
         "fieldConfig": {
           "defaults": {
             "unit": "s",
-            "custom": { "lineWidth": 1, "fillOpacity": 5 }
+            "custom": {
+              "lineWidth": 1,
+              "fillOpacity": 5
+            }
           }
         }
       },
@@ -243,10 +340,92 @@
         "id": 11,
         "title": "Coverage & caveats",
         "type": "text",
-        "gridPos": { "h": 6, "w": 24, "x": 0, "y": 29 },
+        "gridPos": {
+          "h": 6,
+          "w": 24,
+          "x": 0,
+          "y": 29
+        },
         "options": {
           "mode": "markdown",
           "content": "**What produces these numbers.** `AnchorPipeline` (server/integrity/anchor-pipeline.ts) times its own seams on every batch it anchors: Merkle build (`batch`), HSM/software signature (`sign`), the hand-off into the relayer's submission queue (`anchor`), and the wait for the relayer's per-batch confirmation event (`confirm`). Nothing here is synthesised.\n\n**`anchor` is the enqueue, not the transaction.** `submitAnchor` coalesces the request and kicks the relayer's queue without awaiting it, so signature verification, gas estimation and the transaction itself are asynchronous and are accounted to `confirm` (~1ms vs seconds). A breach of the `anchor` budget means the server's event loop is stalled, not that the chain is slow.\n\n**Not measured: `tick`.** The original issue described a field-I/O -> control-loop `tick` stage ahead of `batch`. No control loop feeds the anchor pipeline on this branch, so there is nothing to time and no panel claims to show it. Add the stage to `STAGE_SLO_MS`/`PIPELINE_STAGES`, this dashboard, and the alert rules together once a real loop exists.\n\n**Sentinel panels need the opt-in probe.** `scada_control_loop_sentinel_roundtrip_seconds` and `scada_control_loop_probe_flips_total` only exist when `CONTROL_LOOP_LATENCY_PROBE=true` on an `ANCHOR_BACKEND=l2`/`both` node. `scada_control_loop_probe_up` always exists and reads 0 when the probe is off.\n\n**Unconfirmed batches have no round-trip.** They appear only in *Trace Outcomes*, never as a latency value."
+        }
+      },
+      {
+        "id": 12,
+        "title": "Blueprint Scan Latency (the actual control loop)",
+        "type": "timeseries",
+        "description": "The blueprint control loop's own scan duration. This is NOT a stage of the anchor pipeline — the loop does not feed it, and anchoring every scan would be absurd volume. It is published by server/blueprint/control-loop.ts whenever the loop is running, and is the closest thing to a \"tick\" measurement the platform has. Empty unless BLUEPRINT_CONTROL_LOOP_ENABLED=true.",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 35
+        },
+        "targets": [
+          {
+            "expr": "blueprint_control_loop_tick_p50_ms",
+            "legendFormat": "p50 {{blueprint}}"
+          },
+          {
+            "expr": "blueprint_control_loop_tick_p99_ms",
+            "legendFormat": "p99 {{blueprint}}"
+          },
+          {
+            "expr": "blueprint_control_loop_tick_max_ms",
+            "legendFormat": "max {{blueprint}}"
+          },
+          {
+            "expr": "blueprint_control_loop_scan_period_ms",
+            "legendFormat": "period {{blueprint}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ms",
+            "custom": {
+              "lineWidth": 1,
+              "fillOpacity": 5
+            }
+          }
+        }
+      },
+      {
+        "id": 13,
+        "title": "Blueprint Scan Health — missed deadlines & overruns",
+        "type": "timeseries",
+        "description": "A missed deadline means the scan was DELIVERED late (period + jitter tolerance exceeded); an overrun means the scan itself took longer than the period. Sustained overruns are the more serious of the two: the loop cannot keep its cadence regardless of scheduling.",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 35
+        },
+        "targets": [
+          {
+            "expr": "rate(blueprint_control_loop_missed_deadlines_total[5m])",
+            "legendFormat": "missed deadlines/s {{blueprint}}"
+          },
+          {
+            "expr": "rate(blueprint_control_loop_overruns_total[5m])",
+            "legendFormat": "overruns/s {{blueprint}}"
+          },
+          {
+            "expr": "blueprint_control_loop_running",
+            "legendFormat": "running {{blueprint}}"
+          },
+          {
+            "expr": "blueprint_control_loop_enabled",
+            "legendFormat": "enabled"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "lineWidth": 1,
+              "fillOpacity": 5
+            }
+          }
         }
       }
     ]

--- a/server/integrity/__tests__/control-loop-observability.test.ts
+++ b/server/integrity/__tests__/control-loop-observability.test.ts
@@ -194,6 +194,55 @@ describe('control-loop observability config matches what is produced (#460)', ()
     }
   });
 
+  it('every published control-loop metric is visible somewhere in ops', () => {
+    // The MIRROR of the two tests above. Those catch a dashboard naming a
+    // metric nobody emits; this catches a metric nobody displays.
+    //
+    // Both are silent failures and the second is the sneakier one: the loop
+    // publishes p50/p99/max, missed deadlines and overruns on every scan, and
+    // for as long as no panel or rule named them, an operator watching the
+    // "control-loop latency" dashboard saw the ANCHORING stages and nothing
+    // about the scan loop itself. Nothing was broken, so nothing complained.
+    const published = [
+      'blueprint_control_loop_enabled',
+      'blueprint_control_loop_running',
+      'blueprint_control_loop_tick_p50_ms',
+      'blueprint_control_loop_tick_p99_ms',
+      'blueprint_control_loop_tick_max_ms',
+      'blueprint_control_loop_scan_period_ms',
+      'blueprint_control_loop_missed_deadlines_total',
+      'blueprint_control_loop_overruns_total',
+    ];
+
+    const ops = `${rulesText}
+${dashboardText}`;
+    const invisible = published.filter((metric) => !ops.includes(metric));
+    expect(invisible, 'published but named by no panel and no alert rule').toEqual([]);
+  });
+
+  it('the blueprint-loop alerts exist and cannot page a deployment that is not running it', () => {
+    // The loop is opt-in (BLUEPRINT_CONTROL_LOOP_ENABLED). Every rule about it
+    // must therefore be gated on it actually running, or every deployment that
+    // does not use blueprints pages forever and the alerts get muted — which
+    // is how a real overrun would then go unseen.
+    const parsed = yaml.load(rulesText) as PromRuleFile;
+    const byName = new Map(parsed.groups[0].rules.map((r) => [r.alert, r]));
+
+    for (const name of ['BlueprintControlLoopOverrunning', 'BlueprintControlLoopMissingDeadlines']) {
+      const rule = byName.get(name);
+      expect(rule, `${name} is missing`).toBeDefined();
+      expect(rule!.expr, `${name} is not gated on the loop running`)
+        .toContain('blueprint_control_loop_running == 1');
+    }
+
+    // The stopped alert is the inverse and must NOT require running == 1;
+    // its whole purpose is firing when enabled and running disagree.
+    const stopped = byName.get('BlueprintControlLoopStopped');
+    expect(stopped).toBeDefined();
+    expect(stopped!.expr).toContain('blueprint_control_loop_enabled == 1');
+    expect(stopped!.expr).toContain('blueprint_control_loop_running == 0');
+  });
+
   it('neither the rules nor the dashboard reference the unmeasurable tick stage', () => {
     expect(rulesText).not.toContain('stage="tick"');
     expect(dashboardText).not.toContain('stage=\\"tick\\"');


### PR DESCRIPTION
Closes #668, but **not** in the shape that issue described. I wrote #668 myself yesterday and it was wrong; the investigation behind this PR is why.

## What #668 assumed, and why it was mis-specified

#460's acceptance criteria ask for a `tick` stage in the chain `tick -> batch -> sign -> anchor -> confirm`. `stage-timestamps.ts` records that it cannot be measured because the control loop does not feed the anchor pipeline, and I filed #668 to add it once #457 wired them together.

Two things turned out to be wrong with that.

**1. #457 is closed, and the wiring still does not exist.** I checked rather than assuming — the only non-test, non-probe caller of `ingestEvent` is `dispatchAnchorAuditEvent`, which handles anchor-*routing* audit events. Nothing from `BlueprintRuntime`'s scan reaches the pipeline.

**2. It should never exist.** The loop scans on a 5ms period. Feeding every tick into a pipeline that batches, Merkle-roots, HSM-signs and anchors on-chain is not a wiring gap, it is an absurd volume. `tick` was never a stage of that chain; it belongs to a different subsystem that happens to share the phrase "control loop".

## The actual defect

The loop already measures itself, and has all along:

```
blueprint_control_loop_tick_p50_ms / _p99_ms / _max_ms
blueprint_control_loop_last_tick_duration_ms
blueprint_control_loop_scan_period_ms
blueprint_control_loop_missed_deadlines_total
blueprint_control_loop_overruns_total
```

**Not one of them was named by any Grafana panel or any alert rule.** `grep -c blueprint_control_loop ops/` returned 0 for both files.

That is richer than the single histogram #460 asked for — p50/p99/max plus deadline misses and overruns — and an operator opening the "control-loop latency" dashboard saw the anchoring stages and nothing about the loop that actually runs the plant.

It is the exact inverse of the defect #460 was raised for, and the worse half. A dashboard naming a metric nobody emits shows an empty panel — visible. A metric nobody displays looks like nothing is wrong.

## What landed

Two panels (scan latency; deadline misses and overruns) and three alerts.

Every alert about the loop is gated on `blueprint_control_loop_running == 1`, because the loop is opt-in. An ungated rule would page every deployment that does not use blueprints until somebody muted it — and a muted alert is how a real overrun then goes unseen. `BlueprintControlLoopStopped` is deliberately **not** gated that way: it exists precisely to fire when `enabled` and `running` disagree.

The overrun/missed-deadline distinction is in the annotations, because it decides who gets called: an overrun means the scan itself does not fit in the period (the program), a missed deadline means it was delivered late (the host).

## Guards, and the one that did not bind at first

Both new tests are mirrors of the existing dashboards-vs-reality guard.

| Mutation | Result |
|---|---|
| Remove panels 12 and 13 | **1 failed** ✅ |
| Remove the three alert rules | **1 failed** ✅ |
| Drop `running == 1` from the overrun alert | **1 failed** ✅ |

My first version of the visibility guard passed the middle one. It asserts a metric is named *somewhere* in ops, and the dashboard alone satisfied that — so deleting every alert rule was invisible to it. Rather than over-constrain it into requiring both (not every metric needs an alert), I added a second test that pins the three rules and their gating specifically. The mutation results above are after that fix.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `server/integrity` + `server/blueprint` | **28 files passed, 1 skipped** |
| Observability suite | 8 passed (was 6) |

The dashboard JSON and rules YAML are both parsed by the suite, so a malformed edit fails rather than shipping.