### PR TITLE
docs(opcua): re-point three TODOs away from the now-closed #461

### DIFF
--- a/server/protocols/opcua-server/address-space.ts
+++ b/server/protocols/opcua-server/address-space.ts
@@ -41,7 +41,7 @@ export const OBJECTS_FOLDER_NODE_ID = "ns=0;i=85";
  * everything else (object/array) falls back to BaseDataType (Variant) since
  * this scaffold does not yet synthesise UA structured types for them.
  *
- * TODO(#461): map `array` to a one-dimensional UA array (valueRank 1) and
+ * Tracked in #670: map `array` to a one-dimensional UA array (valueRank 1) and
  * synthesise UA ExtensionObject DataTypes for structured `object` tags.
  */
 export function mapDataType(dataType: DataType): UaDataType {

--- a/server/protocols/opcua-server/index.ts
+++ b/server/protocols/opcua-server/index.ts
@@ -472,7 +472,9 @@ function uaTypeToNodeOpcuaDataType(
       return DataType.String;
     default:
       // Object/array tags are exposed as their JSON encoding until proper UA
-      // structured types are synthesised. TODO(#461).
+      // structured types are synthesised (#670). Honest as far as it goes — the
+      // declared type is String and the value really is a string — but a
+      // conformant client will not know to parse it.
       return DataType.String;
   }
 }

--- a/server/protocols/opcua-server/runtime.ts
+++ b/server/protocols/opcua-server/runtime.ts
@@ -72,8 +72,11 @@ export async function loadSitesFromStorage(): Promise<SourceSite[]> {
  * stored a string for that tag (`string_value`) or only numerics (`value`).
  *
  * Tags are exposed read-only: 0xSCADA has no audited UA write path yet, so the
- * server must not advertise one. TODO(#461): add UA writes behind the
- * control-plane authorisation used for other actuating routes.
+ * server must not advertise one. Read-only is the intended shipped behaviour,
+ * not a placeholder — #461 asked for an address space, and that is what this
+ * is. Writes are tracked separately in #667, because a UA client setting a tag
+ * is a control action and needs scope authorisation and an audit record before
+ * it can be offered at all.
  */
 export async function loadTagCatalogueFromStorage(): Promise<SourceTag[]> {
   const rows = await typedDatabase()


### PR DESCRIPTION
Comments only. No behaviour change.

#461 closed on the strength of #612, but three comments still carried `TODO(#461)` for work that issue never asked for. Anyone following one of them lands on a closed issue and hunts for a requirement that was never in it.

| File | Was | Now |
|---|---|---|
| `runtime.ts` | `TODO(#461): add UA writes` | read-only stated as the intended shipped behaviour, writes tracked in #667 |
| `address-space.ts` | `TODO(#461): map array to valueRank 1` | `Tracked in #670` |
| `index.ts` | `structured types are synthesised. TODO(#461).` | `(#670)`, plus what the limitation actually costs |

The `runtime.ts` one mattered most. `writable: false` read as an unfinished placeholder; it is the correct shipped default. #461 asked for an address space — a read surface — and that is what it is. A UA client setting a tag is a **control action** and needs scope authorisation and an audit record before it can be offered at all, which is why #667 exists rather than a TODO.

On `index.ts` I also said what the JSON-string fallback costs, since "until proper UA structured types are synthesised" reads as harmless:

```ts
// Object/array tags are exposed as their JSON encoding until proper UA
// structured types are synthesised (#670). Honest as far as it goes — the
// declared type is String and the value really is a string — but a
// conformant client will not know to parse it.
```

Nothing is lying about its type, but a third-party HMI browsing the address space sees a String node and treats it as text. Worth a reader knowing without opening the issue.

## Left alone deliberately

The other `#461` references — `"Implements the address-space acceptance criterion of #461"`, `"SAFETY POSTURE (#461)"` — are **provenance**, not action items. Citing a closed issue as the origin of a design is correct and I did not touch them.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `server/protocols/opcua-server` | **129 passed / 7 files** |
| `grep -rn "TODO(#461)"` | no matches |