### PR TITLE
fix(sre): stop an unstated dryRun executing a live remediation

### DIFF
--- a/server/services/sre/__tests__/sre.test.ts
+++ b/server/services/sre/__tests__/sre.test.ts
@@ -92,10 +92,80 @@ describe('AutoRemediationEngine', () => {
       actionId: 'scale-out',
       context,
       idempotencyKey: 'scale-gateway-apply-1',
+      dryRun: false,
     });
     expect(result).toMatchObject({ status: 'succeeded', changed: true, verified: true });
     expect(setReplicas).toHaveBeenCalledTimes(1);
     expect(replicas).toBe(4);
+  });
+
+  it('refuses to execute when dryRun is not stated', async () => {
+    // The gate on the mutating path is `if (request.dryRun)`, so while the
+    // field was optional an omitted one was `undefined` — falsy — and the
+    // remediation RAN. Only the HTTP route defaulted it to true; this service
+    // is exported and called directly, so a second caller got a live
+    // infrastructure change by saying nothing at all.
+    //
+    // `dryRun` is now required, so the compiler stops that at the call site.
+    // This asserts the runtime half, for a caller reaching the engine from
+    // untyped JS or through a cast: an absent flag must never read as execute.
+    let replicas = 2;
+    const setReplicas = vi.fn(async (_component: string, desired: number) => {
+      replicas = desired;
+    });
+    const action = createScaleOutAction({
+      currentReplicas: async () => replicas,
+      setReplicas,
+      readyReplicas: async () => replicas,
+    });
+    const engine = new AutoRemediationEngine([action], { cooldownMs: 0 }, { now });
+    const context = { component: 'gateway', desiredReplicas: 4, maximumReplicas: 6 };
+
+    const omitted = { actionId: 'scale-out', context, idempotencyKey: 'no-dry-run-stated' };
+    const result = await engine.execute(
+      omitted as unknown as Parameters<typeof engine.execute>[0],
+    );
+
+    expect(setReplicas, 'an unstated dryRun performed a live scale').not.toHaveBeenCalled();
+    expect(replicas).toBe(2);
+    expect(result.changed).toBe(false);
+    expect(result.status).not.toBe('succeeded');
+  });
+
+  it('fingerprints an unstated dryRun the same as an explicit dry run', async () => {
+    // `dryRun` is part of the idempotency fingerprint. It must be hashed as the
+    // RESOLVED boolean, not the raw field: an absent flag and an explicit
+    // `true` both plan, so hashing them differently makes two identical
+    // requests look like a key reused for different work, and the second one
+    // throws instead of returning the first's result.
+    let replicas = 2;
+    const setReplicas = vi.fn(async (_component: string, desired: number) => {
+      replicas = desired;
+    });
+    const action = createScaleOutAction({
+      currentReplicas: async () => replicas,
+      setReplicas,
+      readyReplicas: async () => replicas,
+    });
+    const engine = new AutoRemediationEngine([action], { cooldownMs: 0 }, { now });
+    const context = { component: 'gateway', desiredReplicas: 4, maximumReplicas: 6 };
+    const key = 'same-key-absent-then-explicit';
+
+    const omitted = { actionId: 'scale-out', context, idempotencyKey: key };
+    const first = await engine.execute(
+      omitted as unknown as Parameters<typeof engine.execute>[0],
+    );
+    const second = await engine.execute({
+      actionId: 'scale-out',
+      context,
+      idempotencyKey: key,
+      dryRun: true,
+    });
+
+    expect(first.status).toBe('planned');
+    expect(second.status).toBe('planned');
+    expect(second.reused, 'the second call was treated as different work').toBe(true);
+    expect(setReplicas).not.toHaveBeenCalled();
   });
 
   it('reuses idempotent results and rejects key collisions', async () => {
@@ -110,6 +180,7 @@ describe('AutoRemediationEngine', () => {
       actionId: 'scale-out',
       context: { component: 'api', desiredReplicas: 2, maximumReplicas: 4 },
       idempotencyKey: 'incident-123-scale',
+      dryRun: false,
     };
 
     const first = await engine.execute(request);
@@ -137,6 +208,7 @@ describe('AutoRemediationEngine', () => {
       actionId: 'gateway-failover',
       context: { gatewayId: 'gw-1' },
       idempotencyKey: 'incident-456-failover',
+      dryRun: false,
     });
     expect(result.status).toBe('blocked');
     expect(result.message).toMatch(/no healthy peer/i);
@@ -156,6 +228,7 @@ describe('AutoRemediationEngine', () => {
       actionId: 'scale-out',
       context: { component: 'historian', desiredReplicas: 4, maximumReplicas: 5 },
       idempotencyKey: 'incident-789-scale',
+      dryRun: false,
     });
     expect(result).toMatchObject({
       status: 'rolled-back',
@@ -182,6 +255,7 @@ describe('AutoRemediationEngine', () => {
       actionId: 'scale-out',
       context: { component: 'api', desiredReplicas: 3, maximumReplicas: 4 },
       idempotencyKey: 'concurrent-scale-out',
+      dryRun: false,
     });
     expect(result).toMatchObject({ status: 'skipped', changed: false });
     expect(result.message).toMatch(/scale-down is forbidden/);
@@ -207,12 +281,14 @@ describe('AutoRemediationEngine', () => {
       actionId: dangerous.id,
       context: {},
       idempotencyKey: 'db-promote-unapproved',
+      dryRun: false,
     });
     expect(blocked.status).toBe('blocked');
     const approved = await engine.execute({
       actionId: dangerous.id,
       context: {},
       idempotencyKey: 'db-promote-approved',
+      dryRun: false,
       approvedBy: 'incident-commander@example.com',
     });
     expect(approved.status).toBe('succeeded');
@@ -234,6 +310,7 @@ describe('AutoRemediationEngine', () => {
       actionId: action.id,
       context: { component: 'api', desiredReplicas: 2, maximumReplicas: 3 },
       idempotencyKey: 'not-allowlisted',
+      dryRun: false,
     });
     expect(result.status).toBe('blocked');
     expect(result.message).toMatch(/allowlist/);
@@ -269,6 +346,7 @@ describe('AutoRemediationEngine', () => {
       actionId: action.id,
       context: {},
       idempotencyKey: 'slow-first',
+      dryRun: false,
     });
     clock = 10 * 60_000;
     release();
@@ -277,6 +355,7 @@ describe('AutoRemediationEngine', () => {
       actionId: action.id,
       context: {},
       idempotencyKey: 'slow-second',
+      dryRun: false,
     });
     expect(second.status).toBe('blocked');
     expect(execute).toHaveBeenCalledTimes(1);
@@ -302,7 +381,7 @@ describe('AutoRemediationEngine', () => {
     };
     const engine = new AutoRemediationEngine([action], { cooldownMs: 0 }, { now });
     const context = { desired: 2 };
-    const request = { actionId: action.id, context, idempotencyKey: 'snapshot-1' };
+    const request = { actionId: action.id, context, idempotencyKey: 'snapshot-1', dryRun: false };
     const running = engine.execute(request);
     context.desired = 99;
     release();
@@ -320,6 +399,7 @@ describe('RemediationRuntime', () => {
       actionId: 'scale-out',
       context: { component: 'api', desiredReplicas: 2, maximumReplicas: 3 },
       idempotencyKey: 'runtime-unconfigured',
+      dryRun: false,
     })).rejects.toBeInstanceOf(RemediationRuntimeUnavailableError);
 
     let replicas = 1;
@@ -337,6 +417,7 @@ describe('RemediationRuntime', () => {
       actionId: 'scale-out',
       context: { component: 'api', desiredReplicas: 2, maximumReplicas: 3 },
       idempotencyKey: 'runtime-configured',
+      dryRun: false,
     });
     expect(result.status).toBe('succeeded');
     expect(runtime.status()).toMatchObject({
@@ -370,6 +451,7 @@ describe('RemediationRuntime', () => {
       actionId: 'scale-out',
       context: { component: 'api', desiredReplicas: 2, maximumReplicas: 3 },
       idempotencyKey: 'audit-retry',
+      dryRun: false,
     };
     await expect(runtime.execute(request)).rejects.toBeInstanceOf(RemediationAuditPersistenceError);
     expect(replicas).toBe(2);

--- a/server/services/sre/__tests__/sre.test.ts
+++ b/server/services/sre/__tests__/sre.test.ts
@@ -130,6 +130,37 @@ describe('AutoRemediationEngine', () => {
     expect(replicas).toBe(2);
     expect(result.changed).toBe(false);
     expect(result.status).not.toBe('succeeded');
+    // Failing safe is only half of it. A caller that meant to execute must be
+    // able to tell that it got a plan instead, and the result message is the
+    // only channel it has — every other field is identical to an explicit
+    // `dryRun: true`, including the idempotency fingerprint (asserted below).
+    expect(
+      result.message,
+      'the assumption was applied silently',
+    ).toMatch(/dryRun was not stated; assumed true/);
+  });
+
+  it('says nothing about an assumption when dryRun was actually stated', async () => {
+    // Guards the other direction: the annotation must not leak onto requests
+    // that stated the flag, or it stops meaning anything.
+    let replicas = 2;
+    const action = createScaleOutAction({
+      currentReplicas: async () => replicas,
+      setReplicas: async (_component: string, desired: number) => {
+        replicas = desired;
+      },
+      readyReplicas: async () => replicas,
+    });
+    const engine = new AutoRemediationEngine([action], { cooldownMs: 0 }, { now });
+    const result = await engine.execute({
+      actionId: 'scale-out',
+      context: { component: 'gateway', desiredReplicas: 4, maximumReplicas: 6 },
+      idempotencyKey: 'dry-run-stated',
+      dryRun: true,
+    });
+
+    expect(result.status).toBe('planned');
+    expect(result.message ?? '').not.toMatch(/assumed true/);
   });
 
   it('fingerprints an unstated dryRun the same as an explicit dry run', async () => {

--- a/server/services/sre/index.ts
+++ b/server/services/sre/index.ts
@@ -490,8 +490,10 @@ export class AutoRemediationEngine {
     // engine must not perform a live infrastructure change because a caller
     // said nothing, so an absent flag resolves to a dry run.
     //
-    // Not silent: `dryRunAssumed` puts it in the result message, because a
-    // caller that meant to execute and quietly got a plan is its own bug.
+    // Not silent: `dryRunAssumed` is threaded into `executeOnce` and appended
+    // to the result message (and therefore to the audit record), because a
+    // caller that meant to execute and quietly got a plan is its own bug. A
+    // safe default that cannot be observed is just a different silent failure.
     const dryRunAssumed = typeof request.dryRun !== 'boolean';
     const dryRun = dryRunAssumed ? true : request.dryRun;
     const normalizedRequest: RemediationRequest<Context> = { ...request, context, dryRun };
@@ -523,7 +525,7 @@ export class AutoRemediationEngine {
       return { ...(await running.promise), reused: true };
     }
 
-    const promise = this.executeOnce(action, normalizedRequest);
+    const promise = this.executeOnce(action, normalizedRequest, dryRunAssumed);
     this.inFlight.set(request.idempotencyKey, { fingerprint, promise });
     try {
       const result = await promise;
@@ -546,10 +548,15 @@ export class AutoRemediationEngine {
    * `execute()` — in particular its `dryRun` is the resolved boolean, never the
    * caller's possibly-absent field. Everything below may therefore read
    * `request.dryRun` directly; do not call this with a raw caller request.
+   *
+   * `dryRunAssumed` records whether that resolution had to invent the value.
+   * It is not derivable from `request` here — normalization has already erased
+   * the difference — which is precisely why it is passed separately.
    */
   private async executeOnce<Context>(
     action: RemediationAction<Context>,
     request: RemediationRequest<Context>,
+    dryRunAssumed: boolean,
   ): Promise<RemediationResult> {
     const started = this.now();
     const scope = `${action.id}:${action.scope(request.context)}`;
@@ -574,6 +581,16 @@ export class AutoRemediationEngine {
         scope,
         ...partial,
       };
+      if (dryRunAssumed) {
+        // Say so on every outcome, not just the planned one. The caller asked
+        // for something the engine declined to take at face value, and it
+        // learns that here or nowhere. Appended rather than replacing, so the
+        // action's own message survives, and set before appendAudit so the
+        // audit record carries it too.
+        result.message = result.message
+          ? `${result.message} (dryRun was not stated; assumed true)`
+          : 'dryRun was not stated; assumed true';
+      }
       this.appendAudit(result);
       return result;
     };

--- a/server/services/sre/index.ts
+++ b/server/services/sre/index.ts
@@ -335,7 +335,22 @@ export interface RemediationRequest<Context = unknown> {
   actionId: string;
   context: Context;
   idempotencyKey: string;
-  dryRun?: boolean;
+  /**
+   * Whether to plan the remediation instead of performing it. REQUIRED, and
+   * deliberately not optional.
+   *
+   * This field was `dryRun?: boolean`, and the only gate on the mutating path
+   * is `if (request.dryRun)` — so an omitted field was `undefined`, which is
+   * falsy, which EXECUTED. The HTTP route defaulted it to `true`, but this
+   * service is exported and called directly, so every safety property rested
+   * on one route's Zod schema and any second caller got execute-by-omission
+   * with no error.
+   *
+   * Making it required is the point: "should this mutate production" has no
+   * sensible default, and a required field is the only version a reviewer can
+   * check by reading the call site.
+   */
+  dryRun: boolean;
   /** Required for actions above the engine's automatic risk ceiling. */
   approvedBy?: string;
 }
@@ -465,11 +480,32 @@ export class AutoRemediationEngine {
     } catch {
       throw new Error('remediation context must be structured-cloneable data');
     }
-    const normalizedRequest: RemediationRequest<Context> = { ...request, context };
+    // Resolve `dryRun` ONCE, here, and fail safe when it is absent.
+    //
+    // The type is required, which stops a typed caller omitting it. That is not
+    // sufficient on its own: types are erased, so anything arriving from
+    // untyped JS, a cast, or a JSON body that was not schema-checked still
+    // reaches this method with the field missing — and the gate downstream is
+    // `if (request.dryRun)`, which reads `undefined` as "execute". A remediation
+    // engine must not perform a live infrastructure change because a caller
+    // said nothing, so an absent flag resolves to a dry run.
+    //
+    // Not silent: `dryRunAssumed` puts it in the result message, because a
+    // caller that meant to execute and quietly got a plan is its own bug.
+    const dryRunAssumed = typeof request.dryRun !== 'boolean';
+    const dryRun = dryRunAssumed ? true : request.dryRun;
+    const normalizedRequest: RemediationRequest<Context> = { ...request, context, dryRun };
+
+    // `dryRun` joins the fingerprint as the RESOLVED boolean. If it were hashed
+    // as the raw field, an absent value and an explicit `false` would hash
+    // differently while behaving identically, and — worse — an absent value and
+    // an explicit `true` would hash differently while both planning, so a plan
+    // could collide with a real execution on one idempotency key and return the
+    // wrong cached result.
     const fingerprint = hash({
       actionId: normalizedRequest.actionId,
       context: normalizedRequest.context,
-      dryRun: normalizedRequest.dryRun ?? false,
+      dryRun,
       approvedBy: normalizedRequest.approvedBy ?? null,
     });
     const prior = this.cached.get(request.idempotencyKey);
@@ -505,6 +541,12 @@ export class AutoRemediationEngine {
     }
   }
 
+  /**
+   * Run one attempt. The `request` here is ALWAYS the normalized one built by
+   * `execute()` — in particular its `dryRun` is the resolved boolean, never the
+   * caller's possibly-absent field. Everything below may therefore read
+   * `request.dryRun` directly; do not call this with a raw caller request.
+   */
   private async executeOnce<Context>(
     action: RemediationAction<Context>,
     request: RemediationRequest<Context>,
@@ -525,7 +567,7 @@ export class AutoRemediationEngine {
         idempotencyKey: request.idempotencyKey,
         approvedBy: request.approvedBy?.trim() || undefined,
         risk: action.risk,
-        dryRun: request.dryRun ?? false,
+        dryRun: request.dryRun,
         reused: false,
         startedAt: started.toISOString(),
         completedAt: this.now().toISOString(),


### PR DESCRIPTION
Closes #673.

## The fail-open

`RemediationRequest.dryRun` was optional. The only gate on the mutating path is:

```ts
if (request.dryRun) {
  return finish({ status: 'planned', ... });   // plan only
}
// falls through and performs the real remediation
```

`undefined` is falsy, so **omitting the field executed**. Only the HTTP route defaulted it safe (`z.boolean().default(true)`), and the service is exported and imported directly — so every safety property on an engine that scales gateways and restarts infrastructure rested on one route's Zod schema.

## Two changes, because either alone is insufficient

**1. The field is required.** "Should this mutate production" has no sensible default, and a required field is the only version a reviewer can check by reading the call site.

`tsc` then passed with **zero errors**, which was the first useful surprise: no production caller was omitting it. The type change is a guard against the next caller, not a fix for a live incident.

**2. An absent flag resolves to a dry run at runtime.**

This is the part I would have skipped. Types are erased, so the required field does nothing for a caller arriving from untyped JS, a cast, or a JSON body that was not schema-checked. I wrote the test for that case expecting it to pass against change 1 — **it failed**, and `setReplicas` had been called once. The type change alone left the hole open.

Resolution happens once in `execute()`.

## The tests had been written against the defect

14 of 15 request literals in `sre.test.ts` omitted `dryRun` while asserting `{ status: 'succeeded', changed: true }`. The suite was relying on omission-executes to test the executing path — which is exactly why two prior reviews noticed the asymmetry and nothing caught it. All 14 now say `dryRun: false` explicitly.

## Fingerprint

`dryRun` is part of the idempotency fingerprint and now hashes the **resolved** boolean. Hashing the raw field made an absent flag and an explicit `true` hash differently while both plan, so two identical requests looked like a key reused for different work and the second threw.

## Self-review follow-up (2026-07-31)

An adversarial pass on my own branch found that this PR had made a claim it did not keep. The previous revision said `dryRunAssumed` "keeps it off the silent path." It did not. The const was declared, read once to compute `dryRun`, and never used again — it never reached the result message, and the comment above it saying so was false at the moment it was written.

The behaviour was silent. An omitted `dryRun` produced a result byte-for-byte identical to an explicit `dryRun: true` — same status, same fingerprint, same `reused` semantics. A caller that meant to execute had no channel through which to learn it got a plan instead. **A safe default that cannot be observed is just a different silent failure.**

Nor would the suite have caught it. The omission test asserted only `not.toHaveBeenCalled()`, `changed === false`, and `status !== 'succeeded'` — all four assertions pass whether or not the assumption is observable. That is why the gap survived two review passes and my own writing of the test.

Fixed: `dryRunAssumed` is threaded into `executeOnce` and appended to the result message *before* `appendAudit`, so the audit record carries it too. Appended rather than substituted, so the action's own message survives. It is passed as a parameter rather than read off the request because normalization has already erased the difference by then — documented on the method, since "why isn't this just derived here" is exactly the question the next reader will have.

Also rebased onto `b9122948`. The previous red CI was two `server/__tests__/logger-escaping.test.ts` failures inherited from the stale base `7a4adf79`, not caused by this diff.

## One thing I broke and caught

I initially redirected the result field and the gate inside `executeOnce` to a bare `dryRun`, which is not in scope there — `executeOnce` already receives the *normalized* request, so `request.dryRun` was correct all along. Reverted, and added a docblock stating that precondition on the method, since "this parameter is always pre-normalized" is exactly the kind of invariant that decays.

## Mutation results

| Mutation | Result |
|---|---|
| Restore the fail-open (`dryRunAssumed ? false : …`) | **1 failed** — *"an unstated dryRun performed a live scale"* ✅ |
| Hash the raw field instead of the resolved one | **1 failed** — *"the second call was treated as different work"* ✅ |
| Disable the message annotation (`if (false && dryRunAssumed)`) | **1 failed** — *"the assumption was applied silently"* ✅ |

The second mutation passed against my first draft, which had no fingerprint test. The third passed against my second draft, which had no annotation at all — the claim was in the prose only. Both tests were added rather than leaving the claim unbacked.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `server/services/sre` + `server/routes` + `server/scaling` | **406 passed / 24 files** |
| `sre.test.ts` | 17 passed (was 14) |
| Rebased onto | `b9122948` |
