### PR TITLE
feat(opcua): expose typed arrays on the wire (#670)

### DIFF
--- a/server/protocols/opcua-server/__tests__/address-space.test.ts
+++ b/server/protocols/opcua-server/__tests__/address-space.test.ts
@@ -56,6 +56,20 @@ describe("mapDataType", () => {
       valueRank: 1,
     });
   });
+
+  test("rejects an array tag without an explicit scalar element type", () => {
+    expect(() =>
+      buildAddressSpace(sites, [
+        {
+          tagId: "UNTYPED_ARRAY",
+          siteId: "SITE-01",
+          dataType: "array",
+        },
+      ]),
+    ).toThrow(
+      'Array tag "UNTYPED_ARRAY" must declare a scalar elementDataType',
+    );
+  });
 });
 
 describe("NodeId builders", () => {

--- a/server/protocols/opcua-server/__tests__/address-space.test.ts
+++ b/server/protocols/opcua-server/__tests__/address-space.test.ts
@@ -41,6 +41,21 @@ describe("mapDataType", () => {
     expect(mapDataType("object")).toBe(UaDataType.BaseDataType);
     expect(mapDataType("array")).toBe(UaDataType.BaseDataType);
   });
+
+  test("plans a typed one-dimensional UA array", () => {
+    const plan = buildAddressSpace(sites, [
+      {
+        tagId: "TEMPERATURES",
+        siteId: "SITE-01",
+        dataType: "array",
+        elementDataType: "number",
+      },
+    ]);
+    expect(plan.variables[0]).toMatchObject({
+      dataType: UaDataType.Double,
+      valueRank: 1,
+    });
+  });
 });
 
 describe("NodeId builders", () => {

--- a/server/protocols/opcua-server/__tests__/live-binding.test.ts
+++ b/server/protocols/opcua-server/__tests__/live-binding.test.ts
@@ -286,6 +286,34 @@ describe.skipIf(!nodeOpcuaAvailable)(
           23,
         ]);
 
+        dataSource.push({
+          tagId: "TEMPERATURES",
+          value: [21.5, "not-a-number", 23],
+          dataType: "array",
+          quality: "good",
+          timestamp: new Date().toISOString(),
+        });
+        const invalidElementRead =
+          await session.readVariableValue(arrayNodeId);
+        expect(invalidElementRead.statusCode.name).toBe("Bad");
+        expect(
+          Number.isNaN(
+            Array.from(
+              invalidElementRead.value.value as ArrayLike<number>,
+            )[1],
+          ),
+        ).toBe(true);
+
+        dataSource.push({
+          tagId: "TEMPERATURES",
+          value: 21.5,
+          dataType: "number",
+          quality: "good",
+          timestamp: new Date().toISOString(),
+        });
+        const wrongShapeRead = await session.readVariableValue(arrayNodeId);
+        expect(wrongShapeRead.statusCode.name).toBe("Bad");
+
         // 3. Subscribe and receive a DataChangeNotification for a pushed update.
         const subscription = await session.createSubscription2({
           requestedPublishingInterval: 50,

--- a/server/protocols/opcua-server/__tests__/live-binding.test.ts
+++ b/server/protocols/opcua-server/__tests__/live-binding.test.ts
@@ -106,6 +106,12 @@ const SITE: SourceSite = { id: "SITE-01", name: "Refinery" };
 const TAGS: SourceTag[] = [
   { tagId: "PT-101.PV", siteId: "SITE-01", dataType: "number", units: "bar" },
   { tagId: "RUN", siteId: "SITE-01", dataType: "boolean" },
+  {
+    tagId: "TEMPERATURES",
+    siteId: "SITE-01",
+    dataType: "array",
+    elementDataType: "number",
+  },
 ];
 
 /** In-memory {@link TagDataSource}: the 0xSCADA side is not what is under test. */
@@ -208,6 +214,13 @@ describe.skipIf(!nodeOpcuaAvailable)(
         quality: "good",
         timestamp: new Date().toISOString(),
       });
+      dataSource.push({
+        tagId: "TEMPERATURES",
+        value: [21.5, 22.25, 23],
+        dataType: "array",
+        quality: "good",
+        timestamp: new Date().toISOString(),
+      });
       // SecurityPolicy None + anonymous is permitted here only because the bind
       // is loopback and env is "test"; the config layer refuses both otherwise.
       server = makeServer(dataSource, pkiFolder, {
@@ -246,6 +259,7 @@ describe.skipIf(!nodeOpcuaAvailable)(
         const sitesRoot = `ns=${namespaceIndex};s=Sites`;
         const siteFolder = `ns=${namespaceIndex};s=Sites/SITE-01`;
         const tagNodeId = `ns=${namespaceIndex};${TAG_NODE_ID_SUFFIX}`;
+        const arrayNodeId = `ns=${namespaceIndex};s=Tags/SITE-01/TEMPERATURES`;
 
         // 1. Browse: Objects -> Sites -> SITE-01 -> tag variables.
         const sites = await session.browse(sitesRoot);
@@ -263,6 +277,14 @@ describe.skipIf(!nodeOpcuaAvailable)(
         const read = await session.readVariableValue(tagNodeId);
         expect(read.statusCode.name).toBe("Good");
         expect(read.value.value).toBeCloseTo(12.5, 6);
+
+        const arrayRead = await session.readVariableValue(arrayNodeId);
+        expect(arrayRead.statusCode.name).toBe("Good");
+        expect(Array.from(arrayRead.value.value as ArrayLike<number>)).toEqual([
+          21.5,
+          22.25,
+          23,
+        ]);
 
         // 3. Subscribe and receive a DataChangeNotification for a pushed update.
         const subscription = await session.createSubscription2({

--- a/server/protocols/opcua-server/address-space.ts
+++ b/server/protocols/opcua-server/address-space.ts
@@ -38,11 +38,9 @@ export const OBJECTS_FOLDER_NODE_ID = "ns=0;i=85";
 /**
  * Map a 0xSCADA {@link DataType} to a UA built-in DataType. Numbers and
  * booleans map to their concrete UA scalar types; strings to UA String;
- * everything else (object/array) falls back to BaseDataType (Variant) since
- * this scaffold does not yet synthesise UA structured types for them.
- *
- * Tracked in #670: map `array` to a one-dimensional UA array (valueRank 1) and
- * synthesise UA ExtensionObject DataTypes for structured `object` tags.
+ * objects fall back to BaseDataType. The historian has no object schema from
+ * which a stable UA StructureDefinition could be synthesized, so their final
+ * wire representation remains documented JSON text.
  */
 export function mapDataType(dataType: DataType): UaDataType {
   switch (dataType) {
@@ -57,6 +55,12 @@ export function mapDataType(dataType: DataType): UaDataType {
     default:
       return UaDataType.BaseDataType;
   }
+}
+
+function mapTagDataType(tag: SourceTag): UaDataType {
+  return tag.dataType === "array"
+    ? mapDataType(tag.elementDataType ?? "string")
+    : mapDataType(tag.dataType);
 }
 
 /**
@@ -189,7 +193,8 @@ export function buildAddressSpace(
       browseName: tag.tagId,
       displayName: tag.name || tag.tagId,
       parentNodeId: siteFolderNodeId(tag.siteId, namespaceIndex),
-      dataType: mapDataType(tag.dataType),
+      dataType: mapTagDataType(tag),
+      ...(tag.dataType === "array" ? { valueRank: 1 } : {}),
       accessLevel: accessLevelFor(tag),
       units: tag.units,
       tagId: tag.tagId,

--- a/server/protocols/opcua-server/address-space.ts
+++ b/server/protocols/opcua-server/address-space.ts
@@ -58,9 +58,13 @@ export function mapDataType(dataType: DataType): UaDataType {
 }
 
 function mapTagDataType(tag: SourceTag): UaDataType {
-  return tag.dataType === "array"
-    ? mapDataType(tag.elementDataType ?? "string")
-    : mapDataType(tag.dataType);
+  if (tag.dataType !== "array") return mapDataType(tag.dataType);
+  if (tag.elementDataType === undefined) {
+    throw new Error(
+      `Array tag "${tag.tagId}" must declare a scalar elementDataType`,
+    );
+  }
+  return mapDataType(tag.elementDataType);
 }
 
 /**

--- a/server/protocols/opcua-server/index.ts
+++ b/server/protocols/opcua-server/index.ts
@@ -343,6 +343,9 @@ export class OxScadaOpcuaServer {
           ? `${variable.tagId} [${variable.units}]`
           : variable.tagId,
         dataType: uaTypeToNodeOpcuaDataType(variable.dataType, DataType),
+        ...(variable.valueRank === undefined
+          ? {}
+          : { valueRank: variable.valueRank }),
         // Read-only unless the source tag is explicitly marked writable. Without
         // this the UA node would inherit node-opcua's default access level.
         accessLevel: variable.accessLevel,
@@ -357,7 +360,13 @@ export class OxScadaOpcuaServer {
                 callback(
                   null,
                   new DataValue({
-                    value: toVariant(variable, sample, Variant, DataType),
+                    value: toVariant(
+                      variable,
+                      sample,
+                      Variant,
+                      DataType,
+                      nodeOpcua.VariantArrayType,
+                    ),
                     statusCode:
                       sample === undefined || sample.quality === "bad"
                         ? StatusCodes.Bad
@@ -422,7 +431,13 @@ export class OxScadaOpcuaServer {
       const meta = variablesByTag.get(sample.tagId);
       if (!uaVar || !meta) return;
       uaVar.setValueFromSource(
-        toVariant(meta, sample, Variant, DataType),
+        toVariant(
+          meta,
+          sample,
+          Variant,
+          DataType,
+          nodeOpcua.VariantArrayType,
+        ),
         sample.quality === "bad" ? StatusCodes.Bad : StatusCodes.Good,
         toDate(sample.timestamp),
       );
@@ -487,8 +502,17 @@ function toVariant(
   sample: TagSample | undefined,
   Variant: NodeOpcuaApi["Variant"],
   DataType: Record<string, unknown>,
+  VariantArrayType: Record<string, unknown>,
 ): UaHandle {
   const raw = sample?.value;
+  if (meta.valueRank === 1) {
+    const values = Array.isArray(raw) ? raw : [];
+    return new Variant({
+      dataType: uaTypeToNodeOpcuaDataType(meta.dataType, DataType),
+      arrayType: VariantArrayType.Array,
+      value: values.map((value) => coerceScalar(meta.dataType, value)),
+    });
+  }
   switch (meta.dataType) {
     case UaDataType.Boolean:
       return new Variant({ dataType: DataType.Boolean, value: Boolean(raw) });
@@ -509,6 +533,19 @@ function toVariant(
         dataType: DataType.String,
         value: raw == null ? "" : JSON.stringify(raw),
       });
+  }
+}
+
+function coerceScalar(type: UaDataType, value: unknown): unknown {
+  switch (type) {
+    case UaDataType.Boolean:
+      return Boolean(value);
+    case UaDataType.Double: {
+      const numeric = typeof value === "number" ? value : Number(value);
+      return Number.isFinite(numeric) ? numeric : 0;
+    }
+    default:
+      return value == null ? "" : String(value);
   }
 }
 

--- a/server/protocols/opcua-server/index.ts
+++ b/server/protocols/opcua-server/index.ts
@@ -367,10 +367,11 @@ export class OxScadaOpcuaServer {
                       DataType,
                       nodeOpcua.VariantArrayType,
                     ),
-                    statusCode:
-                      sample === undefined || sample.quality === "bad"
-                        ? StatusCodes.Bad
-                        : StatusCodes.Good,
+                    statusCode: statusCodeForSample(
+                      variable,
+                      sample,
+                      StatusCodes,
+                    ),
                     sourceTimestamp: toDate(sample?.timestamp),
                   }),
                 );
@@ -438,7 +439,7 @@ export class OxScadaOpcuaServer {
           DataType,
           nodeOpcua.VariantArrayType,
         ),
-        sample.quality === "bad" ? StatusCodes.Bad : StatusCodes.Good,
+        statusCodeForSample(meta, sample, StatusCodes),
         toDate(sample.timestamp),
       );
     });
@@ -506,6 +507,9 @@ function toVariant(
 ): UaHandle {
   const raw = sample?.value;
   if (meta.valueRank === 1) {
+    // A non-array source value is paired with StatusCodes.Bad by
+    // statusCodeForSample. Keep the Variant shape valid without presenting the
+    // empty fallback as a successful process reading.
     const values = Array.isArray(raw) ? raw : [];
     return new Variant({
       dataType: uaTypeToNodeOpcuaDataType(meta.dataType, DataType),
@@ -541,12 +545,46 @@ function coerceScalar(type: UaDataType, value: unknown): unknown {
     case UaDataType.Boolean:
       return Boolean(value);
     case UaDataType.Double: {
-      const numeric = typeof value === "number" ? value : Number(value);
-      return Number.isFinite(numeric) ? numeric : 0;
+      return coerceFiniteNumber(value);
     }
     default:
       return value == null ? "" : String(value);
   }
+}
+
+/** Convert a source value to a finite number without inventing process data. */
+function coerceFiniteNumber(value: unknown): number {
+  const numeric =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim() !== ""
+        ? Number(value)
+        : Number.NaN;
+  return Number.isFinite(numeric) ? numeric : Number.NaN;
+}
+
+/**
+ * Derive UA quality from both source quality and the declared array contract.
+ * Shape/type failures are quality events; they must never look like a valid
+ * empty array or a plausible numeric zero to an operator.
+ */
+function statusCodeForSample(
+  meta: UaVariableNode,
+  sample: TagSample | undefined,
+  StatusCodes: Record<string, unknown>,
+): unknown {
+  if (sample === undefined || sample.quality === "bad") {
+    return StatusCodes.Bad;
+  }
+  if (meta.valueRank !== 1) return StatusCodes.Good;
+  if (!Array.isArray(sample.value)) return StatusCodes.Bad;
+  if (
+    meta.dataType === UaDataType.Double &&
+    sample.value.some((value) => Number.isNaN(coerceFiniteNumber(value)))
+  ) {
+    return StatusCodes.Bad;
+  }
+  return StatusCodes.Good;
 }
 
 export { buildAddressSpace, summarizePlan } from "./address-space";

--- a/server/protocols/opcua-server/node-opcua-api.ts
+++ b/server/protocols/opcua-server/node-opcua-api.ts
@@ -43,6 +43,7 @@ export interface UaAddVariableOptions {
   displayName: string;
   description?: string;
   dataType: unknown;
+  valueRank?: number;
   accessLevel: number;
   userAccessLevel: number;
   minimumSamplingInterval: number;
@@ -140,7 +141,11 @@ export interface NodeOpcuaApi {
   OPCUACertificateManager: new (
     options: UaCertificateManagerOptions,
   ) => UaCertificateManager;
-  Variant: new (options: { dataType: unknown; value: unknown }) => UaHandle;
+  Variant: new (options: {
+    dataType: unknown;
+    value: unknown;
+    arrayType?: unknown;
+  }) => UaHandle;
   DataValue: new (options: {
     value: UaHandle;
     statusCode: unknown;
@@ -148,6 +153,7 @@ export interface NodeOpcuaApi {
   }) => UaHandle;
   /** `DataType` enum, indexed by member name (`"Double"`, `"Boolean"`, …). */
   DataType: Record<string, unknown>;
+  VariantArrayType: Record<string, unknown>;
   /** `StatusCodes` table, indexed by member name (`"Good"`, `"Bad"`, …). */
   StatusCodes: Record<string, unknown>;
   /** `SecurityPolicy` enum, indexed by member name (`"Basic256Sha256"`, …). */
@@ -174,6 +180,7 @@ const REQUIRED_MEMBERS: readonly (keyof NodeOpcuaApi)[] = [
   "Variant",
   "DataValue",
   "DataType",
+  "VariantArrayType",
   "StatusCodes",
   "SecurityPolicy",
   "MessageSecurityMode",

--- a/server/protocols/opcua-server/storage-data-source.ts
+++ b/server/protocols/opcua-server/storage-data-source.ts
@@ -24,7 +24,7 @@ import type { SourceSite, SourceTag, TagSample } from "./types";
 /** Update shape emitted by the existing tag-stream fabric. */
 export interface IncomingTagUpdate {
   tagName: string;
-  value: unknown;
+  value: number | string | boolean | unknown[];
   quality: Quality;
   timestamp: string;
 }

--- a/server/protocols/opcua-server/storage-data-source.ts
+++ b/server/protocols/opcua-server/storage-data-source.ts
@@ -24,7 +24,7 @@ import type { SourceSite, SourceTag, TagSample } from "./types";
 /** Update shape emitted by the existing tag-stream fabric. */
 export interface IncomingTagUpdate {
   tagName: string;
-  value: number | string | boolean;
+  value: unknown;
   quality: Quality;
   timestamp: string;
 }

--- a/server/protocols/opcua-server/types.ts
+++ b/server/protocols/opcua-server/types.ts
@@ -31,6 +31,8 @@ export interface SourceTag {
   siteId: string;
   /** 0xSCADA data type; mapped to a UA built-in DataType. */
   dataType: DataType;
+  /** Scalar element type. Required for an `array` tag to be strongly typed. */
+  elementDataType?: Exclude<DataType, "array" | "object">;
   /** Engineering units (mapped to UA EUInformation when present). */
   units?: string;
   /** Whether UA clients may write this variable. Defaults to read-only. */
@@ -99,6 +101,8 @@ export interface UaVariableNode {
   /** NodeId of the owning site folder. */
   parentNodeId: string;
   dataType: UaDataType;
+  /** UA ValueRank (`1` means a one-dimensional array). */
+  valueRank?: number;
   accessLevel: number;
   units?: string;
   /** Echo of the originating tag id for value routing. */

--- a/server/protocols/opcua-server/types.ts
+++ b/server/protocols/opcua-server/types.ts
@@ -31,7 +31,10 @@ export interface SourceTag {
   siteId: string;
   /** 0xSCADA data type; mapped to a UA built-in DataType. */
   dataType: DataType;
-  /** Scalar element type. Required for an `array` tag to be strongly typed. */
+  /**
+   * Scalar element type. {@link buildAddressSpace} rejects an `array` tag when
+   * this is absent so the server never silently advertises the wrong UA type.
+   */
   elementDataType?: Exclude<DataType, "array" | "object">;
   /** Engineering units (mapped to UA EUInformation when present). */
   units?: string;


### PR DESCRIPTION
## Summary

Closes #670.

- Exposes typed OPC UA arrays as genuine one-dimensional UA arrays (`ValueRank = 1`).
- Keeps structured object values at the documented JSON-string boundary.

## Review follow-up

- Invalid numeric array elements now remain `NaN` and mark the outgoing `DataValue` bad instead of fabricating zero.
- Scalar source values for array variables are marked bad rather than silently becoming an empty array.
- Array tags without `elementDataType` are rejected while planning the address space.
- `IncomingTagUpdate.value` is narrowed to `number | string | boolean | unknown[]`.
- Rebased onto the current `main` branch.

## Attribution

City-Agent: codex

## Verification

- [x] `npm run typecheck`
- [x] Targeted typed-array tests (41 passed)
- [x] `npx vitest run server/protocols/opcua-server/__tests__` (131 passed)
- [x] `git diff --check`

## Gate

- [x] Tests added/updated
- [x] Typecheck passes
- [x] DCO-signed commits
