### PR TITLE
feat(opcua): gate and audit tag writes (#667)

### DIFF
--- a/server/protocols/opcua-server/__tests__/address-space.test.ts
+++ b/server/protocols/opcua-server/__tests__/address-space.test.ts
@@ -26,7 +26,13 @@ const sites: SourceSite[] = [
 
 const tags: SourceTag[] = [
   { tagId: "PT-101.PV", siteId: "SITE-01", dataType: "number", units: "bar" },
-  { tagId: "RUN", siteId: "SITE-01", dataType: "boolean", writable: true },
+  {
+    tagId: "RUN",
+    siteId: "SITE-01",
+    dataType: "boolean",
+    writable: true,
+    direction: "input",
+  },
   { tagId: "BATCH-ID", siteId: "SITE-02", dataType: "string" },
 ];
 
@@ -104,9 +110,21 @@ describe("accessLevelFor", () => {
       siteId: "s",
       dataType: "number",
       writable: true,
+      direction: "input",
     });
     expect(level & UaAccessLevel.CurrentRead).toBeTruthy();
     expect(level & UaAccessLevel.CurrentWrite).toBeTruthy();
+  });
+
+  test("refuses write access for non-input tags", () => {
+    const level = accessLevelFor({
+      tagId: "t",
+      siteId: "s",
+      dataType: "number",
+      writable: true,
+      direction: "output",
+    });
+    expect(level).toBe(UaAccessLevel.CurrentRead);
   });
 });
 

--- a/server/protocols/opcua-server/__tests__/config.test.ts
+++ b/server/protocols/opcua-server/__tests__/config.test.ts
@@ -265,6 +265,8 @@ describe("loadOpcuaServerConfigFromEnv", () => {
     expect(config.allowAnonymous).toBe(false);
     expect(config.securityPolicy).toBe("Basic256Sha256");
     expect(config.env).toBe("production");
+    expect(config.writesEnabled).toBe(false);
+    expect(config.writableTags).toEqual([]);
   });
 
   test("a development NODE_ENV still refuses anonymous access", () => {
@@ -289,6 +291,16 @@ describe("loadOpcuaServerConfigFromEnv", () => {
       loadOpcuaServerConfigFromEnv({ OPCUA_SERVER_ENABLED: "true" }).enabled,
     ).toBe(true);
     expect(loadOpcuaServerConfigFromEnv({}).enabled).toBe(false);
+  });
+
+  test("requires a separate write opt-in and parses an explicit tag allowlist", () => {
+    const config = loadOpcuaServerConfigFromEnv({
+      OPCUA_SERVER_ENABLED: "true",
+      OPCUA_SERVER_WRITES_ENABLED: "true",
+      OPCUA_SERVER_WRITABLE_TAGS: "SP-101, SP-202",
+    });
+    expect(config.writesEnabled).toBe(true);
+    expect(config.writableTags).toEqual(["SP-101", "SP-202"]);
   });
 
   test("a routable OPCUA_SERVER_HOST needs OPCUA_SERVER_ALLOW_REMOTE_BIND", () => {

--- a/server/protocols/opcua-server/__tests__/live-binding.test.ts
+++ b/server/protocols/opcua-server/__tests__/live-binding.test.ts
@@ -59,6 +59,10 @@ interface UaBrowseResult {
 interface UaSession {
   browse(nodeToBrowse: string): Promise<UaBrowseResult>;
   readVariableValue(nodeId: string): Promise<UaDataValue>;
+  writeSingleNode(
+    nodeId: string,
+    value: { dataType: unknown; value: unknown },
+  ): Promise<{ name: string }>;
   createSubscription2(options: Record<string, unknown>): Promise<UaSubscription>;
   close(): Promise<void>;
 }
@@ -85,6 +89,7 @@ interface UaClientApi {
   AttributeIds: Record<string, number>;
   TimestampsToReturn: Record<string, number>;
   UserTokenType: Record<string, number>;
+  DataType: Record<string, unknown>;
 }
 
 async function loadClientApi(): Promise<UaClientApi> {
@@ -112,12 +117,20 @@ const TAGS: SourceTag[] = [
     dataType: "array",
     elementDataType: "number",
   },
+  {
+    tagId: "SETPOINT",
+    siteId: "SITE-01",
+    dataType: "number",
+    writable: true,
+    direction: "input",
+  },
 ];
 
 /** In-memory {@link TagDataSource}: the 0xSCADA side is not what is under test. */
 class InMemoryTagDataSource implements TagDataSource {
   private readonly latest = new Map<string, TagSample>();
   private readonly listeners = new Set<(sample: TagSample) => void>();
+  readonly writes: { tagId: string; username: string; value: unknown }[] = [];
 
   async loadSites(): Promise<SourceSite[]> {
     return [SITE];
@@ -136,6 +149,17 @@ class InMemoryTagDataSource implements TagDataSource {
     return () => {
       this.listeners.delete(onChange);
     };
+  }
+
+  async writeTag(request: {
+    tagId: string;
+    username: string;
+    value: unknown;
+  }): Promise<void> {
+    if (request.username !== OPERATOR.username) {
+      throw new Error("opcua.write scope denied");
+    }
+    this.writes.push(request);
   }
 
   push(sample: TagSample): void {
@@ -314,6 +338,12 @@ describe.skipIf(!nodeOpcuaAvailable)(
         const wrongShapeRead = await session.readVariableValue(arrayNodeId);
         expect(wrongShapeRead.statusCode.name).toBe("Bad");
 
+        const refused = await session.writeSingleNode(tagNodeId, {
+          dataType: api.DataType.Double,
+          value: 99,
+        });
+        expect(refused.name).toBe("BadNotWritable");
+
         // 3. Subscribe and receive a DataChangeNotification for a pushed update.
         const subscription = await session.createSubscription2({
           requestedPublishingInterval: 50,
@@ -375,12 +405,14 @@ describe.skipIf(!nodeOpcuaAvailable)(
     let pkiFolder: string;
     let server: OxScadaOpcuaServer;
     let api: UaClientApi;
+    let dataSource: InMemoryTagDataSource;
 
     beforeAll(async () => {
       api = await loadClientApi();
       pkiFolder = fs.mkdtempSync(path.join(os.tmpdir(), "oxscada-opcua-auth-"));
       // The shipped default: anonymous access OFF.
-      server = makeServer(new InMemoryTagDataSource(), pkiFolder, {
+      dataSource = new InMemoryTagDataSource();
+      server = makeServer(dataSource, pkiFolder, {
         securityPolicy: "None",
         allowAnonymous: false,
         trustUnknownClientCertificates: true,
@@ -427,6 +459,31 @@ describe.skipIf(!nodeOpcuaAvailable)(
         return true;
       });
       expect(closed).toBe(true);
+    }, 60_000);
+
+    test("accepts an explicitly enabled input write and attributes it", async () => {
+      await withClient(async (client) => {
+        const session = await client.createSession({
+          type: api.UserTokenType.UserName,
+          userName: OPERATOR.username,
+          password: PASSWORD,
+        });
+        try {
+          const ns = server.addressSpacePlan!.namespaceIndex;
+          const status = await session.writeSingleNode(
+            `ns=${ns};s=Tags/SITE-01/SETPOINT`,
+            { dataType: api.DataType.Double, value: 33.5 },
+          );
+          expect(status.name).toBe("Good");
+        } finally {
+          await session.close();
+        }
+      });
+      expect(dataSource.writes).toContainEqual(expect.objectContaining({
+        tagId: "SETPOINT",
+        username: OPERATOR.username,
+        value: 33.5,
+      }));
     }, 60_000);
 
     test("refuses a bad password", async () => {

--- a/server/protocols/opcua-server/__tests__/live-binding.test.ts
+++ b/server/protocols/opcua-server/__tests__/live-binding.test.ts
@@ -504,6 +504,28 @@ describe.skipIf(!nodeOpcuaAvailable)(
       }));
     }, 60_000);
 
+    test("rejects a type-confused write before it reaches storage", async () => {
+      const before = dataSource.writes.length;
+      await withClient(async (client) => {
+        const session = await client.createSession({
+          type: api.UserTokenType.UserName,
+          userName: OPERATOR.username,
+          password: PASSWORD,
+        });
+        try {
+          const ns = server.addressSpacePlan!.namespaceIndex;
+          const status = await session.writeSingleNode(
+            `ns=${ns};s=Tags/SITE-01/SETPOINT`,
+            { dataType: api.DataType.String, value: "open" },
+          );
+          expect(status.name).toBe("BadTypeMismatch");
+        } finally {
+          await session.close();
+        }
+      });
+      expect(dataSource.writes).toHaveLength(before);
+    }, 60_000);
+
     test("rejects IndexRange writes without mutating the whole value", async () => {
       const before = dataSource.writes.length;
       await withClient(async (client) => {

--- a/server/protocols/opcua-server/__tests__/live-binding.test.ts
+++ b/server/protocols/opcua-server/__tests__/live-binding.test.ts
@@ -63,6 +63,12 @@ interface UaSession {
     nodeId: string,
     value: { dataType: unknown; value: unknown },
   ): Promise<{ name: string }>;
+  write(nodeToWrite: {
+    nodeId: string;
+    attributeId: number;
+    indexRange: string;
+    value: { value: { dataType: unknown; value: unknown } };
+  }): Promise<{ name: string }>;
   createSubscription2(options: Record<string, unknown>): Promise<UaSubscription>;
   close(): Promise<void>;
 }
@@ -156,7 +162,10 @@ class InMemoryTagDataSource implements TagDataSource {
     username: string;
     value: unknown;
   }): Promise<void> {
-    if (request.username !== OPERATOR.username) {
+    if (
+      request.username !== OPERATOR.username &&
+      request.username !== NAMED_ANONYMOUS.username
+    ) {
       throw new Error("opcua.write scope denied");
     }
     this.writes.push(request);
@@ -183,8 +192,17 @@ const OPERATOR: AuthUserRecord = {
   isActive: true,
 };
 
-const userLookup: UserLookup = async (username) =>
-  username === OPERATOR.username ? OPERATOR : null;
+const NAMED_ANONYMOUS: AuthUserRecord = {
+  ...OPERATOR,
+  id: "user-2",
+  username: "anonymous",
+};
+
+const userLookup: UserLookup = async (username) => {
+  if (username === OPERATOR.username) return OPERATOR;
+  if (username === NAMED_ANONYMOUS.username) return NAMED_ANONYMOUS;
+  return null;
+};
 
 const nodeOpcuaAvailable = await isNodeOpcuaAvailable();
 if (!nodeOpcuaAvailable) {
@@ -484,6 +502,55 @@ describe.skipIf(!nodeOpcuaAvailable)(
         username: OPERATOR.username,
         value: 33.5,
       }));
+    }, 60_000);
+
+    test("rejects IndexRange writes without mutating the whole value", async () => {
+      const before = dataSource.writes.length;
+      await withClient(async (client) => {
+        const session = await client.createSession({
+          type: api.UserTokenType.UserName,
+          userName: OPERATOR.username,
+          password: PASSWORD,
+        });
+        try {
+          const ns = server.addressSpacePlan!.namespaceIndex;
+          const status = await session.write({
+            nodeId: `ns=${ns};s=Tags/SITE-01/SETPOINT`,
+            attributeId: api.AttributeIds.Value,
+            indexRange: "0",
+            value: {
+              value: { dataType: api.DataType.Double, value: 44 },
+            },
+          });
+          expect(status.name).toBe("BadIndexRangeInvalid");
+        } finally {
+          await session.close();
+        }
+      });
+      expect(dataSource.writes).toHaveLength(before);
+    }, 60_000);
+
+    test("authorizes by token type, not the literal username", async () => {
+      await withClient(async (client) => {
+        const session = await client.createSession({
+          type: api.UserTokenType.UserName,
+          userName: NAMED_ANONYMOUS.username,
+          password: PASSWORD,
+        });
+        try {
+          const ns = server.addressSpacePlan!.namespaceIndex;
+          const status = await session.writeSingleNode(
+            `ns=${ns};s=Tags/SITE-01/SETPOINT`,
+            { dataType: api.DataType.Double, value: 34.5 },
+          );
+          expect(status.name).toBe("Good");
+        } finally {
+          await session.close();
+        }
+      });
+      expect(dataSource.writes).toContainEqual(
+        expect.objectContaining({ username: NAMED_ANONYMOUS.username }),
+      );
     }, 60_000);
 
     test("refuses a bad password", async () => {

--- a/server/protocols/opcua-server/__tests__/storage-data-source.test.ts
+++ b/server/protocols/opcua-server/__tests__/storage-data-source.test.ts
@@ -6,6 +6,7 @@
  * or database required (definitions are injected).
  */
 import { describe, test, expect, vi } from "vitest";
+import * as logger from "../../../logger";
 import {
   StorageTagDataSource,
   inferDataType,
@@ -47,6 +48,26 @@ describe("StorageTagDataSource", () => {
     const src = makeSource();
     expect(await src.loadSites()).toHaveLength(1);
     expect((await src.loadTags())[0].tagId).toBe("PT-101.PV");
+  });
+
+  test("warns once when a writable tag is absent from the catalogue", async () => {
+    const warnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+    const src = new StorageTagDataSource({
+      loadSites: async () => [],
+      loadTagDefs: async () => [
+        { tagId: "SETPOINT", siteId: "SITE-01", dataType: "number" },
+      ],
+      writableInputTags: new Set(["SETPOINT", "MISSPELLED-SETPOINT"]),
+    });
+
+    await src.loadTags();
+    await src.loadTags();
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("MISSPELLED-SETPOINT"),
+    );
+    warnSpy.mockRestore();
   });
 
   test("readTag returns undefined until an update arrives", async () => {

--- a/server/protocols/opcua-server/__tests__/storage-data-source.test.ts
+++ b/server/protocols/opcua-server/__tests__/storage-data-source.test.ts
@@ -10,7 +10,12 @@ import {
   StorageTagDataSource,
   inferDataType,
 } from "../storage-data-source";
-import type { SourceSite, SourceTag, TagSample } from "../types";
+import type {
+  SourceSite,
+  SourceTag,
+  TagSample,
+  TagWriteRequest,
+} from "../types";
 
 describe("inferDataType", () => {
   test("infers scalar types", () => {
@@ -104,5 +109,32 @@ describe("StorageTagDataSource", () => {
       timestamp: "t",
     });
     expect(good).toHaveBeenCalledOnce();
+  });
+
+  test("re-checks the writable-input allowlist at the write boundary", async () => {
+    const backend = vi.fn(async (_request: TagWriteRequest) => undefined);
+    const src = new StorageTagDataSource({
+      loadSites: async () => [],
+      loadTagDefs: async () => [],
+      writableInputTags: new Set(["SETPOINT"]),
+      writeTag: backend,
+    });
+    const base = {
+      siteId: "SITE-01",
+      value: 12.5,
+      username: "operator",
+      timestamp: new Date("2026-07-31T00:00:00Z"),
+    };
+
+    await expect(src.writeTag({ ...base, tagId: "OUTPUT" })).rejects.toThrow(
+      /writable-input allowlist/,
+    );
+    expect(backend).not.toHaveBeenCalled();
+
+    await expect(
+      src.writeTag({ ...base, tagId: "SETPOINT" }),
+    ).resolves.toBeUndefined();
+    expect(backend).toHaveBeenCalledOnce();
+    expect((await src.readTag("SETPOINT"))?.value).toBe(12.5);
   });
 });

--- a/server/protocols/opcua-server/address-space.ts
+++ b/server/protocols/opcua-server/address-space.ts
@@ -101,7 +101,7 @@ export function tagVariableNodeId(
 /** Compute the UA AccessLevel byte for a tag (read-only by default). */
 export function accessLevelFor(tag: SourceTag): number {
   let level = UaAccessLevel.CurrentRead;
-  if (tag.writable) {
+  if (tag.writable && tag.direction === "input") {
     level |= UaAccessLevel.CurrentWrite;
   }
   return level;
@@ -202,6 +202,8 @@ export function buildAddressSpace(
       accessLevel: accessLevelFor(tag),
       units: tag.units,
       tagId: tag.tagId,
+      siteId: tag.siteId,
+      direction: tag.direction,
     });
     // tagIndex is keyed by bare tagId for value routing on data-change. If the
     // same tagId exists in multiple sites the last sorted site wins; callers

--- a/server/protocols/opcua-server/config.ts
+++ b/server/protocols/opcua-server/config.ts
@@ -136,6 +136,10 @@ const BaseOpcuaServerConfigSchema = z
     minSamplingIntervalMs: z.coerce.number().int().min(10).default(100),
     /** Max concurrent client connections per endpoint. */
     maxSessions: z.coerce.number().int().min(1).default(100),
+    /** Master switch for the control write path. Off by default. */
+    writesEnabled: z.boolean().default(false),
+    /** Explicit per-tag allowlist. Empty means no writable tags. */
+    writableTags: z.array(z.string().trim().min(1)).default([]),
   })
   .strict();
 
@@ -314,6 +318,11 @@ export function loadOpcuaServerConfigFromEnv(
       env.OPCUA_SERVER_TRUST_UNKNOWN_CLIENT_CERTS,
       false,
     ),
+    writesEnabled: parseEnvBoolean(
+      "OPCUA_SERVER_WRITES_ENABLED",
+      env.OPCUA_SERVER_WRITES_ENABLED,
+      false,
+    ),
   };
 
   const host = optional(env.OPCUA_SERVER_HOST);
@@ -334,6 +343,10 @@ export function loadOpcuaServerConfigFromEnv(
   if (sampling !== undefined) raw.minSamplingIntervalMs = sampling;
   const maxSessions = optional(env.OPCUA_SERVER_MAX_SESSIONS);
   if (maxSessions !== undefined) raw.maxSessions = maxSessions;
+  const writableTags = optional(env.OPCUA_SERVER_WRITABLE_TAGS);
+  if (writableTags !== undefined) {
+    raw.writableTags = writableTags.split(",").map((tag) => tag.trim()).filter(Boolean);
+  }
 
   // NODE_ENV drives `env`, but only when it is one this module understands. An
   // unrecognised value falls through to the schema default ("production"), the

--- a/server/protocols/opcua-server/config.ts
+++ b/server/protocols/opcua-server/config.ts
@@ -138,7 +138,12 @@ const BaseOpcuaServerConfigSchema = z
     maxSessions: z.coerce.number().int().min(1).default(100),
     /** Master switch for the control write path. Off by default. */
     writesEnabled: z.boolean().default(false),
-    /** Explicit per-tag allowlist. Empty means no writable tags. */
+    /**
+     * Explicit per-tag declaration that each named historian tag is a control
+     * input. The historian has no independent direction metadata; inclusion is
+     * therefore the operator's direction assertion as well as the allowlist.
+     * Empty means no writable tags.
+     */
     writableTags: z.array(z.string().trim().min(1)).default([]),
   })
   .strict();

--- a/server/protocols/opcua-server/index.ts
+++ b/server/protocols/opcua-server/index.ts
@@ -47,6 +47,7 @@ import type {
   SourceSite,
   SourceTag,
   TagSample,
+  TagWriteRequest,
   UaVariableNode,
 } from "./types";
 import { UaDataType } from "./types";
@@ -68,6 +69,8 @@ export interface TagDataSource {
    * DataChangeNotifications.
    */
   subscribe(onChange: (sample: TagSample) => void): () => void;
+  /** Persist/dispatch an authorized control write and its audit record. */
+  writeTag?(request: TagWriteRequest): Promise<void>;
 }
 
 export interface OpcuaServerDeps {
@@ -383,6 +386,36 @@ export class OxScadaOpcuaServer {
           },
         },
       });
+      if (
+        variable.accessLevel & 0x02 &&
+        variable.direction === "input" &&
+        this.dataSource.writeTag
+      ) {
+        const writeTag = this.dataSource.writeTag.bind(this.dataSource);
+        uaVar.writeValue = (context, dataValue, _indexRange, callback) => {
+          const username = context.getUserName();
+          if (!username || username === "anonymous") {
+            callback(null, StatusCodes.BadUserAccessDenied);
+            return;
+          }
+          writeTag({
+            tagId: variable.tagId,
+            siteId: variable.siteId,
+            value: dataValue.value.value,
+            username,
+            timestamp: new Date(),
+          }).then(
+            () => {
+              uaVar.setValueFromSource(dataValue.value, StatusCodes.Good, new Date());
+              callback(null, StatusCodes.Good);
+            },
+            (error: unknown) => {
+              logError(error, `[opcua-server] write denied for ${variable.tagId}`);
+              callback(null, StatusCodes.BadUserAccessDenied);
+            },
+          );
+        };
+      }
       this.uaVariables.set(variable.nodeId, uaVar);
     }
   }

--- a/server/protocols/opcua-server/index.ts
+++ b/server/protocols/opcua-server/index.ts
@@ -50,7 +50,7 @@ import type {
   TagWriteRequest,
   UaVariableNode,
 } from "./types";
-import { UaDataType } from "./types";
+import { UaAccessLevel, UaDataType } from "./types";
 
 /**
  * Data source the server reads from. Implementations live behind
@@ -69,7 +69,11 @@ export interface TagDataSource {
    * DataChangeNotifications.
    */
   subscribe(onChange: (sample: TagSample) => void): () => void;
-  /** Persist/dispatch an authorized control write and its audit record. */
+  /**
+   * Accept an authorized supervisory value and its audit record. The shipped
+   * storage implementation persists inside 0xSCADA; it does not dispatch to a
+   * PLC or field protocol.
+   */
   writeTag?(request: TagWriteRequest): Promise<void>;
 }
 
@@ -387,14 +391,18 @@ export class OxScadaOpcuaServer {
         },
       });
       if (
-        variable.accessLevel & 0x02 &&
+        variable.accessLevel & UaAccessLevel.CurrentWrite &&
         variable.direction === "input" &&
         this.dataSource.writeTag
       ) {
         const writeTag = this.dataSource.writeTag.bind(this.dataSource);
-        uaVar.writeValue = (context, dataValue, _indexRange, callback) => {
-          const username = context.getUserName();
-          if (!username || username === "anonymous") {
+        uaVar.writeValue = (context, dataValue, indexRange, callback) => {
+          if (indexRange && !indexRange.isEmpty()) {
+            callback(null, StatusCodes.BadIndexRangeInvalid);
+            return;
+          }
+          const tokenUserName = context.session?.userIdentityToken?.userName;
+          if (typeof tokenUserName !== "string" || tokenUserName.length === 0) {
             callback(null, StatusCodes.BadUserAccessDenied);
             return;
           }
@@ -402,7 +410,7 @@ export class OxScadaOpcuaServer {
             tagId: variable.tagId,
             siteId: variable.siteId,
             value: dataValue.value.value,
-            username,
+            username: tokenUserName,
             timestamp: new Date(),
           }).then(
             () => {

--- a/server/protocols/opcua-server/index.ts
+++ b/server/protocols/opcua-server/index.ts
@@ -406,6 +406,15 @@ export class OxScadaOpcuaServer {
             callback(null, StatusCodes.BadUserAccessDenied);
             return;
           }
+          // Replacing writeValue bypasses node-opcua's default compatibility
+          // guard, so run the library's own validation before persistence.
+          const compatibilityStatus = uaVar.checkVariantCompatibility(
+            dataValue.value,
+          );
+          if (compatibilityStatus.isNot(StatusCodes.Good)) {
+            callback(null, compatibilityStatus);
+            return;
+          }
           writeTag({
             tagId: variable.tagId,
             siteId: variable.siteId,

--- a/server/protocols/opcua-server/node-opcua-api.ts
+++ b/server/protocols/opcua-server/node-opcua-api.ts
@@ -33,6 +33,12 @@ export interface UaVariable {
     statusCode?: unknown,
     sourceTimestamp?: Date,
   ): void;
+  writeValue(
+    context: { getUserName(): string },
+    dataValue: { value: { value: unknown } },
+    indexRange: unknown,
+    callback: (err: Error | null, statusCode?: unknown) => void,
+  ): void;
 }
 
 /** Options accepted by `Namespace.addVariable` that this server sets. */

--- a/server/protocols/opcua-server/node-opcua-api.ts
+++ b/server/protocols/opcua-server/node-opcua-api.ts
@@ -39,6 +39,16 @@ export interface UaNumericRange {
   isEmpty(): boolean;
 }
 
+/** `StatusCode` comparison surface returned by node-opcua validation. */
+export interface UaStatusCode {
+  isNot(other: unknown): boolean;
+}
+
+/** Incoming `Variant` surface needed for compatibility checks and persistence. */
+export interface UaVariant {
+  readonly value: unknown;
+}
+
 /** node-opcua `UAVariable`, restricted to the members the server drives. */
 export interface UaVariable {
   setValueFromSource(
@@ -48,10 +58,11 @@ export interface UaVariable {
   ): void;
   writeValue(
     context: UaSessionContext,
-    dataValue: { value: { value: unknown } },
+    dataValue: { value: UaVariant },
     indexRange: UaNumericRange | null,
     callback: (err: Error | null, statusCode?: unknown) => void,
   ): void;
+  checkVariantCompatibility(value: UaVariant): UaStatusCode;
 }
 
 /** Options accepted by `Namespace.addVariable` that this server sets. */

--- a/server/protocols/opcua-server/node-opcua-api.ts
+++ b/server/protocols/opcua-server/node-opcua-api.ts
@@ -26,6 +26,19 @@
 /** Opaque handle to a node-opcua runtime object we only ever hand back. */
 export type UaHandle = object;
 
+/** Session identity surface needed to authorize a write without string sentinels. */
+export interface UaSessionContext {
+  readonly session?: {
+    readonly userIdentityToken?: { readonly userName?: unknown };
+  };
+  getUserName(): string;
+}
+
+/** `NumericRange` surface used to reject unsupported partial writes. */
+export interface UaNumericRange {
+  isEmpty(): boolean;
+}
+
 /** node-opcua `UAVariable`, restricted to the members the server drives. */
 export interface UaVariable {
   setValueFromSource(
@@ -34,9 +47,9 @@ export interface UaVariable {
     sourceTimestamp?: Date,
   ): void;
   writeValue(
-    context: { getUserName(): string },
+    context: UaSessionContext,
     dataValue: { value: { value: unknown } },
-    indexRange: unknown,
+    indexRange: UaNumericRange | null,
     callback: (err: Error | null, statusCode?: unknown) => void,
   ): void;
 }

--- a/server/protocols/opcua-server/runtime.ts
+++ b/server/protocols/opcua-server/runtime.ts
@@ -20,7 +20,7 @@
  * Part of #461.
  */
 
-import { eq, isNotNull, sql } from "drizzle-orm";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import * as schema from "@shared/schema";
 import { logError, logInfo, logWarn } from "../../logger";
@@ -32,7 +32,7 @@ import {
 } from "./config";
 import { OxScadaOpcuaServer } from "./index";
 import { StorageTagDataSource } from "./storage-data-source";
-import type { SourceSite, SourceTag } from "./types";
+import type { SourceSite, SourceTag, TagWriteRequest } from "./types";
 import type { AuthUserRecord, UserLookup } from "./user-auth";
 
 /** The single flag that turns the subsystem on. */
@@ -78,7 +78,9 @@ export async function loadSitesFromStorage(): Promise<SourceSite[]> {
  * is a control action and needs scope authorisation and an audit record before
  * it can be offered at all.
  */
-export async function loadTagCatalogueFromStorage(): Promise<SourceTag[]> {
+export async function loadTagCatalogueFromStorage(
+  writableTags: ReadonlySet<string> = new Set(),
+): Promise<SourceTag[]> {
   const rows = await typedDatabase()
     .select({
       tagId: schema.historianData.tagId,
@@ -96,10 +98,55 @@ export async function loadTagCatalogueFromStorage(): Promise<SourceTag[]> {
       tagId: row.tagId,
       siteId: row.siteId,
       dataType: row.hasStringValue ? "string" : "number",
-      writable: false,
+      writable: writableTags.has(row.tagId),
+      direction: writableTags.has(row.tagId) ? "input" : undefined,
     });
   }
   return tags;
+}
+
+/** Authorize, persist, and audit one UA control write as a single transaction. */
+export async function writeTagToStorage(request: TagWriteRequest): Promise<void> {
+  const db = typedDatabase();
+  await db.transaction(async (tx) => {
+    const grants = await tx
+      .select({ userId: schema.users.id })
+      .from(schema.users)
+      .innerJoin(schema.userRoles, eq(schema.userRoles.userId, schema.users.id))
+      .innerJoin(schema.rolePermissions, eq(schema.rolePermissions.roleId, schema.userRoles.roleId))
+      .innerJoin(schema.permissions, eq(schema.permissions.id, schema.rolePermissions.permissionId))
+      .where(and(
+        eq(schema.users.username, request.username),
+        eq(schema.users.isActive, true),
+        eq(schema.permissions.resource, "opcua"),
+        eq(schema.permissions.action, "write"),
+      ))
+      .limit(1);
+    const grant = grants[0];
+    if (!grant) throw new Error("OPC-UA write scope denied");
+
+    const numeric = typeof request.value === "number" ? request.value : null;
+    await tx.insert(schema.historianData).values({
+      tagId: request.tagId,
+      siteId: request.siteId,
+      value: numeric,
+      stringValue: numeric === null ? String(request.value) : null,
+      quality: 192,
+      timestamp: request.timestamp,
+    });
+    await tx.insert(schema.auditLogs).values({
+      userId: grant.userId,
+      action: "UPDATE",
+      resource: "opcua-tag",
+      resourceId: request.tagId,
+      siteId: request.siteId,
+      details: {
+        protocol: "opcua",
+        value: request.value,
+        sessionIdentity: request.username,
+      },
+    });
+  });
 }
 
 /** Resolve a username against the existing `users` table. */
@@ -174,9 +221,13 @@ export async function startOpcuaServer(
     );
   }
 
+  const writableTags = config.writesEnabled
+    ? new Set(config.writableTags)
+    : new Set<string>();
   const dataSource = new StorageTagDataSource({
     loadSites: loadSitesFromStorage,
-    loadTagDefs: loadTagCatalogueFromStorage,
+    loadTagDefs: () => loadTagCatalogueFromStorage(writableTags),
+    ...(config.writesEnabled ? { writeTag: writeTagToStorage } : {}),
   });
 
   const server = new OxScadaOpcuaServer({

--- a/server/protocols/opcua-server/runtime.ts
+++ b/server/protocols/opcua-server/runtime.ts
@@ -17,6 +17,11 @@
  * gateway scan loop and the field simulator already publish to. Authentication
  * resolves against the existing `users` table — no parallel credential store.
  *
+ * WRITE BOUNDARY (#667): an accepted UA write is a durable supervisory value
+ * and audit event inside 0xSCADA. It does not dispatch to a PLC or field-bus
+ * adapter. `Good` therefore means that 0xSCADA accepted and persisted the
+ * value, not that physical equipment applied a setpoint.
+ *
  * Part of #461.
  */
 
@@ -37,6 +42,9 @@ import type { AuthUserRecord, UserLookup } from "./user-auth";
 
 /** The single flag that turns the subsystem on. */
 export const OPCUA_SERVER_ENABLED_ENV = "OPCUA_SERVER_ENABLED";
+
+/** OPC quality code used for an accepted, persisted supervisory value. */
+export const OPCUA_QUALITY_GOOD = 0xc0;
 
 let activeServer: OxScadaOpcuaServer | null = null;
 let detachTagStream: (() => void) | null = null;
@@ -71,15 +79,13 @@ export async function loadSitesFromStorage(): Promise<SourceSite[]> {
  * produced, and the UA data type is derived from whether the historian ever
  * stored a string for that tag (`string_value`) or only numerics (`value`).
  *
- * Tags are exposed read-only: 0xSCADA has no audited UA write path yet, so the
- * server must not advertise one. Read-only is the intended shipped behaviour,
- * not a placeholder — #461 asked for an address space, and that is what this
- * is. Writes are tracked separately in #667, because a UA client setting a tag
- * is a control action and needs scope authorisation and an audit record before
- * it can be offered at all.
+ * The historian table has no direction column. Consequently, entries in
+ * `writableInputTags` are an explicit operator assertion that the named tag is
+ * a control input; the allowlist and direction are not independent production
+ * gates. An omitted tag remains read-only.
  */
 export async function loadTagCatalogueFromStorage(
-  writableTags: ReadonlySet<string> = new Set(),
+  writableInputTags: ReadonlySet<string> = new Set(),
 ): Promise<SourceTag[]> {
   const rows = await typedDatabase()
     .select({
@@ -98,15 +104,23 @@ export async function loadTagCatalogueFromStorage(
       tagId: row.tagId,
       siteId: row.siteId,
       dataType: row.hasStringValue ? "string" : "number",
-      writable: writableTags.has(row.tagId),
-      direction: writableTags.has(row.tagId) ? "input" : undefined,
+      writable: writableInputTags.has(row.tagId),
+      direction: writableInputTags.has(row.tagId) ? "input" : undefined,
     });
   }
   return tags;
 }
 
 /** Authorize, persist, and audit one UA control write as a single transaction. */
-export async function writeTagToStorage(request: TagWriteRequest): Promise<void> {
+export async function writeTagToStorage(
+  request: TagWriteRequest,
+  writableInputTags: ReadonlySet<string>,
+): Promise<void> {
+  if (!writableInputTags.has(request.tagId)) {
+    throw new Error(
+      `OPC-UA tag ${request.tagId} is not in the writable-input allowlist`,
+    );
+  }
   const db = typedDatabase();
   await db.transaction(async (tx) => {
     const grants = await tx
@@ -131,7 +145,7 @@ export async function writeTagToStorage(request: TagWriteRequest): Promise<void>
       siteId: request.siteId,
       value: numeric,
       stringValue: numeric === null ? String(request.value) : null,
-      quality: 192,
+      quality: OPCUA_QUALITY_GOOD,
       timestamp: request.timestamp,
     });
     await tx.insert(schema.auditLogs).values({
@@ -221,13 +235,19 @@ export async function startOpcuaServer(
     );
   }
 
-  const writableTags = config.writesEnabled
+  const writableInputTags = config.writesEnabled
     ? new Set(config.writableTags)
     : new Set<string>();
   const dataSource = new StorageTagDataSource({
     loadSites: loadSitesFromStorage,
-    loadTagDefs: () => loadTagCatalogueFromStorage(writableTags),
-    ...(config.writesEnabled ? { writeTag: writeTagToStorage } : {}),
+    loadTagDefs: () => loadTagCatalogueFromStorage(writableInputTags),
+    writableInputTags,
+    ...(config.writesEnabled
+      ? {
+          writeTag: (request: TagWriteRequest) =>
+            writeTagToStorage(request, writableInputTags),
+        }
+      : {}),
   });
 
   const server = new OxScadaOpcuaServer({

--- a/server/protocols/opcua-server/storage-data-source.ts
+++ b/server/protocols/opcua-server/storage-data-source.ts
@@ -14,6 +14,10 @@
  * Keeping the queries injected means this module stays pure and unit-testable
  * with no database.
  *
+ * A successful `writeTag` means the configured 0xSCADA backend accepted the
+ * supervisory value. The production backend persists and audits it but does
+ * not claim that a PLC or other field device applied it.
+ *
  * Part of #461.
  */
 
@@ -41,6 +45,8 @@ export interface StorageDataSourceDeps {
   loadTagDefs: () => Promise<SourceTag[]>;
   /** Optional fail-closed write backend. Absence keeps every node read-only. */
   writeTag?: (request: TagWriteRequest) => Promise<void>;
+  /** Exact tags the operator has declared to be writable control inputs. */
+  writableInputTags?: ReadonlySet<string>;
 }
 
 /** Infer a 0xSCADA DataType from a runtime value. */
@@ -94,6 +100,11 @@ export class StorageTagDataSource implements TagDataSource {
   async writeTag(request: TagWriteRequest): Promise<void> {
     if (!this.deps.writeTag) {
       throw new Error("OPC-UA writes are not configured");
+    }
+    if (!this.deps.writableInputTags?.has(request.tagId)) {
+      throw new Error(
+        `OPC-UA tag ${request.tagId} is not in the writable-input allowlist`,
+      );
     }
     if (
       typeof request.value !== "number" &&

--- a/server/protocols/opcua-server/storage-data-source.ts
+++ b/server/protocols/opcua-server/storage-data-source.ts
@@ -22,6 +22,7 @@
  */
 
 import type { DataType, Quality } from "@shared/types/core/common";
+import { logWarn } from "../../logger";
 import type { TagDataSource } from "./index";
 import type {
   SourceSite,
@@ -73,6 +74,7 @@ export class StorageTagDataSource implements TagDataSource {
   private readonly deps: StorageDataSourceDeps;
   private readonly latest = new Map<string, TagSample>();
   private readonly listeners = new Set<(sample: TagSample) => void>();
+  private readonly warnedMissingWritableTags = new Set<string>();
 
   constructor(deps: StorageDataSourceDeps) {
     this.deps = deps;
@@ -82,8 +84,22 @@ export class StorageTagDataSource implements TagDataSource {
     return this.deps.loadSites();
   }
 
-  loadTags(): Promise<SourceTag[]> {
-    return this.deps.loadTagDefs();
+  async loadTags(): Promise<SourceTag[]> {
+    const tags = await this.deps.loadTagDefs();
+    const knownTagIds = new Set(tags.map((tag) => tag.tagId));
+    for (const tagId of this.deps.writableInputTags ?? []) {
+      if (
+        !knownTagIds.has(tagId) &&
+        !this.warnedMissingWritableTags.has(tagId)
+      ) {
+        this.warnedMissingWritableTags.add(tagId);
+        logWarn(
+          `[opcua-server] writable tag "${tagId}" was not found in the historian catalogue; ` +
+            "no writable UA node was created",
+        );
+      }
+    }
+    return tags;
   }
 
   async readTag(tagId: string): Promise<TagSample | undefined> {

--- a/server/protocols/opcua-server/storage-data-source.ts
+++ b/server/protocols/opcua-server/storage-data-source.ts
@@ -19,7 +19,12 @@
 
 import type { DataType, Quality } from "@shared/types/core/common";
 import type { TagDataSource } from "./index";
-import type { SourceSite, SourceTag, TagSample } from "./types";
+import type {
+  SourceSite,
+  SourceTag,
+  TagSample,
+  TagWriteRequest,
+} from "./types";
 
 /** Update shape emitted by the existing tag-stream fabric. */
 export interface IncomingTagUpdate {
@@ -34,6 +39,8 @@ export interface StorageDataSourceDeps {
   loadSites: () => Promise<SourceSite[]>;
   /** Load the tag catalogue (distinct `historian_data` tag ids per site). */
   loadTagDefs: () => Promise<SourceTag[]>;
+  /** Optional fail-closed write backend. Absence keeps every node read-only. */
+  writeTag?: (request: TagWriteRequest) => Promise<void>;
 }
 
 /** Infer a 0xSCADA DataType from a runtime value. */
@@ -82,6 +89,26 @@ export class StorageTagDataSource implements TagDataSource {
     return () => {
       this.listeners.delete(onChange);
     };
+  }
+
+  async writeTag(request: TagWriteRequest): Promise<void> {
+    if (!this.deps.writeTag) {
+      throw new Error("OPC-UA writes are not configured");
+    }
+    if (
+      typeof request.value !== "number" &&
+      typeof request.value !== "string" &&
+      typeof request.value !== "boolean"
+    ) {
+      throw new Error("OPC-UA writes only accept scalar tag values");
+    }
+    await this.deps.writeTag(request);
+    this.pushTagUpdate({
+      tagName: request.tagId,
+      value: request.value,
+      quality: "good",
+      timestamp: request.timestamp.toISOString(),
+    });
   }
 
   /**

--- a/server/protocols/opcua-server/types.ts
+++ b/server/protocols/opcua-server/types.ts
@@ -40,7 +40,11 @@ export interface SourceTag {
   units?: string;
   /** Whether UA clients may write this variable. Defaults to read-only. */
   writable?: boolean;
-  /** Control-flow direction. Only `input` tags may accept UA writes. */
+  /**
+   * Control-flow direction. Only `input` tags may accept UA writes. Sources
+   * with real direction metadata provide it directly; the historian adapter's
+   * explicit writable-input allowlist is also its direction assertion.
+   */
   direction?: "input" | "output" | "internal";
   /** Optional source address (PLC register, OPC item id, …) for diagnostics. */
   address?: string;

--- a/server/protocols/opcua-server/types.ts
+++ b/server/protocols/opcua-server/types.ts
@@ -40,6 +40,8 @@ export interface SourceTag {
   units?: string;
   /** Whether UA clients may write this variable. Defaults to read-only. */
   writable?: boolean;
+  /** Control-flow direction. Only `input` tags may accept UA writes. */
+  direction?: "input" | "output" | "internal";
   /** Optional source address (PLC register, OPC item id, …) for diagnostics. */
   address?: string;
 }
@@ -110,6 +112,16 @@ export interface UaVariableNode {
   units?: string;
   /** Echo of the originating tag id for value routing. */
   tagId: string;
+  siteId: string;
+  direction?: SourceTag["direction"];
+}
+
+export interface TagWriteRequest {
+  tagId: string;
+  siteId: string;
+  value: unknown;
+  username: string;
+  timestamp: Date;
 }
 
 export type UaNode = UaFolderNode | UaVariableNode;


### PR DESCRIPTION
## Summary

Closes #667.

Adds a fail-closed OPC-UA supervisory write path:

- `OPCUA_SERVER_WRITES_ENABLED` is false by default;
- `OPCUA_SERVER_WRITABLE_TAGS` explicitly declares the historian tags that the operator asserts are writable control inputs;
- the authenticated UA username must hold the existing RBAC permission with resource `opcua` and action `write`;
- the allowlist is enforced both when nodes are exposed and again at the storage write boundary.

The historian catalogue has no independent direction column. The allowlist is therefore both the operative per-tag gate and the operator's input-direction assertion; they are not claimed as independent gates.

An accepted write persists the supervisory value and its `audit_logs` record in one database transaction. The audit includes the UA session username, tag, site, protocol, timestamp, and value.

### Explicit boundary

`Good` means 0xSCADA accepted and persisted the supervisory value. This PR does **not** dispatch the value to a PLC or field-bus adapter and does not claim that physical equipment applied a setpoint.

## Review follow-up

- Validates the incoming UA Variant with node-opcua's own `checkVariantCompatibility` before storage is touched; a String write to a Double node now returns `BadTypeMismatch`.
- Adds a real wire-level type-confusion test and proves the rejected value never reaches the data source.
- Rejects non-empty `IndexRange` writes with `BadIndexRangeInvalid` instead of silently replacing the whole value.
- Authorizes only a real UserName identity token; a legitimate user literally named `anonymous` is no longer blocked by a string sentinel.
- Uses `UaAccessLevel.CurrentWrite` and the named `OPCUA_QUALITY_GOOD` constant instead of magic numbers.
- Re-checks the writable-input allowlist in `StorageTagDataSource.writeTag` and `writeTagToStorage`.
- Warns once for each configured writable tag that is absent from the historian catalogue.
- Documents the historian-direction and device-dispatch boundaries in code and here.
- Rebased onto current `main` at `e87a9f377`, including merged PR #676.

## Attribution

City-Agent: codex

## Verification

- `npm run typecheck` — pass.
- `npx vitest run server/protocols/opcua-server/__tests__` — 139 passed, including real `node-opcua` wire tests for default refusal, authenticated attribution, type mismatch, IndexRange rejection, typed arrays, and a username literally named `anonymous`.
- Repository-wide parallel run exposed unrelated load-sensitive timing failures; all implicated files passed immediately in isolation (6/6, 53/53, and 4/4).
- `git diff --check` — pass.

## Gate self-check

- [x] Every commit is signed off (DCO)
- [x] The `City-Agent:` line above is filled in
- [x] `npx tsc --noEmit` is clean
- [x] No new `any` types
- [x] No new modules requiring barrel exports
- [x] Tests added/updated for every claim in the summary
- [x] PR is scoped to a single issue
